### PR TITLE
fix: add currency control and round-trip booking URLs for flights

### DIFF
--- a/.claude/skills/trvl.md
+++ b/.claude/skills/trvl.md
@@ -53,7 +53,7 @@ From?|To?|When?|Flex?|Travelers?|Budget? Check calendar (Google/Apple/manual) fo
 ## CORE TOOLS (selected high-signal tools; trvl exposes 42 MCP tools overall via gateway_invoke server="trvl")
 | Tool | Use | Key params |
 |------|-----|-----------|
-| `search_flights` | Flights A→B | origin,destination,departure_date,[return_date,cabin_class,max_stops] |
+| `search_flights` | Flights A→B | origin,destination,departure_date,[return_date,cabin_class,max_stops,currency] |
 | `search_dates` | Cheapest dates | origin,destination,start_date,end_date |
 | `search_hotels` | Hotels by city | location,check_in,check_out,[guests,stars,eco_certified] |
 | `hotel_prices` | Provider comparison | hotel_id,check_in,check_out |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,7 @@ Optional parameters:
 - `max_duration`: integer — maximum total duration in minutes — server-side
 - `exclude_basic`: true/false — exclude basic economy fares — server-side
 - `airlines`: comma-separated IATA codes to restrict results (e.g. "AY,LH")
+- `currency`: ISO 4217 currency code (e.g. "USD", "EUR", "JPY") — server-side pricing via Google's `curr` parameter. Overrides IP-based default.
 
 ### search_dates — Find the cheapest day to fly
 ```json
@@ -345,7 +346,7 @@ Returns: effective cents-per-point, floor/ceiling valuation for the program, ver
 
 - Results include `booking_url` — share these with the user for direct Google links
 - Results include `suggestions` — use these to offer follow-up searches
-- Prices reflect the user's IP geolocation currency
+- Prices reflect the user's IP geolocation currency unless `currency` is specified
 - For trip planning: search flights first, then hotels at the destination
 - For budget trips: use `weekend_getaway` or `suggest_dates` to find the cheapest options
 - For multi-city: use `optimize_multi_city` to find the cheapest routing order
@@ -357,7 +358,7 @@ Returns: effective cents-per-point, floor/ceiling valuation for the program, ver
 
 - **"command not found"**: `which trvl` — if empty, the binary isn't in PATH. Re-run Step 1.
 - **No results**: Google may rate-limit. Wait 60 seconds and retry.
-- **Wrong currency**: Normal — currency follows IP geolocation.
+- **Wrong currency**: Use `currency` parameter on `search_flights` to override IP-based default (e.g. `"currency": "USD"`).
 - **MCP tools not showing**: Restart Claude Code / Claude Desktop after Step 2.
 
 ## Source

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ That's it. Your AI assistant now has 42 travel tools available. Just ask natural
 | Exclude basic economy | `exclude_basic` | Drops BE fares — server-side |
 | Sort | `sort_by` | `cheapest`, `duration`, `departure`, `arrival` |
 | Airlines | `airlines` | Comma-separated IATA codes (e.g. `AY,LH`) |
+| Currency | `currency` | ISO 4217 code (e.g. `USD`, `EUR`, `JPY`) — server-side via Google's `curr` parameter |
 
 ### Hotel Filters (`search_hotels`)
 
@@ -323,7 +324,7 @@ See [Quick Setup step 3](#3-optional-teach-your-ai-about-trvl) above for AGENTS.
 
 trvl also works as a standalone CLI tool with 40 commands:
 
-All search commands accept `--currency <CODE>` (e.g. `--currency EUR`) to convert displayed prices. trvl detects the actual API currency and converts at the display layer — no hardcoded currencies.
+All search commands accept `--currency <CODE>` (e.g. `--currency EUR`) to convert displayed prices. For `search_flights`, this also controls server-side pricing via Google's `curr` parameter, so prices come directly in the requested currency. For other commands, trvl detects the API currency and converts at the display layer.
 
 ### Flights
 

--- a/capabilities/trvl_search_flights.yaml
+++ b/capabilities/trvl_search_flights.yaml
@@ -31,6 +31,9 @@ schema:
       sort_by:
         type: string
         description: "Sort order: cheapest, duration, departure, or arrival (default: cheapest)"
+      currency:
+        type: string
+        description: "Target currency for prices (ISO 4217, e.g. USD, EUR, JPY). Controls server-side pricing via Google's curr parameter. Empty = IP-based default."
     required: [origin, destination, departure_date]
   output:
     type: object

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -78,6 +78,7 @@ Examples:
 				SortBy:     sort,
 				Airlines:   airlines,
 				Adults:     adults,
+				Currency:   targetCurrency,
 			}
 
 			// --compare-cabins: search all cabin classes in parallel.

--- a/internal/batchexec/client.go
+++ b/internal/batchexec/client.go
@@ -16,6 +16,7 @@ import (
 	"math/rand/v2"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -368,13 +369,24 @@ func backoffSleep(ctx context.Context, attempt int) error {
 // doWithRetry is thoroughly tested (client_test.go, client_extra_test.go).
 // Covered by integration proof tests.
 func (c *Client) SearchFlights(ctx context.Context, encodedFilters string) (int, []byte, error) {
+	return c.SearchFlightsWithCurrency(ctx, encodedFilters, "")
+}
+
+// SearchFlightsWithCurrency is like SearchFlights but appends a curr query
+// parameter to control the currency of returned prices.
+// An empty currency uses Google's IP-based default.
+func (c *Client) SearchFlightsWithCurrency(ctx context.Context, encodedFilters, currency string) (int, []byte, error) {
+	endpoint := FlightsURL
+	if currency != "" {
+		endpoint += "&curr=" + url.QueryEscape(currency)
+	}
 	payload := "f.req=" + encodedFilters
-	if data, ok := c.getCached(FlightsURL, payload); ok {
+	if data, ok := c.getCached(endpoint, payload); ok {
 		return 200, data, nil
 	}
-	status, body, err := c.PostForm(ctx, FlightsURL, payload)
+	status, body, err := c.PostForm(ctx, endpoint, payload)
 	if err == nil && status == 200 {
-		c.setCached(FlightsURL, payload, body, FlightCacheTTL)
+		c.setCached(endpoint, payload, body, FlightCacheTTL)
 	}
 	return status, body, err
 }

--- a/internal/flights/calendar.go
+++ b/internal/flights/calendar.go
@@ -416,7 +416,7 @@ func detectSourceCurrencyWithClient(ctx context.Context, client *batchexec.Clien
 		return "EUR"
 	}
 
-	status, body, err := client.SearchFlights(quickCtx, encoded)
+	status, body, err := client.SearchFlightsWithCurrency(quickCtx, encoded, opts.Currency)
 	if err != nil || status != 200 {
 		return "EUR"
 	}

--- a/internal/flights/provider.go
+++ b/internal/flights/provider.go
@@ -20,5 +20,6 @@ func (p *DefaultProvider) SearchFlights(ctx context.Context, origin, dest, date 
 		SortBy:     opts.SortBy,
 		Airlines:   opts.Airlines,
 		Adults:     opts.Adults,
+		Currency:   opts.Currency,
 	})
 }

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -193,7 +193,7 @@ func searchGoogleFlightsWithClient(ctx context.Context, client *batchexec.Client
 	// Currency conversion, if needed, happens in the CLI display layer.
 	for i := range flights {
 		flights[i].Provider = "google_flights"
-		flights[i].BookingURL = buildFlightBookingURL(origin, destination, date)
+		flights[i].BookingURL = buildFlightBookingURL(origin, destination, date, opts.ReturnDate)
 	}
 
 	return &models.FlightSearchResult{
@@ -205,8 +205,13 @@ func searchGoogleFlightsWithClient(ctx context.Context, client *batchexec.Client
 }
 
 // buildFlightBookingURL constructs a Google Flights deep link for a route and date.
-func buildFlightBookingURL(origin, destination, date string) string {
-	return fmt.Sprintf("https://www.google.com/travel/flights?q=Flights+to+%s+from+%s+on+%s", destination, origin, date)
+// For round-trip, the return date is appended so Google shows both legs.
+func buildFlightBookingURL(origin, destination, date, returnDate string) string {
+	url := fmt.Sprintf("https://www.google.com/travel/flights?q=Flights+to+%s+from+%s+on+%s", destination, origin, date)
+	if returnDate != "" {
+		url += fmt.Sprintf("+through+%s", returnDate)
+	}
+	return url
 }
 
 // buildFilters constructs the nested array structure for the flight search payload.

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -36,6 +36,10 @@ type SearchOptions struct {
 	Airlines   []string          // Restrict to these airline IATA codes
 	Adults     int               // Number of adult passengers (default: 1)
 
+	// Currency controls server-side pricing via Google's curr query parameter (ISO 4217, e.g. "USD").
+	// When set, prices are returned in this currency. Empty = IP-based default.
+	Currency string
+
 	// Server-side filters passed to Google Flights batchexecute.
 	MaxPrice    int // Max price in whole currency units (0 = no limit)
 	MaxDuration int // Max total flight duration in minutes (0 = no limit)
@@ -151,7 +155,7 @@ func searchGoogleFlightsWithClient(ctx context.Context, client *batchexec.Client
 		}, fmt.Errorf("encode filters: %w", err)
 	}
 
-	status, body, err := client.SearchFlights(ctx, encoded)
+	status, body, err := client.SearchFlightsWithCurrency(ctx, encoded, opts.Currency)
 	if err != nil {
 		return &models.FlightSearchResult{
 			Error: fmt.Sprintf("request failed: %v", err),

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -193,7 +193,7 @@ func searchGoogleFlightsWithClient(ctx context.Context, client *batchexec.Client
 	// Currency conversion, if needed, happens in the CLI display layer.
 	for i := range flights {
 		flights[i].Provider = "google_flights"
-		flights[i].BookingURL = buildFlightBookingURL(origin, destination, date, opts.ReturnDate)
+		flights[i].BookingURL = buildFlightBookingURL(origin, destination, date, opts.ReturnDate, opts.Currency)
 	}
 
 	return &models.FlightSearchResult{
@@ -206,10 +206,13 @@ func searchGoogleFlightsWithClient(ctx context.Context, client *batchexec.Client
 
 // buildFlightBookingURL constructs a Google Flights deep link for a route and date.
 // For round-trip, the return date is appended so Google shows both legs.
-func buildFlightBookingURL(origin, destination, date, returnDate string) string {
+func buildFlightBookingURL(origin, destination, date, returnDate, currency string) string {
 	url := fmt.Sprintf("https://www.google.com/travel/flights?q=Flights+to+%s+from+%s+on+%s", destination, origin, date)
 	if returnDate != "" {
 		url += fmt.Sprintf("+through+%s", returnDate)
+	}
+	if currency != "" {
+		url += "&curr=" + currency
 	}
 	return url
 }

--- a/internal/flights/search_extra_test.go
+++ b/internal/flights/search_extra_test.go
@@ -579,7 +579,7 @@ func TestSearchDates_ReversedDates(t *testing.T) {
 // --- buildFlightBookingURL ---
 
 func TestBuildFlightBookingURL_Basic(t *testing.T) {
-	url := buildFlightBookingURL("HEL", "NRT", "2026-06-15", "")
+	url := buildFlightBookingURL("HEL", "NRT", "2026-06-15", "", "")
 	if url == "" {
 		t.Fatal("expected non-empty URL")
 	}
@@ -598,7 +598,7 @@ func TestBuildFlightBookingURL_Basic(t *testing.T) {
 }
 
 func TestBuildFlightBookingURL_Format(t *testing.T) {
-	url := buildFlightBookingURL("JFK", "LAX", "2027-01-01", "")
+	url := buildFlightBookingURL("JFK", "LAX", "2027-01-01", "", "")
 	expected := "https://www.google.com/travel/flights?q=Flights+to+LAX+from+JFK+on+2027-01-01"
 	if url != expected {
 		t.Errorf("URL = %q, want %q", url, expected)
@@ -614,7 +614,7 @@ func TestBuildFlightBookingURL_DifferentRoutes(t *testing.T) {
 		{"SFO", "BCN", "2027-07-15"},
 	}
 	for _, tt := range tests {
-		url := buildFlightBookingURL(tt.origin, tt.dest, tt.date, "")
+		url := buildFlightBookingURL(tt.origin, tt.dest, tt.date, "", "")
 		if !strings.Contains(url, tt.dest) {
 			t.Errorf("URL for %s->%s missing destination: %s", tt.origin, tt.dest, url)
 		}
@@ -630,7 +630,7 @@ func TestBuildFlightBookingURL_DifferentRoutes(t *testing.T) {
 // --- buildFilters passengers ---
 
 func TestBuildFlightBookingURL_RoundTrip(t *testing.T) {
-	url := buildFlightBookingURL("HEL", "NRT", "2026-06-15", "2026-06-30")
+	url := buildFlightBookingURL("HEL", "NRT", "2026-06-15", "2026-06-30", "")
 	if !strings.Contains(url, "through+2026-06-30") {
 		t.Errorf("round-trip URL missing return date: %s", url)
 	}
@@ -639,9 +639,25 @@ func TestBuildFlightBookingURL_RoundTrip(t *testing.T) {
 	}
 
 	// One-way should not contain "through"
-	oneWay := buildFlightBookingURL("HEL", "NRT", "2026-06-15", "")
+	oneWay := buildFlightBookingURL("HEL", "NRT", "2026-06-15", "", "")
 	if strings.Contains(oneWay, "through") {
 		t.Errorf("one-way URL should not contain return date: %s", oneWay)
+	}
+}
+
+func TestBuildFlightBookingURL_Currency(t *testing.T) {
+	url := buildFlightBookingURL("MDE", "MAD", "2026-05-01", "2026-05-20", "USD")
+	if !strings.Contains(url, "&curr=USD") {
+		t.Errorf("URL missing currency param: %s", url)
+	}
+	if !strings.Contains(url, "through+2026-05-20") {
+		t.Errorf("URL missing return date: %s", url)
+	}
+
+	// Without currency, no &curr= in URL
+	noCurrency := buildFlightBookingURL("HEL", "NRT", "2026-06-15", "", "")
+	if strings.Contains(noCurrency, "curr=") {
+		t.Errorf("URL should not contain currency: %s", noCurrency)
 	}
 }
 

--- a/internal/flights/search_extra_test.go
+++ b/internal/flights/search_extra_test.go
@@ -579,7 +579,7 @@ func TestSearchDates_ReversedDates(t *testing.T) {
 // --- buildFlightBookingURL ---
 
 func TestBuildFlightBookingURL_Basic(t *testing.T) {
-	url := buildFlightBookingURL("HEL", "NRT", "2026-06-15")
+	url := buildFlightBookingURL("HEL", "NRT", "2026-06-15", "")
 	if url == "" {
 		t.Fatal("expected non-empty URL")
 	}
@@ -598,7 +598,7 @@ func TestBuildFlightBookingURL_Basic(t *testing.T) {
 }
 
 func TestBuildFlightBookingURL_Format(t *testing.T) {
-	url := buildFlightBookingURL("JFK", "LAX", "2027-01-01")
+	url := buildFlightBookingURL("JFK", "LAX", "2027-01-01", "")
 	expected := "https://www.google.com/travel/flights?q=Flights+to+LAX+from+JFK+on+2027-01-01"
 	if url != expected {
 		t.Errorf("URL = %q, want %q", url, expected)
@@ -614,7 +614,7 @@ func TestBuildFlightBookingURL_DifferentRoutes(t *testing.T) {
 		{"SFO", "BCN", "2027-07-15"},
 	}
 	for _, tt := range tests {
-		url := buildFlightBookingURL(tt.origin, tt.dest, tt.date)
+		url := buildFlightBookingURL(tt.origin, tt.dest, tt.date, "")
 		if !strings.Contains(url, tt.dest) {
 			t.Errorf("URL for %s->%s missing destination: %s", tt.origin, tt.dest, url)
 		}
@@ -624,6 +624,24 @@ func TestBuildFlightBookingURL_DifferentRoutes(t *testing.T) {
 		if !strings.Contains(url, tt.date) {
 			t.Errorf("URL for %s->%s missing date: %s", tt.origin, tt.dest, url)
 		}
+	}
+}
+
+// --- buildFilters passengers ---
+
+func TestBuildFlightBookingURL_RoundTrip(t *testing.T) {
+	url := buildFlightBookingURL("HEL", "NRT", "2026-06-15", "2026-06-30")
+	if !strings.Contains(url, "through+2026-06-30") {
+		t.Errorf("round-trip URL missing return date: %s", url)
+	}
+	if !strings.Contains(url, "on+2026-06-15") {
+		t.Errorf("round-trip URL missing departure date: %s", url)
+	}
+
+	// One-way should not contain "through"
+	oneWay := buildFlightBookingURL("HEL", "NRT", "2026-06-15", "")
+	if strings.Contains(oneWay, "through") {
+		t.Errorf("one-way URL should not contain return date: %s", oneWay)
 	}
 }
 

--- a/internal/models/interfaces.go
+++ b/internal/models/interfaces.go
@@ -11,6 +11,7 @@ type FlightSearchOptions struct {
 	SortBy     SortBy     // Result sort order
 	Airlines   []string   // Restrict to these airline IATA codes
 	Adults     int        // Number of adult passengers (default: 1)
+	Currency   string     // Target currency for prices (ISO 4217, e.g. "USD"); empty = IP default
 }
 
 // HotelSearchOptions mirrors hotels.HotelSearchOptions for the provider interface.

--- a/mcp/tools_flights.go
+++ b/mcp/tools_flights.go
@@ -140,6 +140,7 @@ func searchFlightsTool() ToolDef {
 				"carry_on_bags":       {Type: "integer", Description: "Require N carry-on bags included in price (0 = no filter, 1 = require carry-on). Server-side price recalculation."},
 				"checked_bags":        {Type: "integer", Description: "Checked bags pricing hint (0 = default, 1+ = recalculate prices including N checked bags). Changes price display, does not remove flights. Use require_checked_bag for actual filtering."},
 				"require_checked_bag": {Type: "boolean", Description: "Only show flights with ≥1 free checked bag included (default: false). Client-side post-filter on response data."},
+				"currency":            {Type: "string", Description: "Target currency for prices (ISO 4217, e.g. USD, EUR, JPY). Controls server-side pricing via Google's curr parameter. Empty = IP-based default."},
 			},
 			Required: []string{"origin", "destination", "departure_date"},
 		},
@@ -227,6 +228,7 @@ func handleSearchFlights(ctx context.Context, args map[string]any, elicit Elicit
 		CarryOnBags:       argInt(args, "carry_on_bags", 0),
 		CheckedBags:       argInt(args, "checked_bags", 0),
 		RequireCheckedBag: argBool(args, "require_checked_bag", false),
+		Currency:          argString(args, "currency"),
 	}
 
 	if cc := argString(args, "cabin_class"); cc != "" {


### PR DESCRIPTION
## Summary

Fixes #32

- **Currency control**: Add `currency` parameter (CLI `--currency` flag and MCP `currency` param) that passes the target currency to Google Flights via the `curr=` query parameter. Prices are now returned in the specified currency instead of relying on IP-based geolocation defaults.
- **Round-trip booking URLs**: Include the return date (`+through+YYYY-MM-DD`) and currency (`&curr=CURR`) in Google Flights deep links so that round-trip search results link to the correct round-trip booking page.

## Changes

| File | Change |
|------|--------|
| `internal/batchexec/client.go` | Add `SearchFlightsWithCurrency` that appends `&curr=` to the endpoint |
| `internal/flights/search.go` | Wire currency through search, update `buildFlightBookingURL` with return date + currency |
| `internal/flights/calendar.go` | Use `SearchFlightsWithCurrency` for currency detection |
| `internal/flights/provider.go` | Pass currency through provider interface |
| `internal/models/interfaces.go` | Add `Currency` field to `FlightSearchOptions` |
| `cmd/trvl/flights.go` | Pass `targetCurrency` to search options |
| `mcp/tools_flights.go` | Add `currency` to MCP tool input schema and handler |
| `internal/flights/search_extra_test.go` | Tests for round-trip and currency booking URLs |
| `capabilities/trvl_search_flights.yaml` | Document `currency` in input schema |
| `AGENTS.md` | Document `currency` param, update troubleshooting |
| `README.md` | Add currency to flight filters table, clarify `--currency` behavior |
| `.claude/skills/trvl.md` | Add `currency` to search_flights key params |

## Test plan

- [x] `make test` passes (all existing + new tests)
- [x] `bin/trvl flights HEL NRT 2026-06-15 --currency USD` — prices shown in USD
- [x] `bin/trvl flights HEL NRT 2026-06-15 --return 2026-06-30 --currency EUR` — booking URL contains return date and currency
- [x] `bin/trvl flights HEL NRT 2026-06-15` — one-way search unchanged (no currency override)
- [x] MCP tool accepts `currency` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)