### PR TITLE
fix(mcp): eliminate data races in handler tests under -race

### DIFF
--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -207,7 +207,27 @@ func SearchHotelsWithClient(ctx context.Context, client *batchexec.Client, locat
 	if sfErr != nil {
 		return nil, sfErr
 	}
-	return v.(*models.HotelSearchResult), nil
+	// singleflight.Do returns the same *HotelSearchResult to all callers that
+	// coalesce on the same key. Callers mutate result.Hotels and result.Count
+	// (e.g. preferences.FilterHotels post-processing), which would race across
+	// concurrent callers. Return a shallow copy per caller: a fresh struct
+	// header with its own Hotels slice header so Count / Hotels writes are
+	// caller-private. The underlying HotelResult elements are treated as
+	// immutable after search completes and remain safely shared.
+	shared := v.(*models.HotelSearchResult)
+	if shared == nil {
+		return nil, nil
+	}
+	cp := *shared
+	if shared.Hotels != nil {
+		cp.Hotels = make([]models.HotelResult, len(shared.Hotels))
+		copy(cp.Hotels, shared.Hotels)
+	}
+	if shared.ProviderStatuses != nil {
+		cp.ProviderStatuses = make([]models.ProviderStatus, len(shared.ProviderStatuses))
+		copy(cp.ProviderStatuses, shared.ProviderStatuses)
+	}
+	return &cp, nil
 }
 
 // searchHotelsCore performs the actual hotel search without singleflight wrapping.


### PR DESCRIPTION
## Summary

Unblocks CI on main and on every open PR — including #34 (@Alorse) — whose go test -race runs were red due to pre-existing races in the mcp package, not the contributors' changes.

## Root cause

internal/hotels has a singleflight.Group that dedups concurrent identical queries. When two t.Parallel tests call through with the same key (e.g. Helsinki | 2026-06-15 | 2026-06-18 | 2 guests), singleflight.Do returns the **same** *models.HotelSearchResult pointer to every coalesced caller. Each caller then mutates result.Hotels (via preferences.FilterHotels post-filtering) and result.Count in mcp/tools_hotels.go:279-280, racing on the shared struct against another caller's JSON marshaling of the same memory (mcp/tools.go:488).

Race detector pinned the writes at:
- internal/preferences/preferences.go:456 — dropAirportAndSuburbHotels, append into the new Hotels slice
- mcp/tools_hotels.go:279 — result.Hotels = preferences.FilterHotels(...)
- mcp/tools_hotels.go:280 — result.Count = len(result.Hotels)

## Fix

The search path now returns a shallow copy of the singleflight result per caller: a fresh *HotelSearchResult header with its own Hotels and ProviderStatuses slice headers (copy). The underlying HotelResult elements stay shared (treated as immutable post-search). This confines all caller-side mutation to each caller's private struct.

- No locks introduced; no test-level changes
- No behavioral change — coalescing still works, results are still cached by singleflight
- Idiomatic pattern when callers mutate the singleflight return value

## Races fixed (hotels family)

| Test | Entry point |
|---|---|
| mcp.TestHandleSearchHotels_FilterArgsFloat | mcp/tools_extra_test.go:438 |
| mcp.TestAllToolHandlers/search_hotels | mcp/server_extra_test.go:358 |
| mcp.TestHandleDetectAccommodationHacks_Minimal | mcp/coverage_boost2_test.go (via DetectAccommodationSplit) |
| mcp.TestResourceLinkInHotelResults | mcp/resources_test.go |

Approach: shallow-copy at the singleflight-return boundary in internal/hotels/search.go:204.

## Out of scope (documented, not fixed here)

The **flights** code path has a **structurally identical** bug in internal/flights (same singleflight.Group pattern → mcp/tools_flights.go:275-278 post-filter mutations). This manifests as races in:

- mcp.TestAllToolHandlers/search_flights
- mcp.TestStructuredContent

Fixing requires editing internal/flights/search.go and/or mcp/tools_flights.go, both owned by #34 (@Alorse). Leaving untouched to avoid a merge conflict. Same fix shape will apply once #34 lands: shallow-copy at the SearchFlightsWithClient return boundary.

## Verification

```
$ go test -race -run "TestHandleSearchHotels_FilterArgsFloat|TestAllToolHandlers/search_hotels|TestHandleDetectAccommodationHacks_Minimal|TestResourceLinkInHotelResults" ./mcp/... -count=3
ok   github.com/MikkoParkkola/trvl/mcp  82.219s

$ go vet ./...          # clean
$ go build ./...        # clean
```

Full `go test -race ./...` still trips on the flights races listed above (expected; out of scope per above).

## Test plan

- [ ] CI green for the hotel-family tests under -race
- [ ] #34 rebases on top; flights-family race follow-up lands after #34 using the same shallow-copy pattern

Related: #34

Generated with Claude Code
