### PR TITLE
fix(mcp): extend singleflight shallow-copy to flight search

### DIFF
--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -116,7 +116,23 @@ func SearchFlightsWithClient(ctx context.Context, client *batchexec.Client, orig
 		}
 		return &models.FlightSearchResult{Error: err.Error()}, err
 	}
-	return v.(*models.FlightSearchResult), nil
+	// singleflight.Do returns the same *FlightSearchResult to all callers that
+	// coalesce on the same key. Callers mutate result.Flights and result.Count
+	// (e.g. preferences filtering in mcp/tools_flights.go), which would race
+	// across concurrent callers. Return a shallow copy per caller: a fresh
+	// struct header with its own Flights slice header so Count / Flights
+	// writes are caller-private. The underlying FlightResult elements are
+	// treated as immutable after search completes and remain safely shared.
+	shared := v.(*models.FlightSearchResult)
+	if shared == nil {
+		return nil, nil
+	}
+	cp := *shared
+	if shared.Flights != nil {
+		cp.Flights = make([]models.FlightResult, len(shared.Flights))
+		copy(cp.Flights, shared.Flights)
+	}
+	return &cp, nil
 }
 
 // searchFlightsCore performs the actual flight search without singleflight wrapping.


### PR DESCRIPTION
Mirrors the hotel-side fix from #39. Same pattern: coalesced singleflight callers each get a fresh `*FlightSearchResult` header with an independent `Flights` slice header, so post-filter mutations in `mcp/tools_flights.go` (preferences filtering, `Count = len(Flights)`) don't race with sibling JSON marshaling.

Only touches `internal/flights/search.go` — scoped to the singleflight return boundary in `SearchFlightsWithClient`. Mutation-visible fields (`Flights`, `Count`) get per-caller-private headers; underlying `FlightResult` elements are treated as immutable post-search and remain safely shared.

Unblocks external contributor PR #34 (@Alorse) fully.

## Verification

- `go test -race -run "TestAllToolHandlers/search_flights|TestStructuredContent" ./mcp/... -count=3` — pass
- `go test -race ./... -count=1` — all packages pass, no remaining race failures
- `go vet ./...` — clean
- `go build ./...` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>