### PR TITLE
feat: add --first flag to return single best-priced flight result

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ![trvl demo](https://raw.githubusercontent.com/MikkoParkkola/trvl/main/demo.gif?v=1.0.5)
 
-> **54 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, travel hacks, weather forecasts, baggage rules, airport lounges, destination intel. Free. API-first.**
+> **55 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, travel hacks, weather forecasts, baggage rules, airport lounges, destination intel. Free. API-first.**
 >
 > Also works as a standalone CLI with 42 commands.
 
@@ -124,7 +124,7 @@ The profile makes every subsequent search smarter — it skips questions it alre
 
 ### 5. Ask your AI to search
 
-That's it. Your AI assistant now has 54 travel tools available. Just ask naturally:
+That's it. Your AI assistant now has 55 travel tools available. Just ask naturally:
 
 - *"Search flights from JFK to Tokyo on July 1st, business class"*
 - *"Find hotels in Paris for July 1-5, at least 4 stars"*

--- a/capabilities/trvl_search_flights.yaml
+++ b/capabilities/trvl_search_flights.yaml
@@ -31,6 +31,12 @@ schema:
       sort_by:
         type: string
         description: "Sort order: cheapest, duration, departure, or arrival (default: cheapest)"
+      first_result:
+        type: boolean
+        description: >-
+          Return only the first result with a valid price after sorting.
+          Use with sort_by to get e.g. the cheapest or shortest priced flight.
+          Default: false.
     required: [origin, destination, departure_date]
   output:
     type: object

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -32,6 +32,7 @@ func flightsCmd() *cobra.Command {
 		format         string
 		targetCurrency string
 		compareCabins  bool
+		firstResult    bool
 	)
 
 	cmd := &cobra.Command{
@@ -78,13 +79,14 @@ Examples:
 			}
 
 			opts := flights.SearchOptions{
-				ReturnDate: returnDate,
-				CabinClass: cabinClass,
-				MaxStops:   stops,
-				SortBy:     sort,
-				Airlines:   airlines,
-				Adults:     adults,
-				Currency:   targetCurrency,
+				ReturnDate:  returnDate,
+				CabinClass:  cabinClass,
+				MaxStops:    stops,
+				SortBy:      sort,
+				Airlines:    airlines,
+				Adults:      adults,
+				Currency:    targetCurrency,
+				FirstResult: firstResult,
 			}
 
 			// --compare-cabins: search all cabin classes in parallel.
@@ -124,6 +126,11 @@ Examples:
 				})
 			}
 
+			if opts.FirstResult && result != nil && result.Success {
+				result.Flights = flights.FirstPricedResult(result.Flights)
+				result.Count = len(result.Flights)
+			}
+
 			if format == "json" {
 				return models.FormatJSON(os.Stdout, result)
 			}
@@ -152,6 +159,7 @@ Examples:
 	cmd.Flags().StringVar(&format, "format", "table", "Output format: table, json")
 	cmd.Flags().StringVar(&targetCurrency, "currency", "", "Convert prices to this currency (e.g. EUR, USD). Empty = show API default")
 	cmd.Flags().BoolVar(&compareCabins, "compare-cabins", false, "Compare prices across all cabin classes (economy, premium, business, first)")
+	cmd.Flags().BoolVar(&firstResult, "first", false, "Return only the first result with a valid price (respects --sort order)")
 
 	cmd.ValidArgsFunction = airportCompletion
 

--- a/internal/flights/filter.go
+++ b/internal/flights/filter.go
@@ -56,6 +56,17 @@ func FilterFlightsByBudget(flights []models.FlightResult, maxPrice float64) []mo
 	return out
 }
 
+// FirstPricedResult returns the first flight with Price > 0 from a pre-sorted slice.
+// Returns nil if no priced flight exists.
+func FirstPricedResult(flights []models.FlightResult) []models.FlightResult {
+	for _, f := range flights {
+		if f.Price > 0 {
+			return []models.FlightResult{f}
+		}
+	}
+	return nil
+}
+
 // extractDepartureHHMM extracts the "HH:MM" departure time from the first leg.
 // Returns "" if the flight has no legs or the time cannot be parsed.
 func extractDepartureHHMM(f models.FlightResult) string {

--- a/internal/flights/filter_test.go
+++ b/internal/flights/filter_test.go
@@ -134,6 +134,33 @@ func TestFilterFlightsByBudget_ZeroPrice_Kept(t *testing.T) {
 	}
 }
 
+func TestFirstPricedResult_SkipsZeroPrice(t *testing.T) {
+	flts := []models.FlightResult{{Price: 0}, {Price: 150}, {Price: 200}}
+	got := FirstPricedResult(flts)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 flight, got %d", len(got))
+	}
+	if got[0].Price != 150 {
+		t.Errorf("expected price 150, got %.0f", got[0].Price)
+	}
+}
+
+func TestFirstPricedResult_AllZero(t *testing.T) {
+	flts := []models.FlightResult{{Price: 0}, {Price: 0}}
+	got := FirstPricedResult(flts)
+	if got != nil {
+		t.Errorf("all zero prices: expected nil, got %v", got)
+	}
+}
+
+func TestFirstPricedResult_AllPriced(t *testing.T) {
+	flts := []models.FlightResult{{Price: 100}, {Price: 200}}
+	got := FirstPricedResult(flts)
+	if len(got) != 1 || got[0].Price != 100 {
+		t.Errorf("all priced: expected [{Price:100}], got %v", got)
+	}
+}
+
 func TestExtractDepartureHHMM(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -55,6 +55,7 @@ type SearchOptions struct {
 
 	// Client-side post-filters (applied after server response).
 	RequireCheckedBag bool // Only show flights with ≥1 free checked bag
+	FirstResult       bool // Return only the first flight with Price > 0 after sorting
 }
 
 // defaults fills in zero-value fields with sensible defaults.

--- a/mcp/tools_flights.go
+++ b/mcp/tools_flights.go
@@ -152,6 +152,7 @@ func searchFlightsTool() ToolDef {
 				"checked_bags":        {Type: "integer", Description: "Checked bags pricing hint (0 = default, 1+ = recalculate prices including N checked bags). Changes price display, does not remove flights. Use require_checked_bag for actual filtering."},
 				"require_checked_bag": {Type: "boolean", Description: "Only show flights with ≥1 free checked bag included (default: false). Client-side post-filter on response data."},
 				"currency":            {Type: "string", Description: "Target currency for prices (ISO 4217, e.g. USD, EUR, JPY). Controls server-side pricing via Google's curr parameter. Empty = IP-based default."},
+				"first_result":        {Type: "boolean", Description: "Return only the first result with a valid price after sorting. Combine with sort_by to get e.g. the shortest priced flight (duration) or cheapest. Default: false."},
 			},
 			Required: []string{"origin", "destination", "departure_date"},
 		},
@@ -224,6 +225,7 @@ func handleSearchFlights(ctx context.Context, args map[string]any, elicit Elicit
 		CarryOnBags:       argInt(args, "carry_on_bags", 0),
 		CheckedBags:       argInt(args, "checked_bags", 0),
 		RequireCheckedBag: argBool(args, "require_checked_bag", false),
+		FirstResult:       argBool(args, "first_result", false),
 		Currency:          argString(args, "currency"),
 	}
 
@@ -277,6 +279,11 @@ func handleSearchFlights(ctx context.Context, args map[string]any, elicit Elicit
 		result.Flights = flights.FilterFlightsByBudget(result.Flights, prefs.BudgetFlightMax)
 		result.Flights = flights.FilterFlightsByTimePreference(result.Flights, prefs.FlightTimeEarliest, prefs.FlightTimeLatest)
 		result.Flights = flights.AdjustBagAllowance(result.Flights, prefs.FrequentFlyerPrograms)
+		result.Count = len(result.Flights)
+	}
+
+	if opts.FirstResult && result != nil && result.Success {
+		result.Flights = flights.FirstPricedResult(result.Flights)
 		result.Count = len(result.Flights)
 	}
 


### PR DESCRIPTION
## Summary

Adds an optional `--first` flag (CLI) and `first_result` boolean parameter (MCP) to flight search. When enabled, returns only the first flight with a valid price (`Price > 0`) after applying the current sort order — effectively a limit of 1 on priced results.

- `--sort cheapest --first` → cheapest priced flight
- `--sort duration --first` → shortest priced flight
- Default is `false`; existing behavior is unchanged

## Use cases

- **Price calendars** — fetch one price per date across many parallel requests without processing full result lists
- **Quick estimates** — answer "roughly how much is a flight to X?" before refining search parameters
- **Price alerts / daemons** — only the current best price is needed per polling cycle
- **Route comparison** — compare 10+ origin-destination pairs with one number per route
- **AI assistant responses** — a single price answer requires far fewer tokens than a full flight list
- **Date validation** — confirm a date has bookable flights (Price > 0) without loading the full payload

## Changes

- `internal/flights/filter.go` — new `FirstPricedResult()` post-filter
- `internal/flights/search.go` — `FirstResult bool` field in `SearchOptions`
- `cmd/trvl/flights.go` — `--first` CLI flag
- `mcp/tools_flights.go` — `first_result` MCP parameter
- `capabilities/trvl_search_flights.yaml` — parameter documented
- `README.md` — fix pre-existing 54→55 tool count mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)