### PR TITLE
fix(test): stop Windows CI false-positives from platform-specific asserts

### DIFF
--- a/cmd/trvl/cli_cov_test.go
+++ b/cmd/trvl/cli_cov_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -692,9 +693,11 @@ func TestSaveKeysTo_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat failed: %v", err)
 	}
-	perm := info.Mode().Perm()
-	if perm&0o077 != 0 {
-		t.Errorf("keys file should be owner-only, got permissions %o", perm)
+	if runtime.GOOS != "windows" {
+		perm := info.Mode().Perm()
+		if perm&0o077 != 0 {
+			t.Errorf("keys file should be owner-only, got permissions %o", perm)
+		}
 	}
 }
 

--- a/cmd/trvl/cli_max_test.go
+++ b/cmd/trvl/cli_max_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1278,7 +1279,9 @@ func TestSaveKeysTo_CreatesParentDirs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stat: %v", err)
 	}
-	if info.Mode().Perm() != 0o600 {
-		t.Errorf("file mode = %o, want 0600", info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("file mode = %o, want 0600", info.Mode().Perm())
+		}
 	}
 }

--- a/internal/cookies/cookies_coverage_test.go
+++ b/internal/cookies/cookies_coverage_test.go
@@ -202,6 +202,9 @@ func TestOpenBrowserForAuth_CooldownExactBoundary(t *testing.T) {
 }
 
 func TestOpenBrowserForAuth_DomainOnlyNoSlash(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("browser-opener command differs on Windows; tracked in #45")
+	}
 	origNow := browserAuthNow
 	origStart := browserAuthStart
 	now := time.Unix(1_700_000_000, 0)

--- a/internal/watch/watch_max_test.go
+++ b/internal/watch/watch_max_test.go
@@ -582,6 +582,9 @@ func TestLoadJSON_ReadError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestSaveLocked_HistorySaveError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("filesystem chmod semantics differ on Windows; tracked in #45")
+	}
 	dir := t.TempDir()
 	store := NewStore(dir)
 	store.watches = []Watch{{ID: "test1", Type: "flight"}}
@@ -603,6 +606,9 @@ func TestSaveLocked_HistorySaveError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRemove_SaveError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("filesystem chmod semantics differ on Windows; tracked in #45")
+	}
 	dir := t.TempDir()
 	store := NewStore(dir)
 	w := Watch{Type: "flight", Origin: "HEL", Destination: "BCN", DepartDate: "2026-07-01"}
@@ -629,6 +635,9 @@ func TestRemove_SaveError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAdd_SaveError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("filesystem chmod semantics differ on Windows; tracked in #45")
+	}
 	dir := t.TempDir()
 	store := NewStore(dir)
 
@@ -678,13 +687,16 @@ func TestSaveJSON_NormalPath(t *testing.T) {
 		t.Fatalf("saveJSON: %v", err)
 	}
 
-	// Verify file permissions.
+	// Verify file permissions (Unix only; Windows does not honor POSIX mode
+	// bits — see #45).
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("Stat: %v", err)
 	}
-	if info.Mode().Perm() != 0o600 {
-		t.Errorf("file mode = %o, want 0600", info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("file mode = %o, want 0600", info.Mode().Perm())
+		}
 	}
 
 	// Verify content.
@@ -728,6 +740,9 @@ func TestCheckRoom_UpdateWatchError(t *testing.T) {
 }
 
 func TestCheckRoom_RecordPriceError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("filesystem chmod semantics differ on Windows; tracked in #45")
+	}
 	dir := t.TempDir()
 	store := NewStore(dir)
 	w := Watch{
@@ -785,6 +800,9 @@ func TestCheckOne_UpdateWatchError(t *testing.T) {
 }
 
 func TestCheckOne_RecordPriceError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("filesystem chmod semantics differ on Windows; tracked in #45")
+	}
 	dir := t.TempDir()
 	store := NewStore(dir)
 	w := Watch{Type: "flight", Origin: "HEL", Destination: "BCN", DepartDate: "2026-07-01"}

--- a/mcp/coverage_boost4_test.go
+++ b/mcp/coverage_boost4_test.go
@@ -237,6 +237,9 @@ func TestHandleWatchPrice_DefaultCurrency(t *testing.T) {
 // ============================================================
 
 func TestHandleListWatches_Empty(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_INTEGRATIONS") != "1" {
+		t.Skip("hits live external APIs; set TRVL_TEST_LIVE_INTEGRATIONS=1 to run. Tracked in #45")
+	}
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 
@@ -291,6 +294,9 @@ func TestHandleListWatches_WithEntries(t *testing.T) {
 // ============================================================
 
 func TestHandleCheckWatches_Empty(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_INTEGRATIONS") != "1" {
+		t.Skip("hits live external APIs; set TRVL_TEST_LIVE_INTEGRATIONS=1 to run. Tracked in #45")
+	}
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 
@@ -480,6 +486,9 @@ func TestMCPPriceChecker_ReturnsZero(t *testing.T) {
 // ============================================================
 
 func TestHandleProviderHealth_EmptyLog(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_INTEGRATIONS") != "1" {
+		t.Skip("hits live external APIs; set TRVL_TEST_LIVE_INTEGRATIONS=1 to run. Tracked in #45")
+	}
 	// Use a temp dir that has no health.jsonl.
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -497,6 +506,9 @@ func TestHandleProviderHealth_EmptyLog(t *testing.T) {
 }
 
 func TestHandleProviderHealth_WithData(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_INTEGRATIONS") != "1" {
+		t.Skip("hits live external APIs; set TRVL_TEST_LIVE_INTEGRATIONS=1 to run. Tracked in #45")
+	}
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 
@@ -573,6 +585,9 @@ func TestHandleProviderHealth_WithData(t *testing.T) {
 }
 
 func TestHandleProviderHealth_WithErrorsAndTimeouts(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_INTEGRATIONS") != "1" {
+		t.Skip("hits live external APIs; set TRVL_TEST_LIVE_INTEGRATIONS=1 to run. Tracked in #45")
+	}
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 

--- a/mcp/coverage_boost5_test.go
+++ b/mcp/coverage_boost5_test.go
@@ -361,6 +361,9 @@ func TestBuildProfileSummary_AllOptionalFieldsFilled(t *testing.T) {
 // ============================================================
 
 func TestReadTripsUpcoming_WithTrip(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_INTEGRATIONS") != "1" {
+		t.Skip("hits live external APIs; set TRVL_TEST_LIVE_INTEGRATIONS=1 to run. Tracked in #45")
+	}
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 
@@ -415,6 +418,9 @@ func TestReadTripsUpcoming_WithTrip(t *testing.T) {
 // ============================================================
 
 func TestReadTripByURI_WithTrip(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_INTEGRATIONS") != "1" {
+		t.Skip("hits live external APIs; set TRVL_TEST_LIVE_INTEGRATIONS=1 to run. Tracked in #45")
+	}
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 


### PR DESCRIPTION
## Summary

- Stops `test (1.26.2, windows-latest)` from giving false positives. On `main` it has been red for 5+ consecutive runs on tests that encode Unix-only filesystem semantics and live-network assumptions — not on real regressions.
- Categorized the failures from run 24696691011 and applied the minimum fix per category. No production-code changes, no new deps, per-test gates only.
- External contributors (most recently @Alorse in #42) were seeing a red check on their PR that had nothing to do with their work.

Tracks #45.

## Changes per category

| Cat | Failure mode | Fix | Tests |
|---|---|---|---|
| A | Unix mode-bit asserts (`perm & 0o077`) fail on NTFS | Wrap only the perm check in `runtime.GOOS != "windows"`; keep content check cross-platform | `TestSaveKeysTo_RoundTrip`, `TestSaveKeysTo_CreatesParentDirs`, `TestSaveJSON_NormalPath` |
| B | Chmod a file read-only, expect subsequent write to fail | Skip on Windows (NTFS does not enforce POSIX read-only for owning process) | `TestSaveLocked_HistorySaveError`, `TestRemove_SaveError`, `TestAdd_SaveError`, `TestCheckRoom_RecordPriceError`, `TestCheckOne_RecordPriceError` |
| C | Browser-opener exec command differs on Windows | Skip on Windows | `TestOpenBrowserForAuth_DomainOnlyNoSlash` |
| D | Live HTTP calls to nominatim / trivago / kiwi leak into default CI, rate-limiter context-canceled under slower Windows runner | Gate behind `TRVL_TEST_LIVE_INTEGRATIONS=1` (matches `CLAUDE.md` live-integration pattern) | `TestHandleListWatches_Empty`, `TestHandleCheckWatches_Empty`, `TestHandleProviderHealth_EmptyLog` / `_WithData` / `_WithErrorsAndTimeouts`, `TestReadTripsUpcoming_WithTrip`, `TestReadTripByURI_WithTrip` |

## Test plan

- [x] `go vet ./...` — clean
- [x] `GOTOOLCHAIN=go1.26.2 go test ./... -short -timeout 5m` — 33 ok / 0 FAIL on macOS
- [x] Spot-checked Category A/B/C tests PASS (not SKIP) on macOS
- [x] Category D tests correctly SKIP without `TRVL_TEST_LIVE_INTEGRATIONS=1` on macOS
- [ ] CI: ubuntu-latest should stay green
- [ ] CI: windows-latest should go green for the first time in weeks
- [ ] Follow-up in #45: either make the Category D tests use `httptest.Server` stubs so they run in default CI, or keep them opt-in

## Notes

Every skip carries `— see #45` so nobody loses the trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
