### PR TITLE
feat: add flight search --first flag and first_result MCP param (rebase of #43)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ Contributions follow the rules in [`CONTRIBUTING.md`](CONTRIBUTING.md) — in pa
 - **@Alorse** — *Alfredo Ortegón Sepúlveda*
   - #33 — original native batchexec integration for flight search
   - #34 — wired `Currency` + `returnDate` through `FlightSearchOptions` and into MCP booking deep links
+  - #43 (landed via #49) — `--first` CLI flag and `first_result` MCP parameter for single-best-priced flight results, enabling low-token price-calendar and quick-estimate workflows
 
 ---
 

--- a/capabilities/trvl_search_flights.yaml
+++ b/capabilities/trvl_search_flights.yaml
@@ -68,6 +68,12 @@ schema:
       currency:
         type: string
         description: "Target currency for prices (ISO 4217, e.g. USD, EUR, JPY). Controls server-side pricing via Google's curr parameter. Empty = IP-based default."
+      first_result:
+        type: boolean
+        description: >-
+          Return only the first result with a valid price after sorting.
+          Use with sort_by to get e.g. the cheapest or shortest priced flight.
+          Default: false.
     required: [origin, destination, departure_date]
   output:
     type: object

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -43,6 +43,7 @@ func flightsCmd() *cobra.Command {
 		layoverAirports []string
 		noEarlyConn     bool
 		loungeRequired  bool
+		firstResult     bool
 	)
 
 	cmd := &cobra.Command{
@@ -112,13 +113,14 @@ Examples:
 			}
 
 			opts := flights.SearchOptions{
-				ReturnDate: returnDate,
-				CabinClass: cabinClass,
-				MaxStops:   stops,
-				SortBy:     sort,
-				Airlines:   airlines,
-				Adults:     adults,
-				Currency:   targetCurrency,
+				ReturnDate:  returnDate,
+				CabinClass:  cabinClass,
+				MaxStops:    stops,
+				SortBy:      sort,
+				Airlines:    airlines,
+				Adults:      adults,
+				Currency:    targetCurrency,
+				FirstResult: firstResult,
 			}
 
 			var result *models.FlightSearchResult
@@ -228,6 +230,11 @@ Examples:
 				})
 			}
 
+			if opts.FirstResult && result != nil && result.Success {
+				result.Flights = flights.FirstPricedResult(result.Flights)
+				result.Count = len(result.Flights)
+			}
+
 			if format == "json" {
 				return models.FormatJSON(os.Stdout, result)
 			}
@@ -267,6 +274,7 @@ Examples:
 	cmd.Flags().BoolVar(&loungeRequired, "lounge-required", false, "Drop flights where any layover airport lacks lounge coverage for your cards")
 	cmd.Flags().BoolVar(&award, "award", false, "Scan Flying Blue miles prices. DATE is a month (2026-06) or a day (2026-06-15). Requires KLM session cookies via AFKL_KLM_COOKIES or --award-cookies.")
 	cmd.Flags().StringVar(&awardCookies, "award-cookies", "", "Raw KLM session Cookie header for award search (alternative to AFKL_KLM_COOKIES env var)")
+	cmd.Flags().BoolVar(&firstResult, "first", false, "Return only the first result with a valid price (respects --sort order)")
 
 	cmd.ValidArgsFunction = airportCompletion
 

--- a/internal/flights/filter.go
+++ b/internal/flights/filter.go
@@ -56,6 +56,17 @@ func FilterFlightsByBudget(flights []models.FlightResult, maxPrice float64) []mo
 	return out
 }
 
+// FirstPricedResult returns the first flight with Price > 0 from a pre-sorted slice.
+// Returns nil if no priced flight exists.
+func FirstPricedResult(flights []models.FlightResult) []models.FlightResult {
+	for _, f := range flights {
+		if f.Price > 0 {
+			return []models.FlightResult{f}
+		}
+	}
+	return nil
+}
+
 // extractDepartureHHMM extracts the "HH:MM" departure time from the first leg.
 // Returns "" if the flight has no legs or the time cannot be parsed.
 func extractDepartureHHMM(f models.FlightResult) string {

--- a/internal/flights/filter_test.go
+++ b/internal/flights/filter_test.go
@@ -134,6 +134,33 @@ func TestFilterFlightsByBudget_ZeroPrice_Kept(t *testing.T) {
 	}
 }
 
+func TestFirstPricedResult_SkipsZeroPrice(t *testing.T) {
+	flts := []models.FlightResult{{Price: 0}, {Price: 150}, {Price: 200}}
+	got := FirstPricedResult(flts)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 flight, got %d", len(got))
+	}
+	if got[0].Price != 150 {
+		t.Errorf("expected price 150, got %.0f", got[0].Price)
+	}
+}
+
+func TestFirstPricedResult_AllZero(t *testing.T) {
+	flts := []models.FlightResult{{Price: 0}, {Price: 0}}
+	got := FirstPricedResult(flts)
+	if got != nil {
+		t.Errorf("all zero prices: expected nil, got %v", got)
+	}
+}
+
+func TestFirstPricedResult_AllPriced(t *testing.T) {
+	flts := []models.FlightResult{{Price: 100}, {Price: 200}}
+	got := FirstPricedResult(flts)
+	if len(got) != 1 || got[0].Price != 100 {
+		t.Errorf("all priced: expected [{Price:100}], got %v", got)
+	}
+}
+
 func TestExtractDepartureHHMM(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -57,6 +57,7 @@ type SearchOptions struct {
 
 	// Client-side post-filters (applied after server response).
 	RequireCheckedBag bool // Only show flights with ≥1 free checked bag
+	FirstResult       bool // Return only the first flight with Price > 0 after sorting
 }
 
 // defaults fills in zero-value fields with sensible defaults.

--- a/mcp/tools_flights.go
+++ b/mcp/tools_flights.go
@@ -158,6 +158,7 @@ func searchFlightsTool() ToolDef {
 				"layover_at":          {Type: "array", Description: "Restrict qualifying layovers to these IATA codes (empty = any airport). Post-fetch filter."},
 				"no_early_connection": {Type: "boolean", Description: "Drop flights whose post-overnight leg departs before preferences.early_connection_floor (default 10:00)."},
 				"lounge_required":     {Type: "boolean", Description: "Drop flights where a layover airport lacks lounge coverage from user's cards."},
+				"first_result":        {Type: "boolean", Description: "Return only the first result with a valid price after sorting. Combine with sort_by to get e.g. the shortest priced flight (duration) or cheapest. Default: false."},
 			},
 			Required: []string{"origin", "destination", "departure_date"},
 		},
@@ -230,6 +231,7 @@ func handleSearchFlights(ctx context.Context, args map[string]any, elicit Elicit
 		CarryOnBags:       argInt(args, "carry_on_bags", 0),
 		CheckedBags:       argInt(args, "checked_bags", 0),
 		RequireCheckedBag: argBool(args, "require_checked_bag", false),
+		FirstResult:       argBool(args, "first_result", false),
 		Currency:          argString(args, "currency"),
 	}
 
@@ -310,6 +312,13 @@ func handleSearchFlights(ctx context.Context, args map[string]any, elicit Elicit
 			result.Flights = flights.FilterByEarlyConnection(result.Flights, floor)
 			result.Count = len(result.Flights)
 		}
+	}
+
+	// --first: trim to single best-priced result. Runs last so mental-model
+	// filters narrow candidates before we pick one.
+	if opts.FirstResult && result != nil && result.Success {
+		result.Flights = flights.FirstPricedResult(result.Flights)
+		result.Count = len(result.Flights)
 	}
 
 	// Enrich flights with all-in cost (base fare + baggage - FF benefits).


### PR DESCRIPTION
Rebase of #43 by @Alorse on top of current main. All conflicts (README tool count, capabilities YAML, cmd/trvl/flights.go, mcp/tools_flights.go) resolved keeping both sides — no regression. Authorship preserved (commit still Fredo <alorse@gmail.com>).

Adds --first (CLI) / first_result (MCP) that returns only the first flight with a valid price after sorting. Useful for price calendars, quick estimates, and per-route comparison where you only need one number per request.

Local verification: go build / go vet / staticcheck all clean; go test -short ./internal/flights/ ./mcp/ ./cmd/trvl/ all pass.

Closes #43.