### PR TITLE
ci: add tag-triggered release workflow + codesign fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+# Release workflow — fires on v* tag push.
+#
+# Runs GoReleaser on macOS so the Darwin builds can be adhoc-codesigned with a
+# proper bundle identifier (Go's default linker-sign stamps Identifier=a.out,
+# which combined with com.apple.quarantine causes Gatekeeper to SIGKILL the
+# binary with exit code 137 on end-user Macs).
+#
+# Optional secrets:
+#   HOMEBREW_TAP_TOKEN — PAT with `contents: write` on
+#     MikkoParkkola/homebrew-tap, enabling goreleaser's `brews` block to
+#     auto-bump the formula. Without it, the brews step will fail; remove or
+#     comment out the `brews:` block in .goreleaser.yaml if unavailable.
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26.2"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          # Skip docker (macos-14 runners don't have Docker) and homebrew
+          # (requires HOMEBREW_TAP_TOKEN PAT with write access to
+          # MikkoParkkola/homebrew-tap — the default GITHUB_TOKEN cannot push
+          # to another repo). Remove these skips once:
+          #   - docker: a separate Linux job handles it, OR
+          #   - homebrew: HOMEBREW_TAP_TOKEN secret is configured.
+          args: release --clean --skip=docker --skip=homebrew
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,14 @@ before:
     - go mod tidy
     - go vet ./...
     - go test -short ./...
+    # Sync npm/package.json version with the release tag before archives are
+    # built. Previously lived under a top-level `after:` block which is not a
+    # valid key in goreleaser v2 and made `goreleaser check` fail. Running it
+    # in `before.hooks` is equivalent for our needs (version bump ships inside
+    # the npm package when published; the Go binary version comes from
+    # ldflags, not this file).
+    - >-
+        sh -c "cd npm && sed -i.bak 's/\"version\": \".*\"/\"version\": \"{{ .Version }}\"/' package.json && rm -f package.json.bak"
 
 builds:
   - id: trvl
@@ -23,6 +31,17 @@ builds:
       - arm64
     ldflags:
       - -s -w -X main.Version={{.Version}} -X github.com/MikkoParkkola/trvl/mcp.serverVersion={{.Version}}
+    # Re-sign darwin binaries with a proper bundle identifier. Go's default
+    # linker adhoc-sign stamps Identifier=a.out which Gatekeeper rejects with
+    # SIGKILL (exit 137) once Homebrew applies com.apple.quarantine. This
+    # replaces the identifier while keeping the adhoc (ad-hoc) signature — no
+    # Apple Developer ID or notarization required. The hook only runs on
+    # darwin artifacts because codesign is a darwin-only binary; Linux and
+    # Windows build hosts never reach this path during `goreleaser release`
+    # executed from macOS-14 runners.
+    hooks:
+      post:
+        - cmd: sh -c 'if [ "{{ .Os }}" = "darwin" ]; then codesign -s - -i com.mikkoparkkola.trvl -f -o runtime "{{ .Path }}"; fi'
 
 archives:
   - id: trvl
@@ -78,6 +97,16 @@ brews:
     license: "PolyForm-Noncommercial-1.0.0"
     install: |
       bin.install "trvl"
+      # Strip com.apple.quarantine that Homebrew applies to downloaded
+      # tarballs on macOS. Combined with the adhoc codesign identifier
+      # baked into the binary at release time (see .goreleaser.yaml
+      # builds.hooks.post), this prevents Gatekeeper from SIGKILLing
+      # trvl on first launch.
+      begin
+        system "xattr", "-dr", "com.apple.quarantine", "#{bin}/trvl"
+      rescue
+        # xattr is macOS-only; ignore on Linux brew.
+      end
     test: |
       system "#{bin}/trvl", "version"
 
@@ -108,12 +137,9 @@ dockers:
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.licenses=MIT"
 
-after:
-  hooks:
-    - cmd: |
-        cd npm &&
-        sed -i.bak "s/\"version\": \".*\"/\"version\": \"{{ .Version }}\"/" package.json &&
-        rm -f package.json.bak
+# Note: the previous top-level `after.hooks` that bumped npm/package.json was
+# moved into `before.hooks` at the top of this file. `after:` is not a valid
+# goreleaser v2 key; retaining it made `goreleaser check` fail.
 
 docker_manifests:
   - name_template: "ghcr.io/mikkoparkkola/trvl:{{ .Version }}"


### PR DESCRIPTION
## Problem

- 13 commits unreleased since v0.9.1 because no release workflow exists; `goreleaser release` has never been run on CI for v1.0.x.
- Homebrew install of v0.9.0 SIGKILLs on macOS (exit 137): Go's default linker stamps `Identifier=a.out`, Homebrew applies `com.apple.quarantine`, Gatekeeper rejects the combo.
- `.goreleaser.yaml` had a schema error: top-level `after:` is invalid in goreleaser v2, so `goreleaser check` would always fail.

## Changes

- `.github/workflows/release.yml` — triggers on `push: tags: [v*]`, runs on `macos-14` with Go 1.26.2, executes `goreleaser release --clean --skip=docker --skip=homebrew` with `contents: write` permission. Docker skipped (macOS runners lack Docker); Homebrew skipped (needs `HOMEBREW_TAP_TOKEN` PAT). Skips are documented inline and can be removed once the tap PAT is configured or a separate Linux docker job is added.
- `.goreleaser.yaml`
  - `builds.hooks.post` runs `codesign -s - -i com.mikkoparkkola.trvl -f -o runtime` on darwin artifacts only (shell conditional on `{{ .Os }}`). Replaces `a.out` identifier with a proper bundle ID while keeping adhoc signing — no Apple Developer ID / notarization required.
  - `brews.install` strips `com.apple.quarantine` on user machines as defence in depth.
  - Moves the pre-existing npm `package.json` version-bump from the invalid `after:` block into `before.hooks` so `goreleaser check` passes.

## Verification

- `goreleaser check` → exit 0, "configuration is valid". Remaining warnings (archives.format, dockers, brews) are pre-existing deprecations out of scope.

## Test plan

- [ ] After merge, cut v1.0.7 to trigger the first clean release on GitHub Actions.
- [ ] Download the darwin-arm64 tarball; run codesign -dvvv and confirm Identifier=com.mikkoparkkola.trvl (not a.out).
- [ ] brew update && brew upgrade trvl on macOS; launch trvl version and confirm no SIGKILL.
- [ ] Optionally configure HOMEBREW_TAP_TOKEN secret and remove --skip=homebrew in a follow-up.