### PR TITLE
feat: ProfileMatch scoring, opportunity Watch, hidden-city matrix search (MIK-3062, MIK-3065, MIK-3074, MIK-3078)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl",
   "version": "1.0.0",
-  "description": "AI Travel Agent — 56 MCP tools for flights, hotels (5 providers: Google Hotels + Trivago + Airbnb + Booking.com + Hostelworld), trains, buses, ferries (20 ground providers incl. 8 ferry operators + night-train specialists European Sleeper & Snälltåget), 36 travel hack detectors, traveller profile with email history learning, deals, price alerts, and destination intel. Free, no API keys required.",
+  "description": "AI Travel Agent — 57 MCP tools for flights, hotels (5 providers: Google Hotels + Trivago + Airbnb + Booking.com + Hostelworld), trains, buses, ferries (20 ground providers incl. 8 ferry operators + night-train specialists European Sleeper & Snälltåget), 36 travel hack detectors, traveller profile with email history learning, deals, price alerts, and destination intel. Free, no API keys required.",
   "author": {
     "name": "Mikko Parkkola",
     "url": "https://github.com/MikkoParkkola"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl",
   "version": "1.0.0",
-  "description": "AI Travel Agent — 54 MCP tools for flights, hotels (5 providers: Google Hotels + Trivago + Airbnb + Booking.com + Hostelworld), trains, buses, ferries (20 ground providers incl. 8 ferry operators + night-train specialists European Sleeper & Snälltåget), 36 travel hack detectors, traveller profile with email history learning, deals, price alerts, and destination intel. Free, no API keys required.",
+  "description": "AI Travel Agent — 56 MCP tools for flights, hotels (5 providers: Google Hotels + Trivago + Airbnb + Booking.com + Hostelworld), trains, buses, ferries (20 ground providers incl. 8 ferry operators + night-train specialists European Sleeper & Snälltåget), 36 travel hack detectors, traveller profile with email history learning, deals, price alerts, and destination intel. Free, no API keys required.",
   "author": {
     "name": "Mikko Parkkola",
     "url": "https://github.com/MikkoParkkola"

--- a/.claude/skills/trvl.md
+++ b/.claude/skills/trvl.md
@@ -50,7 +50,7 @@ Read `~/.claude/travel-profile.md` if exists. Apply: departure time prefs, FF st
 ## ASK FIRST (2-3 Qs max)
 From?|To?|When?|Flex?|Travelers?|Budget? Check calendar (Google/Apple/manual) for conflicts. Don't re-ask obvious info.
 
-## CORE TOOLS (selected high-signal tools; trvl exposes 56 MCP tools overall via gateway_invoke server="trvl")
+## CORE TOOLS (selected high-signal tools; trvl exposes 57 MCP tools overall via gateway_invoke server="trvl")
 | Tool | Use | Key params |
 |------|-----|-----------|
 | `search_flights` | Flights A→B | origin,destination,departure_date,[return_date,cabin_class,max_stops] |

--- a/.claude/skills/trvl.md
+++ b/.claude/skills/trvl.md
@@ -50,7 +50,7 @@ Read `~/.claude/travel-profile.md` if exists. Apply: departure time prefs, FF st
 ## ASK FIRST (2-3 Qs max)
 From?|To?|When?|Flex?|Travelers?|Budget? Check calendar (Google/Apple/manual) for conflicts. Don't re-ask obvious info.
 
-## CORE TOOLS (selected high-signal tools; trvl exposes 54 MCP tools overall via gateway_invoke server="trvl")
+## CORE TOOLS (selected high-signal tools; trvl exposes 56 MCP tools overall via gateway_invoke server="trvl")
 | Tool | Use | Key params |
 |------|-----|-----------|
 | `search_flights` | Flights A→B | origin,destination,departure_date,[return_date,cabin_class,max_stops] |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ trvl flights HEL LHR 2026-07-01 --format json | head -5
 # Expected: JSON with flight results
 ```
 
-Tell the user: "trvl is installed with 56 MCP tools and 2 bundled Claude skills. It includes 37 travel hack detectors (including error fare and flash sale detection) that auto-fire on searches, a unified optimizer (optimize_booking) with 9 expansion strategies (alternative origins/destinations, rail+fly, date flex, hidden city, departure tax avoidance, rail competition alternatives, ferry cabin as hotel) that searches all combinations in parallel, all-in pricing with FF status (bag fees included, FF benefits subtracted), pre-priced candidate pipeline for ground alternatives, miles tracking and earning estimates, and cross-provider hotel price comparison with cross-currency savings display. I can search flights, hotels, destinations, plan trips, find weekend getaways, find optimal travel windows, optimize multi-city routes, find nearby restaurants, check local events, search ground transport (buses, trains, ferries, night trains), detect travel hacks, check weather forecasts, look up airline baggage rules, find airport lounges, check visa requirements, calculate points-vs-cash redemptions, and configure additional data providers (Airbnb, Booking.com, Hostelworld). Just ask me anything about travel."
+Tell the user: "trvl is installed with 57 MCP tools and 2 bundled Claude skills. It includes 37 travel hack detectors (including error fare and flash sale detection) that auto-fire on searches, a unified optimizer (optimize_booking) with 9 expansion strategies (alternative origins/destinations, rail+fly, date flex, hidden city, departure tax avoidance, rail competition alternatives, ferry cabin as hotel) that searches all combinations in parallel, all-in pricing with FF status (bag fees included, FF benefits subtracted), pre-priced candidate pipeline for ground alternatives, miles tracking and earning estimates, and cross-provider hotel price comparison with cross-currency savings display. I can search flights, hotels, destinations, plan trips, find weekend getaways, find optimal travel windows, optimize multi-city routes, find nearby restaurants, check local events, search ground transport (buses, trains, ferries, night trains), detect travel hacks, check weather forecasts, look up airline baggage rules, find airport lounges, check visa requirements, calculate points-vs-cash redemptions, and configure additional data providers (Airbnb, Booking.com, Hostelworld). Just ask me anything about travel."
 
 ### Step 5: Build travel profile (recommended)
 
@@ -181,7 +181,7 @@ Save with `update_preferences`.
 | Field | Behavior |
 |-------|----------|
 | `home_airports` | Default origin for flight/trip/weekend/discover searches |
-| `display_currency` | Price display across all 56 tools |
+| `display_currency` | Price display across all 57 tools |
 | `no_dormitories` | `FilterHotels()` drops hostels, capsules, guesthouse rooms by chain name + regex |
 | `ensuite_only` | `FilterHotels()` drops shared-bathroom properties |
 | `min_hotel_stars` | Passed to Google Hotels API as search filter |
@@ -263,7 +263,7 @@ CLI alternative: `trvl prefs init`
 
 ## How To Use (after setup)
 
-You now have 56 MCP tools available. Use them when the user asks about travel:
+You now have 57 MCP tools available. Use them when the user asks about travel:
 
 ### search_flights — Find flights between airports
 ```json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ trvl flights HEL LHR 2026-07-01 --format json | head -5
 # Expected: JSON with flight results
 ```
 
-Tell the user: "trvl is installed with 54 MCP tools and 2 bundled Claude skills. It includes 37 travel hack detectors (including error fare and flash sale detection) that auto-fire on searches, a unified optimizer (optimize_booking) with 9 expansion strategies (alternative origins/destinations, rail+fly, date flex, hidden city, departure tax avoidance, rail competition alternatives, ferry cabin as hotel) that searches all combinations in parallel, all-in pricing with FF status (bag fees included, FF benefits subtracted), pre-priced candidate pipeline for ground alternatives, miles tracking and earning estimates, and cross-provider hotel price comparison with cross-currency savings display. I can search flights, hotels, destinations, plan trips, find weekend getaways, find optimal travel windows, optimize multi-city routes, find nearby restaurants, check local events, search ground transport (buses, trains, ferries, night trains), detect travel hacks, check weather forecasts, look up airline baggage rules, find airport lounges, check visa requirements, calculate points-vs-cash redemptions, and configure additional data providers (Airbnb, Booking.com, Hostelworld). Just ask me anything about travel."
+Tell the user: "trvl is installed with 56 MCP tools and 2 bundled Claude skills. It includes 37 travel hack detectors (including error fare and flash sale detection) that auto-fire on searches, a unified optimizer (optimize_booking) with 9 expansion strategies (alternative origins/destinations, rail+fly, date flex, hidden city, departure tax avoidance, rail competition alternatives, ferry cabin as hotel) that searches all combinations in parallel, all-in pricing with FF status (bag fees included, FF benefits subtracted), pre-priced candidate pipeline for ground alternatives, miles tracking and earning estimates, and cross-provider hotel price comparison with cross-currency savings display. I can search flights, hotels, destinations, plan trips, find weekend getaways, find optimal travel windows, optimize multi-city routes, find nearby restaurants, check local events, search ground transport (buses, trains, ferries, night trains), detect travel hacks, check weather forecasts, look up airline baggage rules, find airport lounges, check visa requirements, calculate points-vs-cash redemptions, and configure additional data providers (Airbnb, Booking.com, Hostelworld). Just ask me anything about travel."
 
 ### Step 5: Build travel profile (recommended)
 
@@ -181,7 +181,7 @@ Save with `update_preferences`.
 | Field | Behavior |
 |-------|----------|
 | `home_airports` | Default origin for flight/trip/weekend/discover searches |
-| `display_currency` | Price display across all 54 tools |
+| `display_currency` | Price display across all 56 tools |
 | `no_dormitories` | `FilterHotels()` drops hostels, capsules, guesthouse rooms by chain name + regex |
 | `ensuite_only` | `FilterHotels()` drops shared-bathroom properties |
 | `min_hotel_stars` | Passed to Google Hotels API as search filter |
@@ -263,7 +263,7 @@ CLI alternative: `trvl prefs init`
 
 ## How To Use (after setup)
 
-You now have 54 MCP tools available. Use them when the user asks about travel:
+You now have 56 MCP tools available. Use them when the user asks about travel:
 
 ### search_flights — Find flights between airports
 ```json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+- **`ValueScore` removed** — `DiscoverResult.value_score` (float64, 0-1) is replaced by `ProfileMatch` (int, 0-100) and `MatchBreakdown` (map[string]float64). Consumers of the `value_score` JSON field must migrate to `profile_match`. The score is computed on-demand; no data migration is required. To restore the old behaviour, revert the commit introducing this change.
+
 ### Added
+- **`ProfileMatch` score** — `DiscoverResult.profile_match` (int 0-100) is a weighted sum across 12 factors: budget_fit, loyalty_earn, time_window_fit, directness, district_match, airport_affinity, early_connection_compliance, status_retention, lounge_at_transit, bucket_list_boost, warsaw_filter (hard exclusion), family_mode_compatibility. Factor weights are user-tunable via `match_weights` in `preferences.json`.
+- **Per-factor breakdown** — `DiscoverResult.match_breakdown` (map[string]float64) exposes per-factor scores in [0,1] so users can see exactly why a trip scored 73 instead of 91.
+- **`--explain` flag** — `trvl discover --explain` prints an ASCII progress bar table of per-factor scores beneath the main result table.
+- **`match_weights` in preferences** — user can override default factor weights; missing keys keep the built-in default.
+- **`airport_affinity` in preferences** — maps destination IATA codes to affinity scores in [0,1]; used by the airport_affinity factor.
+- **`excluded_destinations` in preferences** — hard-excludes cities or airport codes from all results (warsaw_filter returns 0 for these; ProfileMatch returns 0 for the whole result).
 - **`FixHintCode` enum** — typed root-cause classifier (`AKAMAI_BLOCK`, `DNS_FAIL`, `TLS_TIMEOUT`, `COOKIE_EXPIRED`, `RATE_LIMITED`, `RESPONSE_SHAPE_CHANGED`, `PREFLIGHT_FAILED`, `UNCLASSIFIED`) surfaced in MCP search responses (`fix_hint_code` field on `provider_statuses`) and in the `provider_health` aggregate (`last_hint_code`); persisted per-entry in `~/.trvl/health.jsonl` (`hint_code` field)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`FixHintCode` enum** — typed root-cause classifier (`AKAMAI_BLOCK`, `DNS_FAIL`, `TLS_TIMEOUT`, `COOKIE_EXPIRED`, `RATE_LIMITED`, `RESPONSE_SHAPE_CHANGED`, `PREFLIGHT_FAILED`, `UNCLASSIFIED`) surfaced in MCP search responses (`fix_hint_code` field on `provider_statuses`) and in the `provider_health` aggregate (`last_hint_code`); persisted per-entry in `~/.trvl/health.jsonl` (`hint_code` field)
+
 ### Changed
 - **Hotel singleflight cache keys** — hotel deduplication keys now include the full `HotelSearchOptions` filter set, with order-insensitive amenity matching, so distinct hotel searches no longer share in-flight results accidentally
+- **`providerFixHint`** — now delegates to the new `classifyProviderError` classifier; hint text updated to be more actionable and accurate (back-compatible: the `fix_hint` string field is still populated)
 
 ### Fixed
 - **MCP handler race safety** — singleflight winners for flights, ground, and hotels are now cloned before caller-specific post-filtering mutates counts, slices, or nested pointers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Hotel singleflight cache keys** — hotel deduplication keys now include the full `HotelSearchOptions` filter set, with order-insensitive amenity matching, so distinct hotel searches no longer share in-flight results accidentally
+
+### Fixed
+- **MCP handler race safety** — singleflight winners for flights, ground, and hotels are now cloned before caller-specific post-filtering mutates counts, slices, or nested pointers
+- **Singleflight timeout isolation** — shared flight, ground, and hotel upstream work now outlives the first caller's timeout, so one canceled request no longer aborts identical concurrent searches for other callers
+- **Watch scheduler shutdown** — calling `Stop()` before `Start()` no longer deadlocks; lifecycle state is synchronized and remains idempotent
+- **Race regression coverage** — new and expanded tests lock in caller-private result cloning and scheduler lifecycle behavior across the touched packages
+
 ## [1.0.3] - 2026-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `search_hidden_city` MCP tool: hidden-city matrix search ranks priced Origin×hub-beyond offers, computes layover risk score, and returns pre-filled booking URLs per carrier (MIK-3078)
+- `trvl hidden-city` CLI command: evaluate a hidden-city routing with customisable risk threshold and booking URL (MIK-3078)
+
 ### Breaking Changes
 - **`ValueScore` removed** — `DiscoverResult.value_score` (float64, 0-1) is replaced by `ProfileMatch` (int, 0-100) and `MatchBreakdown` (map[string]float64). Consumers of the `value_score` JSON field must migrate to `profile_match`. The score is computed on-demand; no data migration is required. To restore the old behaviour, revert the commit introducing this change.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ![trvl demo](https://raw.githubusercontent.com/MikkoParkkola/trvl/main/demo.gif?v=1.0.5)
 
-> **56 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, travel hacks, weather forecasts, baggage rules, airport lounges, destination intel. Free. API-first.**
+> **57 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, travel hacks, weather forecasts, baggage rules, airport lounges, destination intel. Free. API-first.**
 >
 > Also works as a standalone CLI with 43 commands.
 
@@ -124,7 +124,7 @@ The profile makes every subsequent search smarter — it skips questions it alre
 
 ### 5. Ask your AI to search
 
-That's it. Your AI assistant now has 56 travel tools available. Just ask naturally:
+That's it. Your AI assistant now has 57 travel tools available. Just ask naturally:
 
 - *"Search flights from JFK to Tokyo on July 1st, business class"*
 - *"Find hotels in Paris for July 1-5, at least 4 stars"*
@@ -232,7 +232,7 @@ That's it. Your AI assistant now has 56 travel tools available. Just ask natural
 |---------|---------|
 | **Structured content** | Typed JSON (`structuredContent`) alongside human-readable summaries |
 | **Content annotations** | `audience: ["user"]` for summaries, `audience: ["assistant"]` for data |
-| **Output schemas** | Full JSON Schema validation for all 56 tool responses |
+| **Output schemas** | Full JSON Schema validation for all 57 tool responses |
 | **Prompts** | `plan-trip`, `find-cheapest-dates`, `compare-hotels`, `where-should-i-go` |
 | **Resources** | Airport codes (50 major hubs), flight/hotel usage guides, price-watch subscriptions |
 | **Tool description orchestration** | `find_trip_window` instructs the LLM to fetch calendar data first, then pass busy intervals in — works on every MCP client. See [docs/MCP-ORCHESTRATION.md](docs/MCP-ORCHESTRATION.md) |
@@ -641,7 +641,7 @@ The AI uses these to give you actionable recommendations: "Book here: [link]". N
 | **Binary** | Single static ~15MB for API-first flows. Optional protected-provider fallbacks may use local browser/python tooling. |
 | **Data** | Real-time from Google Flights + 5 hotel sources (Google Hotels, Trivago, Airbnb, Booking.com, Hostelworld) + 20 ground providers (FlixBus, RegioJet, Eurostar, DB, ÖBB, NS, VR, SNCF, Trainline, Transitous, Renfe, European Sleeper, Snälltåget, Tallink, Viking Line, Eckerö Line, Finnlines, Stena Line, DFDS, Ferryhopper) + 5 free destination APIs |
 | **Auth** | No personal API keys required. Two providers (NS, Digitransit/VR) use public keys embedded in the binary. Optional browser/cookie fallbacks are available for protected providers when explicitly enabled. |
-| **MCP** | Full v2025-11-25 — 56 tools (incl. 4 profile tools, 3 price watch tools, provider health), 7 prompts, resources, structured content, progress notifications, resource subscriptions, tool description orchestration |
+| **MCP** | Full v2025-11-25 — 57 tools (incl. 4 profile tools, 3 price watch tools, provider health), 7 prompts, resources, structured content, progress notifications, resource subscriptions, tool description orchestration |
 | **CLI** | 43 commands (+ 7 watch subcommands) with table/JSON output, color, shell completion |
 | **Booking links** | Every flight and hotel result includes a direct Google booking link |
 | **Travel hacks** | 37 detectors (throwaway, hidden-city, positioning, ferry, multi-modal, stopover, date-flex, error fare, back-to-back, rail competition, and more) |

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 ![trvl demo](https://raw.githubusercontent.com/MikkoParkkola/trvl/main/demo.gif?v=1.0.5)
 
-> **54 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, travel hacks, weather forecasts, baggage rules, airport lounges, destination intel. Free. API-first.**
+> **56 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, travel hacks, weather forecasts, baggage rules, airport lounges, destination intel. Free. API-first.**
 >
-> Also works as a standalone CLI with 42 commands.
+> Also works as a standalone CLI with 43 commands.
 
 ### What it looks like
 
@@ -124,7 +124,7 @@ The profile makes every subsequent search smarter — it skips questions it alre
 
 ### 5. Ask your AI to search
 
-That's it. Your AI assistant now has 54 travel tools available. Just ask naturally:
+That's it. Your AI assistant now has 56 travel tools available. Just ask naturally:
 
 - *"Search flights from JFK to Tokyo on July 1st, business class"*
 - *"Find hotels in Paris for July 1-5, at least 4 stars"*
@@ -232,7 +232,7 @@ That's it. Your AI assistant now has 54 travel tools available. Just ask natural
 |---------|---------|
 | **Structured content** | Typed JSON (`structuredContent`) alongside human-readable summaries |
 | **Content annotations** | `audience: ["user"]` for summaries, `audience: ["assistant"]` for data |
-| **Output schemas** | Full JSON Schema validation for all 54 tool responses |
+| **Output schemas** | Full JSON Schema validation for all 56 tool responses |
 | **Prompts** | `plan-trip`, `find-cheapest-dates`, `compare-hotels`, `where-should-i-go` |
 | **Resources** | Airport codes (50 major hubs), flight/hotel usage guides, price-watch subscriptions |
 | **Tool description orchestration** | `find_trip_window` instructs the LLM to fetch calendar data first, then pass busy intervals in — works on every MCP client. See [docs/MCP-ORCHESTRATION.md](docs/MCP-ORCHESTRATION.md) |
@@ -347,7 +347,7 @@ See [Quick Setup step 3](#3-optional-teach-your-ai-about-trvl) above for AGENTS.
 
 ## CLI Usage
 
-trvl also works as a standalone CLI tool with 42 commands:
+trvl also works as a standalone CLI tool with 43 commands:
 
 All search commands accept `--currency <CODE>` (e.g. `--currency EUR`) to convert displayed prices. trvl detects the actual API currency and converts at the display layer — no hardcoded currencies.
 
@@ -641,8 +641,8 @@ The AI uses these to give you actionable recommendations: "Book here: [link]". N
 | **Binary** | Single static ~15MB for API-first flows. Optional protected-provider fallbacks may use local browser/python tooling. |
 | **Data** | Real-time from Google Flights + 5 hotel sources (Google Hotels, Trivago, Airbnb, Booking.com, Hostelworld) + 20 ground providers (FlixBus, RegioJet, Eurostar, DB, ÖBB, NS, VR, SNCF, Trainline, Transitous, Renfe, European Sleeper, Snälltåget, Tallink, Viking Line, Eckerö Line, Finnlines, Stena Line, DFDS, Ferryhopper) + 5 free destination APIs |
 | **Auth** | No personal API keys required. Two providers (NS, Digitransit/VR) use public keys embedded in the binary. Optional browser/cookie fallbacks are available for protected providers when explicitly enabled. |
-| **MCP** | Full v2025-11-25 — 54 tools (incl. 4 profile tools, 3 price watch tools, provider health), 7 prompts, resources, structured content, progress notifications, resource subscriptions, tool description orchestration |
-| **CLI** | 42 commands (+ 7 watch subcommands) with table/JSON output, color, shell completion |
+| **MCP** | Full v2025-11-25 — 56 tools (incl. 4 profile tools, 3 price watch tools, provider health), 7 prompts, resources, structured content, progress notifications, resource subscriptions, tool description orchestration |
+| **CLI** | 43 commands (+ 7 watch subcommands) with table/JSON output, color, shell completion |
 | **Booking links** | Every flight and hotel result includes a direct Google booking link |
 | **Travel hacks** | 37 detectors (throwaway, hidden-city, positioning, ferry, multi-modal, stopover, date-flex, error fare, back-to-back, rail competition, and more) |
 | **Personal profile** | Learns from your booking history (email parsing + LLM). Remembers FF status, luggage needs, favourite properties, departure preferences, travel hacks used, accommodation preferences, family composition. Pre-search interviews skip questions the profile already answers. |

--- a/cmd/trvl/cli_cov_test.go
+++ b/cmd/trvl/cli_cov_test.go
@@ -224,7 +224,7 @@ func TestPrintTripCostTable_FailedResult(t *testing.T) {
 	defer func() { os.Stdout = old }()
 
 	result := &trip.TripCostResult{Success: false, Error: "test failure"}
-	err := printTripCostTable(result, "HEL", "BCN", 1)
+	err := printTripCostTable(result, "HEL", "BCN", 1, false)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestPrintTripCostTable_SuccessWithWarning(t *testing.T) {
 		PerDay:    103,
 		Nights:    7,
 	}
-	err := printTripCostTable(result, "HEL", "BCN", 1)
+	err := printTripCostTable(result, "HEL", "BCN", 1, false)
 	w.Close()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -278,7 +278,7 @@ func TestPrintOptimizeResults_Empty(t *testing.T) {
 		Success: true,
 		Options: nil,
 	}
-	printOptimizeResults(result)
+	printOptimizeResults(result, "", nil, false)
 	w.Close()
 
 	var buf bytes.Buffer
@@ -318,7 +318,7 @@ func TestPrintOptimizeResults_WithOptions(t *testing.T) {
 			Currency:  "EUR",
 		},
 	}
-	printOptimizeResults(result)
+	printOptimizeResults(result, "", nil, false)
 	w.Close()
 
 	var buf bytes.Buffer
@@ -342,7 +342,7 @@ func TestPrintOptimizeResults_BaselineCheapest(t *testing.T) {
 		},
 		Baseline: &optimizer.BookingOption{AllInCost: 200, Currency: "EUR"},
 	}
-	printOptimizeResults(result)
+	printOptimizeResults(result, "", nil, false)
 	w.Close()
 
 	var buf bytes.Buffer

--- a/cmd/trvl/cli_max_test.go
+++ b/cmd/trvl/cli_max_test.go
@@ -928,7 +928,7 @@ func TestMaybeShowFlightHackTips_SingleFlight(t *testing.T) {
 func TestFormatHotelsTable_NoHotels(t *testing.T) {
 	models.UseColor = false
 	out := captureStdoutMax(t, func() {
-		_ = formatHotelsTable(context.Background(), "", &models.HotelSearchResult{})
+		_ = formatHotelsTable(context.Background(), "", "", &models.HotelSearchResult{}, false)
 	})
 	if !strings.Contains(out, "No hotels found") {
 		t.Errorf("expected 'No hotels found', got %q", out)
@@ -966,7 +966,7 @@ func TestFormatHotelsTable_WithHotels(t *testing.T) {
 		},
 	}
 	out := captureStdoutMax(t, func() {
-		_ = formatHotelsTable(context.Background(), "", result)
+		_ = formatHotelsTable(context.Background(), "", "", result, false)
 	})
 	if !strings.Contains(out, "Showing 2 of 5 hotels") {
 		t.Error("expected 'Showing 2 of 5 hotels'")

--- a/cmd/trvl/discover.go
+++ b/cmd/trvl/discover.go
@@ -22,6 +22,7 @@ func discoverCmd() *cobra.Command {
 		maxNights int
 		top       int
 		formatOut string
+		explain   bool
 	)
 
 	cmd := &cobra.Command{
@@ -34,12 +35,15 @@ You tell it:
   - how much you want to spend (total, including hotel)
   - when you are free (date window + nights range)
 
-It tells you the highest-quality trips it could find, ranked by value score
-(hotel rating × remaining budget slack). No need to pick a destination first.
+It tells you the highest-quality trips it could find, ranked by profile match
+score (0-100) — how well each trip matches your full travel profile.
+
+Use --explain to see a per-factor breakdown of why each trip scored as it did.
 
 Examples:
   trvl discover --from 2026-07-01 --until 2026-07-31 --budget 500
   trvl discover --from 2026-08-01 --until 2026-09-30 --budget 800 --min-nights 3 --max-nights 5
+  trvl discover --from 2026-07-01 --until 2026-07-31 --budget 600 --explain
   trvl discover --from 2026-07-01 --until 2026-07-31 --budget 600 --format json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if origin == "" {
@@ -96,7 +100,7 @@ Examples:
 				return models.FormatJSON(os.Stdout, out)
 			}
 
-			return printDiscoverTable(out)
+			return printDiscoverTable(out, explain)
 		},
 	}
 
@@ -108,6 +112,7 @@ Examples:
 	cmd.Flags().IntVar(&maxNights, "max-nights", 4, "Maximum trip length in nights")
 	cmd.Flags().IntVar(&top, "top", 5, "Number of results to show")
 	cmd.Flags().StringVar(&formatOut, "format", "table", "Output format: table, json")
+	cmd.Flags().BoolVar(&explain, "explain", false, "Show per-factor profile match breakdown for each result")
 
 	_ = cmd.MarkFlagRequired("from")
 	_ = cmd.MarkFlagRequired("until")
@@ -116,7 +121,7 @@ Examples:
 	return cmd
 }
 
-func printDiscoverTable(out *trip.DiscoverOutput) error {
+func printDiscoverTable(out *trip.DiscoverOutput, explain bool) error {
 	if out.Count == 0 {
 		fmt.Printf("No trips found from %s within budget %s %.0f between %s and %s.\n",
 			out.Origin, "EUR", out.Budget, out.From, out.Until)
@@ -126,7 +131,7 @@ func printDiscoverTable(out *trip.DiscoverOutput) error {
 	fmt.Printf("Top %d value trips from %s within %.0f %s (%s to %s)\n\n",
 		out.Count, out.Origin, out.Budget, "EUR", out.From, out.Until)
 
-	headers := []string{"#", "Destination", "Dates", "Nights", "Flight", "Hotel", "Total", "Slack", "Notes"}
+	headers := []string{"#", "Destination", "Dates", "Nights", "Flight", "Hotel", "Total", "Match%", "Notes"}
 	var rows [][]string
 
 	for i, t := range out.Trips {
@@ -142,11 +147,62 @@ func printDiscoverTable(out *trip.DiscoverOutput) error {
 			fmt.Sprintf("%s %.0f", t.Currency, t.FlightPrice),
 			hotelCol,
 			fmt.Sprintf("%s %.0f", t.Currency, t.Total),
-			fmt.Sprintf("%s %.0f", t.Currency, t.BudgetSlack),
+			fmt.Sprintf("%d%%", t.ProfileMatch),
 			t.Reasoning,
 		})
 	}
 
 	models.FormatTable(os.Stdout, headers, rows)
+
+	if explain {
+		fmt.Println()
+		for i, t := range out.Trips {
+			if len(t.MatchBreakdown) == 0 {
+				continue
+			}
+			fmt.Printf("  #%d %s — profile match breakdown:\n", i+1, t.Destination)
+			// Sort factor names for stable output.
+			factors := make([]string, 0, len(t.MatchBreakdown))
+			for k := range t.MatchBreakdown {
+				factors = append(factors, k)
+			}
+			sortStrings(factors)
+			for _, factor := range factors {
+				bar := progressBar(t.MatchBreakdown[factor], 20)
+				fmt.Printf("    %-35s %s  %.0f%%\n", factor, bar, t.MatchBreakdown[factor]*100)
+			}
+			fmt.Println()
+		}
+	}
+
 	return nil
+}
+
+// sortStrings sorts a string slice in place (avoids importing sort at package level).
+func sortStrings(ss []string) {
+	for i := 1; i < len(ss); i++ {
+		for j := i; j > 0 && ss[j] < ss[j-1]; j-- {
+			ss[j], ss[j-1] = ss[j-1], ss[j]
+		}
+	}
+}
+
+// progressBar returns a simple ASCII bar for a value in [0,1] with the given width.
+func progressBar(v float64, width int) string {
+	if v < 0 {
+		v = 0
+	}
+	if v > 1 {
+		v = 1
+	}
+	filled := int(v*float64(width) + 0.5)
+	bar := make([]rune, width)
+	for i := range bar {
+		if i < filled {
+			bar[i] = '█'
+		} else {
+			bar[i] = '░'
+		}
+	}
+	return string(bar)
 }

--- a/cmd/trvl/display_coverage2_test.go
+++ b/cmd/trvl/display_coverage2_test.go
@@ -448,7 +448,7 @@ func TestPrintDiscoverTable_WithTrips(t *testing.T) {
 	}
 
 	output := captureStdout(t, func() {
-		err := printDiscoverTable(out)
+		err := printDiscoverTable(out, false)
 		if err != nil {
 			t.Errorf("printDiscoverTable returned error: %v", err)
 		}
@@ -462,7 +462,6 @@ func TestPrintDiscoverTable_WithTrips(t *testing.T) {
 		"EUR 49",
 		"Hilton Tallinn Park",
 		"EUR 169",
-		"EUR 331",
 		"great value",
 		"Riga (RIX)",
 		"EUR 79",
@@ -486,7 +485,7 @@ func TestPrintDiscoverTable_NoTrips(t *testing.T) {
 	}
 
 	output := captureStdout(t, func() {
-		err := printDiscoverTable(out)
+		err := printDiscoverTable(out, false)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/cmd/trvl/display_coverage_test.go
+++ b/cmd/trvl/display_coverage_test.go
@@ -92,7 +92,7 @@ func TestPrintFlightsTable_Success(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		err := printFlightsTable(context.Background(), "HEL", "AMS", "", result)
+		err := printFlightsTable(context.Background(), "HEL", "AMS", "", result, false)
 		if err != nil {
 			t.Errorf("printFlightsTable returned error: %v", err)
 		}
@@ -116,7 +116,7 @@ func TestPrintFlightsTable_NoFlights(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		err := printFlightsTable(context.Background(), "HEL", "NRT", "", result)
+		err := printFlightsTable(context.Background(), "HEL", "NRT", "", result, false)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -137,7 +137,7 @@ func TestPrintFlightsTable_Failed(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		// Also writes to stderr, but we just check no panic and it runs.
-		_ = printFlightsTable(context.Background(), "HEL", "NRT", "", result)
+		_ = printFlightsTable(context.Background(), "HEL", "NRT", "", result, false)
 	})
 	// The error goes to stderr, stdout may be empty. Just verify no panic.
 	_ = out
@@ -180,7 +180,7 @@ func TestPrintFlightsTable_WithSelfConnect(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		_ = printFlightsTable(context.Background(), "HEL", "BCN", "", result)
+		_ = printFlightsTable(context.Background(), "HEL", "BCN", "", result, false)
 	})
 
 	if !strings.Contains(out, "self-connect") {
@@ -215,7 +215,7 @@ func TestPrintFlightsTable_WithProvider(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		_ = printFlightsTable(context.Background(), "HEL", "AMS", "", result)
+		_ = printFlightsTable(context.Background(), "HEL", "AMS", "", result, false)
 	})
 
 	if !strings.Contains(out, "Kiwi") {
@@ -256,7 +256,7 @@ func TestFormatHotelsTable_Success(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		err := formatHotelsTable(context.Background(), "", result)
+		err := formatHotelsTable(context.Background(), "", "", result, false)
 		if err != nil {
 			t.Errorf("formatHotelsTable returned error: %v", err)
 		}
@@ -279,7 +279,7 @@ func TestFormatHotelsTable_Empty(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		err := formatHotelsTable(context.Background(), "", result)
+		err := formatHotelsTable(context.Background(), "", "", result, false)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -310,7 +310,7 @@ func TestFormatHotelsTable_WithSources(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		_ = formatHotelsTable(context.Background(), "", result)
+		_ = formatHotelsTable(context.Background(), "", "", result, false)
 	})
 
 	// Should show Sources column since booking != Google.
@@ -336,7 +336,7 @@ func TestFormatHotelsTable_TotalAvailable(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		_ = formatHotelsTable(context.Background(), "", result)
+		_ = formatHotelsTable(context.Background(), "", "", result, false)
 	})
 
 	if !strings.Contains(out, "Showing 1 of 50") {

--- a/cmd/trvl/explain.go
+++ b/cmd/trvl/explain.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+// printMatchBreakdown prints an ASCII bar-chart per-factor breakdown for a
+// single result's profile match score. label identifies the result (e.g. "#1 KLM").
+// score is 0-100; breakdown maps factor names to per-factor scores in [0,1].
+func printMatchBreakdown(label string, score int, breakdown map[string]float64) {
+	if len(breakdown) == 0 {
+		return
+	}
+	fmt.Printf("  %s — profile match breakdown (%d%%):\n", label, score)
+	factors := make([]string, 0, len(breakdown))
+	for k := range breakdown {
+		factors = append(factors, k)
+	}
+	sort.Strings(factors)
+	for _, factor := range factors {
+		bar := progressBar(breakdown[factor], 20)
+		fmt.Printf("    %-35s %s  %.0f%%\n", factor, bar, breakdown[factor]*100)
+	}
+	fmt.Println()
+}

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -18,6 +18,7 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/points"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/scoring"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +33,7 @@ func flightsCmd() *cobra.Command {
 		format         string
 		targetCurrency string
 		compareCabins  bool
+		explain        bool
 	)
 
 	cmd := &cobra.Command{
@@ -127,7 +129,7 @@ Examples:
 				return models.FormatJSON(os.Stdout, result)
 			}
 
-			if err := printFlightsTable(cmd.Context(), strings.Join(origins, ","), strings.Join(destinations, ","), targetCurrency, result); err != nil {
+			if err := printFlightsTable(cmd.Context(), strings.Join(origins, ","), strings.Join(destinations, ","), targetCurrency, result, explain); err != nil {
 				return err
 			}
 
@@ -151,6 +153,7 @@ Examples:
 	cmd.Flags().StringVar(&format, "format", "table", "Output format: table, json")
 	cmd.Flags().StringVar(&targetCurrency, "currency", "", "Convert prices to this currency (e.g. EUR, USD). Empty = show API default")
 	cmd.Flags().BoolVar(&compareCabins, "compare-cabins", false, "Compare prices across all cabin classes (economy, premium, business, first)")
+	cmd.Flags().BoolVar(&explain, "explain", false, "Show per-factor profile match breakdown for each result")
 
 	cmd.ValidArgsFunction = airportCompletion
 
@@ -159,7 +162,7 @@ Examples:
 
 // printFlightsTable renders flight results as an ASCII table.
 // If targetCurrency is set and differs from API currency, converts prices.
-func printFlightsTable(ctx context.Context, origin, destination, targetCurrency string, result *models.FlightSearchResult) error {
+func printFlightsTable(ctx context.Context, origin, destination, targetCurrency string, result *models.FlightSearchResult, explain bool) error {
 	if !result.Success {
 		fmt.Fprintf(os.Stderr, "Search failed: %s\n", result.Error)
 		return nil
@@ -332,6 +335,32 @@ func printFlightsTable(ctx context.Context, origin, destination, targetCurrency 
 			printMilesEarning(prefs, origin, destination, cheapest)
 		}
 	}
+
+	// --explain: per-flight profile match breakdown.
+	if explain {
+		fmt.Println()
+		// Determine primary destination IATA for scoring (first element if multi-airport).
+		destCode := destination
+		if idx := strings.Index(destination, ","); idx >= 0 {
+			destCode = destination[:idx]
+		}
+		for i, f := range result.Flights {
+			matchScore, breakdown := scoring.ComputeProfileMatch(prefs, scoring.DiscoverInput{
+				AirportCode:  destCode,
+				FlightPrice:  f.Price,
+				Total:        f.Price,
+				Stops:        f.Stops,
+				DepartTime:   flightDepartHHMM(f),
+				AirlineCodes: flightAirlineCodes(f),
+			})
+			label := fmt.Sprintf("#%d", i+1)
+			if len(f.Legs) > 0 && f.Legs[0].Airline != "" {
+				label = fmt.Sprintf("#%d %s", i+1, f.Legs[0].Airline)
+			}
+			printMatchBreakdown(label, matchScore, breakdown)
+		}
+	}
+
 	return nil
 }
 
@@ -625,4 +654,39 @@ func hackTypeLabel(t string) string {
 	default:
 		return strings.ReplaceAll(t, "_", " ")
 	}
+}
+
+// flightDepartHHMM extracts the "HH:MM" clock time from the first leg's
+// DepartureTime, which may be "2006-01-02T15:04" or similar ISO-ish formats.
+func flightDepartHHMM(f models.FlightResult) string {
+	if len(f.Legs) == 0 {
+		return ""
+	}
+	dt := f.Legs[0].DepartureTime
+	// ISO datetime: "2026-06-15T06:55" or "2026-06-15T06:55:00"
+	if len(dt) >= len("2006-01-02T15:04") {
+		clock := dt[len("2006-01-02T"):]
+		if len(clock) > 5 {
+			clock = clock[:5]
+		}
+		return clock
+	}
+	// Already HH:MM.
+	if len(dt) == 5 && dt[2] == ':' {
+		return dt
+	}
+	return ""
+}
+
+// flightAirlineCodes returns the unique IATA airline codes across all legs.
+func flightAirlineCodes(f models.FlightResult) []string {
+	seen := make(map[string]bool, len(f.Legs))
+	codes := make([]string, 0, len(f.Legs))
+	for _, leg := range f.Legs {
+		if leg.AirlineCode != "" && !seen[leg.AirlineCode] {
+			seen[leg.AirlineCode] = true
+			codes = append(codes, leg.AirlineCode)
+		}
+	}
+	return codes
 }

--- a/cmd/trvl/hiddencity.go
+++ b/cmd/trvl/hiddencity.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/hacks"
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/spf13/cobra"
+)
+
+func hiddenCityCmd() *cobra.Command {
+	var (
+		carrier         string
+		price           float64
+		currency        string
+		carryOnOnly     bool
+		separateTickets bool
+		layoverMinutes  int
+		directBaseline  float64
+		maxLayoverRisk  int
+		topK            int
+		departDate      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "hidden-city ORIGIN HUB HUB_BEYOND",
+		Short: "Find hidden-city savings (disembark at layover, skip final leg)",
+		Long: `Evaluate a hidden-city routing where you board ORIGIN→HUB→HUB_BEYOND
+but disembark at HUB, using the cheaper long-haul ticket.
+
+Only safe with carry-on luggage — checked bags travel to HUB_BEYOND.
+
+ORIGIN, HUB, and HUB_BEYOND are IATA airport codes.
+
+Examples:
+  trvl hidden-city AMS HEL RIX --price 89.50 --carrier AY --layover-min 90 --carry-on --date 2026-05-15
+  trvl hidden-city AMS FRA MUC --price 110 --carrier LH --layover-min 60 --date 2026-06-01`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			origin := strings.ToUpper(args[0])
+			hub := strings.ToUpper(args[1])
+			hubBeyond := strings.ToUpper(args[2])
+
+			if price <= 0 {
+				return fmt.Errorf("--price is required and must be > 0")
+			}
+			if currency == "" {
+				currency = "EUR"
+			}
+
+			offer := hacks.HiddenCityOffer{
+				Origin:          origin,
+				Hub:             hub,
+				HubBeyond:       hubBeyond,
+				Carrier:         strings.ToUpper(carrier),
+				Price:           price,
+				Currency:        currency,
+				CarryOnOnly:     carryOnOnly,
+				SeparateTickets: separateTickets,
+				LayoverMinutes:  layoverMinutes,
+			}
+
+			candidates := hacks.ExpandMatrix([]hacks.HiddenCityOffer{offer}, hacks.MatrixOptions{
+				AllowHiddenCity: true,
+				DirectBaseline:  directBaseline,
+				DepartDate:      departDate,
+				MaxLayoverRisk:  maxLayoverRisk,
+				TopK:            topK,
+			})
+
+			if len(candidates) == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "No viable hidden-city candidates (risk score above threshold).\n")
+				return nil
+			}
+
+			for _, c := range candidates {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s → %s (skip last leg to %s)\n", c.Origin, c.HubBeyond, c.Hub)
+				fmt.Fprintf(cmd.OutOrStdout(), "  Carrier: %s  Price: %s %.2f", c.Carrier, c.Currency, c.Price)
+				if c.SavingsPct > 0 {
+					fmt.Fprintf(cmd.OutOrStdout(), "  Saves: %.0f%% (%.2f %s)", c.SavingsPct, c.SavingsEUR, c.Currency)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "\n  Risk: %s — %s\n", colorizeHiddenCityRisk(c.LayoverRisk), c.Reason)
+				fmt.Fprintf(cmd.OutOrStdout(), "  Booking: %s\n\n", c.BookingURL)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&carrier, "carrier", "", "Airline IATA code (e.g. AY, KL, LH)")
+	cmd.Flags().Float64Var(&price, "price", 0, "Ticket price for the full Origin→HubBeyond routing (required)")
+	cmd.Flags().StringVar(&currency, "currency", "EUR", "Price currency (default: EUR)")
+	cmd.Flags().BoolVar(&carryOnOnly, "carry-on", false, "Carry-on only — safer for hidden-city (no checked bags routed to HubBeyond)")
+	cmd.Flags().BoolVar(&separateTickets, "separate-tickets", false, "Itinerary spans two PNRs (separate-ticket risk)")
+	cmd.Flags().IntVar(&layoverMinutes, "layover-min", 120, "Scheduled layover at Hub in minutes")
+	cmd.Flags().Float64Var(&directBaseline, "baseline", 0, "Cheapest known direct Origin→Hub price for savings computation")
+	cmd.Flags().IntVar(&maxLayoverRisk, "max-risk", 60, "Drop candidates with risk score above this (0-100, default 60)")
+	cmd.Flags().IntVar(&topK, "top-k", 3, "Maximum candidates to return")
+	cmd.Flags().StringVar(&departDate, "date", "", "Departure date (YYYY-MM-DD) for booking URL")
+	_ = cmd.MarkFlagRequired("price")
+
+	return cmd
+}
+
+// printHiddenCityTable is a helper for testing.
+func printHiddenCityTable(out interface{ Write([]byte) (int, error) }, candidates []hacks.HiddenCityCandidate) {
+	for _, c := range candidates {
+		fmt.Fprintf(out, "%s → %s (skip to %s) %s %.2f risk:%d %s\n",
+			c.Origin, c.HubBeyond, c.Hub,
+			c.Currency, c.Price, c.LayoverRisk, c.Reason)
+	}
+}
+
+// colorizeHiddenCityRisk returns a color-coded risk label.
+func colorizeHiddenCityRisk(risk int) string {
+	switch {
+	case risk < 25:
+		return models.Green(fmt.Sprintf("%d/100", risk))
+	case risk < 50:
+		return models.Yellow(fmt.Sprintf("%d/100", risk))
+	default:
+		return models.Red(fmt.Sprintf("%d/100", risk))
+	}
+}

--- a/cmd/trvl/hotels.go
+++ b/cmd/trvl/hotels.go
@@ -15,6 +15,7 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
 	"github.com/MikkoParkkola/trvl/internal/providers"
+	"github.com/MikkoParkkola/trvl/internal/scoring"
 	"github.com/spf13/cobra"
 )
 
@@ -57,6 +58,7 @@ Examples:
 	cmd.Flags().Bool("sustainable", false, "Only show eco/sustainable properties (Booking)")
 	cmd.Flags().Bool("meal-plan", false, "Only show properties with breakfast/meals included (Booking)")
 	cmd.Flags().Bool("include-sold-out", false, "Include sold-out properties (Booking)")
+	cmd.Flags().Bool("explain", false, "Show per-factor profile match breakdown for each result")
 
 	_ = cmd.MarkFlagRequired("checkin")
 	_ = cmd.MarkFlagRequired("checkout")
@@ -108,6 +110,7 @@ func runHotels(cmd *cobra.Command, args []string) error {
 	sustainable, _ := cmd.Flags().GetBool("sustainable")
 	mealPlan, _ := cmd.Flags().GetBool("meal-plan")
 	includeSoldOut, _ := cmd.Flags().GetBool("include-sold-out")
+	explain, _ := cmd.Flags().GetBool("explain")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -198,7 +201,7 @@ func runHotels(cmd *cobra.Command, args []string) error {
 		return models.FormatJSON(os.Stdout, result)
 	}
 
-	if err := formatHotelsTable(cmd.Context(), currency, result); err != nil {
+	if err := formatHotelsTable(cmd.Context(), currency, location, result, explain); err != nil {
 		return err
 	}
 
@@ -212,7 +215,7 @@ func runHotels(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func formatHotelsTable(ctx context.Context, targetCurrency string, result *models.HotelSearchResult) error {
+func formatHotelsTable(ctx context.Context, targetCurrency, location string, result *models.HotelSearchResult, explain bool) error {
 	if len(result.Hotels) == 0 {
 		fmt.Println("No hotels found.")
 		return nil
@@ -327,6 +330,23 @@ func formatHotelsTable(ctx context.Context, targetCurrency string, result *model
 			models.Summary(os.Stdout, strings.Join(parts, " · "))
 		}
 	}
+
+	// --explain: per-hotel profile match breakdown.
+	if explain {
+		fmt.Println()
+		prefs, _ := preferences.Load()
+		for i, h := range result.Hotels {
+			matchScore, breakdown := scoring.ComputeProfileMatch(prefs, scoring.DiscoverInput{
+				CityName:    location,
+				HotelPrice:  h.Price,
+				Total:       h.Price,
+				HotelRating: h.Rating,
+				HotelName:   h.Name,
+			})
+			printMatchBreakdown(fmt.Sprintf("#%d %s", i+1, truncateName(h.Name, 30)), matchScore, breakdown)
+		}
+	}
+
 	return nil
 }
 

--- a/cmd/trvl/opportunities.go
+++ b/cmd/trvl/opportunities.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+	"github.com/spf13/cobra"
+)
+
+func opportunitiesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "opportunities",
+		Short: "Manage opportunity watches (rolling window, favourite destinations)",
+		Long: `Monitor a rolling time window for deals to your favourite destinations.
+
+Examples:
+  trvl opportunities
+  trvl opportunities create --favourites "PRG,KRK,ZRH" --window-from next_30d --window-to next_90d
+  trvl opportunities create --min-score 90 --min-nights 3 --max-nights 10`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runListOpportunities(cmd)
+		},
+	}
+	cmd.AddCommand(opportunitiesCreateCmd())
+	return cmd
+}
+
+func runListOpportunities(_ *cobra.Command) error {
+	store, err := watch.DefaultStore()
+	if err != nil {
+		return err
+	}
+	if err := store.Load(); err != nil {
+		return err
+	}
+
+	var opps []watch.Watch
+	for _, w := range store.List() {
+		if w.IsOpportunityWatch() {
+			opps = append(opps, w)
+		}
+	}
+
+	if len(opps) == 0 {
+		fmt.Println("No opportunity watches. Use 'trvl opportunities create' to add one.")
+		return nil
+	}
+
+	if format == "json" {
+		return models.FormatJSON(os.Stdout, opps)
+	}
+
+	headers := []string{"ID", "Favourites", "Window From", "Window To", "Min Score", "Nights", "Created"}
+	rows := make([][]string, 0, len(opps))
+	for _, w := range opps {
+		favStr := strings.Join(w.Favourites, ",")
+		if favStr == "" {
+			favStr = "(profile)"
+		}
+		minScore := w.MinScore
+		if minScore == 0 {
+			minScore = 85
+		}
+		minNights := w.MinNights
+		if minNights == 0 {
+			minNights = 3
+		}
+		maxNights := w.MaxNights
+		if maxNights == 0 {
+			maxNights = 14
+		}
+		rows = append(rows, []string{
+			w.ID,
+			favStr,
+			w.WindowFrom,
+			w.WindowTo,
+			fmt.Sprintf("%d", minScore),
+			fmt.Sprintf("%d-%d", minNights, maxNights),
+			w.CreatedAt.Format("2006-01-02"),
+		})
+	}
+	models.FormatTable(os.Stdout, headers, rows)
+	return nil
+}
+
+func opportunitiesCreateCmd() *cobra.Command {
+	var (
+		favouritesStr string
+		windowFrom    string
+		windowTo      string
+		minScore      int
+		minNights     int
+		maxNights     int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new opportunity watch",
+		Long: `Create a new opportunity watch that tracks deals to favourite destinations
+within a rolling time window.
+
+Examples:
+  trvl opportunities create --favourites "PRG,KRK,ZRH"
+  trvl opportunities create --window-from next_30d --window-to next_90d --min-score 90`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var favourites []string
+			if favouritesStr != "" {
+				for _, code := range strings.Split(favouritesStr, ",") {
+					code = strings.ToUpper(strings.TrimSpace(code))
+					if code != "" {
+						favourites = append(favourites, code)
+					}
+				}
+			}
+
+			if windowFrom == "" {
+				windowFrom = "next_30d"
+			}
+			if windowTo == "" {
+				windowTo = "next_90d"
+			}
+			if minScore == 0 {
+				minScore = 85
+			}
+			if minNights == 0 {
+				minNights = 3
+			}
+			if maxNights == 0 {
+				maxNights = 14
+			}
+
+			store, err := watch.DefaultStore()
+			if err != nil {
+				return err
+			}
+			if err := store.Load(); err != nil {
+				return err
+			}
+
+			w := watch.Watch{
+				Type:       "opportunity",
+				Favourites: favourites,
+				WindowFrom: windowFrom,
+				WindowTo:   windowTo,
+				MinScore:   minScore,
+				MinNights:  minNights,
+				MaxNights:  maxNights,
+			}
+
+			id, err := store.Add(w)
+			if err != nil {
+				return fmt.Errorf("create opportunity watch: %w", err)
+			}
+
+			favStr := strings.Join(favourites, ", ")
+			if favStr == "" {
+				favStr = "(from profile)"
+			}
+			fmt.Printf("Created opportunity watch %s\n", id)
+			fmt.Printf("  Favourites: %s\n", favStr)
+			fmt.Printf("  Window: %s → %s\n", windowFrom, windowTo)
+			fmt.Printf("  Min score: %d | Nights: %d-%d\n", minScore, minNights, maxNights)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&favouritesStr, "favourites", "", "Comma-separated destination IATA codes (e.g. PRG,KRK,ZRH)")
+	cmd.Flags().StringVar(&windowFrom, "window-from", "next_30d", "Window start (YYYY-MM-DD or next_Nd)")
+	cmd.Flags().StringVar(&windowTo, "window-to", "next_90d", "Window end (YYYY-MM-DD or next_Nd)")
+	cmd.Flags().IntVar(&minScore, "min-score", 85, "Minimum composite score to alert (0-100)")
+	cmd.Flags().IntVar(&minNights, "min-nights", 3, "Minimum trip length in nights")
+	cmd.Flags().IntVar(&maxNights, "max-nights", 14, "Maximum trip length in nights")
+
+	return cmd
+}

--- a/cmd/trvl/optimize.go
+++ b/cmd/trvl/optimize.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/optimizer"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/scoring"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +32,7 @@ Examples:
 	cmd.Flags().Int("guests", 1, "Number of guests")
 	cmd.Flags().String("currency", "", "Display currency")
 	cmd.Flags().Int("results", 5, "Number of results")
+	cmd.Flags().Bool("explain", false, "Show per-factor profile match breakdown for each result")
 	_ = cmd.MarkFlagRequired("depart")
 	return cmd
 }
@@ -93,11 +95,12 @@ func runOptimize(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	printOptimizeResults(result)
+	explain, _ := cmd.Flags().GetBool("explain")
+	printOptimizeResults(result, dest, prefs, explain)
 	return nil
 }
 
-func printOptimizeResults(result *optimizer.OptimizeResult) {
+func printOptimizeResults(result *optimizer.OptimizeResult, destCode string, prefs *preferences.Preferences, explain bool) {
 	models.Banner(os.Stdout, "⚡", "Optimize", fmt.Sprintf("Found %d booking strategies", len(result.Options)))
 	fmt.Println()
 
@@ -149,6 +152,29 @@ func printOptimizeResults(result *optimizer.OptimizeResult) {
 				"Direct booking is already the cheapest: %s %.0f",
 				result.Baseline.Currency, result.Baseline.AllInCost,
 			))
+		}
+	}
+
+	// --explain: per-strategy profile match breakdown.
+	if explain {
+		fmt.Println()
+		for i, opt := range result.Options {
+			// Extract destination from legs: last flight leg's destination.
+			code := destCode
+			if len(opt.Legs) > 0 {
+				for j := len(opt.Legs) - 1; j >= 0; j-- {
+					if strings.EqualFold(opt.Legs[j].Type, "flight") && opt.Legs[j].To != "" {
+						code = opt.Legs[j].To
+						break
+					}
+				}
+			}
+			matchScore, breakdown := scoring.ComputeProfileMatch(prefs, scoring.DiscoverInput{
+				AirportCode: code,
+				FlightPrice: opt.AllInCost,
+				Total:       opt.AllInCost,
+			})
+			printMatchBreakdown(fmt.Sprintf("#%d %s", i+1, opt.Strategy), matchScore, breakdown)
 		}
 	}
 }

--- a/cmd/trvl/public_claims_test.go
+++ b/cmd/trvl/public_claims_test.go
@@ -21,7 +21,7 @@ import (
 // The dynamic count from rootCmd.Commands() includes all cobra-registered
 // commands, but marketing materials only count functional travel commands.
 // Current exclusions: version, providers (both are utility/meta commands).
-const cliCommandCountMarketed = 42
+const cliCommandCountMarketed = 43
 
 var readmeToolMarkers = []string{
 	"search_flights",

--- a/cmd/trvl/root.go
+++ b/cmd/trvl/root.go
@@ -90,6 +90,7 @@ func init() {
 	rootCmd.AddCommand(upgradeCmd())
 	rootCmd.AddCommand(optimizeCmd())
 	rootCmd.AddCommand(profileCmd())
+	rootCmd.AddCommand(opportunitiesCmd())
 }
 
 // airportCompletion provides IATA code completion for cobra commands.

--- a/cmd/trvl/root.go
+++ b/cmd/trvl/root.go
@@ -72,6 +72,7 @@ func init() {
 	rootCmd.AddCommand(watchCmd())
 	rootCmd.AddCommand(roomsCmd())
 	rootCmd.AddCommand(hacksCmd())
+	rootCmd.AddCommand(hiddenCityCmd())
 	rootCmd.AddCommand(accomHackCmd())
 	rootCmd.AddCommand(mcpCmd())
 	rootCmd.AddCommand(prefsCmd())

--- a/cmd/trvl/tripcost.go
+++ b/cmd/trvl/tripcost.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/scoring"
 	"github.com/MikkoParkkola/trvl/internal/trip"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +21,7 @@ func tripCostCmd() *cobra.Command {
 		guests     int
 		currency   string
 		format     string
+		explain    bool
 	)
 
 	cmd := &cobra.Command{
@@ -60,7 +63,7 @@ Examples:
 				return models.FormatJSON(os.Stdout, result)
 			}
 
-			return printTripCostTable(result, origin, dest, guests)
+			return printTripCostTable(result, origin, dest, guests, explain)
 		},
 	}
 
@@ -69,6 +72,7 @@ Examples:
 	cmd.Flags().IntVar(&guests, "guests", 1, "Number of guests (must be >= 1)")
 	cmd.Flags().StringVar(&currency, "currency", "", "Convert prices to this currency (e.g. EUR). Empty = API default")
 	cmd.Flags().StringVar(&format, "format", "table", "Output format: table, json")
+	cmd.Flags().BoolVar(&explain, "explain", false, "Show per-factor profile match breakdown for the trip")
 
 	_ = cmd.MarkFlagRequired("depart")
 	_ = cmd.MarkFlagRequired("return")
@@ -76,7 +80,7 @@ Examples:
 	return cmd
 }
 
-func printTripCostTable(result *trip.TripCostResult, origin, dest string, guests int) error {
+func printTripCostTable(result *trip.TripCostResult, origin, dest string, guests int, explain bool) error {
 	if !result.Success {
 		fmt.Fprintf(os.Stderr, "Trip cost estimation failed: %s\n", result.Error)
 		return nil
@@ -115,6 +119,22 @@ func printTripCostTable(result *trip.TripCostResult, origin, dest string, guests
 	rows = append(rows, []string{"Per day", fmt.Sprintf("%s %.0f", cur, result.PerDay), ""})
 
 	models.FormatTable(os.Stdout, headers, rows)
+
+	// --explain: show profile match breakdown for this trip.
+	if explain {
+		fmt.Println()
+		prefs, _ := preferences.Load()
+		matchScore, breakdown := scoring.ComputeProfileMatch(prefs, scoring.DiscoverInput{
+			AirportCode: dest,
+			FlightPrice: result.Flights.Outbound + result.Flights.Return,
+			HotelPrice:  result.Hotels.Total,
+			Total:       result.Total,
+			HotelName:   result.Hotels.Name,
+			Stops:       result.Flights.OutboundStops,
+		})
+		printMatchBreakdown(fmt.Sprintf("%s → %s", origin, dest), matchScore, breakdown)
+	}
+
 	return nil
 }
 

--- a/cmd/trvl/tripcost_test.go
+++ b/cmd/trvl/tripcost_test.go
@@ -62,7 +62,7 @@ func TestPrintTripCostTable_PartialFailureWarning(t *testing.T) {
 	}
 
 	stdout, stderr, err := captureTripCostOutput(t, func() error {
-		return printTripCostTable(result, "HEL", "BCN", 1)
+		return printTripCostTable(result, "HEL", "BCN", 1, false)
 	})
 	if err != nil {
 		t.Fatalf("printTripCostTable returned error: %v", err)
@@ -88,7 +88,7 @@ func TestPrintTripCostTable_UnavailableComponents(t *testing.T) {
 	}
 
 	stdout, stderr, err := captureTripCostOutput(t, func() error {
-		return printTripCostTable(result, "HEL", "BCN", 1)
+		return printTripCostTable(result, "HEL", "BCN", 1, false)
 	})
 	if err != nil {
 		t.Fatalf("printTripCostTable returned error: %v", err)

--- a/cmd/trvl/watch_daemon.go
+++ b/cmd/trvl/watch_daemon.go
@@ -86,7 +86,7 @@ func runWatchCheckCycleWithRooms(ctx context.Context, checker watch.PriceChecker
 	checkCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	notifier.NotifyAll(watch.CheckAllWithRooms(checkCtx, store, checker, roomChecker))
+	notifier.NotifyAll(watch.CheckAllWithRoomsAndWebhookContext(checkCtx, ctx, store, checker, roomChecker))
 	return len(watches), nil
 }
 

--- a/cmd/trvl/watch_daemon_test.go
+++ b/cmd/trvl/watch_daemon_test.go
@@ -4,14 +4,27 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/watch"
 )
 
 type stubWatchDaemonTicker struct {
 	ch      chan time.Time
 	stopped bool
+}
+
+type stubDaemonPriceChecker struct {
+	price    float64
+	currency string
+}
+
+func (c *stubDaemonPriceChecker) CheckPrice(context.Context, watch.Watch) (float64, string, string, error) {
+	return c.price, c.currency, "", nil
 }
 
 func (t *stubWatchDaemonTicker) Chan() <-chan time.Time {
@@ -118,4 +131,91 @@ func TestRunWatchDaemonRejectsInvalidInterval(t *testing.T) {
 	if got := err.Error(); got != "watch interval must be greater than zero" {
 		t.Fatalf("unexpected error: %q", got)
 	}
+}
+
+type blockingDaemonWebhookTransport struct {
+	started   chan struct{}
+	cancelled chan struct{}
+	once      sync.Once
+}
+
+func newBlockingDaemonWebhookTransport() *blockingDaemonWebhookTransport {
+	return &blockingDaemonWebhookTransport{
+		started:   make(chan struct{}),
+		cancelled: make(chan struct{}),
+	}
+}
+
+func (t *blockingDaemonWebhookTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.once.Do(func() {
+		close(t.started)
+	})
+	<-req.Context().Done()
+	close(t.cancelled)
+	return nil, req.Context().Err()
+}
+
+func installBlockingDaemonWebhookClient(t *testing.T) *blockingDaemonWebhookTransport {
+	t.Helper()
+
+	transport := newBlockingDaemonWebhookTransport()
+	oldClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: transport}
+	t.Cleanup(func() {
+		http.DefaultClient = oldClient
+	})
+	return transport
+}
+
+func waitForDaemonSignal(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal(msg)
+	}
+}
+
+func TestRunWatchCheckCycleWithRooms_WebhookUsesDaemonContext(t *testing.T) {
+	transport := installBlockingDaemonWebhookClient(t)
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	store, err := watch.DefaultStore()
+	if err != nil {
+		t.Fatalf("DefaultStore: %v", err)
+	}
+	if _, err := store.Add(watch.Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "NRT",
+		DepartDate:  "2099-07-01",
+		LastPrice:   500,
+		WebhookURL:  "http://example.test/webhook",
+	}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = runWatchCheckCycleWithRooms(ctx, &stubDaemonPriceChecker{price: 450, currency: "EUR"}, nil, &watch.Notifier{Out: &bytes.Buffer{}})
+		close(done)
+	}()
+
+	waitForDaemonSignal(t, transport.started, "daemon webhook request did not start")
+	waitForDaemonSignal(t, done, "runWatchCheckCycleWithRooms did not return")
+
+	select {
+	case <-transport.cancelled:
+		t.Fatal("daemon webhook request was cancelled when the cycle timeout finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	waitForDaemonSignal(t, transport.cancelled, "daemon webhook request did not observe daemon cancellation")
 }

--- a/demo.tape
+++ b/demo.tape
@@ -67,7 +67,7 @@ Sleep 3s
 # ═══ CLOSING ═══
 
 Sleep 300ms
-Type "# 54 MCP tools · 42 CLI commands · 21 providers · No API keys"
+Type "# 56 MCP tools · 43 CLI commands · 21 providers · No API keys"
 Enter
 Sleep 300ms
 Type "# brew install MikkoParkkola/tap/trvl"

--- a/demo.tape
+++ b/demo.tape
@@ -67,7 +67,7 @@ Sleep 3s
 # ═══ CLOSING ═══
 
 Sleep 300ms
-Type "# 56 MCP tools · 43 CLI commands · 21 providers · No API keys"
+Type "# 57 MCP tools · 43 CLI commands · 21 providers · No API keys"
 Enter
 Sleep 300ms
 Type "# brew install MikkoParkkola/tap/trvl"

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/refraction-networking/utls v1.8.2
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/net v0.53.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.42.0
 	golang.org/x/text v0.36.0
 	golang.org/x/time v0.15.0
@@ -31,7 +32,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/zalando/go-keyring v0.2.7 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
 )

--- a/internal/dealquality/dealquality.go
+++ b/internal/dealquality/dealquality.go
@@ -1,0 +1,347 @@
+// Package dealquality scores how good a travel deal is relative to historical prices.
+// All scoring is pure (no I/O in scoring functions). Store provides persistence.
+package dealquality
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const historyLayout = "2006-01-02"
+
+// Sample is one observed price for a route+season.
+type Sample struct {
+	Route  string  `json:"route"`  // "HEL-BCN" (sorted IATA pair, uppercase)
+	Season string  `json:"season"` // "Q1", "Q2", "Q3", "Q4"
+	Date   string  `json:"date"`   // YYYY-MM-DD of observation
+	Price  float64 `json:"price"`  // price in any consistent currency
+	Kind   string  `json:"kind"`   // "flight" or "hotel"
+}
+
+// Score holds the result of a DealQuality computation.
+type Score struct {
+	Total   int     // 0-100
+	Reason  string  // e.g. "price_at_p08" or "insufficient_history"
+	Samples int     // how many historical samples were used
+	P10     float64 // 10th-percentile price (0 if insufficient)
+	P20     float64 // 20th-percentile price
+	P50     float64 // median price
+}
+
+// SeasonOf returns "Q1"/"Q2"/"Q3"/"Q4" for a YYYY-MM-DD date string.
+// Returns "Q1" for unparseable dates.
+func SeasonOf(date string) string {
+	t, err := time.Parse(historyLayout, date)
+	if err != nil {
+		return "Q1"
+	}
+	switch (int(t.Month()) - 1) / 3 {
+	case 0:
+		return "Q1"
+	case 1:
+		return "Q2"
+	case 2:
+		return "Q3"
+	default:
+		return "Q4"
+	}
+}
+
+// RouteKey returns a canonical "ORG-DST" key: sorted alphabetically, uppercase.
+func RouteKey(a, b string) string {
+	a = strings.ToUpper(strings.TrimSpace(a))
+	b = strings.ToUpper(strings.TrimSpace(b))
+	if a > b {
+		a, b = b, a
+	}
+	return a + "-" + b
+}
+
+// ScoreAgainst computes DealQuality 0-100 for a given price against historical samples.
+//
+// Scoring bands:
+//
+//	price ≤ p10 → 95-100 (lerp)
+//	price ≤ p20 → 80-95 (lerp)
+//	price ≤ p50 → 50-80 (lerp)
+//	price > p50 → ramp linearly to 0 at 2×p50; clamp to 0 below that
+//
+// Sparse (<10 samples): returns Score{Total: 50, Reason: "insufficient_history", Samples: n}.
+func ScoreAgainst(price float64, samples []Sample) Score {
+	n := len(samples)
+	if n < 10 {
+		return Score{Total: 50, Reason: "insufficient_history", Samples: n}
+	}
+
+	prices := make([]float64, 0, n)
+	for _, s := range samples {
+		prices = append(prices, s.Price)
+	}
+	sort.Float64s(prices)
+
+	p10 := percentile(prices, 10)
+	p20 := percentile(prices, 20)
+	p50 := percentile(prices, 50)
+
+	var total int
+	var reason string
+
+	switch {
+	case price <= p10:
+		total = lerp(p10, 95, 100, price, p10)
+		// price at or below p10 → find approximate percentile for reason
+		pct := pricePercentile(prices, price)
+		reason = fmt.Sprintf("price_at_p%02d", pct)
+	case price <= p20:
+		total = lerp(p20, 80, 95, price, p10)
+		pct := pricePercentile(prices, price)
+		reason = fmt.Sprintf("price_at_p%02d", pct)
+	case price <= p50:
+		total = lerp(p50, 50, 80, price, p20)
+		pct := pricePercentile(prices, price)
+		reason = fmt.Sprintf("price_at_p%02d", pct)
+	default:
+		// linear ramp from 50 at p50 to 0 at 2×p50
+		if p50 <= 0 {
+			total = 0
+			reason = "above_median"
+		} else {
+			cap := 2 * p50
+			if price >= cap {
+				total = 0
+			} else {
+				frac := (cap - price) / p50 // goes from 1.0 at p50 to 0 at 2*p50
+				total = int(frac * 50)
+				if total < 0 {
+					total = 0
+				}
+			}
+			reason = "above_median"
+		}
+	}
+
+	return Score{
+		Total:   total,
+		Reason:  reason,
+		Samples: n,
+		P10:     p10,
+		P20:     p20,
+		P50:     p50,
+	}
+}
+
+// percentile returns the p-th percentile of a sorted slice (0-100).
+func percentile(sorted []float64, p int) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 100 {
+		return sorted[len(sorted)-1]
+	}
+	idx := float64(p) / 100.0 * float64(len(sorted)-1)
+	lo := int(idx)
+	hi := lo + 1
+	if hi >= len(sorted) {
+		return sorted[lo]
+	}
+	frac := idx - float64(lo)
+	return sorted[lo]*(1-frac) + sorted[hi]*frac
+}
+
+// pricePercentile returns the approximate percentile rank of price in sorted prices.
+func pricePercentile(sorted []float64, price float64) int {
+	count := 0
+	for _, p := range sorted {
+		if p <= price {
+			count++
+		}
+	}
+	return count * 100 / len(sorted)
+}
+
+// lerp interpolates linearly. Returns minScore when price==high, maxScore when price==low.
+// Used for scoring bands where lower price → higher score.
+func lerp(high float64, minScore, maxScore int, price, low float64) int {
+	if high <= low {
+		return maxScore
+	}
+	span := high - low
+	pos := price - low
+	if pos <= 0 {
+		return maxScore
+	}
+	if pos >= span {
+		return minScore
+	}
+	frac := pos / span
+	score := float64(maxScore) - frac*float64(maxScore-minScore)
+	return int(score)
+}
+
+// Store is a concurrency-safe, atomic-write store for deal history.
+// Persists to dir/deal-history.json.
+type Store struct {
+	mu      sync.Mutex
+	dir     string
+	samples []Sample
+}
+
+// NewStore creates a store rooted at the given directory.
+func NewStore(dir string) *Store {
+	return &Store{dir: dir}
+}
+
+// DefaultStore returns a store at ~/.trvl/.
+func DefaultStore() (*Store, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home directory: %w", err)
+	}
+	return NewStore(filepath.Join(home, ".trvl")), nil
+}
+
+func (s *Store) historyPath() string {
+	return filepath.Join(s.dir, "deal-history.json")
+}
+
+func (s *Store) ensureDir() error {
+	return os.MkdirAll(s.dir, 0o700)
+}
+
+// Load reads samples from disk. If the file does not exist, the store starts empty.
+func (s *Store) Load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.samples = nil
+	return s.loadLocked()
+}
+
+func (s *Store) loadLocked() error {
+	data, err := os.ReadFile(s.historyPath())
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read deal history: %w", err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	return json.Unmarshal(data, &s.samples)
+}
+
+func (s *Store) saveLocked() error {
+	if err := s.ensureDir(); err != nil {
+		return fmt.Errorf("create storage dir: %w", err)
+	}
+	b, err := json.MarshalIndent(s.samples, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal deal history: %w", err)
+	}
+
+	dir := filepath.Dir(s.historyPath())
+	tmp, err := os.CreateTemp(dir, "deal-history.json.tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpPath, s.historyPath()); err != nil {
+		if runtime.GOOS == "windows" {
+			_ = os.Remove(s.historyPath())
+			if err2 := os.Rename(tmpPath, s.historyPath()); err2 == nil {
+				cleanup = false
+				return nil
+			}
+		}
+		return err
+	}
+
+	cleanup = false
+	return nil
+}
+
+// Append adds a sample, deduplicating exact (Route,Kind,Date,Price) matches
+// and pruning entries older than 90 days.
+func (s *Store) Append(sample Sample) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Load latest from disk first so concurrent writers don't lose data.
+	if err := s.loadLocked(); err != nil {
+		return fmt.Errorf("reload before append: %w", err)
+	}
+
+	// Dedup exact matches.
+	for _, existing := range s.samples {
+		if existing.Route == sample.Route &&
+			existing.Kind == sample.Kind &&
+			existing.Date == sample.Date &&
+			existing.Price == sample.Price {
+			return nil // already present
+		}
+	}
+
+	// Prune samples older than 90 days.
+	cutoff := time.Now().AddDate(0, 0, -90).Format(historyLayout)
+	pruned := s.samples[:0]
+	for _, existing := range s.samples {
+		if existing.Date >= cutoff {
+			pruned = append(pruned, existing)
+		}
+	}
+	s.samples = pruned
+
+	s.samples = append(s.samples, sample)
+	return s.saveLocked()
+}
+
+// Query returns all samples for route+kind+season within 90 days.
+func (s *Store) Query(route, kind, season string) []Sample {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cutoff := time.Now().AddDate(0, 0, -90).Format(historyLayout)
+	var out []Sample
+	for _, sample := range s.samples {
+		if sample.Route == route &&
+			sample.Kind == kind &&
+			sample.Season == season &&
+			sample.Date >= cutoff {
+			out = append(out, sample)
+		}
+	}
+	return out
+}

--- a/internal/dealquality/dealquality_test.go
+++ b/internal/dealquality/dealquality_test.go
@@ -1,0 +1,305 @@
+package dealquality
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// makeSamples creates n synthetic samples for route "HEL-BCN", kind "flight", season "Q2".
+// Prices are evenly distributed from minPrice to maxPrice.
+func makeSamples(n int, minPrice, maxPrice float64) []Sample {
+	samples := make([]Sample, n)
+	if n == 1 {
+		samples[0] = Sample{Route: "HEL-BCN", Season: "Q2", Date: "2026-05-01", Price: minPrice, Kind: "flight"}
+		return samples
+	}
+	for i := 0; i < n; i++ {
+		price := minPrice + float64(i)*(maxPrice-minPrice)/float64(n-1)
+		samples[i] = Sample{
+			Route:  "HEL-BCN",
+			Season: "Q2",
+			Date:   "2026-05-01",
+			Price:  price,
+			Kind:   "flight",
+		}
+	}
+	return samples
+}
+
+func TestSeasonOf(t *testing.T) {
+	tests := []struct {
+		date   string
+		want   string
+	}{
+		{"2026-01-15", "Q1"},
+		{"2026-03-31", "Q1"},
+		{"2026-04-01", "Q2"},
+		{"2026-06-30", "Q2"},
+		{"2026-07-01", "Q3"},
+		{"2026-09-30", "Q3"},
+		{"2026-10-01", "Q4"},
+		{"2026-12-31", "Q4"},
+		{"bad-date", "Q1"}, // fallback
+	}
+	for _, tc := range tests {
+		got := SeasonOf(tc.date)
+		if got != tc.want {
+			t.Errorf("SeasonOf(%q) = %q, want %q", tc.date, got, tc.want)
+		}
+	}
+}
+
+func TestRouteKey(t *testing.T) {
+	if RouteKey("BCN", "HEL") != "BCN-HEL" {
+		t.Error("expected BCN-HEL (sorted)")
+	}
+	if RouteKey("HEL", "BCN") != "BCN-HEL" {
+		t.Error("expected BCN-HEL (sorted)")
+	}
+	if RouteKey("hel", "bcn") != "BCN-HEL" {
+		t.Error("expected uppercase")
+	}
+}
+
+func TestSparse(t *testing.T) {
+	for n := 0; n < 10; n++ {
+		samples := makeSamples(n, 100, 500)
+		s := ScoreAgainst(300, samples)
+		if s.Total != 50 {
+			t.Errorf("n=%d: expected Total=50 for sparse, got %d", n, s.Total)
+		}
+		if s.Reason != "insufficient_history" {
+			t.Errorf("n=%d: expected reason=insufficient_history, got %s", n, s.Reason)
+		}
+		if s.Samples != n {
+			t.Errorf("n=%d: expected Samples=%d, got %d", n, n, s.Samples)
+		}
+	}
+}
+
+func TestDensePercentiles(t *testing.T) {
+	// 100 samples evenly distributed 100..1099
+	samples := makeSamples(100, 100, 1099)
+	s := ScoreAgainst(200, samples) // price well below median → high score
+	if s.Total < 60 {
+		t.Errorf("expected high score for low price, got %d", s.Total)
+	}
+	if s.P10 <= 0 || s.P20 <= 0 || s.P50 <= 0 {
+		t.Errorf("expected non-zero percentiles: p10=%f p20=%f p50=%f", s.P10, s.P20, s.P50)
+	}
+}
+
+func TestP10Band(t *testing.T) {
+	// 20 samples: prices 100..119
+	samples := makeSamples(20, 100, 119)
+	// p10 ≈ 101.9, p20 ≈ 103.8, p50 ≈ 109.5
+	// Price at exactly p10 → score near 95-100
+	s := ScoreAgainst(100, samples)
+	if s.Total < 95 {
+		t.Errorf("price at p10 band: expected >=95, got %d", s.Total)
+	}
+}
+
+func TestP20Band(t *testing.T) {
+	samples := makeSamples(20, 100, 200)
+	// For 20 samples [100..200]: p10 ≈ 110, p20 ≈ 120, p50 ≈ 150
+	// Use 115 which is between p10 and p20
+	s := ScoreAgainst(115, samples)
+	if s.Total < 80 || s.Total > 95 {
+		t.Errorf("price between p10-p20: expected 80-95, got %d", s.Total)
+	}
+}
+
+func TestP50Band(t *testing.T) {
+	samples := makeSamples(20, 100, 200)
+	// p50 ≈ 150
+	s := ScoreAgainst(135, samples) // between p20 and p50
+	if s.Total < 50 || s.Total > 80 {
+		t.Errorf("price between p20-p50: expected 50-80, got %d", s.Total)
+	}
+}
+
+func TestAboveMedian(t *testing.T) {
+	samples := makeSamples(20, 100, 200)
+	// p50 ≈ 150
+	s := ScoreAgainst(175, samples) // above p50 but below 2×p50=300
+	if s.Total >= 50 || s.Total < 0 {
+		t.Errorf("above median: expected 0-49, got %d", s.Total)
+	}
+	if s.Reason != "above_median" {
+		t.Errorf("expected above_median reason, got %s", s.Reason)
+	}
+}
+
+func TestOutlierAbove2xP50(t *testing.T) {
+	samples := makeSamples(20, 100, 200) // p50 ≈ 150
+	s := ScoreAgainst(400, samples)       // well above 2×150=300
+	if s.Total != 0 {
+		t.Errorf("outlier above 2×p50: expected 0, got %d", s.Total)
+	}
+}
+
+func TestConcurrentAppends(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	var wg sync.WaitGroup
+	errors := make(chan error, 50)
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			err := store.Append(Sample{
+				Route:  "HEL-BCN",
+				Season: "Q2",
+				Date:   fmt.Sprintf("2026-05-%02d", (i%28)+1),
+				Price:  float64(100 + i),
+				Kind:   "flight",
+			})
+			if err != nil {
+				errors <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errors)
+
+	for err := range errors {
+		t.Errorf("concurrent append error: %v", err)
+	}
+
+	samples := store.Query("HEL-BCN", "flight", "Q2")
+	if len(samples) == 0 {
+		t.Error("expected samples after concurrent appends")
+	}
+}
+
+func TestDedup(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	sample := Sample{Route: "HEL-BCN", Season: "Q2", Date: "2026-05-01", Price: 150, Kind: "flight"}
+	_ = store.Append(sample)
+	_ = store.Append(sample) // duplicate
+	_ = store.Append(sample) // duplicate
+
+	samples := store.Query("HEL-BCN", "flight", "Q2")
+	if len(samples) != 1 {
+		t.Errorf("expected 1 sample after dedup, got %d", len(samples))
+	}
+}
+
+func TestPrune(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	// Add an old sample (100 days ago) directly to the store's slice then save.
+	oldDate := time.Now().AddDate(0, 0, -100).Format(historyLayout)
+	recentDate := time.Now().AddDate(0, 0, -5).Format(historyLayout)
+
+	store.mu.Lock()
+	store.samples = []Sample{
+		{Route: "HEL-BCN", Season: "Q2", Date: oldDate, Price: 100, Kind: "flight"},
+		{Route: "HEL-BCN", Season: "Q2", Date: recentDate, Price: 200, Kind: "flight"},
+	}
+	_ = store.saveLocked()
+	store.mu.Unlock()
+
+	// Appending any new sample triggers prune.
+	newSeason := SeasonOf(recentDate)
+	_ = store.Append(Sample{Route: "HEL-BCN", Season: newSeason, Date: recentDate, Price: 300, Kind: "flight"})
+
+	all := store.Query("HEL-BCN", "flight", SeasonOf(recentDate))
+	for _, s := range all {
+		if s.Date == oldDate {
+			t.Error("old sample should have been pruned")
+		}
+	}
+}
+
+func TestQueryFilters(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	_ = store.Append(Sample{Route: "HEL-BCN", Season: "Q2", Date: "2026-05-01", Price: 150, Kind: "flight"})
+	_ = store.Append(Sample{Route: "HEL-BCN", Season: "Q2", Date: "2026-05-02", Price: 200, Kind: "hotel"})
+	_ = store.Append(Sample{Route: "HEL-PRG", Season: "Q2", Date: "2026-05-01", Price: 100, Kind: "flight"})
+
+	flights := store.Query("HEL-BCN", "flight", "Q2")
+	if len(flights) != 1 {
+		t.Errorf("expected 1 flight sample, got %d", len(flights))
+	}
+}
+
+func TestStoreDefaultPath(t *testing.T) {
+	// Just verify DefaultStore() doesn't crash and returns a non-nil store.
+	home, _ := os.UserHomeDir()
+	expectedDir := filepath.Join(home, ".trvl")
+	store, err := DefaultStore()
+	if err != nil {
+		t.Fatalf("DefaultStore() error: %v", err)
+	}
+	if store.dir != expectedDir {
+		t.Errorf("expected dir %s, got %s", expectedDir, store.dir)
+	}
+}
+
+func TestStoreLoad(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	// Load on empty dir should not error.
+	if err := store.Load(); err != nil {
+		t.Fatalf("Load() on empty dir error: %v", err)
+	}
+
+	// Append a sample, then create a new store and load it.
+	_ = store.Append(Sample{Route: "HEL-BCN", Season: "Q2", Date: "2026-05-01", Price: 150, Kind: "flight"})
+
+	store2 := NewStore(dir)
+	if err := store2.Load(); err != nil {
+		t.Fatalf("Load() after write error: %v", err)
+	}
+	samples := store2.Query("HEL-BCN", "flight", "Q2")
+	if len(samples) != 1 {
+		t.Errorf("expected 1 sample after load, got %d", len(samples))
+	}
+}
+
+func TestPercentileEdgeCases(t *testing.T) {
+	// Test percentile with single-element slice and edge p values.
+	single := []float64{42.0}
+	if v := percentile(single, 0); v != 42.0 {
+		t.Errorf("percentile(single,0) = %f, want 42", v)
+	}
+	if v := percentile(single, 100); v != 42.0 {
+		t.Errorf("percentile(single,100) = %f, want 42", v)
+	}
+	if v := percentile(single, 50); v != 42.0 {
+		t.Errorf("percentile(single,50) = %f, want 42", v)
+	}
+
+	// Test percentile on empty slice.
+	empty := []float64{}
+	if v := percentile(empty, 50); v != 0 {
+		t.Errorf("percentile(empty,50) = %f, want 0", v)
+	}
+}
+
+func TestLerpBoundaries(t *testing.T) {
+	// When high == low, returns maxScore.
+	score := lerp(100, 50, 95, 100, 100)
+	if score != 95 {
+		t.Errorf("lerp with high==low: expected 95, got %d", score)
+	}
+	// price < low → maxScore
+	score = lerp(200, 50, 95, 50, 100)
+	if score != 95 {
+		t.Errorf("lerp price<low: expected 95, got %d", score)
+	}
+}

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/searchctx"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -16,6 +19,8 @@ import (
 // Only truly concurrent requests are coalesced; the existing cache layer handles
 // TTL-based reuse between sequential calls.
 var flightGroup singleflight.Group
+
+const sharedFlightSearchTimeout = 30 * time.Second
 
 // DefaultClient returns a shared batchexec.Client for the flights package.
 // The client is created once and reused across all requests, enabling
@@ -84,10 +89,19 @@ func flightSearchKey(origin, destination, date string, opts SearchOptions) strin
 		origin, destination, date, opts.ReturnDate,
 		opts.CabinClass, opts.MaxStops, opts.SortBy, opts.Adults,
 		opts.MaxPrice, opts.MaxDuration, opts.CarryOnBags, opts.CheckedBags,
-		opts.Currency, strings.Join(opts.Airlines, ","),
+		opts.Currency, canonicalStringSlice(opts.Airlines),
 		opts.ExcludeBasic, opts.LessEmissions, opts.RequireCheckedBag,
-		strings.Join(opts.Alliances, ","), opts.DepartAfter, opts.DepartBefore,
+		canonicalStringSlice(opts.Alliances), opts.DepartAfter, opts.DepartBefore,
 	)
+}
+
+func canonicalStringSlice(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	sorted := append([]string(nil), values...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ",")
 }
 
 // SearchFlightsWithClient is like SearchFlights but accepts a pre-built client,
@@ -107,16 +121,32 @@ func SearchFlightsWithClient(ctx context.Context, client *batchexec.Client, orig
 	}
 
 	key := flightSearchKey(origin, destination, date, opts)
-	v, err, _ := flightGroup.Do(key, func() (any, error) {
-		return searchFlightsCore(ctx, client, origin, destination, date, opts)
+	return doFlightSearchSingleflight(ctx, key, func(sharedCtx context.Context) (*models.FlightSearchResult, error) {
+		return searchFlightsCore(sharedCtx, client, origin, destination, date, opts)
 	})
-	if err != nil {
-		if r, ok := v.(*models.FlightSearchResult); ok {
-			return r, err
-		}
-		return &models.FlightSearchResult{Error: err.Error()}, err
+}
+
+func doFlightSearchSingleflight(ctx context.Context, key string, fn func(context.Context) (*models.FlightSearchResult, error)) (*models.FlightSearchResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
-	return v.(*models.FlightSearchResult), nil
+
+	ch := flightGroup.DoChan(key, func() (any, error) {
+		sharedCtx, cancel := searchctx.DetachedWithin(ctx, sharedFlightSearchTimeout)
+		defer cancel()
+		return fn(sharedCtx)
+	})
+
+	select {
+	case <-ctx.Done():
+		// The first caller may time out before the shared worker returns and
+		// singleflight evicts the key. Forget it now so a fresh caller does not
+		// attach to an already-doomed execution.
+		flightGroup.Forget(key)
+		return nil, ctx.Err()
+	case res := <-ch:
+		return sharedFlightResult(res.Val, res.Err)
+	}
 }
 
 // searchFlightsCore performs the actual flight search without singleflight wrapping.
@@ -170,6 +200,50 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	return &models.FlightSearchResult{
 		Error: "unreachable flight search state",
 	}, fmt.Errorf("unreachable flight search state")
+}
+
+func cloneFlightSearchResult(shared *models.FlightSearchResult) *models.FlightSearchResult {
+	if shared == nil {
+		return nil
+	}
+
+	// singleflight.Do shares the winning *FlightSearchResult pointer across all
+	// concurrent callers for the same key. MCP handlers post-filter Flights and
+	// rewrite Count, so each caller needs its own result header and independent
+	// nested slices/pointers to avoid racing on shared state.
+	cp := *shared
+	if shared.Flights != nil {
+		cp.Flights = make([]models.FlightResult, len(shared.Flights))
+		for i, flight := range shared.Flights {
+			flightCopy := flight
+			if flight.Warnings != nil {
+				flightCopy.Warnings = append([]string(nil), flight.Warnings...)
+			}
+			if flight.Legs != nil {
+				flightCopy.Legs = append([]models.FlightLeg(nil), flight.Legs...)
+			}
+			if flight.CarryOnIncluded != nil {
+				carryOn := *flight.CarryOnIncluded
+				flightCopy.CarryOnIncluded = &carryOn
+			}
+			if flight.CheckedBagsIncluded != nil {
+				checkedBags := *flight.CheckedBagsIncluded
+				flightCopy.CheckedBagsIncluded = &checkedBags
+			}
+			cp.Flights[i] = flightCopy
+		}
+	}
+	return &cp
+}
+
+func sharedFlightResult(v any, err error) (*models.FlightSearchResult, error) {
+	if err != nil {
+		if r, ok := v.(*models.FlightSearchResult); ok {
+			return cloneFlightSearchResult(r), err
+		}
+		return &models.FlightSearchResult{Error: err.Error()}, err
+	}
+	return cloneFlightSearchResult(v.(*models.FlightSearchResult)), nil
 }
 
 func searchGoogleFlightsWithClient(ctx context.Context, client *batchexec.Client, origin, destination, date string, opts SearchOptions) (*models.FlightSearchResult, error) {

--- a/internal/flights/singleflight_regression_test.go
+++ b/internal/flights/singleflight_regression_test.go
@@ -1,0 +1,245 @@
+package flights
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func TestSearchFlightsWithClient_ConcurrentCallersGetPrivateResults(t *testing.T) {
+	body := makeFlightResponseBody(t)
+
+	var requestCount atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer ts.Close()
+
+	client := batchexec.NewTestClient(ts.URL)
+
+	const n = 2
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make([]*models.FlightSearchResult, n)
+	errs := make([]error, n)
+
+	for i := range n {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx], errs[idx] = SearchFlightsWithClient(t.Context(), client, "HEL", "NRT", "2026-06-15", SearchOptions{})
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("caller %d search error: %v", i, err)
+		}
+	}
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("requestCount = %d, want 1 shared upstream request", got)
+	}
+	if results[0] == results[1] {
+		t.Fatal("concurrent callers received the same FlightSearchResult pointer")
+	}
+	if len(results[0].Flights) == 0 || len(results[1].Flights) == 0 {
+		t.Fatal("expected both callers to receive flights")
+	}
+	if &results[0].Flights[0] == &results[1].Flights[0] {
+		t.Fatal("concurrent callers reused the same FlightResult backing storage")
+	}
+
+	otherCount := results[1].Count
+	otherPrice := results[1].Flights[0].Price
+	otherFlightsLen := len(results[1].Flights)
+
+	results[0].Count = 0
+	results[0].Flights[0].Price = otherPrice + 99
+	results[0].Flights = results[0].Flights[:0]
+
+	if results[1].Count != otherCount {
+		t.Fatalf("caller 1 Count changed to %d, want %d", results[1].Count, otherCount)
+	}
+	if len(results[1].Flights) != otherFlightsLen {
+		t.Fatalf("caller 1 len(Flights) changed to %d, want %d", len(results[1].Flights), otherFlightsLen)
+	}
+	if results[1].Flights[0].Price != otherPrice {
+		t.Fatalf("caller 1 flight price changed to %v, want %v", results[1].Flights[0].Price, otherPrice)
+	}
+}
+
+func TestSearchFlightsWithClient_ConcurrentEquivalentFilterSetsShareUpstreamRequest(t *testing.T) {
+	body := makeFlightResponseBody(t)
+
+	var requestCount atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer ts.Close()
+
+	client := batchexec.NewTestClient(ts.URL)
+	optsA := SearchOptions{
+		Airlines:    []string{"AY", "JL"},
+		Alliances:   []string{"ONEWORLD", "STAR_ALLIANCE"},
+		MaxPrice:    1500,
+		MaxDuration: 900,
+	}
+	optsB := SearchOptions{
+		Airlines:    []string{"JL", "AY"},
+		Alliances:   []string{"STAR_ALLIANCE", "ONEWORLD"},
+		MaxPrice:    1500,
+		MaxDuration: 900,
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make([]error, 2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, errs[0] = SearchFlightsWithClient(t.Context(), client, "HEL", "NRT", "2026-06-15", optsA)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		_, errs[1] = SearchFlightsWithClient(t.Context(), client, "HEL", "NRT", "2026-06-15", optsB)
+	}()
+
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("caller %d search error: %v", i, err)
+		}
+	}
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("requestCount = %d, want 1 shared upstream request for equivalent filters", got)
+	}
+	if gotA, gotB := flightSearchKey("HEL", "NRT", "2026-06-15", optsA), flightSearchKey("HEL", "NRT", "2026-06-15", optsB); gotA != gotB {
+		t.Fatalf("flightSearchKey mismatch for equivalent filters: %q != %q", gotA, gotB)
+	}
+}
+
+func TestSharedFlightResult_ClonesPartialErrorResult(t *testing.T) {
+	carryOn := true
+	checkedBags := 1
+	shared := &models.FlightSearchResult{
+		Success:  false,
+		Count:    1,
+		TripType: "one_way",
+		Flights: []models.FlightResult{
+			{
+				Price:               123,
+				Warnings:            []string{"Self-connect risk"},
+				Legs:                []models.FlightLeg{{AirlineCode: "AY"}},
+				CarryOnIncluded:     &carryOn,
+				CheckedBagsIncluded: &checkedBags,
+			},
+		},
+		Error: "provider partial failure",
+	}
+
+	wantErr := errors.New("provider partial failure")
+	got, err := sharedFlightResult(shared, wantErr)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if got == shared {
+		t.Fatal("sharedFlightResult returned the original pointer")
+	}
+	if &got.Flights[0] == &shared.Flights[0] {
+		t.Fatal("sharedFlightResult reused the shared Flights backing array")
+	}
+	if got.Flights[0].CarryOnIncluded == shared.Flights[0].CarryOnIncluded {
+		t.Fatal("sharedFlightResult reused the shared CarryOnIncluded pointer")
+	}
+	if got.Flights[0].CheckedBagsIncluded == shared.Flights[0].CheckedBagsIncluded {
+		t.Fatal("sharedFlightResult reused the shared CheckedBagsIncluded pointer")
+	}
+
+	got.Flights[0].Warnings[0] = "changed"
+	got.Flights[0].Legs[0].AirlineCode = "JL"
+	*got.Flights[0].CarryOnIncluded = false
+	*got.Flights[0].CheckedBagsIncluded = 2
+
+	if shared.Flights[0].Warnings[0] != "Self-connect risk" {
+		t.Fatalf("shared warning = %q, want %q", shared.Flights[0].Warnings[0], "Self-connect risk")
+	}
+	if shared.Flights[0].Legs[0].AirlineCode != "AY" {
+		t.Fatalf("shared airline = %q, want %q", shared.Flights[0].Legs[0].AirlineCode, "AY")
+	}
+	if got := *shared.Flights[0].CarryOnIncluded; !got {
+		t.Fatalf("shared CarryOnIncluded = %v, want true", got)
+	}
+	if got := *shared.Flights[0].CheckedBagsIncluded; got != 1 {
+		t.Fatalf("shared CheckedBagsIncluded = %d, want 1", got)
+	}
+}
+
+func TestDoFlightSearchSingleflight_ShortCallerDeadlineDoesNotPoisonSharedWork(t *testing.T) {
+	key := "flight|HEL|NRT|2026-09-01|shared-timeout"
+
+	var callCount atomic.Int64
+	firstCtx, firstCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer firstCancel()
+	firstDeadline, ok := firstCtx.Deadline()
+	if !ok {
+		t.Fatal("first caller context unexpectedly has no deadline")
+	}
+
+	sharedDeadlineCh := make(chan time.Time, 1)
+	_, firstErr := doFlightSearchSingleflight(firstCtx, key, func(sharedCtx context.Context) (*models.FlightSearchResult, error) {
+		callCount.Add(1)
+		sharedDeadline, ok := sharedCtx.Deadline()
+		if !ok {
+			t.Fatal("shared context unexpectedly has no deadline")
+		}
+		sharedDeadlineCh <- sharedDeadline
+		<-sharedCtx.Done()
+		return nil, sharedCtx.Err()
+	})
+
+	if !errors.Is(firstErr, context.DeadlineExceeded) {
+		t.Fatalf("firstErr = %v, want context deadline exceeded", firstErr)
+	}
+	sharedDeadline := <-sharedDeadlineCh
+	if !sharedDeadline.After(firstDeadline.Add(100 * time.Millisecond)) {
+		t.Fatalf("shared deadline %v unexpectedly inherited short caller deadline %v", sharedDeadline, firstDeadline)
+	}
+	secondCtx, secondCancel := context.WithTimeout(context.Background(), time.Second)
+	defer secondCancel()
+	secondResult, secondErr := doFlightSearchSingleflight(secondCtx, key, func(sharedCtx context.Context) (*models.FlightSearchResult, error) {
+		callCount.Add(1)
+		return &models.FlightSearchResult{Success: true, Count: 1}, nil
+	})
+	if secondErr != nil {
+		t.Fatalf("secondErr = %v, want nil", secondErr)
+	}
+	if secondResult == nil || !secondResult.Success || secondResult.Count != 1 {
+		t.Fatalf("secondResult = %#v, want successful result from a fresh execution", secondResult)
+	}
+	if got := callCount.Load(); got != 2 {
+		t.Fatalf("callCount = %d, want 2 executions after the timed-out winner stops", got)
+	}
+}

--- a/internal/flights/singleflight_test.go
+++ b/internal/flights/singleflight_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
 // TestFlightSingleflight verifies that concurrent calls with the same key
@@ -105,5 +107,73 @@ func TestSearchFlightsWithClient_Singleflight(t *testing.T) {
 		if err == nil {
 			t.Errorf("goroutine %d: expected error for missing origin, got nil", i)
 		}
+	}
+}
+
+func TestCloneFlightSearchResult_ReturnsCallerPrivateCopy(t *testing.T) {
+	carryOn := true
+	checkedBags := 1
+	shared := &models.FlightSearchResult{
+		Success:  true,
+		Count:    2,
+		TripType: "one_way",
+		Flights: []models.FlightResult{
+			{
+				Price:               123,
+				Warnings:            []string{"Self-connect risk"},
+				Legs:                []models.FlightLeg{{AirlineCode: "AY"}},
+				CarryOnIncluded:     &carryOn,
+				CheckedBagsIncluded: &checkedBags,
+			},
+			{Price: 456},
+		},
+	}
+
+	clone := cloneFlightSearchResult(shared)
+	if clone == shared {
+		t.Fatal("cloneFlightSearchResult returned the original pointer")
+	}
+	if len(clone.Flights) != len(shared.Flights) {
+		t.Fatalf("len(clone.Flights) = %d, want %d", len(clone.Flights), len(shared.Flights))
+	}
+	if len(clone.Flights) > 0 && &clone.Flights[0] == &shared.Flights[0] {
+		t.Fatal("cloneFlightSearchResult reused the shared Flights backing array")
+	}
+	if len(clone.Flights[0].Warnings) > 0 && &clone.Flights[0].Warnings[0] == &shared.Flights[0].Warnings[0] {
+		t.Fatal("cloneFlightSearchResult reused the shared Warnings backing array")
+	}
+	if len(clone.Flights[0].Legs) > 0 && &clone.Flights[0].Legs[0] == &shared.Flights[0].Legs[0] {
+		t.Fatal("cloneFlightSearchResult reused the shared Legs backing array")
+	}
+	if clone.Flights[0].CarryOnIncluded == shared.Flights[0].CarryOnIncluded {
+		t.Fatal("cloneFlightSearchResult reused the shared CarryOnIncluded pointer")
+	}
+	if clone.Flights[0].CheckedBagsIncluded == shared.Flights[0].CheckedBagsIncluded {
+		t.Fatal("cloneFlightSearchResult reused the shared CheckedBagsIncluded pointer")
+	}
+
+	clone.Count = 1
+	clone.Flights[0].Warnings[0] = "changed"
+	clone.Flights[0].Legs[0].AirlineCode = "JL"
+	*clone.Flights[0].CarryOnIncluded = false
+	*clone.Flights[0].CheckedBagsIncluded = 2
+	clone.Flights = clone.Flights[:1]
+	if shared.Count != 2 {
+		t.Fatalf("shared.Count = %d, want 2", shared.Count)
+	}
+	if len(shared.Flights) != 2 {
+		t.Fatalf("len(shared.Flights) = %d, want 2", len(shared.Flights))
+	}
+	if got := shared.Flights[0].Warnings[0]; got != "Self-connect risk" {
+		t.Fatalf("shared warning = %q, want %q", got, "Self-connect risk")
+	}
+	if got := shared.Flights[0].Legs[0].AirlineCode; got != "AY" {
+		t.Fatalf("shared leg airline = %q, want %q", got, "AY")
+	}
+	if got := *shared.Flights[0].CarryOnIncluded; !got {
+		t.Fatalf("shared CarryOnIncluded = %v, want true", got)
+	}
+	if got := *shared.Flights[0].CheckedBagsIncluded; got != 1 {
+		t.Fatalf("shared CheckedBagsIncluded = %d, want 1", got)
 	}
 }

--- a/internal/ground/search.go
+++ b/internal/ground/search.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/MikkoParkkola/trvl/internal/cache"
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/searchctx"
 	"golang.org/x/sync/singleflight"
 	"golang.org/x/time/rate"
 )
@@ -30,6 +31,8 @@ var groundCache = cache.New()
 
 // groundCacheTTL is the TTL for cached ground transport results.
 const groundCacheTTL = 10 * time.Minute
+
+const sharedGroundSearchTimeout = 30 * time.Second
 
 // httpClient is a shared HTTP client with sensible timeouts for FlixBus/RegioJet.
 var httpClient = &http.Client{
@@ -111,13 +114,78 @@ func SearchByName(ctx context.Context, from, to, date string, opts SearchOptions
 	// Deduplicate concurrent identical in-flight searches. The cache check above
 	// already handles TTL-based reuse; singleflight only coalesces truly concurrent
 	// requests that both missed the cache.
-	v, err, _ := groundGroup.Do(cacheKey, func() (any, error) {
-		return searchByNameCore(ctx, from, to, date, opts, cacheKey, allowBrowserFallbacks)
+	return doGroundSearchSingleflight(ctx, cacheKey, func(sharedCtx context.Context) (*models.GroundSearchResult, error) {
+		return searchByNameCore(sharedCtx, from, to, date, opts, cacheKey, allowBrowserFallbacks)
 	})
-	if err != nil {
+}
+
+func doGroundSearchSingleflight(ctx context.Context, key string, fn func(context.Context) (*models.GroundSearchResult, error)) (*models.GroundSearchResult, error) {
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	return v.(*models.GroundSearchResult), nil
+
+	ch := groundGroup.DoChan(key, func() (any, error) {
+		sharedCtx, cancel := searchctx.DetachedWithin(ctx, sharedGroundSearchTimeout)
+		defer cancel()
+		return fn(sharedCtx)
+	})
+
+	select {
+	case <-ctx.Done():
+		// Forget timed-out work eagerly so the next caller can launch a fresh
+		// execution instead of inheriting the prior caller's deadline-bound run.
+		groundGroup.Forget(key)
+		return nil, ctx.Err()
+	case res := <-ch:
+		return sharedGroundResult(res.Val, res.Err)
+	}
+}
+
+func sharedGroundResult(v any, err error) (*models.GroundSearchResult, error) {
+	if err != nil {
+		if r, ok := v.(*models.GroundSearchResult); ok {
+			return cloneGroundSearchResult(r), err
+		}
+		return nil, err
+	}
+	return cloneGroundSearchResult(v.(*models.GroundSearchResult)), nil
+}
+
+func cloneGroundSearchResult(shared *models.GroundSearchResult) *models.GroundSearchResult {
+	if shared == nil {
+		return nil
+	}
+
+	// singleflight.Do shares the winner's *GroundSearchResult pointer across
+	// concurrent callers. MCP handlers can post-filter Routes and rewrite Count,
+	// so each caller needs a private copy of the result header and nested mutable
+	// slices/pointers to avoid racing on shared state.
+	cp := *shared
+	if shared.Routes != nil {
+		cp.Routes = make([]models.GroundRoute, len(shared.Routes))
+		for i, route := range shared.Routes {
+			routeCopy := route
+			if route.Amenities != nil {
+				routeCopy.Amenities = append([]string(nil), route.Amenities...)
+			}
+			if route.Legs != nil {
+				routeCopy.Legs = make([]models.GroundLeg, len(route.Legs))
+				for j, leg := range route.Legs {
+					legCopy := leg
+					if leg.Amenities != nil {
+						legCopy.Amenities = append([]string(nil), leg.Amenities...)
+					}
+					routeCopy.Legs[j] = legCopy
+				}
+			}
+			if route.SeatsLeft != nil {
+				seatsLeft := *route.SeatsLeft
+				routeCopy.SeatsLeft = &seatsLeft
+			}
+			cp.Routes[i] = routeCopy
+		}
+	}
+	return &cp
 }
 
 // searchByNameCore performs the actual ground search without singleflight wrapping.

--- a/internal/ground/singleflight_test.go
+++ b/internal/ground/singleflight_test.go
@@ -1,9 +1,14 @@
 package ground
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
 // TestGroundSingleflight verifies that concurrent calls with the same key
@@ -98,4 +103,268 @@ func TestSearchByNameSingleflight_NoCache(t *testing.T) {
 	// We just verify it doesn't panic/deadlock; result doesn't matter.
 	result, _ := SearchByName(t.Context(), "TestCityXYZ99", "TestCityABC88", "2026-06-15", opts)
 	_ = result
+}
+
+func TestGroundSingleflight_ConcurrentCallersGetPrivateResults(t *testing.T) {
+	seatsLeft := 3
+	shared := &models.GroundSearchResult{
+		Success: true,
+		Count:   1,
+		Routes: []models.GroundRoute{
+			{
+				Provider:  "flixbus",
+				Price:     49,
+				Amenities: []string{"wifi", "toilet"},
+				Legs: []models.GroundLeg{
+					{
+						Provider:  "flixbus",
+						Amenities: []string{"power"},
+					},
+				},
+				SeatsLeft: &seatsLeft,
+			},
+		},
+	}
+
+	const n = 2
+	key := "ground|Amsterdam|Paris|2026-06-15|EUR|flixbus|0.00||false"
+
+	var callCount atomic.Int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make([]*models.GroundSearchResult, n)
+	errs := make([]error, n)
+
+	for i := range n {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			v, err, _ := groundGroup.Do(key, func() (any, error) {
+				callCount.Add(1)
+				time.Sleep(50 * time.Millisecond)
+				return shared, nil
+			})
+			if err == nil {
+				results[idx] = cloneGroundSearchResult(v.(*models.GroundSearchResult))
+			}
+			errs[idx] = err
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("caller %d singleflight error: %v", i, err)
+		}
+	}
+	if got := callCount.Load(); got != 1 {
+		t.Fatalf("callCount = %d, want 1 shared singleflight execution", got)
+	}
+	if results[0] == results[1] {
+		t.Fatal("concurrent callers received the same GroundSearchResult pointer")
+	}
+	if len(results[0].Routes) == 0 || len(results[1].Routes) == 0 {
+		t.Fatal("expected both callers to receive routes")
+	}
+	if &results[0].Routes[0] == &results[1].Routes[0] {
+		t.Fatal("concurrent callers reused the same GroundRoute backing storage")
+	}
+
+	otherCount := results[1].Count
+	otherPrice := results[1].Routes[0].Price
+	otherSeatsLeft := *results[1].Routes[0].SeatsLeft
+	otherRoutesLen := len(results[1].Routes)
+
+	results[0].Count = 0
+	results[0].Routes[0].Price = otherPrice + 10
+	results[0].Routes[0].Amenities[0] = "changed"
+	results[0].Routes[0].Legs[0].Amenities[0] = "usb"
+	*results[0].Routes[0].SeatsLeft = 1
+	results[0].Routes = results[0].Routes[:0]
+
+	if results[1].Count != otherCount {
+		t.Fatalf("caller 1 Count changed to %d, want %d", results[1].Count, otherCount)
+	}
+	if len(results[1].Routes) != otherRoutesLen {
+		t.Fatalf("caller 1 len(Routes) changed to %d, want %d", len(results[1].Routes), otherRoutesLen)
+	}
+	if results[1].Routes[0].Price != otherPrice {
+		t.Fatalf("caller 1 route price changed to %v, want %v", results[1].Routes[0].Price, otherPrice)
+	}
+	if got := results[1].Routes[0].Amenities[0]; got != "wifi" {
+		t.Fatalf("caller 1 route amenity changed to %q, want %q", got, "wifi")
+	}
+	if got := results[1].Routes[0].Legs[0].Amenities[0]; got != "power" {
+		t.Fatalf("caller 1 leg amenity changed to %q, want %q", got, "power")
+	}
+	if got := *results[1].Routes[0].SeatsLeft; got != otherSeatsLeft {
+		t.Fatalf("caller 1 SeatsLeft changed to %d, want %d", got, otherSeatsLeft)
+	}
+}
+
+func TestCloneGroundSearchResult_ReturnsCallerPrivateCopy(t *testing.T) {
+	seatsLeft := 3
+	shared := &models.GroundSearchResult{
+		Success: true,
+		Count:   1,
+		Routes: []models.GroundRoute{
+			{
+				Provider:  "flixbus",
+				Price:     49,
+				Amenities: []string{"wifi", "toilet"},
+				Legs: []models.GroundLeg{
+					{
+						Provider:  "flixbus",
+						Amenities: []string{"power"},
+					},
+				},
+				SeatsLeft: &seatsLeft,
+			},
+		},
+	}
+
+	clone := cloneGroundSearchResult(shared)
+	if clone == shared {
+		t.Fatal("cloneGroundSearchResult returned the original pointer")
+	}
+	if len(clone.Routes) != len(shared.Routes) {
+		t.Fatalf("len(clone.Routes) = %d, want %d", len(clone.Routes), len(shared.Routes))
+	}
+	if &clone.Routes[0] == &shared.Routes[0] {
+		t.Fatal("cloneGroundSearchResult reused the shared Routes backing array")
+	}
+	if &clone.Routes[0].Amenities[0] == &shared.Routes[0].Amenities[0] {
+		t.Fatal("cloneGroundSearchResult reused the shared Amenities backing array")
+	}
+	if &clone.Routes[0].Legs[0] == &shared.Routes[0].Legs[0] {
+		t.Fatal("cloneGroundSearchResult reused the shared Legs backing array")
+	}
+	if &clone.Routes[0].Legs[0].Amenities[0] == &shared.Routes[0].Legs[0].Amenities[0] {
+		t.Fatal("cloneGroundSearchResult reused the shared leg Amenities backing array")
+	}
+	if clone.Routes[0].SeatsLeft == shared.Routes[0].SeatsLeft {
+		t.Fatal("cloneGroundSearchResult reused the shared SeatsLeft pointer")
+	}
+
+	clone.Count = 0
+	clone.Routes[0].Amenities[0] = "changed"
+	clone.Routes[0].Legs[0].Amenities[0] = "usb"
+	*clone.Routes[0].SeatsLeft = 1
+	clone.Routes = clone.Routes[:0]
+	if shared.Count != 1 {
+		t.Fatalf("shared.Count = %d, want 1", shared.Count)
+	}
+	if len(shared.Routes) != 1 {
+		t.Fatalf("len(shared.Routes) = %d, want 1", len(shared.Routes))
+	}
+	if got := shared.Routes[0].Amenities[0]; got != "wifi" {
+		t.Fatalf("shared route amenity = %q, want %q", got, "wifi")
+	}
+	if got := shared.Routes[0].Legs[0].Amenities[0]; got != "power" {
+		t.Fatalf("shared leg amenity = %q, want %q", got, "power")
+	}
+	if got := *shared.Routes[0].SeatsLeft; got != 3 {
+		t.Fatalf("shared SeatsLeft = %d, want 3", got)
+	}
+}
+
+func TestSharedGroundResult_ClonesPartialErrorResult(t *testing.T) {
+	seatsLeft := 3
+	shared := &models.GroundSearchResult{
+		Success: false,
+		Count:   1,
+		Routes: []models.GroundRoute{
+			{
+				Provider:  "flixbus",
+				Price:     49,
+				Amenities: []string{"wifi"},
+				Legs: []models.GroundLeg{
+					{
+						Provider:  "flixbus",
+						Amenities: []string{"power"},
+					},
+				},
+				SeatsLeft: &seatsLeft,
+			},
+		},
+	}
+
+	wantErr := errors.New("provider partial failure")
+	got, err := sharedGroundResult(shared, wantErr)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if got == shared {
+		t.Fatal("sharedGroundResult returned the original pointer")
+	}
+	if &got.Routes[0] == &shared.Routes[0] {
+		t.Fatal("sharedGroundResult reused the shared Routes backing array")
+	}
+	if got.Routes[0].SeatsLeft == shared.Routes[0].SeatsLeft {
+		t.Fatal("sharedGroundResult reused the shared SeatsLeft pointer")
+	}
+
+	got.Routes[0].Amenities[0] = "changed"
+	got.Routes[0].Legs[0].Amenities[0] = "usb"
+	*got.Routes[0].SeatsLeft = 1
+
+	if shared.Routes[0].Amenities[0] != "wifi" {
+		t.Fatalf("shared amenity = %q, want %q", shared.Routes[0].Amenities[0], "wifi")
+	}
+	if shared.Routes[0].Legs[0].Amenities[0] != "power" {
+		t.Fatalf("shared leg amenity = %q, want %q", shared.Routes[0].Legs[0].Amenities[0], "power")
+	}
+	if got := *shared.Routes[0].SeatsLeft; got != 3 {
+		t.Fatalf("shared SeatsLeft = %d, want 3", got)
+	}
+}
+
+func TestDoGroundSearchSingleflight_ShortCallerDeadlineDoesNotPoisonSharedWork(t *testing.T) {
+	key := "ground|Amsterdam|Paris|2026-09-01|shared-timeout"
+
+	var callCount atomic.Int64
+	firstCtx, firstCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer firstCancel()
+	firstDeadline, ok := firstCtx.Deadline()
+	if !ok {
+		t.Fatal("first caller context unexpectedly has no deadline")
+	}
+
+	sharedDeadlineCh := make(chan time.Time, 1)
+	_, firstErr := doGroundSearchSingleflight(firstCtx, key, func(sharedCtx context.Context) (*models.GroundSearchResult, error) {
+		callCount.Add(1)
+		sharedDeadline, ok := sharedCtx.Deadline()
+		if !ok {
+			t.Fatal("shared context unexpectedly has no deadline")
+		}
+		sharedDeadlineCh <- sharedDeadline
+		<-sharedCtx.Done()
+		return nil, sharedCtx.Err()
+	})
+
+	if !errors.Is(firstErr, context.DeadlineExceeded) {
+		t.Fatalf("firstErr = %v, want context deadline exceeded", firstErr)
+	}
+	sharedDeadline := <-sharedDeadlineCh
+	if !sharedDeadline.After(firstDeadline.Add(100 * time.Millisecond)) {
+		t.Fatalf("shared deadline %v unexpectedly inherited short caller deadline %v", sharedDeadline, firstDeadline)
+	}
+	secondCtx, secondCancel := context.WithTimeout(context.Background(), time.Second)
+	defer secondCancel()
+	secondResult, secondErr := doGroundSearchSingleflight(secondCtx, key, func(sharedCtx context.Context) (*models.GroundSearchResult, error) {
+		callCount.Add(1)
+		return &models.GroundSearchResult{Success: true, Count: 1}, nil
+	})
+	if secondErr != nil {
+		t.Fatalf("secondErr = %v, want nil", secondErr)
+	}
+	if secondResult == nil || !secondResult.Success || secondResult.Count != 1 {
+		t.Fatalf("secondResult = %#v, want successful result from a fresh execution", secondResult)
+	}
+	if got := callCount.Load(); got != 2 {
+		t.Fatalf("callCount = %d, want 2 executions after the timed-out winner stops", got)
+	}
 }

--- a/internal/hacks/hidden_city_integration_test.go
+++ b/internal/hacks/hidden_city_integration_test.go
@@ -1,0 +1,101 @@
+package hacks_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/hacks"
+)
+
+// TestHiddenCityFixture_AMS_HEL_RIX tests the canonical AMS→HEL→RIX route where
+// the user disembarks at HEL (home airport) on an AMS→RIX ticket via Finnair,
+// saving ~30% vs a direct AMS→HEL booking.
+func TestHiddenCityFixture_AMS_HEL_RIX(t *testing.T) {
+	// Fixture: AY sells AMS→HEL→RIX for €89.50; direct AMS→HEL costs €129.
+	offers := []hacks.HiddenCityOffer{
+		{
+			Origin:          "AMS",
+			Hub:             "HEL",
+			HubBeyond:       "RIX",
+			Carrier:         "AY",
+			Price:           89.50,
+			Currency:        "EUR",
+			CarryOnOnly:     true, // boarding pass issued to HEL only
+			SeparateTickets: false,
+			LayoverMinutes:  90, // comfortable HEL layover
+		},
+	}
+	candidates := hacks.ExpandMatrix(offers, hacks.MatrixOptions{
+		AllowHiddenCity: true,
+		DirectBaseline:  129.0,
+		DepartDate:      "2026-05-15",
+	})
+
+	if len(candidates) == 0 {
+		t.Fatal("expected at least one hidden-city candidate for AMS→HEL→RIX")
+	}
+	c := candidates[0]
+	if c.Origin != "AMS" {
+		t.Errorf("origin: want AMS, got %s", c.Origin)
+	}
+	if c.Hub != "HEL" {
+		t.Errorf("hub: want HEL, got %s", c.Hub)
+	}
+	if c.HubBeyond != "RIX" {
+		t.Errorf("hub_beyond: want RIX, got %s", c.HubBeyond)
+	}
+	if c.Price != 89.50 {
+		t.Errorf("price: want 89.50, got %.2f", c.Price)
+	}
+	if c.SavingsEUR <= 0 {
+		t.Errorf("savings_eur: want >0, got %.2f", c.SavingsEUR)
+	}
+	if c.SavingsPct <= 0 {
+		t.Errorf("savings_pct: want >0, got %.2f", c.SavingsPct)
+	}
+	if c.BookingURL == "" {
+		t.Error("booking_url: want non-empty")
+	}
+	// AY should produce a Finnair booking URL
+	if !strings.Contains(c.BookingURL, "finnair.com") {
+		t.Errorf("booking_url: want finnair.com URL, got %s", c.BookingURL)
+	}
+}
+
+// TestHiddenCityFixture_AMS_FRA_Stop tests AMS→FRA routing where FRA is the
+// desired destination but LH sells it cheaper as AMS→FRA→MUC.
+func TestHiddenCityFixture_AMS_FRA_Stop(t *testing.T) {
+	offers := []hacks.HiddenCityOffer{
+		{
+			Origin:          "AMS",
+			Hub:             "FRA",
+			HubBeyond:       "MUC",
+			Carrier:         "LH",
+			Price:           65.00,
+			Currency:        "EUR",
+			CarryOnOnly:     true,
+			SeparateTickets: false,
+			LayoverMinutes:  75,
+		},
+	}
+	candidates := hacks.ExpandMatrix(offers, hacks.MatrixOptions{
+		AllowHiddenCity: true,
+		DirectBaseline:  95.0,
+		DepartDate:      "2026-06-01",
+	})
+
+	if len(candidates) == 0 {
+		t.Fatal("expected at least one hidden-city candidate for AMS→FRA→MUC")
+	}
+	c := candidates[0]
+	if c.Hub != "FRA" {
+		t.Errorf("hub: want FRA, got %s", c.Hub)
+	}
+	if c.HubBeyond != "MUC" {
+		t.Errorf("hub_beyond: want MUC, got %s", c.HubBeyond)
+	}
+	// LH group should produce a Lufthansa booking URL
+	if !strings.Contains(c.BookingURL, "lufthansa.com") {
+		t.Errorf("booking_url: want lufthansa.com URL, got %s", c.BookingURL)
+	}
+}

--- a/internal/hacks/hidden_city_matrix.go
+++ b/internal/hacks/hidden_city_matrix.go
@@ -1,0 +1,271 @@
+package hacks
+
+// MIK-3078: hidden-city *matrix* search — generalises the existing
+// detector (which scans only one origin+destination pair) into a full
+// {origin in nearby_airports} × {hub_extension} grid so the optimizer
+// can surface the cheapest hidden-city itinerary even when the user's
+// home airport is not the cheapest origin.
+//
+// This file ships the pure expander + ranker only: it consumes priced
+// HiddenCityOffer fixtures and returns ranked alternatives with cost,
+// carrier, layover risk score, and a pre-filled booking URL. Live
+// flight pricing + the MCP/CLI surface compose on top of this in a
+// follow-up change so the math stays trivially testable.
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// HiddenCityOffer is one priced candidate in the matrix. Origin is the
+// airport the user actually boards from (must be in their nearby
+// allowlist). HubBeyond is the carrier destination listed on the
+// ticket — the user disembarks at the intermediate Hub and skips the
+// final leg, so HubBeyond must differ from Hub.
+type HiddenCityOffer struct {
+	Origin    string
+	Hub       string
+	HubBeyond string
+	Carrier   string
+	Price     float64
+	Currency  string
+	// CarryOnOnly is true when the offer guarantees no checked-baggage
+	// transfer (boarding pass issued only to Hub). Hidden-city is
+	// unsafe with checked bags because the airline routes them all the
+	// way to HubBeyond.
+	CarryOnOnly bool
+	// SeparateTickets is true when the itinerary spans two PNRs — the
+	// risk of a missed connection on the throwaway leg falls on the
+	// user, and EU261 protections do not apply across the break.
+	SeparateTickets bool
+	// LayoverMinutes is the scheduled layover at Hub. Below 60 the
+	// user has too little buffer for the disembark; above 240 the
+	// layover itself becomes painful even when the disembark is safe.
+	LayoverMinutes int
+}
+
+// HiddenCityCandidate is one ranked output of the matrix search.
+type HiddenCityCandidate struct {
+	Origin     string
+	Hub        string
+	HubBeyond  string
+	Carrier    string
+	Price      float64
+	Currency   string
+	SavingsEUR float64
+	SavingsPct float64
+	// LayoverRisk is a 0..100 score where 0 means comfortable and 100
+	// means unsafe. Composite of layover length, carry-on enforcement,
+	// ticket-separation. Below 25 = green; 25-50 = caution; 50+ =
+	// decline unless risk_posture.hidden_city.acceptable is set.
+	LayoverRisk int
+	Reason      string
+	BookingURL  string
+}
+
+// MatrixOptions tune the expander. Zero-value is a sensible baseline:
+// permissive risk gate, no preference toggle, returns up to 3
+// candidates per the AC.
+type MatrixOptions struct {
+	// AllowHiddenCity gates the entire response. Mirror the user's
+	// preferences.RiskPosture.HiddenCity.Acceptable flag here so the
+	// caller can short-circuit cheaply. When false, ExpandMatrix
+	// returns nil regardless of other inputs.
+	AllowHiddenCity bool
+	// MaxLayoverRisk drops candidates whose composite risk score
+	// exceeds the threshold. Defaults to 60 when zero — leaves the
+	// "decline unless explicit" caution band visible.
+	MaxLayoverRisk int
+	// TopK clips the result. Defaults to 3 when zero (matches the AC).
+	TopK int
+	// DirectBaseline is the cheapest direct Origin->Hub price the
+	// caller observed; used to compute SavingsEUR/SavingsPct. Zero
+	// means no baseline available, in which case the candidate keeps
+	// SavingsEUR at zero rather than reporting an invented figure.
+	DirectBaseline float64
+	// DepartDate is propagated into BookingURL templates (ISO 8601).
+	DepartDate string
+}
+
+// ExpandMatrix takes a slice of priced offers (caller fans out the
+// origin × hub-beyond grid via flights.SearchFlights and fixtures)
+// and returns the top K candidates after risk-gating, sort, and
+// savings recompute. Pure function — no I/O.
+func ExpandMatrix(offers []HiddenCityOffer, opt MatrixOptions) []HiddenCityCandidate {
+	if !opt.AllowHiddenCity {
+		return nil
+	}
+	if len(offers) == 0 {
+		return nil
+	}
+	if opt.MaxLayoverRisk == 0 {
+		opt.MaxLayoverRisk = 60
+	}
+	if opt.TopK == 0 {
+		opt.TopK = 3
+	}
+	out := make([]HiddenCityCandidate, 0, len(offers))
+	for _, o := range offers {
+		if !validOffer(o) {
+			continue
+		}
+		risk := scoreLayoverRisk(o)
+		if risk > opt.MaxLayoverRisk {
+			continue
+		}
+		c := HiddenCityCandidate{
+			Origin:      strings.ToUpper(strings.TrimSpace(o.Origin)),
+			Hub:         strings.ToUpper(strings.TrimSpace(o.Hub)),
+			HubBeyond:   strings.ToUpper(strings.TrimSpace(o.HubBeyond)),
+			Carrier:     strings.ToUpper(strings.TrimSpace(o.Carrier)),
+			Price:       o.Price,
+			Currency:    o.Currency,
+			LayoverRisk: risk,
+			BookingURL:  bookingURLFor(o, opt.DepartDate),
+		}
+		c.Reason = describeRisk(o, risk, c.Carrier)
+		applySavings(&c, opt.DirectBaseline)
+		out = append(out, c)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		// Prefer cheaper, then lower risk on ties so the deterministic
+		// "best" candidate is the user's likely click.
+		if out[i].Price != out[j].Price {
+			return out[i].Price < out[j].Price
+		}
+		return out[i].LayoverRisk < out[j].LayoverRisk
+	})
+	if opt.TopK < len(out) {
+		out = out[:opt.TopK]
+	}
+	return out
+}
+
+func validOffer(o HiddenCityOffer) bool {
+	if o.Price <= 0 {
+		return false
+	}
+	if strings.TrimSpace(o.Origin) == "" {
+		return false
+	}
+	if strings.TrimSpace(o.Hub) == "" {
+		return false
+	}
+	if strings.TrimSpace(o.HubBeyond) == "" {
+		return false
+	}
+	if strings.EqualFold(o.Hub, o.HubBeyond) {
+		// Throwaway leg must exist; identical codes are a degenerate
+		// fixture that we silently drop rather than panic on.
+		return false
+	}
+	if strings.EqualFold(o.Origin, o.Hub) {
+		return false
+	}
+	return true
+}
+
+// scoreLayoverRisk composes three signals into one 0..100 score.
+// Layover length: <60min adds 60 (likely missed at boarding-pass
+// pickup); 60-90 adds 20; 90-180 adds 0; 180-240 adds 10; >240 adds
+// 25. Not carry-on-only adds 35 (checked bag will fly to HubBeyond,
+// defeating the whole hack). Separate tickets adds 20 (no protection
+// across the disembark; the user owns any missed-connection redirect).
+// Capped at 100 to keep the rendering layer simple.
+func scoreLayoverRisk(o HiddenCityOffer) int {
+	score := 0
+	switch {
+	case o.LayoverMinutes < 60:
+		score += 60
+	case o.LayoverMinutes <= 90:
+		score += 20
+	case o.LayoverMinutes <= 180:
+		// comfort zone; no penalty
+	case o.LayoverMinutes <= 240:
+		score += 10
+	default:
+		score += 25
+	}
+	if !o.CarryOnOnly {
+		score += 35
+	}
+	if o.SeparateTickets {
+		score += 20
+	}
+	if score > 100 {
+		score = 100
+	}
+	return score
+}
+
+func describeRisk(o HiddenCityOffer, risk int, carrier string) string {
+	switch {
+	case risk == 0:
+		return fmt.Sprintf("clean disembark at %s; carry-on enforced; %d-min layover", o.Hub, o.LayoverMinutes)
+	case risk < 25:
+		return fmt.Sprintf("low-risk hidden-city via %s on %s", o.Hub, carrier)
+	case risk < 50:
+		return fmt.Sprintf("caution: layover %d min, carry-on %v, separate-tickets %v", o.LayoverMinutes, o.CarryOnOnly, o.SeparateTickets)
+	default:
+		return fmt.Sprintf("high-risk: %d/100 — only proceed if explicitly opted-in", risk)
+	}
+}
+
+func applySavings(c *HiddenCityCandidate, baseline float64) {
+	if baseline <= 0 {
+		return
+	}
+	gap := baseline - c.Price
+	if gap < 0 {
+		gap = 0
+	}
+	c.SavingsEUR = gap
+	c.SavingsPct = (gap / baseline) * 100
+}
+
+// bookingURLFor produces a deep-link the user can click straight
+// through to a pre-filled booking page. Format is carrier-specific.
+// Carriers without a template fall back to a Google Flights search
+// URL, which is at least useful as a populated browse target.
+func bookingURLFor(o HiddenCityOffer, departDate string) string {
+	carrier := strings.ToUpper(strings.TrimSpace(o.Carrier))
+	switch carrier {
+	case "KL", "AF", "DL":
+		// AFKLM and Delta share the Offers UI shape.
+		v := url.Values{}
+		v.Set("origin", o.Origin)
+		v.Set("destination", o.HubBeyond)
+		v.Set("date", departDate)
+		v.Set("paxAdt", "1")
+		v.Set("cabinClass", "ECONOMY")
+		return "https://www.airfrance.com/booking/select?" + v.Encode()
+	case "AY":
+		v := url.Values{}
+		v.Set("from", o.Origin)
+		v.Set("to", o.HubBeyond)
+		v.Set("departure", departDate)
+		v.Set("adults", "1")
+		return "https://www.finnair.com/en-fi/book?" + v.Encode()
+	case "LH", "OS", "LX":
+		// Lufthansa group share a search URL pattern.
+		v := url.Values{}
+		v.Set("flightOrigin", o.Origin)
+		v.Set("flightDestination", o.HubBeyond)
+		v.Set("departureDate", departDate)
+		v.Set("paxAdt", "1")
+		return "https://www.lufthansa.com/de/en/flight-search?" + v.Encode()
+	default:
+		// Google Flights deep-link as a universal fallback. The
+		// fragment-style query is what the public site honours when
+		// the user follows the link.
+		v := url.Values{}
+		v.Set("hl", "en")
+		return fmt.Sprintf("https://www.google.com/travel/flights?%s#flt=%s.%s.%s",
+			v.Encode(), o.Origin, o.HubBeyond, departDate)
+	}
+}

--- a/internal/hacks/hidden_city_matrix_test.go
+++ b/internal/hacks/hidden_city_matrix_test.go
@@ -1,0 +1,174 @@
+package hacks
+
+// MIK-3078: tests for the hidden-city matrix expander.
+
+import (
+	"strings"
+	"testing"
+)
+
+func sampleOffers() []HiddenCityOffer {
+	return []HiddenCityOffer{
+		{Origin: "AMS", Hub: "HEL", HubBeyond: "RIX", Carrier: "AY", Price: 180, Currency: "EUR", CarryOnOnly: true, LayoverMinutes: 120},
+		{Origin: "BRU", Hub: "HEL", HubBeyond: "TLL", Carrier: "AY", Price: 220, Currency: "EUR", CarryOnOnly: true, LayoverMinutes: 90},
+		{Origin: "AMS", Hub: "FRA", HubBeyond: "VIE", Carrier: "LH", Price: 160, Currency: "EUR", CarryOnOnly: false, LayoverMinutes: 75},
+		{Origin: "AMS", Hub: "CDG", HubBeyond: "MRS", Carrier: "AF", Price: 195, Currency: "EUR", CarryOnOnly: true, LayoverMinutes: 50, SeparateTickets: true},
+	}
+}
+
+func TestExpandMatrix_AllowFalseReturnsNil(t *testing.T) {
+	got := ExpandMatrix(sampleOffers(), MatrixOptions{AllowHiddenCity: false})
+	if got != nil {
+		t.Errorf("AllowHiddenCity=false should yield nil, got %v", got)
+	}
+}
+
+func TestExpandMatrix_RanksByPriceAscending(t *testing.T) {
+	got := ExpandMatrix(sampleOffers(), MatrixOptions{
+		AllowHiddenCity: true, MaxLayoverRisk: 100, TopK: 4,
+	})
+	if len(got) < 2 {
+		t.Fatalf("got %d, want >= 2", len(got))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i-1].Price > got[i].Price {
+			t.Errorf("not sorted ascending: %v then %v", got[i-1].Price, got[i].Price)
+		}
+	}
+}
+
+func TestExpandMatrix_TopKDefaultsTo3(t *testing.T) {
+	got := ExpandMatrix(sampleOffers(), MatrixOptions{AllowHiddenCity: true, MaxLayoverRisk: 100})
+	if len(got) > 3 {
+		t.Errorf("expected default TopK=3, got %d", len(got))
+	}
+}
+
+func TestExpandMatrix_RiskGateDropsHighRiskOffers(t *testing.T) {
+	// All offers risk-gated to <=10 → only the AMS->HEL->RIX 120-min
+	// carry-on offer survives (risk = 0).
+	got := ExpandMatrix(sampleOffers(), MatrixOptions{
+		AllowHiddenCity: true, MaxLayoverRisk: 10, TopK: 4,
+	})
+	if len(got) != 1 {
+		t.Fatalf("got %d, want 1 surviving offer at MaxLayoverRisk=10", len(got))
+	}
+	if got[0].Hub != "HEL" {
+		t.Errorf("Hub = %q, want HEL", got[0].Hub)
+	}
+}
+
+func TestExpandMatrix_DegenerateOffersRejected(t *testing.T) {
+	got := ExpandMatrix([]HiddenCityOffer{
+		{Origin: "AMS", Hub: "HEL", HubBeyond: "HEL", Carrier: "AY", Price: 100, CarryOnOnly: true, LayoverMinutes: 120}, // Hub = HubBeyond
+		{Origin: "", Hub: "HEL", HubBeyond: "RIX", Carrier: "AY", Price: 100, CarryOnOnly: true, LayoverMinutes: 120},   // empty origin
+		{Origin: "AMS", Hub: "HEL", HubBeyond: "RIX", Carrier: "AY", Price: 0, CarryOnOnly: true, LayoverMinutes: 120},  // zero price
+		{Origin: "AMS", Hub: "AMS", HubBeyond: "RIX", Carrier: "AY", Price: 100, CarryOnOnly: true, LayoverMinutes: 120}, // origin = hub
+	}, MatrixOptions{AllowHiddenCity: true, MaxLayoverRisk: 100})
+	if got != nil {
+		t.Errorf("all-degenerate input should yield nil, got %v", got)
+	}
+}
+
+func TestExpandMatrix_SavingsAgainstBaseline(t *testing.T) {
+	got := ExpandMatrix(sampleOffers(), MatrixOptions{
+		AllowHiddenCity: true,
+		MaxLayoverRisk:  100,
+		TopK:            4,
+		DirectBaseline:  300,
+	})
+	for _, c := range got {
+		want := 300 - c.Price
+		if want < 0 {
+			want = 0
+		}
+		if c.SavingsEUR != want {
+			t.Errorf("Hub=%q SavingsEUR=%.2f, want %.2f", c.Hub, c.SavingsEUR, want)
+		}
+		if c.SavingsPct != (want/300)*100 {
+			t.Errorf("Hub=%q SavingsPct=%.2f, want %.2f", c.Hub, c.SavingsPct, (want/300)*100)
+		}
+	}
+}
+
+func TestExpandMatrix_NoBaselineLeavesSavingsZero(t *testing.T) {
+	got := ExpandMatrix(sampleOffers(), MatrixOptions{
+		AllowHiddenCity: true, MaxLayoverRisk: 100, TopK: 4,
+	})
+	for _, c := range got {
+		if c.SavingsEUR != 0 || c.SavingsPct != 0 {
+			t.Errorf("Hub=%q expected zero savings without baseline, got %.2f / %.2f%%", c.Hub, c.SavingsEUR, c.SavingsPct)
+		}
+	}
+}
+
+func TestExpandMatrix_BookingURLPerCarrier(t *testing.T) {
+	cases := []struct {
+		carrier  string
+		hostpart string
+	}{
+		{"KL", "airfrance.com"},
+		{"AF", "airfrance.com"},
+		{"DL", "airfrance.com"},
+		{"AY", "finnair.com"},
+		{"LH", "lufthansa.com"},
+		{"OS", "lufthansa.com"},
+		{"LX", "lufthansa.com"},
+		{"BA", "google.com/travel/flights"}, // fallback
+	}
+	for _, tc := range cases {
+		offer := HiddenCityOffer{
+			Origin: "AMS", Hub: "HEL", HubBeyond: "RIX",
+			Carrier: tc.carrier, Price: 100,
+			CarryOnOnly: true, LayoverMinutes: 120,
+		}
+		got := ExpandMatrix([]HiddenCityOffer{offer}, MatrixOptions{
+			AllowHiddenCity: true, MaxLayoverRisk: 100, TopK: 1, DepartDate: "2026-06-15",
+		})
+		if len(got) != 1 {
+			t.Fatalf("carrier %q: got %d, want 1", tc.carrier, len(got))
+		}
+		if !strings.Contains(got[0].BookingURL, tc.hostpart) {
+			t.Errorf("carrier %q: BookingURL=%q lacks %q", tc.carrier, got[0].BookingURL, tc.hostpart)
+		}
+	}
+}
+
+func TestScoreLayoverRisk_BoundsAndComposition(t *testing.T) {
+	cases := []struct {
+		name string
+		in   HiddenCityOffer
+		want int
+	}{
+		{"comfort zone carry-on", HiddenCityOffer{LayoverMinutes: 120, CarryOnOnly: true}, 0},
+		{"too short", HiddenCityOffer{LayoverMinutes: 30, CarryOnOnly: true}, 60},
+		{"60-90 band", HiddenCityOffer{LayoverMinutes: 75, CarryOnOnly: true}, 20},
+		{"180-240 band", HiddenCityOffer{LayoverMinutes: 210, CarryOnOnly: true}, 10},
+		{"too long", HiddenCityOffer{LayoverMinutes: 300, CarryOnOnly: true}, 25},
+		{"checked bags penalty", HiddenCityOffer{LayoverMinutes: 120, CarryOnOnly: false}, 35},
+		{"separate tickets penalty", HiddenCityOffer{LayoverMinutes: 120, CarryOnOnly: true, SeparateTickets: true}, 20},
+		{"all worst capped", HiddenCityOffer{LayoverMinutes: 30, CarryOnOnly: false, SeparateTickets: true}, 100},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scoreLayoverRisk(tc.in)
+			if got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExpandMatrix_TieBreakOnRiskWhenPriceEqual(t *testing.T) {
+	in := []HiddenCityOffer{
+		{Origin: "AMS", Hub: "HEL", HubBeyond: "RIX", Carrier: "AY", Price: 200, CarryOnOnly: true, LayoverMinutes: 120}, // risk 0
+		{Origin: "AMS", Hub: "FRA", HubBeyond: "VIE", Carrier: "LH", Price: 200, CarryOnOnly: false, LayoverMinutes: 60}, // risk 55 (60-90 + checked-bag)
+	}
+	got := ExpandMatrix(in, MatrixOptions{AllowHiddenCity: true, MaxLayoverRisk: 100, TopK: 2})
+	if len(got) != 2 {
+		t.Fatalf("got %d, want 2", len(got))
+	}
+	if got[0].LayoverRisk > got[1].LayoverRisk {
+		t.Errorf("equal price: lower risk should sort first; got %d then %d", got[0].LayoverRisk, got[1].LayoverRisk)
+	}
+}

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -207,7 +207,27 @@ func SearchHotelsWithClient(ctx context.Context, client *batchexec.Client, locat
 	if sfErr != nil {
 		return nil, sfErr
 	}
-	return v.(*models.HotelSearchResult), nil
+	// singleflight.Do returns the same *HotelSearchResult to all callers that
+	// coalesce on the same key. Callers mutate result.Hotels and result.Count
+	// (e.g. preferences.FilterHotels post-processing), which would race across
+	// concurrent callers. Return a shallow copy per caller: a fresh struct
+	// header with its own Hotels slice header so Count / Hotels writes are
+	// caller-private. The underlying HotelResult elements are treated as
+	// immutable after search completes and remain safely shared.
+	shared := v.(*models.HotelSearchResult)
+	if shared == nil {
+		return nil, nil
+	}
+	cp := *shared
+	if shared.Hotels != nil {
+		cp.Hotels = make([]models.HotelResult, len(shared.Hotels))
+		copy(cp.Hotels, shared.Hotels)
+	}
+	if shared.ProviderStatuses != nil {
+		cp.ProviderStatuses = make([]models.ProviderStatus, len(shared.ProviderStatuses))
+		copy(cp.ProviderStatuses, shared.ProviderStatuses)
+	}
+	return &cp, nil
 }
 
 // searchHotelsCore performs the actual hotel search without singleflight wrapping.

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -15,6 +15,7 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/providers"
+	"github.com/MikkoParkkola/trvl/internal/searchctx"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -25,6 +26,8 @@ var (
 
 // hotelGroup deduplicates concurrent in-flight searches with identical parameters.
 var hotelGroup singleflight.Group
+
+const sharedHotelSearchTimeout = 30 * time.Second
 
 // externalProviderRuntime is set by the MCP server when providers are configured.
 // It is nil when no external providers are available.
@@ -173,8 +176,69 @@ const pageSize = 20
 var googleSortOrders = []string{"", "3", "8"}
 
 // hotelSearchKey builds a singleflight dedup key from the search parameters.
-func hotelSearchKey(location, checkIn, checkOut string, guests int) string {
-	return fmt.Sprintf("hotel|%s|%s|%s|%d", location, checkIn, checkOut, guests)
+func hotelSearchKey(location string, opts HotelSearchOptions) string {
+	return strings.Join([]string{
+		"hotel",
+		location,
+		opts.CheckIn,
+		opts.CheckOut,
+		strconv.Itoa(opts.Guests),
+		strconv.Itoa(opts.Stars),
+		opts.Sort,
+		opts.Currency,
+		strconv.FormatFloat(opts.MinPrice, 'f', -1, 64),
+		strconv.FormatFloat(opts.MaxPrice, 'f', -1, 64),
+		strconv.FormatFloat(opts.MinRating, 'f', -1, 64),
+		strconv.FormatFloat(opts.MaxDistanceKm, 'f', -1, 64),
+		hotelKeyStringSlice(normalizeHotelAmenityFilters(opts.Amenities)),
+		strconv.FormatFloat(opts.CenterLat, 'f', 6, 64),
+		strconv.FormatFloat(opts.CenterLon, 'f', 6, 64),
+		strconv.FormatBool(opts.EnrichAmenities),
+		strconv.Itoa(opts.EnrichLimit),
+		strconv.Itoa(hotelPageLimit(opts.MaxPages)),
+		strconv.FormatBool(opts.FreeCancellation),
+		opts.PropertyType,
+		strings.ToLower(strings.TrimSpace(opts.Brand)),
+		strconv.FormatBool(opts.EcoCertified),
+		strconv.Itoa(opts.MinBedrooms),
+		strconv.Itoa(opts.MinBathrooms),
+		strconv.Itoa(opts.MinBeds),
+		opts.RoomType,
+		strconv.FormatBool(opts.Superhost),
+		strconv.FormatBool(opts.InstantBook),
+		strconv.Itoa(opts.MaxDistanceM),
+		strconv.FormatBool(opts.Sustainable),
+		strconv.FormatBool(opts.MealPlan),
+		strconv.FormatBool(opts.IncludeSoldOut),
+	}, "|")
+}
+
+func hotelPageLimit(requested int) int {
+	pageLimit := maxPages
+	if requested > 0 && requested < maxPages {
+		pageLimit = requested
+	}
+	return pageLimit
+}
+
+func normalizeHotelAmenityFilters(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized = append(normalized, strings.ToLower(strings.TrimSpace(value)))
+	}
+	return normalized
+}
+
+func hotelKeyStringSlice(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	sorted := append([]string(nil), values...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ",")
 }
 
 // SearchHotelsWithClient is like SearchHotels but reuses the provided client.
@@ -200,42 +264,38 @@ func SearchHotelsWithClient(ctx context.Context, client *batchexec.Client, locat
 		return nil, fmt.Errorf("parse check-out date: %w", err)
 	}
 
-	key := hotelSearchKey(location, opts.CheckIn, opts.CheckOut, opts.Guests)
-	v, sfErr, _ := hotelGroup.Do(key, func() (any, error) {
-		return searchHotelsCore(ctx, client, location, opts)
+	key := hotelSearchKey(location, opts)
+	return doHotelSearchSingleflight(ctx, key, func(sharedCtx context.Context) (*models.HotelSearchResult, error) {
+		return searchHotelsCore(sharedCtx, client, location, opts)
 	})
-	if sfErr != nil {
-		return nil, sfErr
+}
+
+func doHotelSearchSingleflight(ctx context.Context, key string, fn func(context.Context) (*models.HotelSearchResult, error)) (*models.HotelSearchResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
-	// singleflight.Do returns the same *HotelSearchResult to all callers that
-	// coalesce on the same key. Callers mutate result.Hotels and result.Count
-	// (e.g. preferences.FilterHotels post-processing), which would race across
-	// concurrent callers. Return a shallow copy per caller: a fresh struct
-	// header with its own Hotels slice header so Count / Hotels writes are
-	// caller-private. The underlying HotelResult elements are treated as
-	// immutable after search completes and remain safely shared.
-	shared := v.(*models.HotelSearchResult)
-	if shared == nil {
-		return nil, nil
+
+	ch := hotelGroup.DoChan(key, func() (any, error) {
+		sharedCtx, cancel := searchctx.DetachedWithin(ctx, sharedHotelSearchTimeout)
+		defer cancel()
+		return fn(sharedCtx)
+	})
+
+	select {
+	case <-ctx.Done():
+		// The winner keeps running until the detached shared deadline expires; if
+		// the caller times out first, forget the key so later callers do not join
+		// that doomed execution.
+		hotelGroup.Forget(key)
+		return nil, ctx.Err()
+	case res := <-ch:
+		return sharedHotelResult(res.Val, res.Err)
 	}
-	cp := *shared
-	if shared.Hotels != nil {
-		cp.Hotels = make([]models.HotelResult, len(shared.Hotels))
-		copy(cp.Hotels, shared.Hotels)
-	}
-	if shared.ProviderStatuses != nil {
-		cp.ProviderStatuses = make([]models.ProviderStatus, len(shared.ProviderStatuses))
-		copy(cp.ProviderStatuses, shared.ProviderStatuses)
-	}
-	return &cp, nil
 }
 
 // searchHotelsCore performs the actual hotel search without singleflight wrapping.
 func searchHotelsCore(ctx context.Context, client *batchexec.Client, location string, opts HotelSearchOptions) (*models.HotelSearchResult, error) {
-	pageLimit := maxPages
-	if opts.MaxPages > 0 && opts.MaxPages < maxPages {
-		pageLimit = opts.MaxPages
-	}
+	pageLimit := hotelPageLimit(opts.MaxPages)
 
 	// Determine which sort orders to use. When MaxPages is 1 (compound
 	// commands that only need the cheapest result), skip sort diversity.
@@ -460,6 +520,54 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 		Hotels:           hotels,
 		ProviderStatuses: providerStatuses,
 	}, nil
+}
+
+func cloneHotelSearchResult(shared *models.HotelSearchResult) *models.HotelSearchResult {
+	if shared == nil {
+		return nil
+	}
+
+	// singleflight.Do shares the winner's *HotelSearchResult pointer across all
+	// callers. Trip planning and preference filters rewrite Count / Hotels and may
+	// mutate nested hotel slices, so each caller needs an independent deep copy.
+	cp := *shared
+	if shared.Hotels != nil {
+		cp.Hotels = make([]models.HotelResult, len(shared.Hotels))
+		for i, hotel := range shared.Hotels {
+			hotelCopy := hotel
+			if hotel.Amenities != nil {
+				hotelCopy.Amenities = append([]string(nil), hotel.Amenities...)
+			}
+			if hotel.RoomTypes != nil {
+				hotelCopy.RoomTypes = make([]models.Room, len(hotel.RoomTypes))
+				for j, room := range hotel.RoomTypes {
+					roomCopy := room
+					if room.Amenities != nil {
+						roomCopy.Amenities = append([]string(nil), room.Amenities...)
+					}
+					hotelCopy.RoomTypes[j] = roomCopy
+				}
+			}
+			if hotel.Sources != nil {
+				hotelCopy.Sources = append([]models.PriceSource(nil), hotel.Sources...)
+			}
+			cp.Hotels[i] = hotelCopy
+		}
+	}
+	if shared.ProviderStatuses != nil {
+		cp.ProviderStatuses = append([]models.ProviderStatus(nil), shared.ProviderStatuses...)
+	}
+	return &cp
+}
+
+func sharedHotelResult(v any, err error) (*models.HotelSearchResult, error) {
+	if err != nil {
+		if r, ok := v.(*models.HotelSearchResult); ok {
+			return cloneHotelSearchResult(r), err
+		}
+		return nil, err
+	}
+	return cloneHotelSearchResult(v.(*models.HotelSearchResult)), nil
 }
 
 // fetchHotelPage fetches a single page of hotel results at the given offset.

--- a/internal/hotels/singleflight_test.go
+++ b/internal/hotels/singleflight_test.go
@@ -1,9 +1,14 @@
 package hotels
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
 // TestHotelSingleflight verifies that concurrent calls with the same key
@@ -54,12 +59,54 @@ func TestHotelSingleflight(t *testing.T) {
 // TestHotelSearchKey verifies that different parameter combinations produce
 // distinct keys, preventing incorrect deduplication.
 func TestHotelSearchKey(t *testing.T) {
-	k1 := hotelSearchKey("Paris", "2026-06-15", "2026-06-18", 2)
-	k2 := hotelSearchKey("Paris", "2026-06-16", "2026-06-18", 2) // different check-in
-	k3 := hotelSearchKey("London", "2026-06-15", "2026-06-18", 2) // different city
-	k4 := hotelSearchKey("Paris", "2026-06-15", "2026-06-18", 3)  // different guests
+	base := HotelSearchOptions{
+		CheckIn:          "2026-06-15",
+		CheckOut:         "2026-06-18",
+		Guests:           2,
+		Stars:            4,
+		Sort:             "price",
+		Currency:         "EUR",
+		MinPrice:         100,
+		MaxPrice:         250,
+		MinRating:        8.5,
+		MaxDistanceKm:    2,
+		Amenities:        []string{"pool", "wifi"},
+		CenterLat:        48.8566,
+		CenterLon:        2.3522,
+		EnrichAmenities:  true,
+		EnrichLimit:      5,
+		MaxPages:         2,
+		FreeCancellation: true,
+		PropertyType:     "hotel",
+		Brand:            "Hilton",
+		EcoCertified:     true,
+		MinBedrooms:      1,
+		MinBathrooms:     1,
+		MinBeds:          2,
+		RoomType:         "hotel_room",
+		Superhost:        true,
+		InstantBook:      true,
+		MaxDistanceM:     1500,
+		Sustainable:      true,
+		MealPlan:         true,
+		IncludeSoldOut:   true,
+	}
+	k1 := hotelSearchKey("Paris", base)
+	k2 := hotelSearchKey("Paris", HotelSearchOptions{
+		CheckIn:  "2026-06-16",
+		CheckOut: base.CheckOut,
+		Guests:   base.Guests,
+	}) // different check-in
+	k3 := hotelSearchKey("London", base)                                                                         // different city
+	k4 := hotelSearchKey("Paris", HotelSearchOptions{CheckIn: base.CheckIn, CheckOut: base.CheckOut, Guests: 3}) // different guests
+	k5 := hotelSearchKey("Paris", HotelSearchOptions{
+		CheckIn:  base.CheckIn,
+		CheckOut: base.CheckOut,
+		Guests:   base.Guests,
+		Stars:    5,
+	}) // different filter set
 
-	keys := []string{k1, k2, k3, k4}
+	keys := []string{k1, k2, k3, k4, k5}
 	for i := range keys {
 		for j := i + 1; j < len(keys); j++ {
 			if keys[i] == keys[j] {
@@ -69,9 +116,142 @@ func TestHotelSearchKey(t *testing.T) {
 	}
 
 	// Same inputs must produce the same key.
-	k1again := hotelSearchKey("Paris", "2026-06-15", "2026-06-18", 2)
+	k1again := hotelSearchKey("Paris", base)
 	if k1 != k1again {
 		t.Errorf("same inputs produced different keys: %q vs %q", k1, k1again)
+	}
+
+	reorderedAmenities := base
+	reorderedAmenities.Amenities = []string{"wifi", "pool"}
+	k1reorderedAmenities := hotelSearchKey("Paris", reorderedAmenities)
+	if k1 != k1reorderedAmenities {
+		t.Errorf("same amenity set produced different keys: %q vs %q", k1, k1reorderedAmenities)
+	}
+}
+
+func TestHotelSearchKey_FilterRegressionCoverage(t *testing.T) {
+	base := HotelSearchOptions{
+		CheckIn:          "2026-06-15",
+		CheckOut:         "2026-06-18",
+		Guests:           2,
+		Currency:         "EUR",
+		Amenities:        []string{"wifi", "pool"},
+		FreeCancellation: true,
+		PropertyType:     "hotel",
+		Brand:            "Hilton",
+		IncludeSoldOut:   true,
+	}
+
+	sameAmenitiesDifferentOrder := base
+	sameAmenitiesDifferentOrder.Amenities = []string{"pool", "wifi"}
+
+	if got, want := hotelSearchKey("Paris", base), hotelSearchKey("Paris", sameAmenitiesDifferentOrder); got != want {
+		t.Fatalf("amenity ordering should not change key:\n%s\n%s", got, want)
+	}
+
+	cases := []struct {
+		name string
+		mut  func(HotelSearchOptions) HotelSearchOptions
+	}{
+		{
+			name: "free cancellation",
+			mut: func(opts HotelSearchOptions) HotelSearchOptions {
+				opts.FreeCancellation = false
+				return opts
+			},
+		},
+		{
+			name: "property type",
+			mut: func(opts HotelSearchOptions) HotelSearchOptions {
+				opts.PropertyType = "apartment"
+				return opts
+			},
+		},
+		{
+			name: "include sold out",
+			mut: func(opts HotelSearchOptions) HotelSearchOptions {
+				opts.IncludeSoldOut = false
+				return opts
+			},
+		},
+		{
+			name: "amenity membership",
+			mut: func(opts HotelSearchOptions) HotelSearchOptions {
+				opts.Amenities = []string{"wifi", "spa"}
+				return opts
+			},
+		},
+	}
+
+	baseKey := hotelSearchKey("Paris", base)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hotelSearchKey("Paris", tc.mut(base)); got == baseKey {
+				t.Fatalf("%s should change key, but both were %q", tc.name, got)
+			}
+		})
+	}
+
+	brandVariant := base
+	brandVariant.Brand = " hilton "
+	if got, want := hotelSearchKey("Paris", brandVariant), baseKey; got != want {
+		t.Fatalf("brand normalization should keep key stable:\n%s\n%s", got, want)
+	}
+}
+
+func TestHotelSearchKey_NormalizesEffectiveSearchInputs(t *testing.T) {
+	base := HotelSearchOptions{
+		CheckIn:   "2026-06-15",
+		CheckOut:  "2026-06-18",
+		Guests:    2,
+		Currency:  "EUR",
+		MaxPages:  0,
+		Amenities: []string{" wifi ", "POOL"},
+	}
+
+	cases := []struct {
+		name string
+		mut  func(HotelSearchOptions) HotelSearchOptions
+	}{
+		{
+			name: "default max pages and normalized amenities",
+			mut: func(opts HotelSearchOptions) HotelSearchOptions {
+				opts.MaxPages = maxPages
+				opts.Amenities = []string{"pool", "wifi"}
+				return opts
+			},
+		},
+		{
+			name: "max pages above limit still uses effective page limit",
+			mut: func(opts HotelSearchOptions) HotelSearchOptions {
+				opts.MaxPages = maxPages + 4
+				opts.Amenities = []string{"Pool", "WiFi"}
+				return opts
+			},
+		},
+		{
+			name: "negative max pages falls back to default page limit",
+			mut: func(opts HotelSearchOptions) HotelSearchOptions {
+				opts.MaxPages = -1
+				opts.Amenities = []string{"wifi", "pool"}
+				return opts
+			},
+		},
+	}
+
+	baseKey := hotelSearchKey("Paris", base)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hotelSearchKey("Paris", tc.mut(base)); got != baseKey {
+				t.Fatalf("%s should keep the key stable:\n%s\n%s", tc.name, got, baseKey)
+			}
+		})
+	}
+
+	changed := base
+	changed.MaxPages = 1
+	if got := hotelSearchKey("Paris", changed); got == baseKey {
+		t.Fatalf("changing the effective page limit should change the key, but both were %q", got)
 	}
 }
 
@@ -96,5 +276,307 @@ func TestSearchHotelsWithClient_MissingDates(t *testing.T) {
 		if err == nil {
 			t.Errorf("goroutine %d: expected error for missing dates, got nil", i)
 		}
+	}
+}
+
+func TestHotelSingleflight_ConcurrentCallersGetPrivateResults(t *testing.T) {
+	shared := &models.HotelSearchResult{
+		Success: true,
+		Count:   1,
+		Hotels: []models.HotelResult{
+			{
+				Name:        "Hotel Example",
+				Price:       120,
+				Amenities:   []string{"wifi", "spa"},
+				RoomTypes:   []models.Room{{Name: "Deluxe", Amenities: []string{"balcony", "breakfast"}}},
+				Sources:     []models.PriceSource{{Provider: "google_hotels", Price: 120, Currency: "EUR"}},
+				ReviewCount: 42,
+			},
+		},
+		ProviderStatuses: []models.ProviderStatus{{ID: "google_hotels", Name: "Google Hotels", Status: "ok", Results: 1}},
+	}
+
+	const n = 2
+	key := "hotel|Paris|2026-06-15|2026-06-18|2"
+
+	var callCount atomic.Int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make([]*models.HotelSearchResult, n)
+	errs := make([]error, n)
+
+	for i := range n {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			v, err, _ := hotelGroup.Do(key, func() (any, error) {
+				callCount.Add(1)
+				time.Sleep(50 * time.Millisecond)
+				return shared, nil
+			})
+			if err == nil {
+				results[idx] = cloneHotelSearchResult(v.(*models.HotelSearchResult))
+			}
+			errs[idx] = err
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("caller %d singleflight error: %v", i, err)
+		}
+	}
+	if got := callCount.Load(); got != 1 {
+		t.Fatalf("callCount = %d, want 1 shared singleflight execution", got)
+	}
+	if results[0] == results[1] {
+		t.Fatal("concurrent callers received the same HotelSearchResult pointer")
+	}
+	if &results[0].Hotels[0] == &results[1].Hotels[0] {
+		t.Fatal("concurrent callers reused the same HotelResult backing storage")
+	}
+	if &results[0].Hotels[0].Amenities[0] == &results[1].Hotels[0].Amenities[0] {
+		t.Fatal("concurrent callers reused the same hotel Amenities backing storage")
+	}
+	if &results[0].Hotels[0].RoomTypes[0] == &results[1].Hotels[0].RoomTypes[0] {
+		t.Fatal("concurrent callers reused the same Room backing storage")
+	}
+	if &results[0].Hotels[0].RoomTypes[0].Amenities[0] == &results[1].Hotels[0].RoomTypes[0].Amenities[0] {
+		t.Fatal("concurrent callers reused the same room Amenities backing storage")
+	}
+	if &results[0].Hotels[0].Sources[0] == &results[1].Hotels[0].Sources[0] {
+		t.Fatal("concurrent callers reused the same Sources backing storage")
+	}
+	if &results[0].ProviderStatuses[0] == &results[1].ProviderStatuses[0] {
+		t.Fatal("concurrent callers reused the same ProviderStatuses backing storage")
+	}
+
+	otherCount := results[1].Count
+	otherPrice := results[1].Hotels[0].Price
+	otherHotelsLen := len(results[1].Hotels)
+	otherAmenity := results[1].Hotels[0].Amenities[0]
+	otherRoomAmenity := results[1].Hotels[0].RoomTypes[0].Amenities[0]
+	otherProvider := results[1].Hotels[0].Sources[0].Provider
+	otherStatus := results[1].ProviderStatuses[0].Status
+
+	results[0].Count = 0
+	results[0].Hotels[0].Price = otherPrice + 10
+	results[0].Hotels[0].Amenities[0] = "changed"
+	results[0].Hotels[0].RoomTypes[0].Amenities[0] = "suite"
+	results[0].Hotels[0].Sources[0].Provider = "booking"
+	results[0].ProviderStatuses[0].Status = "error"
+	results[0].Hotels = results[0].Hotels[:0]
+
+	if results[1].Count != otherCount {
+		t.Fatalf("caller 1 Count changed to %d, want %d", results[1].Count, otherCount)
+	}
+	if len(results[1].Hotels) != otherHotelsLen {
+		t.Fatalf("caller 1 len(Hotels) changed to %d, want %d", len(results[1].Hotels), otherHotelsLen)
+	}
+	if results[1].Hotels[0].Price != otherPrice {
+		t.Fatalf("caller 1 hotel price changed to %v, want %v", results[1].Hotels[0].Price, otherPrice)
+	}
+	if got := results[1].Hotels[0].Amenities[0]; got != otherAmenity {
+		t.Fatalf("caller 1 amenity changed to %q, want %q", got, otherAmenity)
+	}
+	if got := results[1].Hotels[0].RoomTypes[0].Amenities[0]; got != otherRoomAmenity {
+		t.Fatalf("caller 1 room amenity changed to %q, want %q", got, otherRoomAmenity)
+	}
+	if got := results[1].Hotels[0].Sources[0].Provider; got != otherProvider {
+		t.Fatalf("caller 1 source provider changed to %q, want %q", got, otherProvider)
+	}
+	if got := results[1].ProviderStatuses[0].Status; got != otherStatus {
+		t.Fatalf("caller 1 provider status changed to %q, want %q", got, otherStatus)
+	}
+}
+
+func TestCloneHotelSearchResult_ReturnsCallerPrivateCopy(t *testing.T) {
+	shared := &models.HotelSearchResult{
+		Success: true,
+		Count:   1,
+		Hotels: []models.HotelResult{
+			{
+				Name:      "Hotel Example",
+				Price:     120,
+				Amenities: []string{"wifi", "spa"},
+				RoomTypes: []models.Room{
+					{Name: "Deluxe", Amenities: []string{"balcony", "breakfast"}},
+				},
+				Sources: []models.PriceSource{
+					{Provider: "google_hotels", Price: 120, Currency: "EUR"},
+				},
+			},
+		},
+		ProviderStatuses: []models.ProviderStatus{{ID: "google_hotels", Name: "Google Hotels", Status: "ok", Results: 1}},
+	}
+
+	clone := cloneHotelSearchResult(shared)
+	if clone == shared {
+		t.Fatal("cloneHotelSearchResult returned the original pointer")
+	}
+	if &clone.Hotels[0] == &shared.Hotels[0] {
+		t.Fatal("cloneHotelSearchResult reused the shared Hotels backing array")
+	}
+	if &clone.Hotels[0].Amenities[0] == &shared.Hotels[0].Amenities[0] {
+		t.Fatal("cloneHotelSearchResult reused the shared hotel Amenities backing array")
+	}
+	if &clone.Hotels[0].RoomTypes[0] == &shared.Hotels[0].RoomTypes[0] {
+		t.Fatal("cloneHotelSearchResult reused the shared RoomTypes backing array")
+	}
+	if &clone.Hotels[0].RoomTypes[0].Amenities[0] == &shared.Hotels[0].RoomTypes[0].Amenities[0] {
+		t.Fatal("cloneHotelSearchResult reused the shared room Amenities backing array")
+	}
+	if &clone.Hotels[0].Sources[0] == &shared.Hotels[0].Sources[0] {
+		t.Fatal("cloneHotelSearchResult reused the shared Sources backing array")
+	}
+	if &clone.ProviderStatuses[0] == &shared.ProviderStatuses[0] {
+		t.Fatal("cloneHotelSearchResult reused the shared ProviderStatuses backing array")
+	}
+
+	clone.Count = 0
+	clone.Hotels[0].Price = 99
+	clone.Hotels[0].Amenities[0] = "changed"
+	clone.Hotels[0].RoomTypes[0].Amenities[0] = "suite"
+	clone.Hotels[0].Sources[0].Provider = "booking"
+	clone.ProviderStatuses[0].Status = "error"
+	clone.Hotels = clone.Hotels[:0]
+
+	if shared.Count != 1 {
+		t.Fatalf("shared.Count = %d, want 1", shared.Count)
+	}
+	if len(shared.Hotels) != 1 {
+		t.Fatalf("len(shared.Hotels) = %d, want 1", len(shared.Hotels))
+	}
+	if got := shared.Hotels[0].Price; got != 120 {
+		t.Fatalf("shared hotel price = %v, want 120", got)
+	}
+	if got := shared.Hotels[0].Amenities[0]; got != "wifi" {
+		t.Fatalf("shared amenity = %q, want %q", got, "wifi")
+	}
+	if got := shared.Hotels[0].RoomTypes[0].Amenities[0]; got != "balcony" {
+		t.Fatalf("shared room amenity = %q, want %q", got, "balcony")
+	}
+	if got := shared.Hotels[0].Sources[0].Provider; got != "google_hotels" {
+		t.Fatalf("shared source provider = %q, want %q", got, "google_hotels")
+	}
+	if got := shared.ProviderStatuses[0].Status; got != "ok" {
+		t.Fatalf("shared provider status = %q, want %q", got, "ok")
+	}
+}
+
+func TestDoHotelSearchSingleflight_ShortCallerDeadlineDoesNotPoisonSharedWork(t *testing.T) {
+	key := "hotel|Paris|2026-09-01|2026-09-03|shared-timeout"
+
+	var callCount atomic.Int64
+	firstCtx, firstCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer firstCancel()
+	firstDeadline, ok := firstCtx.Deadline()
+	if !ok {
+		t.Fatal("first caller context unexpectedly has no deadline")
+	}
+
+	sharedDeadlineCh := make(chan time.Time, 1)
+	_, firstErr := doHotelSearchSingleflight(firstCtx, key, func(sharedCtx context.Context) (*models.HotelSearchResult, error) {
+		callCount.Add(1)
+		sharedDeadline, ok := sharedCtx.Deadline()
+		if !ok {
+			t.Fatal("shared context unexpectedly has no deadline")
+		}
+		sharedDeadlineCh <- sharedDeadline
+		<-sharedCtx.Done()
+		return nil, sharedCtx.Err()
+	})
+
+	if !errors.Is(firstErr, context.DeadlineExceeded) {
+		t.Fatalf("firstErr = %v, want context deadline exceeded", firstErr)
+	}
+	sharedDeadline := <-sharedDeadlineCh
+	if !sharedDeadline.After(firstDeadline.Add(100 * time.Millisecond)) {
+		t.Fatalf("shared deadline %v unexpectedly inherited short caller deadline %v", sharedDeadline, firstDeadline)
+	}
+	secondCtx, secondCancel := context.WithTimeout(context.Background(), time.Second)
+	defer secondCancel()
+	secondResult, secondErr := doHotelSearchSingleflight(secondCtx, key, func(sharedCtx context.Context) (*models.HotelSearchResult, error) {
+		callCount.Add(1)
+		return &models.HotelSearchResult{Success: true, Count: 1}, nil
+	})
+	if secondErr != nil {
+		t.Fatalf("secondErr = %v, want nil", secondErr)
+	}
+	if secondResult == nil || !secondResult.Success || secondResult.Count != 1 {
+		t.Fatalf("secondResult = %#v, want successful result from a fresh execution", secondResult)
+	}
+	if got := callCount.Load(); got != 2 {
+		t.Fatalf("callCount = %d, want 2 executions after the timed-out winner stops", got)
+	}
+}
+
+func TestSharedHotelResult_ClonesPartialErrorResult(t *testing.T) {
+	shared := &models.HotelSearchResult{
+		Success: false,
+		Count:   1,
+		Hotels: []models.HotelResult{
+			{
+				Name:      "Hotel Example",
+				Price:     120,
+				Amenities: []string{"wifi"},
+				RoomTypes: []models.Room{
+					{Name: "Deluxe", Amenities: []string{"balcony"}},
+				},
+				Sources: []models.PriceSource{
+					{Provider: "google_hotels", Price: 120, Currency: "EUR"},
+				},
+			},
+		},
+		ProviderStatuses: []models.ProviderStatus{{ID: "google_hotels", Name: "Google Hotels", Status: "partial", Results: 1}},
+	}
+
+	wantErr := errors.New("provider partial failure")
+	got, err := sharedHotelResult(shared, wantErr)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if got == shared {
+		t.Fatal("sharedHotelResult returned the original pointer")
+	}
+	if &got.Hotels[0] == &shared.Hotels[0] {
+		t.Fatal("sharedHotelResult reused the shared Hotels backing array")
+	}
+	if &got.Hotels[0].Amenities[0] == &shared.Hotels[0].Amenities[0] {
+		t.Fatal("sharedHotelResult reused the shared hotel Amenities backing array")
+	}
+	if &got.Hotels[0].RoomTypes[0] == &shared.Hotels[0].RoomTypes[0] {
+		t.Fatal("sharedHotelResult reused the shared RoomTypes backing array")
+	}
+	if &got.Hotels[0].RoomTypes[0].Amenities[0] == &shared.Hotels[0].RoomTypes[0].Amenities[0] {
+		t.Fatal("sharedHotelResult reused the shared room Amenities backing array")
+	}
+	if &got.Hotels[0].Sources[0] == &shared.Hotels[0].Sources[0] {
+		t.Fatal("sharedHotelResult reused the shared Sources backing array")
+	}
+	if &got.ProviderStatuses[0] == &shared.ProviderStatuses[0] {
+		t.Fatal("sharedHotelResult reused the shared ProviderStatuses backing array")
+	}
+
+	got.Hotels[0].Amenities[0] = "changed"
+	got.Hotels[0].RoomTypes[0].Amenities[0] = "suite"
+	got.Hotels[0].Sources[0].Provider = "booking"
+	got.ProviderStatuses[0].Status = "error"
+
+	if shared.Hotels[0].Amenities[0] != "wifi" {
+		t.Fatalf("shared amenity = %q, want %q", shared.Hotels[0].Amenities[0], "wifi")
+	}
+	if shared.Hotels[0].RoomTypes[0].Amenities[0] != "balcony" {
+		t.Fatalf("shared room amenity = %q, want %q", shared.Hotels[0].RoomTypes[0].Amenities[0], "balcony")
+	}
+	if shared.Hotels[0].Sources[0].Provider != "google_hotels" {
+		t.Fatalf("shared source provider = %q, want %q", shared.Hotels[0].Sources[0].Provider, "google_hotels")
+	}
+	if shared.ProviderStatuses[0].Status != "partial" {
+		t.Fatalf("shared provider status = %q, want %q", shared.ProviderStatuses[0].Status, "partial")
 	}
 }

--- a/internal/match/request.go
+++ b/internal/match/request.go
@@ -1,0 +1,196 @@
+// Package match computes how well an offered travel result matches what was requested.
+// All scoring is pure (no I/O), deterministic, and safe for concurrent use.
+package match
+
+import (
+	"fmt"
+	"time"
+)
+
+const dateLayout = "2006-01-02"
+
+// Request describes what was asked for (the user's literal request).
+type Request struct {
+	OriginIATA       string   // e.g. "HEL"
+	DestIATA         string   // empty = any
+	DepartDateCenter string   // YYYY-MM-DD, desired depart date
+	FlexDays         int      // allowed drift either side (0 = exact)
+	Nights           int      // desired trip length; 0 = any
+	MaxNightsDrift   int      // allowed drift from Nights; 0 means exact
+	PreferDirect     bool
+	AcceptedAirports []string // non-empty = alternatives accepted with reduced penalty
+	Currency         string
+	GuestCount       int
+}
+
+// Offered describes what is actually being offered.
+type Offered struct {
+	OriginIATA string
+	DestIATA   string
+	DepartDate string // YYYY-MM-DD
+	ReturnDate string // YYYY-MM-DD; "" means one-way
+	Stops      int
+	Currency   string
+	GuestCount int
+}
+
+// Score holds the result of a RequestMatch computation.
+type Score struct {
+	Total  int    // 0-100
+	Reason string // dominant penalty axis
+}
+
+// Compute returns a RequestMatch score for an offered result against a request.
+// 100 = exact match to literal ask.
+// 0   = completely incompatible.
+func Compute(req Request, off Offered) Score {
+	penalties := map[string]int{
+		"date_drift":           dateDriftPenalty(req, off),
+		"airport_substitution": airportSubPenalty(req, off),
+		"nights_drift":         nightsDriftPenalty(req, off),
+		"currency_mismatch":    currencyMismatchPenalty(req, off),
+		"direct_preference":    directPrefPenalty(req, off),
+	}
+
+	total := 0
+	for _, p := range penalties {
+		total += p
+	}
+	if total > 100 {
+		total = 100
+	}
+
+	score := 100 - total
+	if score < 0 {
+		score = 0
+	}
+
+	reason := dominantAxis(penalties)
+	return Score{Total: score, Reason: reason}
+}
+
+// dateDriftPenalty applies 5 pts/day outside [center ± flexDays]. Max 40.
+func dateDriftPenalty(req Request, off Offered) int {
+	if req.DepartDateCenter == "" || off.DepartDate == "" {
+		return 0
+	}
+	center, err1 := time.Parse(dateLayout, req.DepartDateCenter)
+	offered, err2 := time.Parse(dateLayout, off.DepartDate)
+	if err1 != nil || err2 != nil {
+		return 0
+	}
+
+	diff := int(offered.Sub(center).Hours() / 24)
+	if diff < 0 {
+		diff = -diff
+	}
+	drift := diff - req.FlexDays
+	if drift <= 0 {
+		return 0
+	}
+	penalty := drift * 5
+	if penalty > 40 {
+		penalty = 40
+	}
+	return penalty
+}
+
+// airportSubPenalty: 0 if dest matches or req.DestIATA is empty;
+// 20 if not in AcceptedAirports; 10 if an accepted substitute.
+func airportSubPenalty(req Request, off Offered) int {
+	if req.DestIATA == "" || req.DestIATA == off.DestIATA {
+		return 0
+	}
+	for _, a := range req.AcceptedAirports {
+		if a == off.DestIATA {
+			return 10
+		}
+	}
+	return 20
+}
+
+// nightsDriftPenalty: |offered_nights - req.Nights| × 5; only when Nights > 0
+// and drift exceeds MaxNightsDrift. Max 20.
+func nightsDriftPenalty(req Request, off Offered) int {
+	if req.Nights <= 0 {
+		return 0
+	}
+	offeredNights := offeredNightCount(off)
+	if offeredNights < 0 {
+		return 0
+	}
+	drift := offeredNights - req.Nights
+	if drift < 0 {
+		drift = -drift
+	}
+	if drift <= req.MaxNightsDrift {
+		return 0
+	}
+	penalty := drift * 5
+	if penalty > 20 {
+		penalty = 20
+	}
+	return penalty
+}
+
+// offeredNightCount returns the number of nights implied by DepartDate/ReturnDate.
+// Returns -1 if it cannot be determined.
+func offeredNightCount(off Offered) int {
+	if off.DepartDate == "" || off.ReturnDate == "" {
+		return -1
+	}
+	dep, err1 := time.Parse(dateLayout, off.DepartDate)
+	ret, err2 := time.Parse(dateLayout, off.ReturnDate)
+	if err1 != nil || err2 != nil {
+		return -1
+	}
+	nights := int(ret.Sub(dep).Hours() / 24)
+	if nights < 0 {
+		return 0
+	}
+	return nights
+}
+
+// currencyMismatchPenalty: 10 pts if currencies differ and both non-empty.
+func currencyMismatchPenalty(req Request, off Offered) int {
+	if req.Currency == "" || off.Currency == "" {
+		return 0
+	}
+	if req.Currency != off.Currency {
+		return 10
+	}
+	return 0
+}
+
+// directPrefPenalty: 10 pts if PreferDirect=true and offered has stops.
+func directPrefPenalty(req Request, off Offered) int {
+	if req.PreferDirect && off.Stops > 0 {
+		return 10
+	}
+	return 0
+}
+
+// dominantAxis returns the name of the penalty axis with the highest value.
+// Returns "exact_match" if all are zero.
+func dominantAxis(penalties map[string]int) string {
+	best := ""
+	max := 0
+	// Deterministic order for ties.
+	axes := []string{"date_drift", "airport_substitution", "nights_drift", "currency_mismatch", "direct_preference"}
+	for _, axis := range axes {
+		v := penalties[axis]
+		if v > max {
+			max = v
+			best = axis
+		}
+	}
+	if best == "" {
+		return "exact_match"
+	}
+	return best
+}
+
+// FormatScore returns a human-readable description of a Score.
+func FormatScore(s Score) string {
+	return fmt.Sprintf("score=%d reason=%s", s.Total, s.Reason)
+}

--- a/internal/match/request_test.go
+++ b/internal/match/request_test.go
@@ -1,0 +1,210 @@
+package match
+
+import (
+	"testing"
+)
+
+func TestExactMatch(t *testing.T) {
+	req := Request{
+		OriginIATA:       "HEL",
+		DestIATA:         "BCN",
+		DepartDateCenter: "2026-07-01",
+		FlexDays:         0,
+		Nights:           7,
+		MaxNightsDrift:   0,
+		PreferDirect:     false,
+		Currency:         "EUR",
+	}
+	off := Offered{
+		OriginIATA: "HEL",
+		DestIATA:   "BCN",
+		DepartDate: "2026-07-01",
+		ReturnDate: "2026-07-08",
+		Stops:      0,
+		Currency:   "EUR",
+	}
+	s := Compute(req, off)
+	if s.Total != 100 {
+		t.Errorf("expected 100, got %d", s.Total)
+	}
+	if s.Reason != "exact_match" {
+		t.Errorf("expected exact_match, got %s", s.Reason)
+	}
+}
+
+func TestDateDriftWithinFlex(t *testing.T) {
+	req := Request{
+		DepartDateCenter: "2026-07-01",
+		FlexDays:         3,
+	}
+	off := Offered{DepartDate: "2026-07-03"} // 2 days drift, within flex
+	s := Compute(req, off)
+	if s.Total != 100 {
+		t.Errorf("expected 100 (within flex), got %d", s.Total)
+	}
+}
+
+func TestDateDriftOutsideFlex(t *testing.T) {
+	req := Request{
+		DepartDateCenter: "2026-07-01",
+		FlexDays:         1,
+	}
+	off := Offered{DepartDate: "2026-07-04"} // 3 days drift → 2 outside flex → 10 pts
+	s := Compute(req, off)
+	if s.Total != 90 {
+		t.Errorf("expected 90, got %d (reason: %s)", s.Total, s.Reason)
+	}
+	if s.Reason != "date_drift" {
+		t.Errorf("expected date_drift reason, got %s", s.Reason)
+	}
+}
+
+func TestDateDriftMaxPenalty(t *testing.T) {
+	req := Request{
+		DepartDateCenter: "2026-07-01",
+		FlexDays:         0,
+	}
+	// 10 days drift → 50pts but capped at 40
+	off := Offered{DepartDate: "2026-07-11"}
+	s := Compute(req, off)
+	if s.Total != 60 {
+		t.Errorf("expected 60 (100-40), got %d", s.Total)
+	}
+}
+
+func TestAirportSubstitutionExact(t *testing.T) {
+	req := Request{DestIATA: "BCN"}
+	off := Offered{DestIATA: "BCN"}
+	s := Compute(req, off)
+	if s.Total != 100 {
+		t.Errorf("expected 100 for exact dest match, got %d", s.Total)
+	}
+}
+
+func TestAirportSubstitutionNotAccepted(t *testing.T) {
+	req := Request{DestIATA: "BCN", AcceptedAirports: []string{"GRO"}}
+	off := Offered{DestIATA: "REU"} // not in accepted list
+	s := Compute(req, off)
+	if s.Total != 80 {
+		t.Errorf("expected 80 (20pt penalty), got %d", s.Total)
+	}
+	if s.Reason != "airport_substitution" {
+		t.Errorf("expected airport_substitution, got %s", s.Reason)
+	}
+}
+
+func TestAirportSubstitutionAccepted(t *testing.T) {
+	req := Request{DestIATA: "BCN", AcceptedAirports: []string{"GRO", "REU"}}
+	off := Offered{DestIATA: "GRO"} // in accepted list
+	s := Compute(req, off)
+	if s.Total != 90 {
+		t.Errorf("expected 90 (10pt penalty), got %d", s.Total)
+	}
+}
+
+func TestNightsDriftExact(t *testing.T) {
+	req := Request{Nights: 7, MaxNightsDrift: 0, DepartDateCenter: ""}
+	off := Offered{DepartDate: "2026-07-01", ReturnDate: "2026-07-08"} // 7 nights
+	s := Compute(req, off)
+	if s.Total != 100 {
+		t.Errorf("expected 100 for exact nights, got %d", s.Total)
+	}
+}
+
+func TestNightsDriftPenalty(t *testing.T) {
+	req := Request{Nights: 7, MaxNightsDrift: 0}
+	off := Offered{DepartDate: "2026-07-01", ReturnDate: "2026-07-11"} // 10 nights → 3 drift → 15pts
+	s := Compute(req, off)
+	if s.Total != 85 {
+		t.Errorf("expected 85, got %d", s.Total)
+	}
+	if s.Reason != "nights_drift" {
+		t.Errorf("expected nights_drift, got %s", s.Reason)
+	}
+}
+
+func TestCurrencyMismatch(t *testing.T) {
+	req := Request{Currency: "EUR"}
+	off := Offered{Currency: "USD"}
+	s := Compute(req, off)
+	if s.Total != 90 {
+		t.Errorf("expected 90 (10pt currency penalty), got %d", s.Total)
+	}
+	if s.Reason != "currency_mismatch" {
+		t.Errorf("expected currency_mismatch, got %s", s.Reason)
+	}
+}
+
+func TestCurrencyMatchNopenalty(t *testing.T) {
+	req := Request{Currency: "EUR"}
+	off := Offered{Currency: "EUR"}
+	s := Compute(req, off)
+	if s.Total != 100 {
+		t.Errorf("expected 100 for matching currency, got %d", s.Total)
+	}
+}
+
+func TestDirectPreference(t *testing.T) {
+	req := Request{PreferDirect: true}
+	off := Offered{Stops: 1}
+	s := Compute(req, off)
+	if s.Total != 90 {
+		t.Errorf("expected 90 (10pt direct penalty), got %d", s.Total)
+	}
+	if s.Reason != "direct_preference" {
+		t.Errorf("expected direct_preference, got %s", s.Reason)
+	}
+}
+
+func TestDirectPreferenceNoStops(t *testing.T) {
+	req := Request{PreferDirect: true}
+	off := Offered{Stops: 0}
+	s := Compute(req, off)
+	if s.Total != 100 {
+		t.Errorf("expected 100 for direct flight when preferred, got %d", s.Total)
+	}
+}
+
+func TestStackedPenalties(t *testing.T) {
+	req := Request{
+		DestIATA:         "BCN",
+		DepartDateCenter: "2026-07-01",
+		FlexDays:         0,
+		Nights:           7,
+		MaxNightsDrift:   0,
+		PreferDirect:     true,
+		Currency:         "EUR",
+	}
+	off := Offered{
+		DestIATA:   "GRO", // not in AcceptedAirports → 20pts
+		DepartDate: "2026-07-05", // 4 days drift → 20pts
+		ReturnDate: "2026-07-16", // 11 nights vs 7 → 4 drift → 20pts
+		Stops:      1,            // +10pts
+		Currency:   "USD",        // +10pts
+	}
+	// Total penalty: 20+20+20+10+10 = 80 → score = 20
+	s := Compute(req, off)
+	if s.Total != 20 {
+		t.Errorf("expected 20 for stacked penalties, got %d (reason: %s)", s.Total, s.Reason)
+	}
+}
+
+func TestDestAnyEmpty(t *testing.T) {
+	// Empty DestIATA means "any" — no airport substitution penalty.
+	req := Request{DestIATA: ""}
+	off := Offered{DestIATA: "TXL"}
+	s := Compute(req, off)
+	if s.Total != 100 {
+		t.Errorf("expected 100 for empty dest (any), got %d", s.Total)
+	}
+}
+
+func TestNightsZeroAny(t *testing.T) {
+	// Nights=0 means "any" — no nights drift penalty.
+	req := Request{Nights: 0}
+	off := Offered{DepartDate: "2026-07-01", ReturnDate: "2026-07-30"} // 29 nights
+	s := Compute(req, off)
+	if s.Total != 100 {
+		t.Errorf("expected 100 when nights=0 (any), got %d", s.Total)
+	}
+}

--- a/internal/models/hotel.go
+++ b/internal/models/hotel.go
@@ -58,12 +58,13 @@ type HotelResult struct {
 // Included in search responses so the orchestrating LLM can autonomously
 // diagnose and fix broken providers.
 type ProviderStatus struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Status  string `json:"status"`           // "ok", "error", "disabled"
-	Results int    `json:"results,omitempty"` // number of results returned
-	Error   string `json:"error,omitempty"`   // error message if status != "ok"
-	FixHint string `json:"fix_hint,omitempty"` // actionable hint for the LLM
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Status      string `json:"status"`                  // "ok", "error", "disabled"
+	Results     int    `json:"results,omitempty"`        // number of results returned
+	Error       string `json:"error,omitempty"`          // error message if status != "ok"
+	FixHint     string `json:"fix_hint,omitempty"`       // actionable hint for the LLM
+	FixHintCode string `json:"fix_hint_code,omitempty"`  // typed root-cause code (e.g. "AKAMAI_BLOCK")
 }
 
 // HotelSearchResult is the top-level response for a hotel search.

--- a/internal/optimizer/optimizer.go
+++ b/internal/optimizer/optimizer.go
@@ -72,10 +72,10 @@ type Leg struct {
 
 // OptimizeResult is the output of the optimization engine.
 type OptimizeResult struct {
-	Success  bool           `json:"success"`
+	Success  bool            `json:"success"`
 	Options  []BookingOption `json:"options"`
 	Baseline *BookingOption  `json:"baseline,omitempty"`
-	Error    string         `json:"error,omitempty"`
+	Error    string          `json:"error,omitempty"`
 }
 
 // candidate is an internal search candidate generated during the EXPAND phase.
@@ -281,11 +281,11 @@ func expandCandidates(input OptimizeInput) []*candidate {
 	hiddenCityBeyond := map[string][]string{
 		"AMS": {"HEL", "RIX", "TLL", "ARN"}, // KLM hub — search to Nordics/Baltics via AMS
 		"FRA": {"PRG", "WAW", "BUD", "VIE"}, // Lufthansa hub — search to Central/Eastern Europe via FRA
-		"CDG": {"BRU", "GVA", "LIS"},         // Air France hub
-		"MUC": {"PRG", "VIE", "BUD"},         // Lufthansa hub
-		"IST": {"TBS", "SOF", "OTP"},         // Turkish hub
-		"CPH": {"ARN", "HEL", "OSL"},         // SAS hub
-		"ZRH": {"MXP", "VIE", "MUC"},         // Swiss hub
+		"CDG": {"BRU", "GVA", "LIS"},        // Air France hub
+		"MUC": {"PRG", "VIE", "BUD"},        // Lufthansa hub
+		"IST": {"TBS", "SOF", "OTP"},        // Turkish hub
+		"CPH": {"ARN", "HEL", "OSL"},        // SAS hub
+		"ZRH": {"MXP", "VIE", "MUC"},        // Swiss hub
 	}
 
 	if beyondCities, ok := hiddenCityBeyond[dest]; ok {
@@ -744,7 +744,7 @@ func candidateToOption(c *candidate, rank int, input OptimizeInput) BookingOptio
 		TransferCost: math.Round(c.transferCost),
 		AllInCost:    math.Round(c.allInCost),
 		Currency:     c.currency,
-		HacksApplied: c.hackTypes,
+		HacksApplied: append([]string(nil), c.hackTypes...),
 	}
 }
 

--- a/internal/optimizer/optimizer_aliasing_test.go
+++ b/internal/optimizer/optimizer_aliasing_test.go
@@ -1,0 +1,142 @@
+package optimizer
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func optimizerAliasingCandidate() *candidate {
+	return &candidate{
+		searched:     true,
+		origin:       "TLL",
+		dest:         "BCN",
+		departDate:   "2026-06-01",
+		strategy:     "Fly from Tallinn",
+		hackTypes:    []string{"positioning", "departure_tax"},
+		transferCost: 30,
+		currency:     "EUR",
+		baseCost:     120,
+		allInCost:    150,
+		flights: []models.FlightResult{
+			{
+				Price:    120,
+				Currency: "EUR",
+			},
+		},
+	}
+}
+
+func TestCandidateToOption_clonesHacksApplied(t *testing.T) {
+	c := optimizerAliasingCandidate()
+
+	opt := candidateToOption(c, 1, OptimizeInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+	})
+	opt.HacksApplied[0] = "mutated"
+
+	if got := c.hackTypes[0]; got != "positioning" {
+		t.Fatalf("candidate hackTypes mutated through BookingOption: got %q", got)
+	}
+}
+
+func TestCandidateToOption_parallelOptionsDoNotShareHacksApplied(t *testing.T) {
+	c := optimizerAliasingCandidate()
+	input := OptimizeInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+	}
+
+	const workers = 24
+	start := make(chan struct{})
+	results := make(chan BookingOption, workers)
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(rank int) {
+			defer wg.Done()
+			<-start
+			results <- candidateToOption(c, rank, input)
+		}(i + 1)
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var opts []BookingOption
+	for opt := range results {
+		opts = append(opts, opt)
+	}
+	if len(opts) != workers {
+		t.Fatalf("got %d options, want %d", len(opts), workers)
+	}
+
+	opts[0].HacksApplied[0] = "mutated"
+	for i := 1; i < len(opts); i++ {
+		if got := opts[i].HacksApplied[0]; got != "positioning" {
+			t.Fatalf("option %d shared HacksApplied backing storage: got %q", i, got)
+		}
+	}
+	if got := c.hackTypes[0]; got != "positioning" {
+		t.Fatalf("candidate hackTypes mutated after parallel conversion: got %q", got)
+	}
+}
+
+func TestRankCandidates_clonesHacksAppliedAcrossCalls(t *testing.T) {
+	candidates := []*candidate{
+		{
+			origin:     "HEL",
+			dest:       "BCN",
+			departDate: "2026-06-01",
+			strategy:   "Direct booking",
+			currency:   "EUR",
+			searched:   true,
+			baseCost:   180,
+			allInCost:  180,
+			flights: []models.FlightResult{
+				{Price: 180, Currency: "EUR"},
+			},
+		},
+		optimizerAliasingCandidate(),
+	}
+
+	input := OptimizeInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Currency:    "EUR",
+		MaxResults:  2,
+	}
+
+	res1 := rankCandidates(candidates, input)
+	res2 := rankCandidates(candidates, input)
+
+	var hacked1, hacked2 *BookingOption
+	for i := range res1.Options {
+		if len(res1.Options[i].HacksApplied) > 0 {
+			hacked1 = &res1.Options[i]
+			break
+		}
+	}
+	for i := range res2.Options {
+		if len(res2.Options[i].HacksApplied) > 0 {
+			hacked2 = &res2.Options[i]
+			break
+		}
+	}
+	if hacked1 == nil || hacked2 == nil {
+		t.Fatal("expected hacked booking options in both ranking results")
+	}
+
+	hacked1.HacksApplied[0] = "mutated"
+
+	if got := hacked2.HacksApplied[0]; got != "positioning" {
+		t.Fatalf("rankCandidates reused HacksApplied backing storage across calls: got %q", got)
+	}
+	if got := candidates[1].hackTypes[0]; got != "positioning" {
+		t.Fatalf("candidate hackTypes mutated across rankCandidates calls: got %q", got)
+	}
+}

--- a/internal/preferences/preferences.go
+++ b/internal/preferences/preferences.go
@@ -76,6 +76,23 @@ type Preferences struct {
 
 	// Family members for booking on behalf of
 	FamilyMembers []FamilyMember `json:"family_members,omitempty"`
+
+	// ProfileMatch scoring configuration.
+	//
+	// MatchWeights overrides the default factor weights used by scoring.ComputeProfileMatch.
+	// Only factors with a non-negative value are overridden; missing keys keep the default.
+	// Example: {"budget_fit": 30.0, "bucket_list_boost": 15.0}
+	MatchWeights map[string]float64 `json:"match_weights,omitempty"`
+
+	// AirportAffinity maps destination IATA codes to an affinity score in [0,1].
+	// Populated automatically as the user accepts or rejects suggestions.
+	// Example: {"BCN": 0.9, "WAW": 0.1}
+	AirportAffinity map[string]float64 `json:"airport_affinity,omitempty"`
+
+	// ExcludedDestinations is a list of airport codes or city names that are
+	// hard-excluded from all results (ProfileMatch returns 0 for these).
+	// The warsaw_filter factor reflects this exclusion in the score breakdown.
+	ExcludedDestinations []string `json:"excluded_destinations,omitempty"`
 }
 
 // FamilyMember represents a person the user may book travel for.

--- a/internal/preferences/preferences.go
+++ b/internal/preferences/preferences.go
@@ -48,9 +48,9 @@ type Preferences struct {
 	LoungeCards           []string              `json:"lounge_cards,omitempty"`            // e.g. ["Priority Pass", "Diners Club"]
 
 	// Travel style (extended)
-	DefaultCompanions int      `json:"default_companions"`          // 0 = solo, 1 = couple, 2+ = family/group
-	TripTypes         []string `json:"trip_types,omitempty"`        // "city_break", "beach", "adventure", "business", "remote_work"
-	SeatPreference    string   `json:"seat_preference"`             // "window", "aisle", "no_preference"
+	DefaultCompanions int      `json:"default_companions"`   // 0 = solo, 1 = couple, 2+ = family/group
+	TripTypes         []string `json:"trip_types,omitempty"` // "city_break", "beach", "adventure", "business", "remote_work"
+	SeatPreference    string   `json:"seat_preference"`      // "window", "aisle", "no_preference"
 
 	// Budget
 	BudgetPerNightMin float64 `json:"budget_per_night_min"` // min acceptable hotel price (filters too-cheap-to-trust)
@@ -64,8 +64,8 @@ type Preferences struct {
 	RedEyeOK           bool   `json:"red_eye_ok"`           // overnight flights acceptable?
 
 	// Identity
-	Nationality string   `json:"nationality"`          // ISO 3166-1 alpha-2 (e.g. "FI") — for visa warnings
-	Languages   []string `json:"languages,omitempty"`   // spoken languages (e.g. ["en", "fi", "sv"])
+	Nationality string   `json:"nationality"`         // ISO 3166-1 alpha-2 (e.g. "FI") — for visa warnings
+	Languages   []string `json:"languages,omitempty"` // spoken languages (e.g. ["en", "fi", "sv"])
 
 	// Context (free-text, not filtered but used for personalization)
 	PreviousTrips       []string `json:"previous_trips,omitempty"`       // cities/countries visited
@@ -104,8 +104,9 @@ type FrequentFlyerStatus struct {
 	ProgramName  string `json:"program_name,omitempty"`  // e.g. "Flying Blue", "Royal Plus"
 }
 
-// defaultPath returns the canonical preferences file path (~/.trvl/preferences.json).
-func defaultPath() (string, error) {
+// DefaultPath returns the canonical preferences file path
+// (~/.trvl/preferences.json).
+func DefaultPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve home directory: %w", err)
@@ -125,7 +126,7 @@ func Default() *Preferences {
 // Load reads preferences from ~/.trvl/preferences.json.
 // If the file does not exist, Default() is returned with no error.
 func Load() (*Preferences, error) {
-	path, err := defaultPath()
+	path, err := DefaultPath()
 	if err != nil {
 		return Default(), nil
 	}
@@ -162,7 +163,7 @@ func LoadFrom(path string) (*Preferences, error) {
 
 // Save writes preferences to ~/.trvl/preferences.json atomically.
 func Save(p *Preferences) error {
-	path, err := defaultPath()
+	path, err := DefaultPath()
 	if err != nil {
 		return err
 	}

--- a/internal/providers/auth_httptest_test.go
+++ b/internal/providers/auth_httptest_test.go
@@ -621,10 +621,10 @@ func TestProviderFixHint(t *testing.T) {
 	}{
 		{"preflight request failed", "test_provider"},
 		{"results_path did not resolve", "response structure changed"},
-		{"http 403: blocked", "WAF block"},
-		{"http 202: challenge page", "WAF block"},
+		{"http 403: blocked", "WAF"},
+		{"http 202: challenge page", "WAF"},
 		{"rate limit exceeded", "Rate limited"},
-		{"connection refused", "test_provider"},
+		{"connection refused", "connectivity"},
 	}
 	for _, tc := range tests {
 		hint := providerFixHint(fmt.Errorf("%s", tc.err))

--- a/internal/providers/fixhint.go
+++ b/internal/providers/fixhint.go
@@ -1,0 +1,93 @@
+package providers
+
+import "strings"
+
+// FixHintCode is a typed enum identifying the root cause of a provider failure.
+// It is surfaced in MCP search responses and the health log so an orchestrating
+// LLM can autonomously diagnose and repair broken providers.
+type FixHintCode string
+
+const (
+	FixHintAkamaiBlock          FixHintCode = "AKAMAI_BLOCK"
+	FixHintDNSFail              FixHintCode = "DNS_FAIL"
+	FixHintTLSTimeout           FixHintCode = "TLS_TIMEOUT"
+	FixHintCookieExpired        FixHintCode = "COOKIE_EXPIRED"
+	FixHintRateLimited          FixHintCode = "RATE_LIMITED"
+	FixHintResponseShapeChanged FixHintCode = "RESPONSE_SHAPE_CHANGED"
+	FixHintPreflightFailed      FixHintCode = "PREFLIGHT_FAILED"
+	FixHintUnclassified         FixHintCode = "UNCLASSIFIED"
+)
+
+// classifyProviderError maps a provider error to a typed FixHintCode and a
+// one-line, LLM-readable hint with a documented remediation step.
+// It is a pure function — no I/O, safe to call from any goroutine.
+//
+// Ordering matters: more specific patterns are checked before broader ones so
+// that ambiguous errors (e.g. a 403 that also contains "preflight") are
+// assigned the most actionable code.
+func classifyProviderError(err error) (FixHintCode, string) {
+	if err == nil {
+		return FixHintUnclassified, "No error — check caller logic."
+	}
+	msg := strings.ToLower(err.Error())
+
+	switch {
+	// Rate-limit beats WAF: a 429 is more specific than a generic 403.
+	case strings.Contains(msg, "rate limit") ||
+		strings.Contains(msg, "429") ||
+		strings.Contains(msg, "too many requests"):
+		return FixHintRateLimited,
+			"Rate limited — wait before retrying, or reduce request frequency in provider config."
+
+	// WAF / Akamai block (403, 202 challenge, or explicit "akamai" token).
+	case strings.Contains(msg, "akamai") ||
+		strings.Contains(msg, "http 403") ||
+		strings.Contains(msg, "http 202") ||
+		strings.Contains(msg, "403 forbidden") ||
+		strings.Contains(msg, "access denied"):
+		return FixHintAkamaiBlock,
+			"WAF/Akamai block detected — call test_provider; if it fails, refresh browser cookies via configure_provider."
+
+	// Cookie auth failure (expired session / CSRF token mismatch).
+	case strings.Contains(msg, "cookie") ||
+		strings.Contains(msg, "csrf") ||
+		strings.Contains(msg, "401") ||
+		strings.Contains(msg, "unauthorized"):
+		return FixHintCookieExpired,
+			"Session cookie expired — call configure_provider to re-import fresh browser cookies."
+
+	// Preflight step failed (URL construction or WAF during auth phase).
+	case strings.Contains(msg, "preflight"):
+		return FixHintPreflightFailed,
+			"Preflight auth step failed — call test_provider to diagnose; WAF may need a cookie refresh."
+
+	// Response shape mismatch (results_path or JSON extraction error).
+	case strings.Contains(msg, "results_path") ||
+		strings.Contains(msg, "response shape") ||
+		strings.Contains(msg, "unmarshal") ||
+		strings.Contains(msg, "unexpected end of json"):
+		return FixHintResponseShapeChanged,
+			"API response structure changed — call test_provider to inspect the current response, then update results_path via configure_provider."
+
+	// TLS handshake / connection timeout / network-layer failure.
+	// DNS is checked here first (subset of network errors).
+	case strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "dns") ||
+		strings.Contains(msg, "lookup"):
+		return FixHintDNSFail,
+			"DNS resolution failed — verify the provider base_url is correct and network connectivity is intact."
+
+	case strings.Contains(msg, "tls") ||
+		strings.Contains(msg, "handshake") ||
+		strings.Contains(msg, "deadline exceeded") ||
+		strings.Contains(msg, "context deadline") ||
+		strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "connection refused"):
+		return FixHintTLSTimeout,
+			"TLS/connection timeout — check network connectivity; the provider endpoint may be temporarily unreachable."
+
+	default:
+		return FixHintUnclassified,
+			"Call test_provider with this provider's id to diagnose the issue."
+	}
+}

--- a/internal/providers/fixhint_test.go
+++ b/internal/providers/fixhint_test.go
@@ -1,0 +1,112 @@
+package providers
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestClassifyProviderError_AllCodes(t *testing.T) {
+	cases := []struct {
+		name     string
+		errMsg   string
+		wantCode FixHintCode
+	}{
+		// Rate-limit beats WAF
+		{"rate_limit_text", "upstream: rate limit exceeded", FixHintRateLimited},
+		{"http_429", "server returned http 429 too many requests", FixHintRateLimited},
+		{"too_many_requests", "too many requests from this ip", FixHintRateLimited},
+
+		// Akamai / WAF block
+		{"akamai_explicit", "akamai edge server rejected request", FixHintAkamaiBlock},
+		{"http_403", "http 403 forbidden", FixHintAkamaiBlock},
+		{"http_202", "http 202 challenge page", FixHintAkamaiBlock},
+		{"access_denied", "access denied by provider waf", FixHintAkamaiBlock},
+
+		// Cookie / auth failure
+		{"cookie_expired", "cookie jar expired, re-login required", FixHintCookieExpired},
+		{"csrf_mismatch", "csrf token mismatch on post", FixHintCookieExpired},
+		{"http_401", "server returned 401 unauthorized", FixHintCookieExpired},
+
+		// Preflight step failure
+		{"preflight_fail", "preflight request to /auth failed", FixHintPreflightFailed},
+
+		// Response shape changed
+		{"results_path", "results_path '/data/hotels' not found in response", FixHintResponseShapeChanged},
+		{"unmarshal", "cannot unmarshal string into Go value of type []Hotel", FixHintResponseShapeChanged},
+		{"unexpected_eof", "unexpected end of json input", FixHintResponseShapeChanged},
+
+		// DNS failure
+		{"no_such_host", "dial tcp: lookup booking.com: no such host", FixHintDNSFail},
+		{"dns_explicit", "dns resolution failed for provider endpoint", FixHintDNSFail},
+
+		// TLS / connection timeout
+		{"tls_handshake", "tls handshake timeout after 10s", FixHintTLSTimeout},
+		{"deadline_exceeded", "context deadline exceeded", FixHintTLSTimeout},
+		{"timeout_generic", "connection timeout to provider", FixHintTLSTimeout},
+		{"connection_refused", "connection refused on port 443", FixHintTLSTimeout},
+
+		// Unclassified
+		{"unknown", "something completely unrecognised happened", FixHintUnclassified},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, hint := classifyProviderError(errors.New(tc.errMsg))
+			if code != tc.wantCode {
+				t.Errorf("classifyProviderError(%q) code = %q, want %q", tc.errMsg, code, tc.wantCode)
+			}
+			if hint == "" {
+				t.Errorf("classifyProviderError(%q) returned empty hint", tc.errMsg)
+			}
+		})
+	}
+}
+
+// TestClassifyProviderError_NilError verifies graceful handling of nil.
+func TestClassifyProviderError_NilError(t *testing.T) {
+	code, hint := classifyProviderError(nil)
+	if code != FixHintUnclassified {
+		t.Errorf("nil error should classify as UNCLASSIFIED, got %q", code)
+	}
+	if hint == "" {
+		t.Error("nil error should still return a non-empty hint")
+	}
+}
+
+// TestClassifyProviderError_OrderingPriority pins tie-breaker ordering:
+// rate-limit > WAF > cookie.
+func TestClassifyProviderError_OrderingPriority(t *testing.T) {
+	// A 429 that also contains "403" in the body — rate-limit wins.
+	code, _ := classifyProviderError(errors.New("http 429, previously saw http 403"))
+	if code != FixHintRateLimited {
+		t.Errorf("rate-limit should beat WAF, got %q", code)
+	}
+
+	// A 403 that also mentions "cookie" — WAF wins (403 is checked before cookie).
+	code, _ = classifyProviderError(errors.New("http 403, cookie header was present"))
+	if code != FixHintAkamaiBlock {
+		t.Errorf("WAF (403) should beat cookie when both match, got %q", code)
+	}
+}
+
+// TestProviderFixHint_BackCompat verifies that providerFixHint (the legacy
+// wrapper) returns a non-empty string for every error class.
+func TestProviderFixHint_BackCompat(t *testing.T) {
+	errs := []string{
+		"rate limit exceeded",
+		"http 403 forbidden",
+		"cookie expired",
+		"preflight failed",
+		"results_path not found",
+		"tls handshake timeout",
+		"context deadline exceeded",
+		"no such host",
+		"unrecognised error",
+	}
+	for _, msg := range errs {
+		hint := providerFixHint(errors.New(msg))
+		if hint == "" {
+			t.Errorf("providerFixHint(%q) returned empty hint", msg)
+		}
+	}
+}

--- a/internal/providers/health_log.go
+++ b/internal/providers/health_log.go
@@ -26,6 +26,7 @@ type HealthEntry struct {
 	LatencyMs int64  `json:"latency_ms"`
 	Results   int    `json:"results,omitempty"`
 	Error     string `json:"error,omitempty"`
+	HintCode  string `json:"hint_code,omitempty"` // typed root-cause code when status != "ok"
 }
 
 // ProviderHealth is the per-provider aggregate computed by HealthSummary.
@@ -38,6 +39,7 @@ type ProviderHealth struct {
 	SuccessRate  float64 `json:"success_rate"`
 	AvgLatencyMs int64   `json:"avg_latency_ms"`
 	LastError    string  `json:"last_error,omitempty"`
+	LastHintCode string  `json:"last_hint_code,omitempty"` // most recent root-cause code for failures
 }
 
 // healthWriter is the package-level singleton that owns the write goroutine.
@@ -169,12 +171,13 @@ func HealthSummary(dir string) map[string]ProviderHealth {
 	}
 
 	type agg struct {
-		total     int
-		successes int
-		errors    int
-		timeouts  int
-		latSum    int64
-		lastErr   string
+		total        int
+		successes    int
+		errors       int
+		timeouts     int
+		latSum       int64
+		lastErr      string
+		lastHintCode string
 	}
 	m := make(map[string]*agg)
 
@@ -194,10 +197,16 @@ func HealthSummary(dir string) map[string]ProviderHealth {
 			if e.Error != "" {
 				a.lastErr = e.Error
 			}
+			if e.HintCode != "" {
+				a.lastHintCode = e.HintCode
+			}
 		default:
 			a.errors++
 			if e.Error != "" {
 				a.lastErr = e.Error
+			}
+			if e.HintCode != "" {
+				a.lastHintCode = e.HintCode
 			}
 		}
 	}
@@ -221,6 +230,7 @@ func HealthSummary(dir string) map[string]ProviderHealth {
 			SuccessRate:  rate,
 			AvgLatencyMs: avgLat,
 			LastError:    a.lastErr,
+			LastHintCode: a.lastHintCode,
 		}
 	}
 	return result

--- a/internal/providers/runtime.go
+++ b/internal/providers/runtime.go
@@ -308,19 +308,22 @@ func (rt *Runtime) SearchHotels(ctx context.Context, location string, lat, lon f
 			if isTimeoutError(r.err) {
 				status = "timeout"
 			}
+			hintCode, hint := classifyProviderError(r.err)
 			LogHealth(HealthEntry{
 				Provider:  r.id,
 				Operation: "search",
 				Status:    status,
 				LatencyMs: r.latencyMs,
 				Error:     errMsg,
+				HintCode:  string(hintCode),
 			})
 			statuses = append(statuses, models.ProviderStatus{
-				ID:      r.id,
-				Name:    r.name,
-				Status:  "error",
-				Error:   errMsg,
-				FixHint: providerFixHint(r.err),
+				ID:          r.id,
+				Name:        r.name,
+				Status:      "error",
+				Error:       errMsg,
+				FixHint:     hint,
+				FixHintCode: string(hintCode),
 			})
 			if firstErr == nil {
 				firstErr = r.err
@@ -361,21 +364,12 @@ func isTimeoutError(err error) bool {
 		strings.Contains(msg, "timeout")
 }
 
-// providerFixHint generates an actionable LLM-readable hint for common failures.
+// providerFixHint returns the human-readable hint for a provider error.
+// It delegates to classifyProviderError and is kept for backward compatibility
+// with any callers that only need the hint string.
 func providerFixHint(err error) string {
-	msg := err.Error()
-	switch {
-	case strings.Contains(msg, "preflight"):
-		return "Call test_provider with this provider's id to diagnose. WAF/auth may need refresh."
-	case strings.Contains(msg, "results_path"):
-		return "API response structure changed. Call test_provider to see current response shape, then configure_provider to update results_path."
-	case strings.Contains(msg, "http 403"), strings.Contains(msg, "http 202"):
-		return "WAF block detected. Try test_provider — if it fails, the provider may need browser cookie refresh."
-	case strings.Contains(msg, "rate limit"):
-		return "Rate limited. Wait and retry, or reduce request frequency in provider config."
-	default:
-		return "Call test_provider with this provider's id to diagnose the issue."
-	}
+	_, hint := classifyProviderError(err)
+	return hint
 }
 
 func (rt *Runtime) searchProvider(ctx context.Context, cfg *ProviderConfig, location string, lat, lon float64, checkin, checkout, currency string, guests int, filters *HotelFilterParams) ([]models.HotelResult, error) {

--- a/internal/scoring/profile_match.go
+++ b/internal/scoring/profile_match.go
@@ -1,0 +1,394 @@
+// Package scoring computes multi-factor profile match scores for trvl results.
+//
+// ProfileMatch replaces the old two-factor ValueScore with a weighted sum
+// across ≥ 12 factors that cover all major preference dimensions:
+// budget fit, loyalty, time windows, routing, geography, and travel style.
+//
+// The score is in [0, 100] (integer). 0 is also returned when a hard-exclusion
+// rule fires (e.g. a destination in the user's excluded list). Each call also
+// returns a per-factor breakdown (map[string]float64 with values in [0,1]) so
+// the user can see exactly why a trip scored 73 instead of 91.
+package scoring
+
+import (
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+)
+
+// Factor name constants for breakdown keys and weight maps.
+const (
+	FactorBudgetFit                = "budget_fit"
+	FactorLoyaltyEarn              = "loyalty_earn"
+	FactorTimeWindowFit            = "time_window_fit"
+	FactorDirectness               = "directness"
+	FactorDistrictMatch            = "district_match"
+	FactorAirportAffinity          = "airport_affinity"
+	FactorEarlyConnectionCompliance = "early_connection_compliance"
+	FactorStatusRetention          = "status_retention"
+	FactorLoungeAtTransit          = "lounge_at_transit"
+	FactorBucketListBoost          = "bucket_list_boost"
+	FactorWarsawFilter             = "warsaw_filter"
+	FactorFamilyModeCompatibility  = "family_mode_compatibility"
+)
+
+// DefaultWeights returns sensible default match weights.
+// Values are relative importance; they do not need to sum to any fixed total.
+// The final score is the weighted average of per-factor scores scaled to 0–100.
+func DefaultWeights() map[string]float64 {
+	return map[string]float64{
+		FactorBudgetFit:                 25.0,
+		FactorLoyaltyEarn:               12.0,
+		FactorTimeWindowFit:             8.0,
+		FactorDirectness:                10.0,
+		FactorDistrictMatch:             8.0,
+		FactorAirportAffinity:           8.0,
+		FactorEarlyConnectionCompliance: 5.0,
+		FactorStatusRetention:           7.0,
+		FactorLoungeAtTransit:           4.0,
+		FactorBucketListBoost:           8.0,
+		FactorFamilyModeCompatibility:   5.0,
+		// FactorWarsawFilter is a hard exclusion gate; it has no weight in the
+		// weighted-sum path and is applied before the weighted sum.
+	}
+}
+
+// DiscoverInput is the per-result data available when scoring a discover result.
+// Fields that are unknown (e.g. no detailed flight leg data in explore-mode)
+// may be left at their zero values; factor scorers handle zero gracefully by
+// returning a neutral 0.5.
+type DiscoverInput struct {
+	// Destination identifiers.
+	AirportCode string // IATA code of destination airport, e.g. "BCN"
+	CityName    string // Human-readable city name, e.g. "Barcelona"
+
+	// Trip economics.
+	FlightPrice float64 // one-way fare component in user's currency
+	HotelPrice  float64 // total hotel cost for the stay
+	Total       float64 // FlightPrice + HotelPrice
+	Budget      float64 // user's declared maximum
+
+	// Hotel quality.
+	HotelRating float64 // 0–10 scale (0 = unknown)
+	HotelName   string
+
+	// Optional flight detail (populated when calling from flights/hotels views).
+	Stops       int    // number of stops (0 = direct)
+	DepartTime  string // "HH:MM" 24h format; "" if unknown
+	AirlineCodes []string // IATA airline codes for all legs; nil if unknown
+}
+
+// ComputeProfileMatch scores a single discover/flight/hotel result against the
+// user's full preference profile.
+//
+// Returns:
+//   - score:     0–100 (int). 0 when a hard-exclusion rule fires.
+//   - breakdown: per-factor raw score in [0,1] for the --explain output.
+func ComputeProfileMatch(prefs *preferences.Preferences, input DiscoverInput) (score int, breakdown map[string]float64) {
+	breakdown = make(map[string]float64, 12)
+
+	if prefs == nil {
+		prefs = preferences.Default()
+	}
+
+	// Resolve effective weights (user-tunable via preferences.json).
+	weights := DefaultWeights()
+	for k, v := range prefs.MatchWeights {
+		if v >= 0 {
+			weights[k] = v
+		}
+	}
+
+	// ── Hard-exclusion gate ────────────────────────────────────────────────
+	if isExcluded(prefs, input.AirportCode, input.CityName) {
+		breakdown[FactorWarsawFilter] = 0.0
+		return 0, breakdown
+	}
+	breakdown[FactorWarsawFilter] = 1.0 // destination passes the exclusion filter
+
+	// ── Per-factor scores ─────────────────────────────────────────────────
+	breakdown[FactorBudgetFit] = scoreBudgetFit(input)
+	breakdown[FactorLoyaltyEarn] = scoreLoyaltyEarn(prefs, input)
+	breakdown[FactorTimeWindowFit] = scoreTimeWindowFit(prefs, input)
+	breakdown[FactorDirectness] = scoreDirectness(prefs, input)
+	breakdown[FactorDistrictMatch] = scoreDistrictMatch(prefs, input)
+	breakdown[FactorAirportAffinity] = scoreAirportAffinity(prefs, input)
+	breakdown[FactorEarlyConnectionCompliance] = scoreEarlyConnectionCompliance(prefs, input)
+	breakdown[FactorStatusRetention] = scoreStatusRetention(prefs, input)
+	breakdown[FactorLoungeAtTransit] = scoreLoungeAtTransit(prefs, input)
+	breakdown[FactorBucketListBoost] = scoreBucketListBoost(prefs, input)
+	breakdown[FactorFamilyModeCompatibility] = scoreFamilyModeCompatibility(prefs, input)
+
+	// ── Weighted average → 0–100 ─────────────────────────────────────────
+	var weightedSum, totalWeight float64
+	for factor, w := range weights {
+		if s, ok := breakdown[factor]; ok {
+			weightedSum += w * s
+			totalWeight += w
+		}
+	}
+	if totalWeight == 0 {
+		return 50, breakdown
+	}
+	raw := weightedSum / totalWeight * 100.0
+	if raw < 0 {
+		raw = 0
+	}
+	if raw > 100 {
+		raw = 100
+	}
+	return int(raw + 0.5), breakdown // round to nearest integer
+}
+
+// ── Factor implementations ────────────────────────────────────────────────────
+
+// scoreBudgetFit: how much budget headroom remains (0 at budget, 1 when free).
+func scoreBudgetFit(input DiscoverInput) float64 {
+	if input.Budget <= 0 {
+		return 0.5
+	}
+	fit := 1.0 - (input.Total / input.Budget)
+	if fit < 0 {
+		return 0
+	}
+	if fit > 1 {
+		return 1
+	}
+	return fit
+}
+
+// scoreLoyaltyEarn: does the flight accrue miles in a preferred programme?
+// 1.0 if at least one leg is on a loyalty airline; 0.5 neutral if unknown.
+func scoreLoyaltyEarn(prefs *preferences.Preferences, input DiscoverInput) float64 {
+	if len(prefs.LoyaltyAirlines) == 0 && len(prefs.FrequentFlyerPrograms) == 0 {
+		return 0.5
+	}
+	if len(input.AirlineCodes) == 0 {
+		return 0.5 // unknown — neutral
+	}
+	for _, code := range input.AirlineCodes {
+		for _, la := range prefs.LoyaltyAirlines {
+			if strings.EqualFold(code, la) {
+				return 1.0
+			}
+		}
+		for _, ffp := range prefs.FrequentFlyerPrograms {
+			if strings.EqualFold(code, ffp.AirlineCode) {
+				return 1.0
+			}
+		}
+	}
+	return 0.2
+}
+
+// scoreTimeWindowFit: does departure time fall within the user's preferred window?
+// Returns 0.5 (neutral) when DepartTime is unknown.
+func scoreTimeWindowFit(prefs *preferences.Preferences, input DiscoverInput) float64 {
+	if input.DepartTime == "" {
+		return 0.5
+	}
+	earliest := prefs.FlightTimeEarliest
+	latest := prefs.FlightTimeLatest
+	if earliest == "" && latest == "" {
+		return 0.5
+	}
+	dep := parseHHMM(input.DepartTime)
+	if dep < 0 {
+		return 0.5
+	}
+	// Red-eye check: if departure is very early (before 06:00) and user doesn't want red-eye, penalise.
+	if dep < 360 && !prefs.RedEyeOK { // 06:00 = 360 minutes
+		return 0.1
+	}
+	if earliest != "" {
+		e := parseHHMM(earliest)
+		if e >= 0 && dep < e {
+			return 0.3
+		}
+	}
+	if latest != "" {
+		l := parseHHMM(latest)
+		if l >= 0 && dep > l {
+			return 0.2
+		}
+	}
+	return 1.0
+}
+
+// scoreDirectness: prefer direct flights when prefs.PreferDirect is set.
+// Returns 0.5 (neutral) when stop count is unknown (Stops == 0 and input is
+// from explore-mode which doesn't provide stop details).
+func scoreDirectness(prefs *preferences.Preferences, input DiscoverInput) float64 {
+	if !prefs.PreferDirect {
+		return 0.5 // no preference
+	}
+	if len(input.AirlineCodes) == 0 {
+		return 0.5 // unknown routing from explore-mode
+	}
+	if input.Stops == 0 {
+		return 1.0
+	}
+	return 1.0 / (1.0 + float64(input.Stops)) // 0.5 for 1 stop, 0.33 for 2, etc.
+}
+
+// scoreDistrictMatch: is the hotel in a preferred district for this city?
+func scoreDistrictMatch(prefs *preferences.Preferences, input DiscoverInput) float64 {
+	city := input.CityName
+	if city == "" || input.HotelName == "" {
+		return 0.5
+	}
+	districts := prefs.DistrictsFor(city)
+	if len(districts) == 0 {
+		return 0.5
+	}
+	hotelLower := strings.ToLower(input.HotelName)
+	for _, d := range districts {
+		if strings.Contains(hotelLower, strings.ToLower(d)) {
+			return 1.0
+		}
+	}
+	return 0.3
+}
+
+// scoreAirportAffinity: user's auto-learned affinity for a destination airport.
+func scoreAirportAffinity(prefs *preferences.Preferences, input DiscoverInput) float64 {
+	if len(prefs.AirportAffinity) == 0 {
+		return 0.5
+	}
+	if v, ok := prefs.AirportAffinity[strings.ToUpper(input.AirportCode)]; ok {
+		if v < 0 {
+			return 0
+		}
+		if v > 1 {
+			return 1
+		}
+		return v
+	}
+	return 0.5
+}
+
+// scoreEarlyConnectionCompliance: penalise very early morning connections that
+// require pre-dawn travel from home when the user hasn't opted in.
+func scoreEarlyConnectionCompliance(prefs *preferences.Preferences, input DiscoverInput) float64 {
+	if input.DepartTime == "" {
+		return 0.5
+	}
+	dep := parseHHMM(input.DepartTime)
+	if dep < 0 {
+		return 0.5
+	}
+	if dep < 300 && !prefs.RedEyeOK { // before 05:00
+		return 0.0
+	}
+	if dep < 360 && !prefs.RedEyeOK { // 05:00–06:00
+		return 0.3
+	}
+	return 1.0
+}
+
+// scoreStatusRetention: does the trip help maintain elite status via miles?
+// High score when the airline is a status partner and user has a programme near
+// renewal. Without detailed flight data, returns neutral 0.5.
+func scoreStatusRetention(prefs *preferences.Preferences, input DiscoverInput) float64 {
+	if len(prefs.FrequentFlyerPrograms) == 0 {
+		return 0.5
+	}
+	if len(input.AirlineCodes) == 0 {
+		return 0.5
+	}
+	for _, ffp := range prefs.FrequentFlyerPrograms {
+		for _, code := range input.AirlineCodes {
+			if strings.EqualFold(code, ffp.AirlineCode) {
+				// If they have miles balance, a qualifying trip is more valuable.
+				if ffp.MilesBalance > 0 {
+					return 1.0
+				}
+				return 0.8
+			}
+		}
+	}
+	return 0.2
+}
+
+// scoreLoungeAtTransit: does the user have lounge access at the transit airport?
+// Without detailed routing, returns neutral 0.5. With routing, returns 1.0 if
+// the user has any lounge card and there are transit airports.
+func scoreLoungeAtTransit(prefs *preferences.Preferences, input DiscoverInput) float64 {
+	if len(prefs.LoungeCards) == 0 {
+		return 0.5
+	}
+	// Direct flight: lounge access is irrelevant at transit (there is none).
+	if len(input.AirlineCodes) > 0 && input.Stops == 0 {
+		return 0.5
+	}
+	if len(input.AirlineCodes) == 0 {
+		return 0.5 // unknown
+	}
+	// Has stops + has lounge card → good
+	return 0.8
+}
+
+// scoreBucketListBoost: is the destination on the user's bucket list?
+func scoreBucketListBoost(prefs *preferences.Preferences, input DiscoverInput) float64 {
+	if len(prefs.BucketList) == 0 {
+		return 0.5
+	}
+	city := strings.ToLower(input.CityName)
+	airport := strings.ToUpper(input.AirportCode)
+	for _, item := range prefs.BucketList {
+		item = strings.TrimSpace(item)
+		if strings.EqualFold(item, city) || strings.EqualFold(item, airport) ||
+			strings.Contains(strings.ToLower(item), city) {
+			return 1.0
+		}
+	}
+	return 0.5
+}
+
+// scoreFamilyModeCompatibility: is the trip suitable for the user's travel party?
+// Penalises party-heavy trips for solo travellers and ensures family-suitable
+// hotels when travelling with dependants.
+func scoreFamilyModeCompatibility(prefs *preferences.Preferences, input DiscoverInput) float64 {
+	if prefs.DefaultCompanions == 0 {
+		// Solo traveller: no-dormitory and en-suite checks already handled by filters.
+		return 0.5
+	}
+	// Group travel: prefer higher-rated hotels.
+	if input.HotelRating >= 8.0 {
+		return 1.0
+	}
+	if input.HotelRating >= 7.0 {
+		return 0.7
+	}
+	if input.HotelRating > 0 {
+		return 0.4
+	}
+	return 0.5
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// isExcluded returns true if the destination matches any entry in
+// prefs.ExcludedDestinations (case-insensitive, matches airport code or city).
+func isExcluded(prefs *preferences.Preferences, airportCode, cityName string) bool {
+	for _, excl := range prefs.ExcludedDestinations {
+		excl = strings.TrimSpace(excl)
+		if strings.EqualFold(excl, airportCode) ||
+			strings.EqualFold(excl, cityName) ||
+			(cityName != "" && strings.Contains(strings.ToLower(cityName), strings.ToLower(excl))) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseHHMM converts a "HH:MM" string to minutes-since-midnight.
+// Returns -1 on parse failure.
+func parseHHMM(s string) int {
+	t, err := time.Parse("15:04", s)
+	if err != nil {
+		return -1
+	}
+	return t.Hour()*60 + t.Minute()
+}

--- a/internal/scoring/profile_match_test.go
+++ b/internal/scoring/profile_match_test.go
@@ -1,0 +1,695 @@
+package scoring_test
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/scoring"
+)
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func defaultPrefs() *preferences.Preferences {
+	return preferences.Default()
+}
+
+func baseInput() scoring.DiscoverInput {
+	return scoring.DiscoverInput{
+		AirportCode: "BCN",
+		CityName:    "Barcelona",
+		FlightPrice: 100,
+		HotelPrice:  150,
+		Total:       250,
+		Budget:      500,
+		HotelRating: 8.0,
+		HotelName:   "Hotel Arts Barcelona",
+	}
+}
+
+// ── ComputeProfileMatch — basic contract ─────────────────────────────────────
+
+func TestComputeProfileMatch_NilPrefs(t *testing.T) {
+	score, breakdown := scoring.ComputeProfileMatch(nil, baseInput())
+	if score < 0 || score > 100 {
+		t.Errorf("score %d out of [0,100]", score)
+	}
+	if len(breakdown) == 0 {
+		t.Error("breakdown should not be empty")
+	}
+}
+
+func TestComputeProfileMatch_DefaultPrefs(t *testing.T) {
+	score, breakdown := scoring.ComputeProfileMatch(defaultPrefs(), baseInput())
+	if score <= 0 || score > 100 {
+		t.Errorf("score = %d, want (0, 100]", score)
+	}
+	// All expected factor keys should be present.
+	for _, key := range []string{
+		scoring.FactorBudgetFit,
+		scoring.FactorLoyaltyEarn,
+		scoring.FactorTimeWindowFit,
+		scoring.FactorDirectness,
+		scoring.FactorDistrictMatch,
+		scoring.FactorAirportAffinity,
+		scoring.FactorEarlyConnectionCompliance,
+		scoring.FactorStatusRetention,
+		scoring.FactorLoungeAtTransit,
+		scoring.FactorBucketListBoost,
+		scoring.FactorWarsawFilter,
+		scoring.FactorFamilyModeCompatibility,
+	} {
+		if _, ok := breakdown[key]; !ok {
+			t.Errorf("breakdown missing factor %q", key)
+		}
+	}
+}
+
+func TestComputeProfileMatch_ScoreRange(t *testing.T) {
+	inputs := []scoring.DiscoverInput{
+		{AirportCode: "BCN", Total: 50, Budget: 500},
+		{AirportCode: "NRT", Total: 490, Budget: 500, HotelRating: 9.0},
+		{AirportCode: "HEL", Total: 250, Budget: 300, HotelRating: 7.5},
+	}
+	for _, in := range inputs {
+		score, _ := scoring.ComputeProfileMatch(defaultPrefs(), in)
+		if score < 0 || score > 100 {
+			t.Errorf("score %d out of range for input %+v", score, in)
+		}
+	}
+}
+
+// ── Factor: budget_fit ────────────────────────────────────────────────────────
+
+func TestFactor_BudgetFit_HighSlack(t *testing.T) {
+	in := baseInput()
+	in.Total = 50
+	in.Budget = 500
+	score, bd := scoring.ComputeProfileMatch(defaultPrefs(), in)
+	if bd[scoring.FactorBudgetFit] < 0.8 {
+		t.Errorf("budget_fit = %.2f, want ≥ 0.8 for large slack", bd[scoring.FactorBudgetFit])
+	}
+	_ = score
+}
+
+func TestFactor_BudgetFit_AtBudget(t *testing.T) {
+	in := baseInput()
+	in.Total = 500
+	in.Budget = 500
+	_, bd := scoring.ComputeProfileMatch(defaultPrefs(), in)
+	if bd[scoring.FactorBudgetFit] != 0.0 {
+		t.Errorf("budget_fit = %.2f, want 0.0 when total == budget", bd[scoring.FactorBudgetFit])
+	}
+}
+
+func TestFactor_BudgetFit_HighSlackHigherScore(t *testing.T) {
+	prefs := defaultPrefs()
+	cheapInput := baseInput()
+	cheapInput.Total = 100
+	cheapInput.Budget = 500
+
+	expensiveInput := baseInput()
+	expensiveInput.Total = 450
+	expensiveInput.Budget = 500
+
+	s1, _ := scoring.ComputeProfileMatch(prefs, cheapInput)
+	s2, _ := scoring.ComputeProfileMatch(prefs, expensiveInput)
+	if s1 <= s2 {
+		t.Errorf("cheap trip score %d should be > expensive trip score %d", s1, s2)
+	}
+}
+
+// ── Factor: warsaw_filter (hard exclusion) ────────────────────────────────────
+
+func TestFactor_WarsawFilter_ExcludedAirport(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.ExcludedDestinations = []string{"WAW"}
+
+	in := baseInput()
+	in.AirportCode = "WAW"
+	in.CityName = "Warsaw"
+
+	score, bd := scoring.ComputeProfileMatch(prefs, in)
+	if score != 0 {
+		t.Errorf("score = %d, want 0 for excluded destination", score)
+	}
+	if bd[scoring.FactorWarsawFilter] != 0.0 {
+		t.Errorf("warsaw_filter = %.2f, want 0.0 for excluded destination", bd[scoring.FactorWarsawFilter])
+	}
+}
+
+func TestFactor_WarsawFilter_ExcludedCity(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.ExcludedDestinations = []string{"Warsaw"}
+
+	in := baseInput()
+	in.AirportCode = "WAW"
+	in.CityName = "Warsaw"
+
+	score, _ := scoring.ComputeProfileMatch(prefs, in)
+	if score != 0 {
+		t.Errorf("score = %d, want 0 for excluded city", score)
+	}
+}
+
+func TestFactor_WarsawFilter_NonExcluded(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.ExcludedDestinations = []string{"WAW"}
+
+	in := baseInput()
+	in.AirportCode = "BCN"
+	in.CityName = "Barcelona"
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorWarsawFilter] != 1.0 {
+		t.Errorf("warsaw_filter = %.2f, want 1.0 for non-excluded destination", bd[scoring.FactorWarsawFilter])
+	}
+}
+
+// ── Factor: bucket_list_boost ─────────────────────────────────────────────────
+
+func TestFactor_BucketListBoost_Match(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.BucketList = []string{"Barcelona", "Kyoto"}
+
+	in := baseInput()
+	in.CityName = "Barcelona"
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorBucketListBoost] < 0.9 {
+		t.Errorf("bucket_list_boost = %.2f, want ≥ 0.9 for bucket list city", bd[scoring.FactorBucketListBoost])
+	}
+}
+
+func TestFactor_BucketListBoost_NoMatch(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.BucketList = []string{"Kyoto", "Patagonia"}
+
+	in := baseInput()
+	in.CityName = "Helsinki"
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorBucketListBoost] > 0.6 {
+		t.Errorf("bucket_list_boost = %.2f, want ≤ 0.6 for non-bucket-list city", bd[scoring.FactorBucketListBoost])
+	}
+}
+
+func TestFactor_BucketListBoost_AirportCodeMatch(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.BucketList = []string{"NRT"} // Tokyo Narita by airport code
+
+	in := baseInput()
+	in.AirportCode = "NRT"
+	in.CityName = "Tokyo"
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorBucketListBoost] < 0.9 {
+		t.Errorf("bucket_list_boost = %.2f, want ≥ 0.9 for airport code bucket list match", bd[scoring.FactorBucketListBoost])
+	}
+}
+
+// ── Factor: airport_affinity ──────────────────────────────────────────────────
+
+func TestFactor_AirportAffinity_High(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.AirportAffinity = map[string]float64{"BCN": 0.95}
+
+	_, bd := scoring.ComputeProfileMatch(prefs, baseInput())
+	if bd[scoring.FactorAirportAffinity] < 0.9 {
+		t.Errorf("airport_affinity = %.2f, want ≥ 0.9 for high affinity", bd[scoring.FactorAirportAffinity])
+	}
+}
+
+func TestFactor_AirportAffinity_Low(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.AirportAffinity = map[string]float64{"BCN": 0.1}
+
+	_, bd := scoring.ComputeProfileMatch(prefs, baseInput())
+	if bd[scoring.FactorAirportAffinity] > 0.2 {
+		t.Errorf("airport_affinity = %.2f, want ≤ 0.2 for low affinity", bd[scoring.FactorAirportAffinity])
+	}
+}
+
+func TestFactor_AirportAffinity_Unknown(t *testing.T) {
+	prefs := defaultPrefs()
+	in := baseInput()
+	in.AirportCode = "PRG"
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorAirportAffinity] != 0.5 {
+		t.Errorf("airport_affinity = %.2f, want 0.5 (neutral) for unknown airport", bd[scoring.FactorAirportAffinity])
+	}
+}
+
+// ── Factor: loyalty_earn ──────────────────────────────────────────────────────
+
+func TestFactor_LoyaltyEarn_PreferredAirline(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.LoyaltyAirlines = []string{"KL", "AY"}
+
+	in := baseInput()
+	in.AirlineCodes = []string{"KL"}
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorLoyaltyEarn] < 0.9 {
+		t.Errorf("loyalty_earn = %.2f, want ≥ 0.9 for preferred airline", bd[scoring.FactorLoyaltyEarn])
+	}
+}
+
+func TestFactor_LoyaltyEarn_NoMatch(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.LoyaltyAirlines = []string{"KL", "AY"}
+
+	in := baseInput()
+	in.AirlineCodes = []string{"AA", "UA"}
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorLoyaltyEarn] > 0.3 {
+		t.Errorf("loyalty_earn = %.2f, want ≤ 0.3 for non-preferred airline", bd[scoring.FactorLoyaltyEarn])
+	}
+}
+
+func TestFactor_LoyaltyEarn_NoFlightData(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.LoyaltyAirlines = []string{"KL"}
+
+	in := baseInput()
+	in.AirlineCodes = nil
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorLoyaltyEarn] != 0.5 {
+		t.Errorf("loyalty_earn = %.2f, want 0.5 (neutral) when no flight data", bd[scoring.FactorLoyaltyEarn])
+	}
+}
+
+// ── Factor: time_window_fit ───────────────────────────────────────────────────
+
+func TestFactor_TimeWindowFit_WithinWindow(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.FlightTimeEarliest = "07:00"
+	prefs.FlightTimeLatest = "22:00"
+
+	in := baseInput()
+	in.DepartTime = "09:30"
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorTimeWindowFit] < 0.9 {
+		t.Errorf("time_window_fit = %.2f, want ≥ 0.9 for in-window departure", bd[scoring.FactorTimeWindowFit])
+	}
+}
+
+func TestFactor_TimeWindowFit_TooEarly(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.FlightTimeEarliest = "07:00"
+
+	in := baseInput()
+	in.DepartTime = "05:30"
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorTimeWindowFit] > 0.4 {
+		t.Errorf("time_window_fit = %.2f, want ≤ 0.4 for too-early departure", bd[scoring.FactorTimeWindowFit])
+	}
+}
+
+func TestFactor_TimeWindowFit_UnknownTime(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.FlightTimeEarliest = "07:00"
+
+	in := baseInput()
+	in.DepartTime = ""
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorTimeWindowFit] != 0.5 {
+		t.Errorf("time_window_fit = %.2f, want 0.5 (neutral) when time unknown", bd[scoring.FactorTimeWindowFit])
+	}
+}
+
+// ── Factor: directness ────────────────────────────────────────────────────────
+
+func TestFactor_Directness_PreferDirectFlight(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.PreferDirect = true
+
+	in := baseInput()
+	in.AirlineCodes = []string{"AY"}
+	in.Stops = 0
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorDirectness] < 0.9 {
+		t.Errorf("directness = %.2f, want ≥ 0.9 for direct flight with prefer_direct", bd[scoring.FactorDirectness])
+	}
+}
+
+func TestFactor_Directness_PreferDirectButHasStops(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.PreferDirect = true
+
+	in := baseInput()
+	in.AirlineCodes = []string{"AY"}
+	in.Stops = 1
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorDirectness] > 0.6 {
+		t.Errorf("directness = %.2f, want ≤ 0.6 for connection with prefer_direct", bd[scoring.FactorDirectness])
+	}
+}
+
+func TestFactor_Directness_NoPreference(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.PreferDirect = false
+
+	in := baseInput()
+	in.AirlineCodes = []string{"AY"}
+	in.Stops = 2
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorDirectness] != 0.5 {
+		t.Errorf("directness = %.2f, want 0.5 (neutral) when no directness preference", bd[scoring.FactorDirectness])
+	}
+}
+
+// ── Factor: family_mode_compatibility ─────────────────────────────────────────
+
+func TestFactor_FamilyMode_SoloTraveller(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.DefaultCompanions = 0
+
+	_, bd := scoring.ComputeProfileMatch(prefs, baseInput())
+	if bd[scoring.FactorFamilyModeCompatibility] != 0.5 {
+		t.Errorf("family_mode = %.2f, want 0.5 (neutral) for solo traveller", bd[scoring.FactorFamilyModeCompatibility])
+	}
+}
+
+func TestFactor_FamilyMode_GroupHighRating(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.DefaultCompanions = 2
+
+	in := baseInput()
+	in.HotelRating = 9.0
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorFamilyModeCompatibility] < 0.9 {
+		t.Errorf("family_mode = %.2f, want ≥ 0.9 for group + high-rated hotel", bd[scoring.FactorFamilyModeCompatibility])
+	}
+}
+
+func TestFactor_FamilyMode_GroupLowRating(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.DefaultCompanions = 2
+
+	in := baseInput()
+	in.HotelRating = 5.0
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorFamilyModeCompatibility] > 0.5 {
+		t.Errorf("family_mode = %.2f, want ≤ 0.5 for group + low-rated hotel", bd[scoring.FactorFamilyModeCompatibility])
+	}
+}
+
+// ── Custom weights ────────────────────────────────────────────────────────────
+
+func TestCustomWeights_OverrideBudgetFit(t *testing.T) {
+	prefs := defaultPrefs()
+	// Give extreme weight to bucket list boost and zero to everything else.
+	prefs.MatchWeights = map[string]float64{
+		scoring.FactorBudgetFit:                 0.0,
+		scoring.FactorLoyaltyEarn:               0.0,
+		scoring.FactorTimeWindowFit:             0.0,
+		scoring.FactorDirectness:                0.0,
+		scoring.FactorDistrictMatch:             0.0,
+		scoring.FactorAirportAffinity:           0.0,
+		scoring.FactorEarlyConnectionCompliance: 0.0,
+		scoring.FactorStatusRetention:           0.0,
+		scoring.FactorLoungeAtTransit:           0.0,
+		scoring.FactorBucketListBoost:           100.0,
+		scoring.FactorFamilyModeCompatibility:   0.0,
+	}
+	prefs.BucketList = []string{"Barcelona"}
+
+	// At-budget trip (would score 0 on budget_fit) but bucket-list destination.
+	in := baseInput()
+	in.Total = 500
+	in.Budget = 500
+	in.CityName = "Barcelona"
+
+	score, _ := scoring.ComputeProfileMatch(prefs, in)
+	// With 100% weight on bucket_list (score=1.0), final = 100.
+	if score < 90 {
+		t.Errorf("score = %d, want ≥ 90 when only bucket_list matters and destination matches", score)
+	}
+}
+
+// ── Factor: budget_fit ────────────────────────────────────────────────────────
+
+func TestFactor_BudgetFit_ZeroTotal(t *testing.T) {
+	in := baseInput()
+	in.Total = 0
+	in.Budget = 500
+	_, bd := scoring.ComputeProfileMatch(defaultPrefs(), in)
+	if bd[scoring.FactorBudgetFit] != 1.0 {
+		t.Errorf("budget_fit = %.2f, want 1.0 when total=0", bd[scoring.FactorBudgetFit])
+	}
+}
+
+func TestFactor_BudgetFit_OverBudget(t *testing.T) {
+	in := baseInput()
+	in.Total = 600
+	in.Budget = 500
+	_, bd := scoring.ComputeProfileMatch(defaultPrefs(), in)
+	if bd[scoring.FactorBudgetFit] != 0.0 {
+		t.Errorf("budget_fit = %.2f, want 0.0 when over budget", bd[scoring.FactorBudgetFit])
+	}
+}
+
+func TestFactor_BudgetFit_ZeroBudget(t *testing.T) {
+	in := baseInput()
+	in.Budget = 0
+	_, bd := scoring.ComputeProfileMatch(defaultPrefs(), in)
+	if bd[scoring.FactorBudgetFit] != 0.5 {
+		t.Errorf("budget_fit = %.2f, want 0.5 (neutral) when budget=0", bd[scoring.FactorBudgetFit])
+	}
+}
+
+// ── Factor: district_match ────────────────────────────────────────────────────
+
+func TestFactor_DistrictMatch_HotelInDistrict(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.PreferredDistricts = map[string][]string{"Barcelona": {"Eixample", "Gràcia"}}
+
+	in := baseInput()
+	in.HotelName = "Hotel Eixample Grand"
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorDistrictMatch] < 0.9 {
+		t.Errorf("district_match = %.2f, want ≥ 0.9 when hotel name contains preferred district", bd[scoring.FactorDistrictMatch])
+	}
+}
+
+func TestFactor_DistrictMatch_HotelNotInDistrict(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.PreferredDistricts = map[string][]string{"Barcelona": {"Eixample"}}
+
+	in := baseInput()
+	in.HotelName = "Hotel Barceloneta Beach"
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorDistrictMatch] > 0.4 {
+		t.Errorf("district_match = %.2f, want ≤ 0.4 when hotel not in preferred district", bd[scoring.FactorDistrictMatch])
+	}
+}
+
+func TestFactor_DistrictMatch_NoCityName(t *testing.T) {
+	in := baseInput()
+	in.CityName = ""
+
+	_, bd := scoring.ComputeProfileMatch(defaultPrefs(), in)
+	if bd[scoring.FactorDistrictMatch] != 0.5 {
+		t.Errorf("district_match = %.2f, want 0.5 (neutral) when city name empty", bd[scoring.FactorDistrictMatch])
+	}
+}
+
+// ── Factor: airport_affinity (edge cases) ────────────────────────────────────
+
+func TestFactor_AirportAffinity_Negative(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.AirportAffinity = map[string]float64{"BCN": -0.5}
+
+	_, bd := scoring.ComputeProfileMatch(prefs, baseInput())
+	if bd[scoring.FactorAirportAffinity] != 0.0 {
+		t.Errorf("airport_affinity = %.2f, want 0.0 for negative affinity", bd[scoring.FactorAirportAffinity])
+	}
+}
+
+func TestFactor_AirportAffinity_OverOne(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.AirportAffinity = map[string]float64{"BCN": 1.5}
+
+	_, bd := scoring.ComputeProfileMatch(prefs, baseInput())
+	if bd[scoring.FactorAirportAffinity] != 1.0 {
+		t.Errorf("airport_affinity = %.2f, want 1.0 for affinity > 1 (clamped)", bd[scoring.FactorAirportAffinity])
+	}
+}
+
+// ── Factor: status_retention ──────────────────────────────────────────────────
+
+func TestFactor_StatusRetention_MatchWithMiles(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.FrequentFlyerPrograms = []preferences.FrequentFlyerStatus{
+		{AirlineCode: "AY", MilesBalance: 10000},
+	}
+
+	in := baseInput()
+	in.AirlineCodes = []string{"AY"}
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorStatusRetention] < 0.9 {
+		t.Errorf("status_retention = %.2f, want ≥ 0.9 for matching FFP airline with miles", bd[scoring.FactorStatusRetention])
+	}
+}
+
+func TestFactor_StatusRetention_MatchNoMiles(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.FrequentFlyerPrograms = []preferences.FrequentFlyerStatus{
+		{AirlineCode: "AY", MilesBalance: 0},
+	}
+
+	in := baseInput()
+	in.AirlineCodes = []string{"AY"}
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorStatusRetention] < 0.7 || bd[scoring.FactorStatusRetention] > 0.9 {
+		t.Errorf("status_retention = %.2f, want ≈0.8 for matching FFP airline without miles", bd[scoring.FactorStatusRetention])
+	}
+}
+
+func TestFactor_StatusRetention_NoMatch(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.FrequentFlyerPrograms = []preferences.FrequentFlyerStatus{
+		{AirlineCode: "KL", MilesBalance: 5000},
+	}
+
+	in := baseInput()
+	in.AirlineCodes = []string{"AY", "AA"}
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorStatusRetention] > 0.3 {
+		t.Errorf("status_retention = %.2f, want ≤ 0.3 for non-matching airline", bd[scoring.FactorStatusRetention])
+	}
+}
+
+func TestFactor_StatusRetention_NoAirlineCodes(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.FrequentFlyerPrograms = []preferences.FrequentFlyerStatus{
+		{AirlineCode: "AY"},
+	}
+
+	in := baseInput()
+	in.AirlineCodes = nil
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorStatusRetention] != 0.5 {
+		t.Errorf("status_retention = %.2f, want 0.5 (neutral) when no airline data", bd[scoring.FactorStatusRetention])
+	}
+}
+
+// ── Factor: lounge_at_transit ─────────────────────────────────────────────────
+
+func TestFactor_LoungeAtTransit_HasCardWithStops(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.LoungeCards = []string{"Priority Pass"}
+
+	in := baseInput()
+	in.AirlineCodes = []string{"AY", "BA"}
+	in.Stops = 1
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorLoungeAtTransit] < 0.7 {
+		t.Errorf("lounge_at_transit = %.2f, want ≥ 0.7 for lounge card + connecting flight", bd[scoring.FactorLoungeAtTransit])
+	}
+}
+
+func TestFactor_LoungeAtTransit_HasCardDirectFlight(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.LoungeCards = []string{"Priority Pass"}
+
+	in := baseInput()
+	in.AirlineCodes = []string{"AY"}
+	in.Stops = 0
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorLoungeAtTransit] != 0.5 {
+		t.Errorf("lounge_at_transit = %.2f, want 0.5 (neutral) for direct flight", bd[scoring.FactorLoungeAtTransit])
+	}
+}
+
+func TestFactor_LoungeAtTransit_NoCard(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.LoungeCards = nil
+
+	in := baseInput()
+	in.Stops = 2
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorLoungeAtTransit] != 0.5 {
+		t.Errorf("lounge_at_transit = %.2f, want 0.5 (neutral) when no lounge card", bd[scoring.FactorLoungeAtTransit])
+	}
+}
+
+// ── Factor: early_connection_compliance (edge) ────────────────────────────────
+
+func TestFactor_EarlyConnection_RedEyeOK(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.RedEyeOK = true
+
+	in := baseInput()
+	in.DepartTime = "04:30" // before 05:00 but user has opted in
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorEarlyConnectionCompliance] < 0.9 {
+		t.Errorf("early_connection_compliance = %.2f, want ≥ 0.9 when red_eye_ok and pre-dawn departure", bd[scoring.FactorEarlyConnectionCompliance])
+	}
+}
+
+func TestFactor_EarlyConnection_EarlyMorning_NotOK(t *testing.T) {
+	prefs := defaultPrefs()
+	prefs.RedEyeOK = false
+
+	in := baseInput()
+	in.DepartTime = "05:30" // 05:30 — between 05:00 and 06:00
+
+	_, bd := scoring.ComputeProfileMatch(prefs, in)
+	if bd[scoring.FactorEarlyConnectionCompliance] > 0.4 {
+		t.Errorf("early_connection_compliance = %.2f, want ≤ 0.4 for 05:30 when red_eye_ok=false", bd[scoring.FactorEarlyConnectionCompliance])
+	}
+}
+
+// ── DefaultWeights ────────────────────────────────────────────────────────────
+
+func TestDefaultWeights_AllPositive(t *testing.T) {
+	weights := scoring.DefaultWeights()
+	if len(weights) == 0 {
+		t.Fatal("default weights should not be empty")
+	}
+	for k, v := range weights {
+		if v < 0 {
+			t.Errorf("weight[%q] = %.2f, want ≥ 0", k, v)
+		}
+	}
+}
+
+func TestDefaultWeights_ContainsExpectedFactors(t *testing.T) {
+	weights := scoring.DefaultWeights()
+	for _, factor := range []string{
+		scoring.FactorBudgetFit,
+		scoring.FactorLoyaltyEarn,
+		scoring.FactorBucketListBoost,
+		scoring.FactorFamilyModeCompatibility,
+	} {
+		if _, ok := weights[factor]; !ok {
+			t.Errorf("default weights missing factor %q", factor)
+		}
+	}
+	// WarsawFilter is a hard exclusion and should NOT have a weight.
+	if _, ok := weights[scoring.FactorWarsawFilter]; ok {
+		t.Errorf("default weights should not contain %q (hard exclusion, not weighted)", scoring.FactorWarsawFilter)
+	}
+}

--- a/internal/searchctx/searchctx.go
+++ b/internal/searchctx/searchctx.go
@@ -1,0 +1,14 @@
+package searchctx
+
+import (
+	"context"
+	"time"
+)
+
+// DetachedWithin preserves values from ctx while detaching cancellation fan-out.
+// The returned context is bounded only by max so one short-lived caller cannot
+// shrink a shared singleflight execution for every joined caller.
+func DetachedWithin(ctx context.Context, max time.Duration) (context.Context, context.CancelFunc) {
+	detached := context.WithoutCancel(ctx)
+	return context.WithTimeout(detached, max)
+}

--- a/internal/searchctx/searchctx_test.go
+++ b/internal/searchctx/searchctx_test.go
@@ -1,0 +1,75 @@
+package searchctx
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type contextKey string
+
+func TestDetachedWithin_PreservesValuesAndDetachesParentCancellation(t *testing.T) {
+	parent, parentCancel := context.WithCancel(context.WithValue(context.Background(), contextKey("trace_id"), "abc123"))
+	defer parentCancel()
+
+	shared, sharedCancel := DetachedWithin(parent, time.Second)
+	defer sharedCancel()
+
+	if got := shared.Value(contextKey("trace_id")); got != "abc123" {
+		t.Fatalf("shared context value = %v, want %q", got, "abc123")
+	}
+
+	parentCancel()
+
+	select {
+	case <-shared.Done():
+		t.Fatal("shared context was cancelled by parent cancellation")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	sharedCancel()
+
+	select {
+	case <-shared.Done():
+	case <-time.After(time.Second):
+		t.Fatal("shared context did not observe its own cancellation")
+	}
+}
+
+func TestDetachedWithin_UsesOwnTimeoutInsteadOfParentDeadline(t *testing.T) {
+	parent, parentCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer parentCancel()
+
+	parentDeadline, ok := parent.Deadline()
+	if !ok {
+		t.Fatal("parent context unexpectedly has no deadline")
+	}
+
+	shared, sharedCancel := DetachedWithin(parent, 120*time.Millisecond)
+	defer sharedCancel()
+
+	sharedDeadline, ok := shared.Deadline()
+	if !ok {
+		t.Fatal("shared context unexpectedly has no deadline")
+	}
+	if !sharedDeadline.After(parentDeadline.Add(50 * time.Millisecond)) {
+		t.Fatalf("shared deadline %v unexpectedly tracked parent deadline %v", sharedDeadline, parentDeadline)
+	}
+
+	<-parent.Done()
+
+	select {
+	case <-shared.Done():
+		t.Fatal("shared context ended when parent deadline expired")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	select {
+	case <-shared.Done():
+		if err := shared.Err(); err != context.DeadlineExceeded {
+			t.Fatalf("shared context err = %v, want %v", err, context.DeadlineExceeded)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("shared context did not time out with its own deadline")
+	}
+}

--- a/internal/trip/discover.go
+++ b/internal/trip/discover.go
@@ -19,6 +19,7 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/scoring"
 )
 
 // DiscoverOptions configures an inverted-search discovery.
@@ -35,20 +36,21 @@ type DiscoverOptions struct {
 
 // DiscoverResult is a single ranked trip option.
 type DiscoverResult struct {
-	Destination   string  `json:"destination"`
-	AirportCode   string  `json:"airport_code"`
-	DepartDate    string  `json:"depart_date"`
-	ReturnDate    string  `json:"return_date"`
-	Nights        int     `json:"nights"`
-	FlightPrice   float64 `json:"flight_price"`
-	HotelPrice    float64 `json:"hotel_price"`
-	HotelName     string  `json:"hotel_name"`
-	HotelRating   float64 `json:"hotel_rating"`
-	Total         float64 `json:"total"`
-	Currency      string  `json:"currency"`
-	ValueScore    float64 `json:"value_score"`  // 0..1 — higher is better
-	BudgetSlack   float64 `json:"budget_slack"` // currency units remaining
-	Reasoning     string  `json:"reasoning,omitempty"`
+	Destination    string             `json:"destination"`
+	AirportCode    string             `json:"airport_code"`
+	DepartDate     string             `json:"depart_date"`
+	ReturnDate     string             `json:"return_date"`
+	Nights         int                `json:"nights"`
+	FlightPrice    float64            `json:"flight_price"`
+	HotelPrice     float64            `json:"hotel_price"`
+	HotelName      string             `json:"hotel_name"`
+	HotelRating    float64            `json:"hotel_rating"`
+	Total          float64            `json:"total"`
+	Currency       string             `json:"currency"`
+	ProfileMatch   int                `json:"profile_match"`                     // 0–100; replaces ValueScore
+	MatchBreakdown map[string]float64 `json:"match_breakdown,omitempty"`          // per-factor scores in [0,1]
+	BudgetSlack    float64            `json:"budget_slack"`                       // currency units remaining
+	Reasoning      string             `json:"reasoning,omitempty"`
 }
 
 // DiscoverOutput is the top-level response.
@@ -84,7 +86,8 @@ func (o *DiscoverOptions) applyDefaults() {
 // The strategy is "explore-then-verify": query Google's explore API for each
 // candidate weekend to get cheapest destinations, then search real hotel
 // prices for top candidates with preferences applied. Results are ranked by
-// a value score that rewards hotel quality and remaining budget slack.
+// ProfileMatch score (0-100) — how well each trip matches the user's full
+// travel profile.
 func Discover(ctx context.Context, opts DiscoverOptions) (*DiscoverOutput, error) {
 	opts.applyDefaults()
 
@@ -297,7 +300,7 @@ func Discover(ctx context.Context, opts DiscoverOptions) (*DiscoverOutput, error
 	}
 	hotelWg.Wait()
 
-	results := rankDiscoverTrials(trials, hotelResults, opts.Budget, currency, opts.Top)
+	results := rankDiscoverTrials(trials, hotelResults, opts.Budget, currency, opts.Top, prefs)
 
 	return &DiscoverOutput{
 		Success: true,
@@ -337,20 +340,12 @@ type discoverHotelInfo struct {
 	rating float64
 }
 
-// rankDiscoverTrials scores and ranks discover candidates by value.
+// rankDiscoverTrials scores and ranks discover candidates using ProfileMatch.
 //
-// Phase 3: build ranked results. Score each candidate by value:
-//
-//	value = budget_fit * quality
-//
-// where:
-//
-//	budget_fit = max(0, 1 - total/budget)  (1.0 when free, 0 when at budget)
-//	quality   = 0.5 + 0.5 * (rating / 5)   (0.5..1.0 — rating is a multiplier)
-//
-// This rewards trips that come in well under budget AT a quality hotel,
-// and penalizes trips that blow budget or have weak ratings.
-func rankDiscoverTrials(trials []discoverTrial, hotelResults map[discoverTrialKey]*discoverHotelInfo, budget float64, currency string, top int) []DiscoverResult {
+// Phase 3: build ranked results. Each candidate is scored by
+// scoring.ComputeProfileMatch against the user's full preference profile.
+// Results are sorted by ProfileMatch descending.
+func rankDiscoverTrials(trials []discoverTrial, hotelResults map[discoverTrialKey]*discoverHotelInfo, budget float64, currency string, top int, prefs *preferences.Preferences) []DiscoverResult {
 	var results []DiscoverResult
 	for _, t := range trials {
 		k := discoverTrialKey{airport: t.dest.AirportCode, nights: t.window.nights}
@@ -364,15 +359,6 @@ func rankDiscoverTrials(trials []discoverTrial, hotelResults map[discoverTrialKe
 			continue
 		}
 
-		budgetFit := 1.0 - (total / budget)
-		if budgetFit < 0 {
-			budgetFit = 0
-		}
-		quality := 0.5
-		if h.rating > 0 {
-			quality = 0.5 + 0.5*(h.rating/5.0)
-		}
-		valueScore := budgetFit * quality
 		slack := budget - total
 
 		cityName := t.dest.CityName
@@ -380,29 +366,42 @@ func rankDiscoverTrials(trials []discoverTrial, hotelResults map[discoverTrialKe
 			cityName = models.LookupAirportName(t.dest.AirportCode)
 		}
 
-		reasoning := buildDiscoverReasoning(quality, budgetFit, h.rating, slack, currency)
-
-		results = append(results, DiscoverResult{
-			Destination: cityName,
+		input := scoring.DiscoverInput{
 			AirportCode: t.dest.AirportCode,
-			DepartDate:  t.window.start.Format("2006-01-02"),
-			ReturnDate:  t.window.end.Format("2006-01-02"),
-			Nights:      t.window.nights,
+			CityName:    cityName,
 			FlightPrice: t.dest.Price,
 			HotelPrice:  h.total,
-			HotelName:   h.name,
-			HotelRating: h.rating,
 			Total:       total,
-			Currency:    currency,
-			ValueScore:  valueScore,
-			BudgetSlack: slack,
-			Reasoning:   reasoning,
+			Budget:      budget,
+			HotelRating: h.rating,
+			HotelName:   h.name,
+		}
+
+		matchScore, breakdown := scoring.ComputeProfileMatch(prefs, input)
+		reasoning := buildDiscoverReasoning(h.rating, slack, currency)
+
+		results = append(results, DiscoverResult{
+			Destination:    cityName,
+			AirportCode:    t.dest.AirportCode,
+			DepartDate:     t.window.start.Format("2006-01-02"),
+			ReturnDate:     t.window.end.Format("2006-01-02"),
+			Nights:         t.window.nights,
+			FlightPrice:    t.dest.Price,
+			HotelPrice:     h.total,
+			HotelName:      h.name,
+			HotelRating:    h.rating,
+			Total:          total,
+			Currency:       currency,
+			ProfileMatch:   matchScore,
+			MatchBreakdown: breakdown,
+			BudgetSlack:    slack,
+			Reasoning:      reasoning,
 		})
 	}
 
-	// Rank by value score descending.
+	// Rank by profile match descending.
 	sort.Slice(results, func(i, j int) bool {
-		return results[i].ValueScore > results[j].ValueScore
+		return results[i].ProfileMatch > results[j].ProfileMatch
 	})
 	if len(results) > top {
 		results = results[:top]
@@ -411,7 +410,7 @@ func rankDiscoverTrials(trials []discoverTrial, hotelResults map[discoverTrialKe
 	return results
 }
 
-func buildDiscoverReasoning(quality, budgetFit, rating, slack float64, currency string) string {
+func buildDiscoverReasoning(rating, slack float64, currency string) string {
 	var parts []string
 	if rating > 0 {
 		parts = append(parts, fmt.Sprintf("%.1f★ hotel", rating))
@@ -419,7 +418,5 @@ func buildDiscoverReasoning(quality, budgetFit, rating, slack float64, currency 
 	if slack > 0 {
 		parts = append(parts, fmt.Sprintf("%s %.0f under budget", currency, slack))
 	}
-	_ = quality
-	_ = budgetFit
 	return strings.Join(parts, ", ")
 }

--- a/internal/trip/plan_pure_test.go
+++ b/internal/trip/plan_pure_test.go
@@ -289,7 +289,7 @@ func TestBuildDiscoverReasoning(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildDiscoverReasoning(0, 0, tt.rating, tt.slack, tt.currency)
+			got := buildDiscoverReasoning(tt.rating, tt.slack, tt.currency)
 			if tt.wantSub != "" && !contains(got, tt.wantSub) {
 				t.Errorf("buildDiscoverReasoning() = %q, should contain %q", got, tt.wantSub)
 			}

--- a/internal/trip/trip_coverage3_test.go
+++ b/internal/trip/trip_coverage3_test.go
@@ -357,7 +357,7 @@ func TestDiscoverOptions_MaxNightsClamped(t *testing.T) {
 // ============================================================
 
 func TestBuildDiscoverReasoning_RatingAndSlack(t *testing.T) {
-	got := buildDiscoverReasoning(0.8, 0.6, 4.2, 150, "EUR")
+	got := buildDiscoverReasoning(4.2, 150, "EUR")
 	if !strings.Contains(got, "4.2") {
 		t.Errorf("expected rating in reasoning, got %q", got)
 	}
@@ -367,14 +367,14 @@ func TestBuildDiscoverReasoning_RatingAndSlack(t *testing.T) {
 }
 
 func TestBuildDiscoverReasoning_ZeroRatingZeroSlack(t *testing.T) {
-	got := buildDiscoverReasoning(0, 0, 0, 0, "EUR")
+	got := buildDiscoverReasoning(0, 0, "EUR")
 	if got != "" {
 		t.Errorf("expected empty reasoning when rating=0 and slack=0, got %q", got)
 	}
 }
 
 func TestBuildDiscoverReasoning_OnlyRating(t *testing.T) {
-	got := buildDiscoverReasoning(0, 0, 3.8, 0, "USD")
+	got := buildDiscoverReasoning(3.8, 0, "USD")
 	if !strings.Contains(got, "3.8") {
 		t.Errorf("expected rating in reasoning, got %q", got)
 	}
@@ -384,7 +384,7 @@ func TestBuildDiscoverReasoning_OnlyRating(t *testing.T) {
 }
 
 func TestBuildDiscoverReasoning_OnlySlack(t *testing.T) {
-	got := buildDiscoverReasoning(0, 0, 0, 200, "GBP")
+	got := buildDiscoverReasoning(0, 200, "GBP")
 	if !strings.Contains(got, "GBP") {
 		t.Errorf("expected currency in reasoning, got %q", got)
 	}

--- a/internal/trip/trip_coverage_v7_test.go
+++ b/internal/trip/trip_coverage_v7_test.go
@@ -370,7 +370,7 @@ func TestRankDiscoverTrials_Basic(t *testing.T) {
 	hotelResults := map[discoverTrialKey]*discoverHotelInfo{
 		{airport: "BCN", nights: 2}: {price: 75, total: 150, name: "Hotel BCN", rating: 4.2},
 	}
-	results := rankDiscoverTrials(trials, hotelResults, 500, "EUR", 5)
+	results := rankDiscoverTrials(trials, hotelResults, 500, "EUR", 5, nil)
 	if len(results) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(results))
 	}
@@ -411,8 +411,11 @@ func TestRankDiscoverTrials_Basic(t *testing.T) {
 	if r.BudgetSlack != 250 {
 		t.Errorf("slack = %v, want 250", r.BudgetSlack)
 	}
-	if r.ValueScore <= 0 {
-		t.Errorf("value score = %v, want > 0", r.ValueScore)
+	if r.ProfileMatch <= 0 {
+		t.Errorf("profile match = %v, want > 0", r.ProfileMatch)
+	}
+	if r.MatchBreakdown == nil {
+		t.Error("match breakdown should not be nil")
 	}
 	if r.Reasoning == "" {
 		t.Error("reasoning should not be empty")
@@ -433,7 +436,7 @@ func TestRankDiscoverTrials_ExceedsBudget(t *testing.T) {
 		{airport: "BCN", nights: 2}: {total: 200, name: "H"},
 	}
 	// Budget=500, total=600 -> exceeds.
-	results := rankDiscoverTrials(trials, hotelResults, 500, "EUR", 5)
+	results := rankDiscoverTrials(trials, hotelResults, 500, "EUR", 5, nil)
 	if len(results) != 0 {
 		t.Errorf("expected 0 results for over-budget, got %d", len(results))
 	}
@@ -450,13 +453,13 @@ func TestRankDiscoverTrials_NoHotelData(t *testing.T) {
 		},
 	}
 	// No hotel data for BCN.
-	results := rankDiscoverTrials(trials, map[discoverTrialKey]*discoverHotelInfo{}, 500, "EUR", 5)
+	results := rankDiscoverTrials(trials, map[discoverTrialKey]*discoverHotelInfo{}, 500, "EUR", 5, nil)
 	if len(results) != 0 {
 		t.Errorf("expected 0 results for missing hotel, got %d", len(results))
 	}
 }
 
-func TestRankDiscoverTrials_RankedByValueScore(t *testing.T) {
+func TestRankDiscoverTrials_RankedByProfileMatch(t *testing.T) {
 	fri := time.Date(2026, 8, 7, 0, 0, 0, 0, time.UTC)
 
 	trials := []discoverTrial{
@@ -473,16 +476,16 @@ func TestRankDiscoverTrials_RankedByValueScore(t *testing.T) {
 		{airport: "TLL", nights: 2}: {total: 50, name: "Hostel", rating: 4.5},
 		{airport: "NRT", nights: 2}: {total: 50, name: "Hostel2", rating: 3.0},
 	}
-	results := rankDiscoverTrials(trials, hotelResults, 500, "EUR", 5)
+	results := rankDiscoverTrials(trials, hotelResults, 500, "EUR", 5, nil)
 	if len(results) != 2 {
 		t.Fatalf("expected 2, got %d", len(results))
 	}
-	// Cheap trip (total=100) should have higher value score than expensive (total=450).
+	// Cheap trip (total=100) should have higher profile match than expensive (total=450).
 	if results[0].Destination != "Tallinn" {
-		t.Errorf("highest value = %q, want Tallinn", results[0].Destination)
+		t.Errorf("highest match = %q, want Tallinn", results[0].Destination)
 	}
-	if results[0].ValueScore <= results[1].ValueScore {
-		t.Errorf("Tallinn value (%v) should be > Tokyo value (%v)", results[0].ValueScore, results[1].ValueScore)
+	if results[0].ProfileMatch <= results[1].ProfileMatch {
+		t.Errorf("Tallinn match (%v) should be > Tokyo match (%v)", results[0].ProfileMatch, results[1].ProfileMatch)
 	}
 }
 
@@ -502,7 +505,7 @@ func TestRankDiscoverTrials_TopCap(t *testing.T) {
 			total: 50, name: "H", rating: 4.0,
 		}
 	}
-	results := rankDiscoverTrials(trials, hotelResults, 1000, "EUR", 3)
+	results := rankDiscoverTrials(trials, hotelResults, 1000, "EUR", 3, nil)
 	if len(results) != 3 {
 		t.Errorf("expected 3 (top cap), got %d", len(results))
 	}
@@ -520,13 +523,13 @@ func TestRankDiscoverTrials_ZeroRating(t *testing.T) {
 	hotelResults := map[discoverTrialKey]*discoverHotelInfo{
 		{airport: "RIX", nights: 2}: {total: 100, name: "Hotel", rating: 0},
 	}
-	results := rankDiscoverTrials(trials, hotelResults, 500, "EUR", 5)
+	results := rankDiscoverTrials(trials, hotelResults, 500, "EUR", 5, nil)
 	if len(results) != 1 {
 		t.Fatalf("expected 1, got %d", len(results))
 	}
-	// Zero rating -> quality = 0.5 (base).
-	if results[0].ValueScore <= 0 {
-		t.Errorf("value score = %v, want > 0 even with zero rating", results[0].ValueScore)
+	// Zero rating → other factors still apply; score should be > 0.
+	if results[0].ProfileMatch <= 0 {
+		t.Errorf("profile match = %v, want > 0 even with zero rating", results[0].ProfileMatch)
 	}
 }
 
@@ -542,7 +545,7 @@ func TestRankDiscoverTrials_FallbackCityName(t *testing.T) {
 	hotelResults := map[discoverTrialKey]*discoverHotelInfo{
 		{airport: "HEL", nights: 2}: {total: 100, name: "Hotel", rating: 4.0},
 	}
-	results := rankDiscoverTrials(trials, hotelResults, 500, "EUR", 5)
+	results := rankDiscoverTrials(trials, hotelResults, 500, "EUR", 5, nil)
 	if len(results) != 1 {
 		t.Fatalf("expected 1, got %d", len(results))
 	}
@@ -552,7 +555,7 @@ func TestRankDiscoverTrials_FallbackCityName(t *testing.T) {
 }
 
 func TestRankDiscoverTrials_EmptyTrials(t *testing.T) {
-	results := rankDiscoverTrials(nil, nil, 500, "EUR", 5)
+	results := rankDiscoverTrials(nil, nil, 500, "EUR", 5, nil)
 	if len(results) != 0 {
 		t.Errorf("expected 0 for nil trials, got %d", len(results))
 	}
@@ -561,7 +564,7 @@ func TestRankDiscoverTrials_EmptyTrials(t *testing.T) {
 func TestRankDiscoverTrials_BudgetFitClampedAtZero(t *testing.T) {
 	fri := time.Date(2026, 8, 7, 0, 0, 0, 0, time.UTC)
 
-	// Total exactly at budget -> budgetFit=0 -> valueScore=0.
+	// Total exactly at budget -> budget_fit factor = 0, overall score is lower.
 	trials := []discoverTrial{
 		{
 			window: candidateWindow{start: fri, end: fri.AddDate(0, 0, 2), nights: 2},
@@ -571,12 +574,13 @@ func TestRankDiscoverTrials_BudgetFitClampedAtZero(t *testing.T) {
 	hotelResults := map[discoverTrialKey]*discoverHotelInfo{
 		{airport: "LIS", nights: 2}: {total: 100, name: "H", rating: 5.0},
 	}
-	results := rankDiscoverTrials(trials, hotelResults, 500, "EUR", 5)
+	results := rankDiscoverTrials(trials, hotelResults, 500, "EUR", 5, nil)
 	if len(results) != 1 {
 		t.Fatalf("expected 1, got %d", len(results))
 	}
-	if results[0].ValueScore != 0 {
-		t.Errorf("value score = %v, want 0 (at budget)", results[0].ValueScore)
+	// budget_fit is 0 but other neutral factors contribute; score is < 50.
+	if results[0].ProfileMatch >= 50 {
+		t.Errorf("profile match = %v, want < 50 when at budget (budget_fit=0)", results[0].ProfileMatch)
 	}
 	if results[0].BudgetSlack != 0 {
 		t.Errorf("slack = %v, want 0", results[0].BudgetSlack)

--- a/internal/trip/trip_final_test.go
+++ b/internal/trip/trip_final_test.go
@@ -666,21 +666,21 @@ func TestDiscoverOptions_NegativeTop(t *testing.T) {
 // ============================================================
 
 func TestBuildDiscoverReasoning_ZeroValues(t *testing.T) {
-	got := buildDiscoverReasoning(0, 0, 0, 0, "EUR")
+	got := buildDiscoverReasoning(0, 0, "EUR")
 	if got != "" {
 		t.Errorf("expected empty for zero values, got %q", got)
 	}
 }
 
 func TestBuildDiscoverReasoning_RatingOnly(t *testing.T) {
-	got := buildDiscoverReasoning(0, 0, 4.5, 0, "EUR")
+	got := buildDiscoverReasoning(4.5, 0, "EUR")
 	if got != "4.5★ hotel" {
 		t.Errorf("expected '4.5★ hotel', got %q", got)
 	}
 }
 
 func TestBuildDiscoverReasoning_BothValues(t *testing.T) {
-	got := buildDiscoverReasoning(0, 0, 3.8, 150, "USD")
+	got := buildDiscoverReasoning(3.8, 150, "USD")
 	if got == "" {
 		t.Error("expected non-empty reasoning")
 	}

--- a/internal/watch/check.go
+++ b/internal/watch/check.go
@@ -62,24 +62,37 @@ func CheckAll(ctx context.Context, store *Store, checker PriceChecker) []CheckRe
 // CheckAllWithRooms checks all watches, using the room checker for room-type watches
 // and the price checker for flight/hotel watches.
 func CheckAllWithRooms(ctx context.Context, store *Store, checker PriceChecker, roomChecker RoomChecker) []CheckResult {
-	watches := store.List()
+	return checkWatchesWithRoomsAndWebhookContext(ctx, ctx, store, checker, roomChecker, store.List())
+}
+
+// CheckAllWithRoomsAndWebhookContext checks all watches while allowing webhook
+// delivery to outlive the check timeout. The webhook context should typically be
+// a longer-lived parent context that is canceled when the caller is shutting
+// down.
+func CheckAllWithRoomsAndWebhookContext(checkCtx, webhookCtx context.Context, store *Store, checker PriceChecker, roomChecker RoomChecker) []CheckResult {
+	return checkWatchesWithRoomsAndWebhookContext(checkCtx, webhookCtx, store, checker, roomChecker, store.List())
+}
+
+func checkWatchesWithRoomsAndWebhookContext(checkCtx, webhookCtx context.Context, store *Store, checker PriceChecker, roomChecker RoomChecker, watches []Watch) []CheckResult {
+	checkCtx, webhookCtx = normalizeCheckAndWebhookContexts(checkCtx, webhookCtx)
+
 	results := make([]CheckResult, 0, len(watches))
 
 	for i, w := range watches {
 		var r CheckResult
 		if w.IsRoomWatch() && roomChecker != nil {
-			r = checkRoom(ctx, store, roomChecker, w)
+			r = checkRoomWithWebhookContext(checkCtx, webhookCtx, store, roomChecker, w)
 		} else if w.IsRoomWatch() {
 			r = CheckResult{Watch: w, Error: fmt.Errorf("room checker not configured")}
 		} else {
-			r = checkOne(ctx, store, checker, w)
+			r = checkOneWithWebhookContext(checkCtx, webhookCtx, store, checker, w)
 		}
 		results = append(results, r)
 
 		// Pause between checks to respect rate limits (skip after last).
 		if i < len(watches)-1 {
 			select {
-			case <-ctx.Done():
+			case <-checkCtx.Done():
 				return results
 			case <-time.After(3 * time.Second):
 			}
@@ -90,7 +103,13 @@ func CheckAllWithRooms(ctx context.Context, store *Store, checker PriceChecker, 
 
 // checkOne performs a price check for a single watch.
 func checkOne(ctx context.Context, store *Store, checker PriceChecker, w Watch) CheckResult {
-	price, currency, cheapestDate, err := checker.CheckPrice(ctx, w)
+	return checkOneWithWebhookContext(ctx, ctx, store, checker, w)
+}
+
+func checkOneWithWebhookContext(checkCtx, webhookCtx context.Context, store *Store, checker PriceChecker, w Watch) CheckResult {
+	checkCtx, webhookCtx = normalizeCheckAndWebhookContexts(checkCtx, webhookCtx)
+
+	price, currency, cheapestDate, err := checker.CheckPrice(checkCtx, w)
 	if err != nil {
 		return CheckResult{Watch: w, Error: err}
 	}
@@ -139,9 +158,10 @@ func checkOne(ctx context.Context, store *Store, checker PriceChecker, w Watch) 
 		// Update the result's watch to reflect saved state.
 		result.Watch = w
 
-		// Fire webhook on price drop.
+		// Fire webhook on price drop. The webhook context can outlive the check
+		// timeout, but should still be canceled when the scheduler stops.
 		if result.PriceDrop < 0 {
-			go fireWebhook(result)
+			go fireWebhook(webhookCtx, result)
 		}
 	}
 
@@ -150,7 +170,13 @@ func checkOne(ctx context.Context, store *Store, checker PriceChecker, w Watch) 
 
 // checkRoom performs a room availability check for a room watch.
 func checkRoom(ctx context.Context, store *Store, checker RoomChecker, w Watch) CheckResult {
-	matches, err := checker.CheckRooms(ctx, w)
+	return checkRoomWithWebhookContext(ctx, ctx, store, checker, w)
+}
+
+func checkRoomWithWebhookContext(checkCtx, webhookCtx context.Context, store *Store, checker RoomChecker, w Watch) CheckResult {
+	checkCtx, webhookCtx = normalizeCheckAndWebhookContexts(checkCtx, webhookCtx)
+
+	matches, err := checker.CheckRooms(checkCtx, w)
 	if err != nil {
 		return CheckResult{Watch: w, Error: err}
 	}
@@ -214,10 +240,20 @@ func checkRoom(ctx context.Context, store *Store, checker RoomChecker, w Watch) 
 
 	// Fire webhook on price drop.
 	if result.PriceDrop < 0 {
-		go fireWebhook(result)
+		go fireWebhook(webhookCtx, result)
 	}
 
 	return result
+}
+
+func normalizeCheckAndWebhookContexts(checkCtx, webhookCtx context.Context) (context.Context, context.Context) {
+	if checkCtx == nil {
+		checkCtx = context.Background()
+	}
+	if webhookCtx == nil {
+		webhookCtx = checkCtx
+	}
+	return checkCtx, webhookCtx
 }
 
 // webhookPayload is the JSON body POSTed to a watch's WebhookURL on price drop.
@@ -237,7 +273,7 @@ type webhookPayload struct {
 
 // fireWebhook sends a price-drop notification to the watch's WebhookURL.
 // It is fire-and-forget with a 10-second timeout; errors are logged but not returned.
-func fireWebhook(r CheckResult) {
+func fireWebhook(ctx context.Context, r CheckResult) {
 	if r.Watch.WebhookURL == "" {
 		return
 	}
@@ -262,7 +298,7 @@ func fireWebhook(r CheckResult) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.Watch.WebhookURL, bytes.NewReader(body))

--- a/internal/watch/opportunity.go
+++ b/internal/watch/opportunity.go
@@ -1,0 +1,185 @@
+// Package watch — opportunity.go provides rolling-window opportunity scoring.
+package watch
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/dealquality"
+	"github.com/MikkoParkkola/trvl/internal/match"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/scoring"
+)
+
+const windowDateLayout = "2006-01-02"
+
+// ResolveWindowDates interprets window_from/window_to using "next_Nd" syntax.
+// Returns (from, to time.Time, error).
+// "next_30d" from now → (today, today+30d).
+// YYYY-MM-DD → parsed as literal date.
+func ResolveWindowDates(from, to string, now time.Time) (time.Time, time.Time, error) {
+	fromT, err := resolveWindowDate(from, now)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("window_from: %w", err)
+	}
+	toT, err := resolveWindowDate(to, now)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("window_to: %w", err)
+	}
+	if fromT.After(toT) {
+		return time.Time{}, time.Time{}, fmt.Errorf("window_from must be before window_to")
+	}
+	return fromT, toT, nil
+}
+
+// resolveWindowDate parses a single window boundary.
+func resolveWindowDate(s string, now time.Time) (time.Time, error) {
+	if s == "" {
+		return now, nil
+	}
+	if strings.HasPrefix(s, "next_") && strings.HasSuffix(s, "d") {
+		days, err := strconv.Atoi(strings.TrimPrefix(strings.TrimSuffix(s, "d"), "next_"))
+		if err != nil || days < 0 {
+			return time.Time{}, fmt.Errorf("invalid next_Nd format: %q", s)
+		}
+		return now.AddDate(0, 0, days), nil
+	}
+	t, err := time.Parse(windowDateLayout, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("expected YYYY-MM-DD or next_Nd, got %q", s)
+	}
+	return t, nil
+}
+
+// ResolveFavourites returns the effective favourites list for an opportunity watch.
+// If w.Favourites is non-empty, returns it as-is.
+// Otherwise: union of prefs.BucketList + prefs.PreviousTrips, intersect with
+// keys where prefs.AirportAffinity[code] >= 0.3. Falls back to prefs.BucketList
+// if AirportAffinity is empty.
+func ResolveFavourites(w Watch, prefs *preferences.Preferences) []string {
+	if len(w.Favourites) > 0 {
+		return w.Favourites
+	}
+	if prefs == nil {
+		return nil
+	}
+
+	// Union of BucketList and PreviousTrips.
+	seen := map[string]bool{}
+	var candidates []string
+	for _, code := range prefs.BucketList {
+		if !seen[code] {
+			seen[code] = true
+			candidates = append(candidates, code)
+		}
+	}
+	for _, code := range prefs.PreviousTrips {
+		if !seen[code] {
+			seen[code] = true
+			candidates = append(candidates, code)
+		}
+	}
+
+	if len(prefs.AirportAffinity) == 0 {
+		// Fall back to BucketList only.
+		return prefs.BucketList
+	}
+
+	// Intersect with codes having affinity >= 0.3.
+	var result []string
+	for _, code := range candidates {
+		if aff, ok := prefs.AirportAffinity[code]; ok && aff >= 0.3 {
+			result = append(result, code)
+		}
+	}
+	return result
+}
+
+// OpportunityScore is the composite score for one (destination, depart, return) tuple.
+type OpportunityScore struct {
+	Destination  string
+	DepartDate   string
+	ReturnDate   string
+	Nights       int
+	OverallScore int // 0-100: 0.4*ProfileMatch + 0.2*RequestMatch + 0.4*DealQuality
+	ProfileMatch int
+	RequestMatch int
+	DealQuality  int
+	Reason       string
+}
+
+// ScoreOpportunity computes the composite opportunity score for one tuple.
+// pricePerNight is the estimated price (use 0 if unknown — DealQuality returns 50).
+// dqSamples are the historical samples for the route+season from DealQuality store.
+func ScoreOpportunity(
+	dest, departDate, returnDate string,
+	prefs *preferences.Preferences,
+	dqSamples []dealquality.Sample,
+	price float64,
+) OpportunityScore {
+	nights := nightsBetween(departDate, returnDate)
+
+	// 1. ProfileMatch using existing scoring package.
+	pmScore, _ := scoring.ComputeProfileMatch(prefs, scoring.DiscoverInput{
+		AirportCode: dest,
+		FlightPrice: price,
+		Total:       price,
+		Budget:      prefs.BudgetFlightMax,
+	})
+
+	// 2. RequestMatch — score how well the offer fits a generic "any dest" request.
+	rmScore := match.Compute(match.Request{
+		DestIATA:     dest,
+		Nights:       nights,
+		MaxNightsDrift: 2,
+	}, match.Offered{
+		DestIATA:   dest,
+		DepartDate: departDate,
+		ReturnDate: returnDate,
+	})
+
+	// 3. DealQuality.
+	dqScore := dealquality.ScoreAgainst(price, dqSamples)
+
+	// Composite: 0.4*PM + 0.2*RM + 0.4*DQ
+	overall := int(0.4*float64(pmScore) + 0.2*float64(rmScore.Total) + 0.4*float64(dqScore.Total))
+	if overall > 100 {
+		overall = 100
+	}
+	if overall < 0 {
+		overall = 0
+	}
+
+	reason := dqScore.Reason
+	if reason == "" {
+		reason = rmScore.Reason
+	}
+
+	return OpportunityScore{
+		Destination:  dest,
+		DepartDate:   departDate,
+		ReturnDate:   returnDate,
+		Nights:       nights,
+		OverallScore: overall,
+		ProfileMatch: pmScore,
+		RequestMatch: rmScore.Total,
+		DealQuality:  dqScore.Total,
+		Reason:       reason,
+	}
+}
+
+// nightsBetween returns the number of nights between two YYYY-MM-DD dates.
+func nightsBetween(from, to string) int {
+	dep, err1 := time.Parse(windowDateLayout, from)
+	ret, err2 := time.Parse(windowDateLayout, to)
+	if err1 != nil || err2 != nil {
+		return 0
+	}
+	n := int(ret.Sub(dep).Hours() / 24)
+	if n < 0 {
+		return 0
+	}
+	return n
+}

--- a/internal/watch/opportunity_test.go
+++ b/internal/watch/opportunity_test.go
@@ -1,0 +1,155 @@
+package watch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/dealquality"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+)
+
+func TestResolveWindowDatesNextNd(t *testing.T) {
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	from, to, err := ResolveWindowDates("next_30d", "next_90d", now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectedFrom := now.AddDate(0, 0, 30)
+	expectedTo := now.AddDate(0, 0, 90)
+	if !from.Equal(expectedFrom) {
+		t.Errorf("from: expected %s, got %s", expectedFrom, from)
+	}
+	if !to.Equal(expectedTo) {
+		t.Errorf("to: expected %s, got %s", expectedTo, to)
+	}
+}
+
+func TestResolveWindowDatesLiteral(t *testing.T) {
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	from, to, err := ResolveWindowDates("2026-07-01", "2026-09-01", now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if from.Format("2006-01-02") != "2026-07-01" {
+		t.Errorf("unexpected from: %s", from)
+	}
+	if to.Format("2006-01-02") != "2026-09-01" {
+		t.Errorf("unexpected to: %s", to)
+	}
+}
+
+func TestResolveWindowDatesInvalidOrder(t *testing.T) {
+	now := time.Now()
+	_, _, err := ResolveWindowDates("next_90d", "next_30d", now)
+	if err == nil {
+		t.Error("expected error for from > to")
+	}
+}
+
+func TestResolveFavouritesExplicit(t *testing.T) {
+	w := Watch{Favourites: []string{"BCN", "PRG"}}
+	result := ResolveFavourites(w, nil)
+	if len(result) != 2 || result[0] != "BCN" {
+		t.Errorf("expected explicit favourites, got %v", result)
+	}
+}
+
+func TestResolveFavouritesFromProfile(t *testing.T) {
+	w := Watch{}
+	prefs := &preferences.Preferences{
+		BucketList:      []string{"BCN", "PRG", "ZRH"},
+		PreviousTrips:   []string{"PRG", "TXL"},
+		AirportAffinity: map[string]float64{"BCN": 0.8, "PRG": 0.5, "ZRH": 0.2, "TXL": 0.4},
+	}
+	result := ResolveFavourites(w, prefs)
+	// BCN (0.8>=0.3) ✓, PRG (0.5>=0.3) ✓, ZRH (0.2<0.3) ✗, TXL (0.4>=0.3) ✓
+	if len(result) != 3 {
+		t.Errorf("expected 3 destinations (BCN,PRG,TXL), got %d: %v", len(result), result)
+	}
+}
+
+func TestResolveFavouritesEmptyAffinityFallback(t *testing.T) {
+	w := Watch{}
+	prefs := &preferences.Preferences{
+		BucketList:    []string{"BCN", "PRG"},
+		PreviousTrips: []string{"TXL"},
+		// No AirportAffinity
+	}
+	result := ResolveFavourites(w, prefs)
+	// Falls back to BucketList only
+	if len(result) != 2 {
+		t.Errorf("expected BucketList fallback (2 items), got %d: %v", len(result), result)
+	}
+}
+
+func TestScoreOpportunityFormula(t *testing.T) {
+	prefs := &preferences.Preferences{
+		BudgetFlightMax: 500,
+		AirportAffinity: map[string]float64{"BCN": 0.9},
+		BucketList:      []string{"BCN"},
+	}
+
+	// 15 samples around 200 EUR to give meaningful DQ score
+	samples := make([]dealquality.Sample, 15)
+	for i := 0; i < 15; i++ {
+		samples[i] = dealquality.Sample{
+			Route: "HEL-BCN", Season: "Q3",
+			Date:  "2026-07-15",
+			Price: float64(150 + i*10),
+			Kind:  "flight",
+		}
+	}
+
+	os := ScoreOpportunity("BCN", "2026-07-01", "2026-07-08", prefs, samples, 160)
+	if os.Destination != "BCN" {
+		t.Errorf("unexpected destination: %s", os.Destination)
+	}
+	if os.Nights != 7 {
+		t.Errorf("expected 7 nights, got %d", os.Nights)
+	}
+	if os.OverallScore < 0 || os.OverallScore > 100 {
+		t.Errorf("overall score out of range: %d", os.OverallScore)
+	}
+	// Components should be populated
+	if os.ProfileMatch < 0 || os.ProfileMatch > 100 {
+		t.Errorf("profile match out of range: %d", os.ProfileMatch)
+	}
+	if os.RequestMatch < 0 || os.RequestMatch > 100 {
+		t.Errorf("request match out of range: %d", os.RequestMatch)
+	}
+	if os.DealQuality < 0 || os.DealQuality > 100 {
+		t.Errorf("deal quality out of range: %d", os.DealQuality)
+	}
+}
+
+func TestScoreOpportunityInsufficientHistory(t *testing.T) {
+	prefs := &preferences.Preferences{BudgetFlightMax: 500}
+	os := ScoreOpportunity("PRG", "2026-08-01", "2026-08-07", prefs, nil, 200)
+	// With no history, DealQuality returns 50 → DQ component = 0.4*50 = 20
+	// OverallScore should be reasonable (not zero, not panic)
+	if os.DealQuality != 50 {
+		t.Errorf("expected DealQuality=50 for insufficient history, got %d", os.DealQuality)
+	}
+}
+
+func TestScoreOpportunityCompositeWeights(t *testing.T) {
+	// Verify the formula: 0.4*PM + 0.2*RM + 0.4*DQ
+	prefs := &preferences.Preferences{BudgetFlightMax: 1000}
+	samples := make([]dealquality.Sample, 10)
+	for i := 0; i < 10; i++ {
+		samples[i] = dealquality.Sample{
+			Route: "HEL-ZRH", Season: "Q3",
+			Date: "2026-07-01", Price: float64(200 + i*20), Kind: "flight",
+		}
+	}
+	os := ScoreOpportunity("ZRH", "2026-07-10", "2026-07-17", prefs, samples, 200)
+
+	expected := int(0.4*float64(os.ProfileMatch) + 0.2*float64(os.RequestMatch) + 0.4*float64(os.DealQuality))
+	if expected > 100 {
+		expected = 100
+	}
+	if os.OverallScore != expected {
+		t.Errorf("formula mismatch: 0.4*%d + 0.2*%d + 0.4*%d = %d, got OverallScore=%d",
+			os.ProfileMatch, os.RequestMatch, os.DealQuality, expected, os.OverallScore)
+	}
+}

--- a/internal/watch/scheduler.go
+++ b/internal/watch/scheduler.go
@@ -15,7 +15,12 @@ type Scheduler struct {
 	interval time.Duration // how often to run checks
 	checker  PriceChecker  // injected for testability
 
+	mu        sync.Mutex
+	doneOnce  sync.Once
 	startOnce sync.Once
+	stopOnce  sync.Once
+	started   bool
+	stopped   bool
 	cancel    context.CancelFunc
 	done      chan struct{}
 }
@@ -48,8 +53,14 @@ func NewScheduler(dir string, interval time.Duration, checker PriceChecker) *Sch
 // Start launches the background goroutine. Idempotent — subsequent calls are no-ops.
 func (s *Scheduler) Start() {
 	s.startOnce.Do(func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.stopped {
+			return
+		}
 		ctx, cancel := context.WithCancel(context.Background())
 		s.cancel = cancel
+		s.started = true
 		go s.run(ctx)
 	})
 }
@@ -57,15 +68,26 @@ func (s *Scheduler) Start() {
 // Stop signals the background goroutine to exit and waits for it to finish.
 // Any in-flight price check is cancelled immediately.
 func (s *Scheduler) Stop() {
-	if s.cancel != nil {
-		s.cancel()
-	}
+	s.stopOnce.Do(func() {
+		s.mu.Lock()
+		cancel := s.cancel
+		started := s.started
+		s.stopped = true
+		if !started {
+			s.closeDone()
+		}
+		s.mu.Unlock()
+
+		if cancel != nil {
+			cancel()
+		}
+	})
 	<-s.done
 }
 
 // run is the background loop. ctx is cancelled when Stop is called.
 func (s *Scheduler) run(ctx context.Context) {
-	defer close(s.done)
+	defer s.closeDone()
 
 	// Run one check immediately on startup, then repeat on interval.
 	s.runOnce(ctx)
@@ -107,7 +129,7 @@ func (s *Scheduler) runOnce(ctx context.Context) {
 	checkCtx, cancel := context.WithTimeout(ctx, s.interval/2)
 	defer cancel()
 
-	results := CheckAll(checkCtx, store, s.checker)
+	results := checkWatchesWithRoomsAndWebhookContext(checkCtx, ctx, store, s.checker, nil, active)
 
 	triggered := 0
 	for _, r := range results {
@@ -144,6 +166,12 @@ func (s *Scheduler) runOnce(ctx context.Context) {
 		"checked", len(results),
 		"triggered", triggered,
 	)
+}
+
+func (s *Scheduler) closeDone() {
+	s.doneOnce.Do(func() {
+		close(s.done)
+	})
 }
 
 // activeWatches filters watches to those that are still worth checking:

--- a/internal/watch/scheduler_test.go
+++ b/internal/watch/scheduler_test.go
@@ -2,6 +2,7 @@ package watch
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -94,6 +95,53 @@ func TestScheduler_Stop_DoneAfterStop(t *testing.T) {
 	}
 }
 
+func TestScheduler_StopWithoutStart(t *testing.T) {
+	t.Parallel()
+	s := NewScheduler(t.TempDir(), time.Hour, NoopChecker{})
+
+	done := make(chan struct{})
+	go func() {
+		s.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() timed out before Start()")
+	}
+
+	// Once stopped early, later Start/Stop calls must remain harmless.
+	s.Start()
+	s.Stop()
+}
+
+func TestScheduler_ConcurrentStartStop_DoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 500; i++ {
+		s := NewScheduler(t.TempDir(), time.Hour, NoopChecker{})
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			<-start
+			s.Start()
+		}()
+
+		go func() {
+			defer wg.Done()
+			<-start
+			s.Stop()
+		}()
+
+		close(start)
+		wg.Wait()
+	}
+}
+
 // --- CheckPrice called for active watches ---
 
 // countingChecker counts how many times CheckPrice is called.
@@ -105,6 +153,45 @@ type countingChecker struct {
 func (c *countingChecker) CheckPrice(_ context.Context, _ Watch) (float64, string, string, error) {
 	c.calls.Add(1)
 	return c.price, "EUR", "", nil
+}
+
+type recordingChecker struct {
+	calls atomic.Int64
+	ids   chan string
+	price float64
+}
+
+func (c *recordingChecker) CheckPrice(_ context.Context, w Watch) (float64, string, string, error) {
+	c.calls.Add(1)
+	if c.ids != nil {
+		c.ids <- w.ID
+	}
+	return c.price, "EUR", "", nil
+}
+
+type blockingChecker struct {
+	started   chan struct{}
+	cancelled chan struct{}
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+func newBlockingChecker() *blockingChecker {
+	return &blockingChecker{
+		started:   make(chan struct{}),
+		cancelled: make(chan struct{}),
+	}
+}
+
+func (c *blockingChecker) CheckPrice(ctx context.Context, _ Watch) (float64, string, string, error) {
+	c.startOnce.Do(func() {
+		close(c.started)
+	})
+	<-ctx.Done()
+	c.stopOnce.Do(func() {
+		close(c.cancelled)
+	})
+	return 0, "EUR", "", ctx.Err()
 }
 
 func TestScheduler_CallsCheckerForActiveWatches(t *testing.T) {
@@ -143,6 +230,52 @@ func TestScheduler_CallsCheckerForActiveWatches(t *testing.T) {
 
 	if checker.calls.Load() < 1 {
 		t.Errorf("CheckPrice called %d times, want >= 1", checker.calls.Load())
+	}
+}
+
+func TestScheduler_StopCancelsInflightChecks(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	_, err := store.Add(Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "BCN",
+		DepartDate:  "2099-07-01",
+		BelowPrice:  500,
+		Currency:    "EUR",
+	})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	checker := newBlockingChecker()
+	s := NewScheduler(dir, time.Hour, checker)
+	s.Start()
+
+	select {
+	case <-checker.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CheckPrice did not start")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		s.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-checker.cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CheckPrice did not observe cancellation from Stop")
+	}
+
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() timed out while a check was in flight")
 	}
 }
 
@@ -207,6 +340,66 @@ func TestScheduler_SkipsPastDateRangeWatches(t *testing.T) {
 
 	if checker.calls.Load() != 0 {
 		t.Errorf("CheckPrice called %d times for past date-range watch, want 0", checker.calls.Load())
+	}
+}
+
+func TestScheduler_ChecksOnlyActiveWatchesWhenStoreContainsPastEntries(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	activeID, err := store.Add(Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "BCN",
+		DepartDate:  "2099-07-01",
+		BelowPrice:  500,
+		Currency:    "EUR",
+	})
+	if err != nil {
+		t.Fatalf("Add active watch: %v", err)
+	}
+
+	_, err = store.Add(Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "NRT",
+		DepartDate:  "2000-01-01",
+		BelowPrice:  500,
+		Currency:    "EUR",
+	})
+	if err != nil {
+		t.Fatalf("Add past watch: %v", err)
+	}
+
+	checker := &recordingChecker{
+		ids:   make(chan string, 2),
+		price: 300,
+	}
+	s := NewScheduler(dir, time.Hour, checker)
+	s.Start()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if checker.calls.Load() >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	s.Stop()
+
+	if checker.calls.Load() != 1 {
+		t.Fatalf("CheckPrice called %d times, want 1", checker.calls.Load())
+	}
+
+	select {
+	case gotID := <-checker.ids:
+		if gotID != activeID {
+			t.Fatalf("checked watch %q, want active watch %q", gotID, activeID)
+		}
+	default:
+		t.Fatal("expected scheduler to record checked watch")
 	}
 }
 
@@ -316,8 +509,8 @@ func TestActiveWatches_FiltersCorrectly(t *testing.T) {
 	watches := []Watch{
 		{Type: "flight", Origin: "HEL", Destination: "BCN", DepartDate: "2099-01-01"}, // future
 		{Type: "flight", Origin: "HEL", Destination: "BCN", DepartDate: "2000-01-01"}, // past — skip
-		{Type: "flight", Origin: "HEL", Destination: "BCN"},                            // route — always
-		{Type: "flight", Origin: "HEL", Destination: "BCN", DepartDate: today},         // today
+		{Type: "flight", Origin: "HEL", Destination: "BCN"},                           // route — always
+		{Type: "flight", Origin: "HEL", Destination: "BCN", DepartDate: today},        // today
 	}
 
 	active := activeWatches(watches)

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -47,6 +47,15 @@ type Watch struct {
 	HotelName    string   `json:"hotel_name,omitempty"`    // hotel name for room availability lookups
 	RoomKeywords []string `json:"room_keywords,omitempty"` // all keywords must match room name+description
 	MatchedRoom  string   `json:"matched_room,omitempty"`  // last matched room name (for display)
+
+	// Opportunity watch fields (Type == "opportunity").
+	// Favourites defaults to BucketList ∪ PreviousTrips ∩ AirportAffinity≥0.3 if empty.
+	Favourites []string `json:"favourites,omitempty"`  // IATA codes
+	WindowFrom string   `json:"window_from,omitempty"` // YYYY-MM-DD or "next_Nd" (e.g. "next_30d")
+	WindowTo   string   `json:"window_to,omitempty"`   // YYYY-MM-DD or "next_Nd"
+	MinScore   int      `json:"min_score,omitempty"`   // default 85
+	MinNights  int      `json:"min_nights,omitempty"`  // default 3
+	MaxNights  int      `json:"max_nights,omitempty"`  // default 14
 }
 
 // IsRouteWatch returns true if this watch monitors a route without specific dates.
@@ -62,6 +71,11 @@ func (w Watch) IsDateRange() bool {
 // IsRoomWatch returns true if this watch monitors room availability.
 func (w Watch) IsRoomWatch() bool {
 	return w.Type == "room"
+}
+
+// IsOpportunityWatch returns true if this watch is an opportunity watch.
+func (w Watch) IsOpportunityWatch() bool {
+	return w.Type == "opportunity"
 }
 
 // MatchRoomKeywords checks whether all keywords appear (case-insensitive) in the
@@ -107,6 +121,14 @@ func (w Watch) Validate() error {
 		}
 		if w.DepartDate == "" || w.ReturnDate == "" {
 			return fmt.Errorf("room watch requires check-in (depart_date) and check-out (return_date)")
+		}
+		return nil
+	}
+
+	// Opportunity watch validation.
+	if w.IsOpportunityWatch() {
+		if len(w.Favourites) == 0 && w.MinNights <= 0 {
+			return fmt.Errorf("opportunity watch requires favourites or a min_nights value")
 		}
 		return nil
 	}

--- a/internal/watch/webhook_test.go
+++ b/internal/watch/webhook_test.go
@@ -1,0 +1,235 @@
+package watch
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+type blockingWebhookTransport struct {
+	started   chan struct{}
+	cancelled chan struct{}
+	once      sync.Once
+}
+
+func newBlockingWebhookTransport() *blockingWebhookTransport {
+	return &blockingWebhookTransport{
+		started:   make(chan struct{}),
+		cancelled: make(chan struct{}),
+	}
+}
+
+func (t *blockingWebhookTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.once.Do(func() {
+		close(t.started)
+	})
+	<-req.Context().Done()
+	close(t.cancelled)
+	return nil, req.Context().Err()
+}
+
+func installBlockingWebhookClient(t *testing.T) *blockingWebhookTransport {
+	t.Helper()
+
+	transport := newBlockingWebhookTransport()
+	oldClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: transport}
+	t.Cleanup(func() {
+		http.DefaultClient = oldClient
+	})
+	return transport
+}
+
+func waitForSignal(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal(msg)
+	}
+}
+
+type contextRecordingPriceChecker struct {
+	ctx context.Context
+}
+
+func (c *contextRecordingPriceChecker) CheckPrice(ctx context.Context, _ Watch) (float64, string, string, error) {
+	c.ctx = ctx
+	return 450, "EUR", "", nil
+}
+
+type contextRecordingRoomChecker struct {
+	ctx context.Context
+}
+
+func (c *contextRecordingRoomChecker) CheckRooms(ctx context.Context, _ Watch) ([]RoomMatch, error) {
+	c.ctx = ctx
+	return []RoomMatch{{Name: "Ocean Suite", Price: 180, Currency: "EUR"}}, nil
+}
+
+func TestCheckOne_WebhookUsesCallerContext(t *testing.T) {
+	transport := installBlockingWebhookClient(t)
+
+	dir := t.TempDir()
+	store := NewStore(dir)
+	w := Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "NRT",
+		DepartDate:  "2099-07-01",
+		LastPrice:   500,
+		WebhookURL:  "http://example.test/webhook",
+	}
+	id, err := store.Add(w)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	w.ID = id
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_ = checkOne(ctx, store, &stubPriceChecker{price: 450, currency: "EUR"}, w)
+		close(done)
+	}()
+
+	waitForSignal(t, transport.started, "webhook request did not start")
+	cancel()
+	waitForSignal(t, transport.cancelled, "webhook request did not observe caller cancellation")
+	waitForSignal(t, done, "checkOne did not return")
+}
+
+func TestCheckRoom_WebhookUsesCallerContext(t *testing.T) {
+	transport := installBlockingWebhookClient(t)
+
+	dir := t.TempDir()
+	store := NewStore(dir)
+	w := Watch{
+		Type:         "room",
+		HotelName:    "Test Hotel",
+		RoomKeywords: []string{"suite"},
+		DepartDate:   "2099-07-01",
+		ReturnDate:   "2099-07-08",
+		LastPrice:    250,
+		WebhookURL:   "http://example.test/webhook",
+	}
+	id, err := store.Add(w)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	w.ID = id
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_ = checkRoom(ctx, store, &stubRoomChecker{
+			matches: []RoomMatch{{Name: "Ocean Suite", Price: 180, Currency: "EUR"}},
+		}, w)
+		close(done)
+	}()
+
+	waitForSignal(t, transport.started, "room webhook request did not start")
+	cancel()
+	waitForSignal(t, transport.cancelled, "room webhook request did not observe caller cancellation")
+	waitForSignal(t, done, "checkRoom did not return")
+}
+
+func TestSchedulerRunOnce_WebhookUsesSchedulerContext(t *testing.T) {
+	transport := installBlockingWebhookClient(t)
+
+	dir := t.TempDir()
+	store := NewStore(dir)
+	_, err := store.Add(Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "NRT",
+		DepartDate:  "2099-07-01",
+		LastPrice:   500,
+		WebhookURL:  "http://example.test/webhook",
+	})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	s := NewScheduler(dir, 100*time.Millisecond, &stubPriceChecker{price: 450, currency: "EUR"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		s.runOnce(ctx)
+		close(done)
+	}()
+
+	waitForSignal(t, transport.started, "scheduler webhook request did not start")
+	waitForSignal(t, done, "runOnce did not return")
+
+	select {
+	case <-transport.cancelled:
+		t.Fatal("webhook request was cancelled when the check timeout finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	waitForSignal(t, transport.cancelled, "scheduler webhook request did not observe scheduler cancellation")
+}
+
+func TestCheckAllWithRooms_NilContextFallsBackToBackgroundForPriceChecks(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	_, err := store.Add(Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "NRT",
+		DepartDate:  "2099-07-01",
+	})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	checker := &contextRecordingPriceChecker{}
+	results := CheckAllWithRooms(nil, store, checker, nil)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Error != nil {
+		t.Fatalf("unexpected error: %v", results[0].Error)
+	}
+	if checker.ctx == nil {
+		t.Fatal("expected price checker to receive a non-nil context")
+	}
+}
+
+func TestCheckAllWithRooms_NilContextFallsBackToBackgroundForRoomChecks(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	_, err := store.Add(Watch{
+		Type:         "room",
+		HotelName:    "Test Hotel",
+		RoomKeywords: []string{"suite"},
+		DepartDate:   "2099-07-01",
+		ReturnDate:   "2099-07-08",
+	})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	roomChecker := &contextRecordingRoomChecker{}
+	results := CheckAllWithRooms(nil, store, &contextRecordingPriceChecker{}, roomChecker)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Error != nil {
+		t.Fatalf("unexpected error: %v", results[0].Error)
+	}
+	if roomChecker.ctx == nil {
+		t.Fatal("expected room checker to receive a non-nil context")
+	}
+}

--- a/mcp/handlers_concurrent_live_test.go
+++ b/mcp/handlers_concurrent_live_test.go
@@ -1,0 +1,202 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/testutil"
+)
+
+func TestToolsCallSearchFlights_ConcurrentLiveIntegration(t *testing.T) {
+	t.Parallel()
+	testutil.RequireLiveIntegration(t)
+
+	results := runConcurrentToolCalls(t, ToolCallParams{
+		Name: "search_flights",
+		Arguments: map[string]any{
+			"origin":         "HEL",
+			"destination":    "NRT",
+			"departure_date": "2026-05-15",
+		},
+	})
+
+	for i, result := range results {
+		var structured models.FlightSearchResult
+		assertStructuredResult(t, "flights", i, result, &structured)
+	}
+}
+
+func TestToolsCallSearchGround_ConcurrentLiveIntegration(t *testing.T) {
+	t.Parallel()
+	testutil.RequireLiveIntegration(t)
+
+	results := runConcurrentToolCalls(t, ToolCallParams{
+		Name: "search_ground",
+		Arguments: map[string]any{
+			"from": "Helsinki",
+			"to":   "Espoo",
+			"date": "2026-05-15",
+		},
+	})
+
+	for i, result := range results {
+		var structured models.GroundSearchResult
+		assertStructuredResult(t, "ground", i, result, &structured)
+	}
+}
+
+func TestToolsCallSearchHotels_ConcurrentLiveIntegration(t *testing.T) {
+	t.Parallel()
+	testutil.RequireLiveIntegration(t)
+
+	results := runConcurrentToolCalls(t, ToolCallParams{
+		Name: "search_hotels",
+		Arguments: map[string]any{
+			"location":  "Helsinki",
+			"check_in":  "2026-05-15",
+			"check_out": "2026-05-18",
+		},
+	})
+
+	for i, result := range results {
+		var structured models.HotelSearchResult
+		assertStructuredResult(t, "hotels", i, result, &structured)
+	}
+}
+
+func runConcurrentToolCalls(t *testing.T, params ToolCallParams) []*ToolCallResult {
+	t.Helper()
+
+	const callers = 2
+
+	results := make([]*ToolCallResult, callers)
+	errs := make([]error, callers)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx], errs[idx] = callToolRequest(params, idx+1)
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("caller %d failed: %v", i, err)
+		}
+	}
+
+	return results
+}
+
+func callToolRequest(params ToolCallParams, id int) (*ToolCallResult, error) {
+	s := NewServer()
+
+	rawParams, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshal params: %w", err)
+	}
+
+	req := Request{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  "tools/call",
+		Params:  rawParams,
+	}
+
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	in := bytes.NewBuffer(append(reqBytes, '\n'))
+	out := &bytes.Buffer{}
+
+	if err := s.ServeStdio(in, out); err != nil {
+		return nil, fmt.Errorf("ServeStdio: %w", err)
+	}
+
+	resp, err := decodeToolResponse(out.String())
+	if err != nil {
+		return nil, err
+	}
+	if resp.Error != nil {
+		return nil, fmt.Errorf("rpc error %d: %s", resp.Error.Code, resp.Error.Message)
+	}
+
+	resultJSON, err := json.Marshal(resp.Result)
+	if err != nil {
+		return nil, fmt.Errorf("marshal result: %w", err)
+	}
+
+	var result ToolCallResult
+	if err := json.Unmarshal(resultJSON, &result); err != nil {
+		return nil, fmt.Errorf("unmarshal result: %w", err)
+	}
+	if result.IsError {
+		return nil, fmt.Errorf("tool returned error result: %s", firstContentText(result.Content))
+	}
+
+	return &result, nil
+}
+
+func decodeToolResponse(raw string) (*Response, error) {
+	lines := strings.Split(strings.TrimSpace(raw), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+
+		var resp Response
+		if err := json.Unmarshal([]byte(line), &resp); err != nil {
+			continue
+		}
+		if resp.ID != nil || resp.Error != nil {
+			return &resp, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no JSON-RPC response found in output")
+}
+
+func assertStructuredResult(t *testing.T, tool string, caller int, result *ToolCallResult, out any) {
+	t.Helper()
+
+	if result == nil {
+		t.Fatalf("%s caller %d returned nil result", tool, caller)
+	}
+	if len(result.Content) == 0 {
+		t.Fatalf("%s caller %d returned no content blocks", tool, caller)
+	}
+	if result.StructuredContent == nil {
+		t.Fatalf("%s caller %d returned nil structured content", tool, caller)
+	}
+
+	structuredJSON, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		t.Fatalf("%s caller %d marshal structured content: %v", tool, caller, err)
+	}
+	if err := json.Unmarshal(structuredJSON, out); err != nil {
+		t.Fatalf("%s caller %d unmarshal structured content: %v", tool, caller, err)
+	}
+}
+
+func firstContentText(content []ContentBlock) string {
+	if len(content) == 0 {
+		return ""
+	}
+	return content[0].Text
+}

--- a/mcp/handlers_preferences_race_test.go
+++ b/mcp/handlers_preferences_race_test.go
@@ -1,0 +1,204 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/testutil"
+)
+
+func TestWrappedSearchFlights_ConcurrentPreferencesFiltering_LiveIntegration(t *testing.T) {
+	testutil.RequireLiveIntegration(t)
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	if err := preferences.Save(&preferences.Preferences{
+		DisplayCurrency:    "EUR",
+		Locale:             "en",
+		BudgetFlightMax:    100000,
+		FlightTimeEarliest: "00:00",
+		FlightTimeLatest:   "23:59",
+	}); err != nil {
+		t.Fatalf("save preferences: %v", err)
+	}
+
+	s := NewServer()
+	results := runConcurrentWrappedHandlerCalls(t, s.handlers["search_flights"], map[string]any{
+		"origin":         "HEL",
+		"destination":    "NRT",
+		"departure_date": "2026-05-15",
+	}, 10)
+	assertWrappedStructuredResultsAreDistinct(t, "search_flights", results)
+
+	for i, result := range results {
+		var structured models.FlightSearchResult
+		assertWrappedStructuredResult(t, "search_flights", i, result, &structured)
+	}
+}
+
+func TestWrappedSearchHotels_ConcurrentPreferencesFiltering_LiveIntegration(t *testing.T) {
+	testutil.RequireLiveIntegration(t)
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	if err := preferences.Save(&preferences.Preferences{
+		DisplayCurrency:    "EUR",
+		Locale:             "en",
+		BudgetPerNightMin:  1,
+		DefaultCompanions:  1,
+		PreferredDistricts: map[string][]string{},
+	}); err != nil {
+		t.Fatalf("save preferences: %v", err)
+	}
+
+	s := NewServer()
+	results := runConcurrentWrappedHandlerCalls(t, s.handlers["search_hotels"], map[string]any{
+		"location":  "Helsinki",
+		"check_in":  "2026-05-15",
+		"check_out": "2026-05-18",
+	}, 10)
+	assertWrappedStructuredResultsAreDistinct(t, "search_hotels", results)
+
+	for i, result := range results {
+		var structured models.HotelSearchResult
+		assertWrappedStructuredResult(t, "search_hotels", i, result, &structured)
+	}
+}
+
+func TestWrappedSearchGround_ConcurrentLiveIntegration(t *testing.T) {
+	testutil.RequireLiveIntegration(t)
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	if err := preferences.Save(&preferences.Preferences{
+		DisplayCurrency: "EUR",
+		Locale:          "en",
+	}); err != nil {
+		t.Fatalf("save preferences: %v", err)
+	}
+
+	s := NewServer()
+	results := runConcurrentWrappedHandlerCalls(t, s.handlers["search_ground"], map[string]any{
+		"from": "Helsinki",
+		"to":   "Espoo",
+		"date": "2026-05-15",
+	}, 10)
+	assertWrappedStructuredResultsAreDistinct(t, "search_ground", results)
+
+	for i, result := range results {
+		var structured models.GroundSearchResult
+		assertWrappedStructuredResult(t, "search_ground", i, result, &structured)
+	}
+}
+
+type wrappedHandlerCallResult struct {
+	content    []ContentBlock
+	structured any
+}
+
+func runConcurrentWrappedHandlerCalls(t *testing.T, handler ToolHandler, args map[string]any, callers int) []wrappedHandlerCallResult {
+	t.Helper()
+
+	if handler == nil {
+		t.Fatal("handler is nil")
+	}
+	if callers < 2 {
+		t.Fatalf("callers = %d, want at least 2", callers)
+	}
+
+	results := make([]wrappedHandlerCallResult, callers)
+	errs := make([]error, callers)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			content, structured, err := handler(context.Background(), cloneArgs(args), nil, nil, nil)
+			results[idx] = wrappedHandlerCallResult{
+				content:    content,
+				structured: structured,
+			}
+			errs[idx] = err
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("caller %d failed: %v", i, err)
+		}
+	}
+
+	return results
+}
+
+func cloneArgs(args map[string]any) map[string]any {
+	cloned := make(map[string]any, len(args))
+	for k, v := range args {
+		cloned[k] = v
+	}
+	return cloned
+}
+
+func assertWrappedStructuredResult(t *testing.T, tool string, caller int, result wrappedHandlerCallResult, out any) {
+	t.Helper()
+
+	if len(result.content) == 0 {
+		t.Fatalf("%s caller %d returned no content blocks", tool, caller)
+	}
+	if result.structured == nil {
+		t.Fatalf("%s caller %d returned nil structured content", tool, caller)
+	}
+
+	structuredJSON, err := json.Marshal(result.structured)
+	if err != nil {
+		t.Fatalf("%s caller %d marshal structured content: %v", tool, caller, err)
+	}
+	if err := json.Unmarshal(structuredJSON, out); err != nil {
+		t.Fatalf("%s caller %d unmarshal structured content: %v", tool, caller, err)
+	}
+}
+
+func assertWrappedStructuredResultsAreDistinct(t *testing.T, tool string, results []wrappedHandlerCallResult) {
+	t.Helper()
+
+	if len(results) < 2 || results[0].structured == nil {
+		return
+	}
+
+	first := reflect.ValueOf(results[0].structured)
+	if !pointerLikeKind(first.Kind()) || first.IsNil() {
+		return
+	}
+
+	firstPtr := first.Pointer()
+	for i := 1; i < len(results); i++ {
+		current := reflect.ValueOf(results[i].structured)
+		if !current.IsValid() || current.Kind() != first.Kind() || !pointerLikeKind(current.Kind()) || current.IsNil() {
+			continue
+		}
+		if current.Pointer() == firstPtr {
+			t.Fatalf("%s callers 0 and %d reused the same structured result object", tool, i)
+		}
+	}
+}
+
+func pointerLikeKind(kind reflect.Kind) bool {
+	switch kind {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return true
+	default:
+		return false
+	}
+}

--- a/mcp/server_extra2_test.go
+++ b/mcp/server_extra2_test.go
@@ -51,11 +51,11 @@ func TestNewServer(t *testing.T) {
 	if s == nil {
 		t.Fatal("NewServer returned nil")
 	}
-	if len(s.tools) != 56 {
-		t.Errorf("expected 56 tools, got %d", len(s.tools))
+	if len(s.tools) != 57 {
+		t.Errorf("expected 57 tools, got %d", len(s.tools))
 	}
-	if len(s.handlers) != 56 {
-		t.Errorf("expected 56 handlers, got %d", len(s.handlers))
+	if len(s.handlers) != 57 {
+		t.Errorf("expected 57 handlers, got %d", len(s.handlers))
 	}
 }
 

--- a/mcp/server_extra2_test.go
+++ b/mcp/server_extra2_test.go
@@ -51,11 +51,11 @@ func TestNewServer(t *testing.T) {
 	if s == nil {
 		t.Fatal("NewServer returned nil")
 	}
-	if len(s.tools) != 54 {
-		t.Errorf("expected 54 tools, got %d", len(s.tools))
+	if len(s.tools) != 56 {
+		t.Errorf("expected 56 tools, got %d", len(s.tools))
 	}
-	if len(s.handlers) != 54 {
-		t.Errorf("expected 54 handlers, got %d", len(s.handlers))
+	if len(s.handlers) != 56 {
+		t.Errorf("expected 56 handlers, got %d", len(s.handlers))
 	}
 }
 
@@ -173,6 +173,7 @@ func TestToolAnnotations(t *testing.T) {
 		"build_profile":           true,
 		"add_booking":             true,
 		"watch_price":             true,
+		"watch_opportunities":     true,
 	}
 
 	// Tools that create new resources on each call — not idempotent.
@@ -181,6 +182,7 @@ func TestToolAnnotations(t *testing.T) {
 		"add_booking":             true,
 		"watch_price":             true,
 		"check_watches":           true,
+		"watch_opportunities":     true,
 	}
 
 	s := NewServer()

--- a/mcp/server_extra_test.go
+++ b/mcp/server_extra_test.go
@@ -63,8 +63,8 @@ func TestHTTPHandler_POST_ToolsList(t *testing.T) {
 	var result ToolsListResult
 	json.Unmarshal(resultJSON, &result)
 
-	if len(result.Tools) != 56 {
-		t.Errorf("expected 56 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 57 {
+		t.Errorf("expected 57 tools, got %d", len(result.Tools))
 	}
 }
 

--- a/mcp/server_extra_test.go
+++ b/mcp/server_extra_test.go
@@ -63,8 +63,8 @@ func TestHTTPHandler_POST_ToolsList(t *testing.T) {
 	var result ToolsListResult
 	json.Unmarshal(resultJSON, &result)
 
-	if len(result.Tools) != 54 {
-		t.Errorf("expected 54 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 56 {
+		t.Errorf("expected 56 tools, got %d", len(result.Tools))
 	}
 }
 

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -128,8 +128,8 @@ func TestToolsList(t *testing.T) {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 
-	if len(result.Tools) != 54 {
-		t.Fatalf("expected 54 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 56 {
+		t.Fatalf("expected 56 tools, got %d", len(result.Tools))
 	}
 
 	expected := map[string]bool{

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -128,8 +128,8 @@ func TestToolsList(t *testing.T) {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 
-	if len(result.Tools) != 56 {
-		t.Fatalf("expected 56 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 57 {
+		t.Fatalf("expected 57 tools, got %d", len(result.Tools))
 	}
 
 	expected := map[string]bool{
@@ -187,6 +187,9 @@ func TestToolsList(t *testing.T) {
 		"watch_price":               false,
 		"list_watches":              false,
 		"check_watches":             false,
+		"watch_opportunities":       false,
+		"list_opportunity_watches":  false,
+		"search_hidden_city":        false,
 	}
 	for _, tool := range result.Tools {
 		if _, ok := expected[tool.Name]; !ok {

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -70,6 +70,7 @@ func registerTools(s *Server) {
 		checkWatchesTool(),
 		watchOpportunitiesTool(),
 		listOpportunityWatchesTool(),
+		searchHiddenCityTool(),
 	}
 	s.handlers["search_flights"] = s.wrapHandler(handleSearchFlights)
 	s.handlers["search_dates"] = s.wrapHandler(handleSearchDates)
@@ -127,6 +128,7 @@ func registerTools(s *Server) {
 	s.handlers["check_watches"] = s.wrapHandler(handleCheckWatches)
 	s.handlers["watch_opportunities"] = s.wrapHandler(handleWatchOpportunities)
 	s.handlers["list_opportunity_watches"] = s.wrapHandler(handleListOpportunityWatches)
+	s.handlers["search_hidden_city"] = s.wrapHandler(handleSearchHiddenCity)
 }
 
 // wrapHandler returns a ToolHandler that delegates to the inner handler and

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -68,6 +68,8 @@ func registerTools(s *Server) {
 		watchPriceTool(),
 		listWatchesTool(),
 		checkWatchesTool(),
+		watchOpportunitiesTool(),
+		listOpportunityWatchesTool(),
 	}
 	s.handlers["search_flights"] = s.wrapHandler(handleSearchFlights)
 	s.handlers["search_dates"] = s.wrapHandler(handleSearchDates)
@@ -123,6 +125,8 @@ func registerTools(s *Server) {
 	s.handlers["watch_price"] = s.wrapHandler(handleWatchPrice)
 	s.handlers["list_watches"] = s.wrapHandler(handleListWatches)
 	s.handlers["check_watches"] = s.wrapHandler(handleCheckWatches)
+	s.handlers["watch_opportunities"] = s.wrapHandler(handleWatchOpportunities)
+	s.handlers["list_opportunity_watches"] = s.wrapHandler(handleListOpportunityWatches)
 }
 
 // wrapHandler returns a ToolHandler that delegates to the inner handler and

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"strings"
 )
 
@@ -177,7 +178,14 @@ func (s *Server) wrapHandler(inner ToolHandler) ToolHandler {
 		// Notify subscribers when trip-mutating tools complete.
 		s.notifyTripUpdate(args)
 
-		return content, structured, nil
+		clonedContent := cloneContentBlocks(content)
+
+		clonedStructured, cloneErr := cloneStructuredContent(structured)
+		if cloneErr != nil {
+			return nil, nil, fmt.Errorf("clone structured content: %w", cloneErr)
+		}
+
+		return clonedContent, clonedStructured, nil
 	}
 }
 
@@ -508,4 +516,67 @@ func buildAnnotatedContentBlocks(summary string, data any) ([]ContentBlock, erro
 			},
 		},
 	}, nil
+}
+
+func cloneContentBlocks(blocks []ContentBlock) []ContentBlock {
+	if len(blocks) == 0 {
+		return nil
+	}
+
+	cloned := make([]ContentBlock, len(blocks))
+	copy(cloned, blocks)
+	for i := range cloned {
+		if cloned[i].Annotations != nil {
+			annotation := *cloned[i].Annotations
+			annotation.Audience = append([]string(nil), annotation.Audience...)
+			cloned[i].Annotations = &annotation
+		}
+	}
+
+	return cloned
+}
+
+func cloneStructuredContent(data any) (any, error) {
+	if data == nil {
+		return nil, nil
+	}
+
+	value := reflect.ValueOf(data)
+	if !value.IsValid() {
+		return nil, nil
+	}
+
+	switch value.Kind() {
+	case reflect.Pointer:
+		if value.IsNil() {
+			return data, nil
+		}
+		return cloneStructuredIntoNewValue(data, value.Type().Elem(), true)
+	case reflect.Struct:
+		return cloneStructuredIntoNewValue(data, value.Type(), false)
+	case reflect.Slice, reflect.Map:
+		if value.IsNil() {
+			return data, nil
+		}
+		return cloneStructuredIntoNewValue(data, value.Type(), false)
+	default:
+		return data, nil
+	}
+}
+
+func cloneStructuredIntoNewValue(data any, targetType reflect.Type, returnPointer bool) (any, error) {
+	payload, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal structured content: %w", err)
+	}
+
+	target := reflect.New(targetType)
+	if err := json.Unmarshal(payload, target.Interface()); err != nil {
+		return nil, fmt.Errorf("unmarshal structured content: %w", err)
+	}
+
+	if returnPointer {
+		return target.Interface(), nil
+	}
+	return target.Elem().Interface(), nil
 }

--- a/mcp/tools_extra_test.go
+++ b/mcp/tools_extra_test.go
@@ -310,6 +310,9 @@ func TestToolRegistration_AllTools(t *testing.T) {
 		"watch_price",
 		"list_watches",
 		"check_watches",
+		"watch_opportunities",
+		"list_opportunity_watches",
+		"search_hidden_city",
 	}
 
 	if len(s.tools) != len(expectedTools) {

--- a/mcp/tools_hacks.go
+++ b/mcp/tools_hacks.go
@@ -278,3 +278,4 @@ func buildAccomHacksSummary(city, checkin, checkout string, detected []hacks.Hac
 	}
 	return sb.String()
 }
+

--- a/mcp/tools_hidden_city.go
+++ b/mcp/tools_hidden_city.go
@@ -1,0 +1,176 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/hacks"
+)
+
+func searchHiddenCityTool() ToolDef {
+	return ToolDef{
+		Name:        "search_hidden_city",
+		Title:       "Hidden-City Matrix Search",
+		Description: "Find cheaper flights by boarding Origin\u2192Hub\u2192HubBeyond but disembarking at Hub, skipping the final leg. Only safe with carry-on luggage. Supply priced offers from the origin\u00d7hub-extension grid; returns top-K ranked candidates with booking URLs. Gate on the user's risk_posture.hidden_city.acceptable preference (allow_hidden_city must be true to get results).",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"offers":            {Type: "array", Description: "Priced candidates from the Origin\u00d7hub-beyond grid. Each offer is a JSON object with fields: origin (IATA), hub (IATA), hub_beyond (IATA), carrier (IATA airline code), price (number), currency (string), carry_on_only (bool), separate_tickets (bool), layover_minutes (int)."},
+				"allow_hidden_city": {Type: "boolean", Description: "Must reflect user's risk_posture.hidden_city.acceptable flag. Defaults to false \u2014 return empty when false."},
+				"direct_baseline":   {Type: "number", Description: "Cheapest known direct Origin\u2192Hub price for savings calculation. Omit when unknown."},
+				"depart_date":       {Type: "string", Description: "Departure date (YYYY-MM-DD) for booking URL generation."},
+				"max_layover_risk":  {Type: "integer", Description: "0-100 risk ceiling; candidates above this score are dropped (default 60)."},
+				"top_k":             {Type: "integer", Description: "Maximum candidates to return (default 3)."},
+			},
+			Required: []string{"offers"},
+		},
+		OutputSchema: hiddenCityOutputSchema(),
+		Annotations: &ToolAnnotations{
+			Title:          "Hidden-City Matrix Search",
+			ReadOnlyHint:   true,
+			OpenWorldHint:  false,
+			IdempotentHint: true,
+		},
+	}
+}
+
+func hiddenCityOutputSchema() interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"count":   schemaInt(),
+			"allowed": schemaBool(),
+			"candidates": schemaArray(map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"origin":       schemaString(),
+					"hub":          schemaString(),
+					"hub_beyond":   schemaString(),
+					"carrier":      schemaString(),
+					"price":        schemaNum(),
+					"currency":     schemaString(),
+					"savings_eur":  schemaNum(),
+					"savings_pct":  schemaNum(),
+					"layover_risk": schemaInt(),
+					"reason":       schemaString(),
+					"booking_url":  schemaString(),
+				},
+			}),
+		},
+		"required": []string{"count", "allowed", "candidates"},
+	}
+}
+
+func parseHiddenCityOffers(args map[string]any) []hacks.HiddenCityOffer {
+	offersRaw, ok := args["offers"].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]hacks.HiddenCityOffer, 0, len(offersRaw))
+	for _, raw := range offersRaw {
+		m, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		getString := func(key string) string {
+			v, _ := m[key].(string)
+			return v
+		}
+		getFloat := func(key string) float64 {
+			switch v := m[key].(type) {
+			case float64:
+				return v
+			case int:
+				return float64(v)
+			default:
+				return 0
+			}
+		}
+		getBool := func(key string) bool {
+			v, _ := m[key].(bool)
+			return v
+		}
+		getInt := func(key string) int {
+			switch v := m[key].(type) {
+			case float64:
+				return int(v)
+			case int:
+				return v
+			default:
+				return 0
+			}
+		}
+		out = append(out, hacks.HiddenCityOffer{
+			Origin:          getString("origin"),
+			Hub:             getString("hub"),
+			HubBeyond:       getString("hub_beyond"),
+			Carrier:         getString("carrier"),
+			Price:           getFloat("price"),
+			Currency:        getString("currency"),
+			CarryOnOnly:     getBool("carry_on_only"),
+			SeparateTickets: getBool("separate_tickets"),
+			LayoverMinutes:  getInt("layover_minutes"),
+		})
+	}
+	return out
+}
+
+func handleSearchHiddenCity(_ context.Context, args map[string]any, _ ElicitFunc, _ SamplingFunc, _ ProgressFunc) ([]ContentBlock, interface{}, error) {
+	allowHiddenCity := argBool(args, "allow_hidden_city", false)
+	directBaseline := argFloat(args, "direct_baseline", 0)
+	departDate := argString(args, "depart_date")
+	maxLayoverRisk := argInt(args, "max_layover_risk", 0)
+	topK := argInt(args, "top_k", 0)
+
+	offers := parseHiddenCityOffers(args)
+
+	opt := hacks.MatrixOptions{
+		AllowHiddenCity: allowHiddenCity,
+		DirectBaseline:  directBaseline,
+		DepartDate:      departDate,
+		MaxLayoverRisk:  maxLayoverRisk,
+		TopK:            topK,
+	}
+	candidates := hacks.ExpandMatrix(offers, opt)
+
+	type response struct {
+		Count      int                         `json:"count"`
+		Allowed    bool                        `json:"allowed"`
+		Candidates []hacks.HiddenCityCandidate `json:"candidates"`
+	}
+	resp := response{
+		Count:      len(candidates),
+		Allowed:    allowHiddenCity,
+		Candidates: candidates,
+	}
+	if resp.Candidates == nil {
+		resp.Candidates = []hacks.HiddenCityCandidate{}
+	}
+
+	summary := buildHiddenCitySummary(candidates, allowHiddenCity)
+	content := []ContentBlock{
+		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
+		{Type: "text", Text: "Structured hidden-city data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+	}
+	return content, resp, nil
+}
+
+func buildHiddenCitySummary(candidates []hacks.HiddenCityCandidate, allowed bool) string {
+	if !allowed {
+		return "Hidden-city search is disabled. Set risk_posture.hidden_city.acceptable=true in your preferences to enable it."
+	}
+	if len(candidates) == 0 {
+		return "No hidden-city candidates found within the risk threshold."
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d hidden-city candidate(s):\n\n", len(candidates)))
+	for i, c := range candidates {
+		sb.WriteString(fmt.Sprintf("%d. %s\u2192%s (skip to %s) \u2014 %s %.2f", i+1, c.Origin, c.HubBeyond, c.Hub, c.Currency, c.Price))
+		if c.SavingsPct > 0 {
+			sb.WriteString(fmt.Sprintf(" (saves %.0f%%)", c.SavingsPct))
+		}
+		sb.WriteString(fmt.Sprintf(", risk %d/100\n   %s\n   Booking: %s\n\n", c.LayoverRisk, c.Reason, c.BookingURL))
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}

--- a/mcp/tools_opportunities.go
+++ b/mcp/tools_opportunities.go
@@ -1,0 +1,246 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// --- watch_opportunities tool ---
+
+func watchOpportunitiesTool() ToolDef {
+	return ToolDef{
+		Name:  "watch_opportunities",
+		Title: "Watch Opportunities",
+		Description: "Create an opportunity watch that monitors a rolling time window " +
+			"for deals to your favourite destinations. " +
+			"Favourites default to your profile BucketList × AirportAffinity if not specified. " +
+			"Use list_opportunity_watches to see all active opportunity watches.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"favourites":  {Type: "array", Description: "List of destination IATA codes (optional; defaults to profile)"},
+				"window_from": {Type: "string", Description: "Window start: YYYY-MM-DD or next_Nd (e.g. \"next_30d\"). Default: next_30d"},
+				"window_to":   {Type: "string", Description: "Window end: YYYY-MM-DD or next_Nd (e.g. \"next_90d\"). Default: next_90d"},
+				"min_score":   {Type: "integer", Description: "Minimum composite score to alert (0-100). Default: 85"},
+				"min_nights":  {Type: "integer", Description: "Minimum trip length in nights. Default: 3"},
+				"max_nights":  {Type: "integer", Description: "Maximum trip length in nights. Default: 14"},
+			},
+			Required: []string{},
+		},
+		OutputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"success":    schemaBool(),
+				"watch_id":   schemaString(),
+				"created_at": schemaString(),
+				"error":      schemaString(),
+			},
+			"required": []string{"success"},
+		},
+		Annotations: &ToolAnnotations{
+			Title:          "Watch Opportunities",
+			ReadOnlyHint:   false,
+			IdempotentHint: false,
+			OpenWorldHint:  false,
+		},
+	}
+}
+
+func handleWatchOpportunities(_ context.Context, args map[string]any, _ ElicitFunc, _ SamplingFunc, _ ProgressFunc) ([]ContentBlock, interface{}, error) {
+	var favourites []string
+	for _, v := range argStringSlice(args, "favourites") {
+		code := strings.ToUpper(strings.TrimSpace(v))
+		if code != "" {
+			favourites = append(favourites, code)
+		}
+	}
+
+	windowFrom := argString(args, "window_from")
+	if windowFrom == "" {
+		windowFrom = "next_30d"
+	}
+	windowTo := argString(args, "window_to")
+	if windowTo == "" {
+		windowTo = "next_90d"
+	}
+
+	minScore := argInt(args, "min_score", 85)
+	minNights := argInt(args, "min_nights", 3)
+	maxNights := argInt(args, "max_nights", 14)
+
+	w := watch.Watch{
+		Type:       "opportunity",
+		Favourites: favourites,
+		WindowFrom: windowFrom,
+		WindowTo:   windowTo,
+		MinScore:   minScore,
+		MinNights:  minNights,
+		MaxNights:  maxNights,
+	}
+
+	store, err := watch.DefaultStore()
+	if err != nil {
+		return nil, nil, fmt.Errorf("open watch store: %w", err)
+	}
+	if err := store.Load(); err != nil {
+		return nil, nil, fmt.Errorf("load watch store: %w", err)
+	}
+
+	id, err := store.Add(w)
+	if err != nil {
+		return nil, nil, fmt.Errorf("add opportunity watch: %w", err)
+	}
+
+	type oppResponse struct {
+		Success    bool   `json:"success"`
+		WatchID    string `json:"watch_id"`
+		CreatedAt  string `json:"created_at"`
+		Favourites []string `json:"favourites,omitempty"`
+		WindowFrom string `json:"window_from"`
+		WindowTo   string `json:"window_to"`
+		MinScore   int    `json:"min_score"`
+		MinNights  int    `json:"min_nights"`
+		MaxNights  int    `json:"max_nights"`
+	}
+
+	resp := oppResponse{
+		Success:    true,
+		WatchID:    id,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		Favourites: favourites,
+		WindowFrom: windowFrom,
+		WindowTo:   windowTo,
+		MinScore:   minScore,
+		MinNights:  minNights,
+		MaxNights:  maxNights,
+	}
+
+	var favStr string
+	if len(favourites) > 0 {
+		favStr = strings.Join(favourites, ", ")
+	} else {
+		favStr = "(from profile)"
+	}
+	summary := fmt.Sprintf(
+		"Opportunity watch %s created: destinations=%s, window=%s to %s, min_score=%d, nights=%d-%d.",
+		id, favStr, windowFrom, windowTo, minScore, minNights, maxNights,
+	)
+
+	content, err := buildAnnotatedContentBlocks(summary, resp)
+	if err != nil {
+		return nil, nil, err
+	}
+	return content, resp, nil
+}
+
+// --- list_opportunity_watches tool ---
+
+func listOpportunityWatchesTool() ToolDef {
+	return ToolDef{
+		Name:        "list_opportunity_watches",
+		Title:       "List Opportunity Watches",
+		Description: "List all opportunity watches stored in ~/.trvl/watches.json.",
+		InputSchema: InputSchema{
+			Type:       "object",
+			Properties: map[string]Property{},
+			Required:   []string{},
+		},
+		OutputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"watches": schemaArray(map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"id":           schemaString(),
+						"favourites":   schemaArray(map[string]interface{}{"type": "string"}),
+						"window_from":  schemaString(),
+						"window_to":    schemaString(),
+						"min_score":    schemaInt(),
+						"min_nights":   schemaInt(),
+						"max_nights":   schemaInt(),
+						"created_at":   schemaString(),
+					},
+				}),
+				"count": schemaInt(),
+			},
+		},
+		Annotations: &ToolAnnotations{
+			Title:          "List Opportunity Watches",
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+	}
+}
+
+func handleListOpportunityWatches(_ context.Context, _ map[string]any, _ ElicitFunc, _ SamplingFunc, _ ProgressFunc) ([]ContentBlock, interface{}, error) {
+	store, err := watch.DefaultStore()
+	if err != nil {
+		return nil, nil, fmt.Errorf("open watch store: %w", err)
+	}
+	if err := store.Load(); err != nil {
+		return nil, nil, fmt.Errorf("load watch store: %w", err)
+	}
+
+	type oppWatchSummary struct {
+		ID         string   `json:"id"`
+		Favourites []string `json:"favourites,omitempty"`
+		WindowFrom string   `json:"window_from"`
+		WindowTo   string   `json:"window_to"`
+		MinScore   int      `json:"min_score"`
+		MinNights  int      `json:"min_nights"`
+		MaxNights  int      `json:"max_nights"`
+		CreatedAt  string   `json:"created_at"`
+	}
+
+	var summaries []oppWatchSummary
+	for _, w := range store.List() {
+		if !w.IsOpportunityWatch() {
+			continue
+		}
+		summaries = append(summaries, oppWatchSummary{
+			ID:         w.ID,
+			Favourites: w.Favourites,
+			WindowFrom: w.WindowFrom,
+			WindowTo:   w.WindowTo,
+			MinScore:   w.MinScore,
+			MinNights:  w.MinNights,
+			MaxNights:  w.MaxNights,
+			CreatedAt:  w.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+
+	type listResponse struct {
+		Watches []oppWatchSummary `json:"watches"`
+		Count   int               `json:"count"`
+	}
+
+	if summaries == nil {
+		summaries = []oppWatchSummary{}
+	}
+	resp := listResponse{Watches: summaries, Count: len(summaries)}
+
+	var text string
+	if len(summaries) == 0 {
+		text = "No opportunity watches found. Use watch_opportunities to create one."
+	} else {
+		text = fmt.Sprintf("%d opportunity watch(es):\n", len(summaries))
+		for _, ws := range summaries {
+			favStr := strings.Join(ws.Favourites, ", ")
+			if favStr == "" {
+				favStr = "(from profile)"
+			}
+			text += fmt.Sprintf("  [%s] %s | %s→%s | min_score=%d nights=%d-%d\n",
+				ws.ID, favStr, ws.WindowFrom, ws.WindowTo, ws.MinScore, ws.MinNights, ws.MaxNights)
+		}
+	}
+
+	content, err := buildAnnotatedContentBlocks(text, resp)
+	if err != nil {
+		return nil, nil, err
+	}
+	return content, resp, nil
+}

--- a/mcp/tools_preferences.go
+++ b/mcp/tools_preferences.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
 
 	"github.com/MikkoParkkola/trvl/internal/preferences"
 )
+
+var preferenceUpdateLocks sync.Map
 
 // getPreferencesTool returns the MCP tool definition for get_preferences.
 func getPreferencesTool() ToolDef {
@@ -22,38 +27,38 @@ func getPreferencesTool() ToolDef {
 		OutputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
-				"home_airports":       schemaStringArray(),
-				"home_cities":         schemaStringArray(),
-				"carry_on_only":       schemaBool(),
-				"prefer_direct":       schemaBool(),
-				"no_dormitories":      schemaBool(),
-				"ensuite_only":        schemaBool(),
-				"fast_wifi_needed":    schemaBool(),
-				"min_hotel_stars":     schemaInt(),
-				"min_hotel_rating":    schemaNum(),
-				"display_currency":    schemaString(),
-				"locale":              schemaString(),
-				"loyalty_airlines":    schemaStringArray(),
-				"loyalty_hotels":      schemaStringArray(),
-				"lounge_cards":        schemaStringArray(),
-				"preferred_districts": schemaObject(),
-				"default_companions":     schemaInt(),
-				"trip_types":             schemaStringArray(),
-				"seat_preference":        schemaString(),
-				"budget_per_night_min":   schemaNum(),
-				"budget_per_night_max":   schemaNum(),
-				"budget_flight_max":      schemaNum(),
-				"deal_tolerance":         schemaString(),
-				"flight_time_earliest":   schemaString(),
-				"flight_time_latest":     schemaString(),
-				"red_eye_ok":             schemaBool(),
-				"nationality":            schemaString(),
-				"languages":              schemaStringArray(),
-				"previous_trips":         schemaStringArray(),
-				"bucket_list":            schemaStringArray(),
-				"activity_preferences":   schemaStringArray(),
-				"dietary_needs":          schemaStringArray(),
-				"notes":                  schemaString(),
+				"home_airports":        schemaStringArray(),
+				"home_cities":          schemaStringArray(),
+				"carry_on_only":        schemaBool(),
+				"prefer_direct":        schemaBool(),
+				"no_dormitories":       schemaBool(),
+				"ensuite_only":         schemaBool(),
+				"fast_wifi_needed":     schemaBool(),
+				"min_hotel_stars":      schemaInt(),
+				"min_hotel_rating":     schemaNum(),
+				"display_currency":     schemaString(),
+				"locale":               schemaString(),
+				"loyalty_airlines":     schemaStringArray(),
+				"loyalty_hotels":       schemaStringArray(),
+				"lounge_cards":         schemaStringArray(),
+				"preferred_districts":  schemaObject(),
+				"default_companions":   schemaInt(),
+				"trip_types":           schemaStringArray(),
+				"seat_preference":      schemaString(),
+				"budget_per_night_min": schemaNum(),
+				"budget_per_night_max": schemaNum(),
+				"budget_flight_max":    schemaNum(),
+				"deal_tolerance":       schemaString(),
+				"flight_time_earliest": schemaString(),
+				"flight_time_latest":   schemaString(),
+				"red_eye_ok":           schemaBool(),
+				"nationality":          schemaString(),
+				"languages":            schemaStringArray(),
+				"previous_trips":       schemaStringArray(),
+				"bucket_list":          schemaStringArray(),
+				"activity_preferences": schemaStringArray(),
+				"dietary_needs":        schemaStringArray(),
+				"notes":                schemaString(),
 				"family_members": schemaArray(map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{
@@ -195,71 +200,71 @@ You MUST confirm with the user before calling this tool. Never update silently.`
 				"min_hotel_stars":     {Type: "integer", Description: "Minimum hotel star rating (0-5). 0 means no minimum."},
 				"min_hotel_rating":    {Type: "number", Description: "Minimum hotel review score (e.g. 4.0). 0 means no minimum."},
 				"display_currency":    {Type: "string", Description: "ISO 4217 currency code for display, e.g. \"EUR\"."},
-				"locale":             {Type: "string", Description: "BCP 47 locale tag, e.g. \"en-FI\"."},
+				"locale":              {Type: "string", Description: "BCP 47 locale tag, e.g. \"en-FI\"."},
 				"loyalty_airlines":    {Type: "string", Description: "JSON array of airline IATA codes, e.g. [\"KL\",\"AY\"]. Replaces existing list."},
 				"loyalty_hotels":      {Type: "string", Description: "JSON array of hotel programme names, e.g. [\"Marriott Bonvoy\"]. Replaces existing list."},
 				"lounge_cards":        {Type: "string", Description: "JSON array of lounge access card names, e.g. [\"Priority Pass\",\"Diners Club\"]. Replaces existing list."},
 				"preferred_districts": {Type: "string", Description: "JSON object mapping city names to district arrays, e.g. {\"Prague\":[\"Prague 1\",\"Prague 2\"]}. Merged with existing districts (new cities added, existing cities replaced)."},
 				"family_members":      {Type: "string", Description: "JSON array of family member objects with name, relationship, and notes fields. Replaces entire family list."},
 				// Travel style (extended)
-				"default_companions":    {Type: "integer", Description: "Default number of companions. 0 = solo, 1 = couple, 2+ = family/group."},
-				"trip_types":            {Type: "string", Description: "JSON array of trip types, e.g. [\"city_break\",\"beach\",\"adventure\"]. Replaces existing list."},
-				"seat_preference":       {Type: "string", Description: "Preferred seat: \"window\", \"aisle\", or \"no_preference\"."},
+				"default_companions": {Type: "integer", Description: "Default number of companions. 0 = solo, 1 = couple, 2+ = family/group."},
+				"trip_types":         {Type: "string", Description: "JSON array of trip types, e.g. [\"city_break\",\"beach\",\"adventure\"]. Replaces existing list."},
+				"seat_preference":    {Type: "string", Description: "Preferred seat: \"window\", \"aisle\", or \"no_preference\"."},
 				// Budget
-				"budget_per_night_min":  {Type: "number", Description: "Minimum acceptable hotel price per night (filters too-cheap-to-trust)."},
-				"budget_per_night_max":  {Type: "number", Description: "Maximum hotel price per night."},
-				"budget_flight_max":     {Type: "number", Description: "Maximum one-way flight price."},
-				"deal_tolerance":        {Type: "string", Description: "Price sensitivity: \"price\" (6am flight to save money), \"comfort\" (pay for convenience), or \"balanced\"."},
+				"budget_per_night_min": {Type: "number", Description: "Minimum acceptable hotel price per night (filters too-cheap-to-trust)."},
+				"budget_per_night_max": {Type: "number", Description: "Maximum hotel price per night."},
+				"budget_flight_max":    {Type: "number", Description: "Maximum one-way flight price."},
+				"deal_tolerance":       {Type: "string", Description: "Price sensitivity: \"price\" (6am flight to save money), \"comfort\" (pay for convenience), or \"balanced\"."},
 				// Flight preferences
-				"flight_time_earliest":  {Type: "string", Description: "Earliest acceptable flight departure time, e.g. \"06:00\"."},
-				"flight_time_latest":    {Type: "string", Description: "Latest acceptable flight departure time, e.g. \"23:00\"."},
-				"red_eye_ok":            {Type: "boolean", Description: "True if overnight (red-eye) flights are acceptable."},
+				"flight_time_earliest": {Type: "string", Description: "Earliest acceptable flight departure time, e.g. \"06:00\"."},
+				"flight_time_latest":   {Type: "string", Description: "Latest acceptable flight departure time, e.g. \"23:00\"."},
+				"red_eye_ok":           {Type: "boolean", Description: "True if overnight (red-eye) flights are acceptable."},
 				// Identity
-				"nationality":           {Type: "string", Description: "ISO 3166-1 alpha-2 country code, e.g. \"FI\". Used for visa warnings."},
-				"languages":             {Type: "string", Description: "JSON array of spoken language codes, e.g. [\"en\",\"fi\",\"sv\"]. Replaces existing list."},
+				"nationality": {Type: "string", Description: "ISO 3166-1 alpha-2 country code, e.g. \"FI\". Used for visa warnings."},
+				"languages":   {Type: "string", Description: "JSON array of spoken language codes, e.g. [\"en\",\"fi\",\"sv\"]. Replaces existing list."},
 				// Context (personalization)
-				"previous_trips":        {Type: "string", Description: "JSON array of cities/countries visited, e.g. [\"Japan\",\"Barcelona\"]. Replaces existing list."},
-				"bucket_list":           {Type: "string", Description: "JSON array of dream destinations, e.g. [\"New Zealand\",\"Iceland\"]. Replaces existing list."},
-				"activity_preferences":  {Type: "string", Description: "JSON array of preferred activities, e.g. [\"museums\",\"food\",\"nature\"]. Replaces existing list."},
-				"dietary_needs":         {Type: "string", Description: "JSON array of dietary requirements, e.g. [\"vegetarian\",\"gluten_free\"]. Replaces existing list."},
-				"notes":                 {Type: "string", Description: "Free-text notes for anything that doesn't fit another field."},
+				"previous_trips":       {Type: "string", Description: "JSON array of cities/countries visited, e.g. [\"Japan\",\"Barcelona\"]. Replaces existing list."},
+				"bucket_list":          {Type: "string", Description: "JSON array of dream destinations, e.g. [\"New Zealand\",\"Iceland\"]. Replaces existing list."},
+				"activity_preferences": {Type: "string", Description: "JSON array of preferred activities, e.g. [\"museums\",\"food\",\"nature\"]. Replaces existing list."},
+				"dietary_needs":        {Type: "string", Description: "JSON array of dietary requirements, e.g. [\"vegetarian\",\"gluten_free\"]. Replaces existing list."},
+				"notes":                {Type: "string", Description: "Free-text notes for anything that doesn't fit another field."},
 			},
 		},
 		OutputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
-				"home_airports":       schemaStringArray(),
-				"home_cities":         schemaStringArray(),
-				"carry_on_only":       schemaBool(),
-				"prefer_direct":       schemaBool(),
-				"no_dormitories":      schemaBool(),
-				"ensuite_only":        schemaBool(),
-				"fast_wifi_needed":    schemaBool(),
-				"min_hotel_stars":     schemaInt(),
-				"min_hotel_rating":    schemaNum(),
-				"display_currency":    schemaString(),
-				"locale":              schemaString(),
-				"loyalty_airlines":    schemaStringArray(),
-				"loyalty_hotels":      schemaStringArray(),
-				"lounge_cards":        schemaStringArray(),
-				"preferred_districts": schemaObject(),
-				"default_companions":     schemaInt(),
-				"trip_types":             schemaStringArray(),
-				"seat_preference":        schemaString(),
-				"budget_per_night_min":   schemaNum(),
-				"budget_per_night_max":   schemaNum(),
-				"budget_flight_max":      schemaNum(),
-				"deal_tolerance":         schemaString(),
-				"flight_time_earliest":   schemaString(),
-				"flight_time_latest":     schemaString(),
-				"red_eye_ok":             schemaBool(),
-				"nationality":            schemaString(),
-				"languages":              schemaStringArray(),
-				"previous_trips":         schemaStringArray(),
-				"bucket_list":            schemaStringArray(),
-				"activity_preferences":   schemaStringArray(),
-				"dietary_needs":          schemaStringArray(),
-				"notes":                  schemaString(),
+				"home_airports":        schemaStringArray(),
+				"home_cities":          schemaStringArray(),
+				"carry_on_only":        schemaBool(),
+				"prefer_direct":        schemaBool(),
+				"no_dormitories":       schemaBool(),
+				"ensuite_only":         schemaBool(),
+				"fast_wifi_needed":     schemaBool(),
+				"min_hotel_stars":      schemaInt(),
+				"min_hotel_rating":     schemaNum(),
+				"display_currency":     schemaString(),
+				"locale":               schemaString(),
+				"loyalty_airlines":     schemaStringArray(),
+				"loyalty_hotels":       schemaStringArray(),
+				"lounge_cards":         schemaStringArray(),
+				"preferred_districts":  schemaObject(),
+				"default_companions":   schemaInt(),
+				"trip_types":           schemaStringArray(),
+				"seat_preference":      schemaString(),
+				"budget_per_night_min": schemaNum(),
+				"budget_per_night_max": schemaNum(),
+				"budget_flight_max":    schemaNum(),
+				"deal_tolerance":       schemaString(),
+				"flight_time_earliest": schemaString(),
+				"flight_time_latest":   schemaString(),
+				"red_eye_ok":           schemaBool(),
+				"nationality":          schemaString(),
+				"languages":            schemaStringArray(),
+				"previous_trips":       schemaStringArray(),
+				"bucket_list":          schemaStringArray(),
+				"activity_preferences": schemaStringArray(),
+				"dietary_needs":        schemaStringArray(),
+				"notes":                schemaString(),
 				"family_members": schemaArray(map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{
@@ -288,16 +293,17 @@ func handleUpdatePreferences(_ context.Context, args map[string]any, _ ElicitFun
 // handleUpdatePreferencesWithPath is the testable core: when path is "" it uses
 // the default ~/.trvl/preferences.json; otherwise it uses the given path.
 func handleUpdatePreferencesWithPath(args map[string]any, path string, progress ProgressFunc) ([]ContentBlock, interface{}, error) {
-	// Load current preferences.
-	var (
-		p   *preferences.Preferences
-		err error
-	)
-	if path != "" {
-		p, err = preferences.LoadFrom(path)
-	} else {
-		p, err = preferences.Load()
+	resolvedPath, err := resolvePreferenceUpdatePath(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve preferences path: %w", err)
 	}
+
+	lock := preferenceUpdateLock(resolvedPath)
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Load current preferences.
+	p, err := preferences.LoadFrom(resolvedPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load preferences: %w", err)
 	}
@@ -306,12 +312,7 @@ func handleUpdatePreferencesWithPath(args map[string]any, path string, progress 
 	updated := mergePreferenceArgs(p, args)
 
 	// Save.
-	if path != "" {
-		err = preferences.SaveTo(path, updated)
-	} else {
-		err = preferences.Save(updated)
-	}
-	if err != nil {
+	if err := preferences.SaveTo(resolvedPath, updated); err != nil {
 		return nil, nil, fmt.Errorf("save preferences: %w", err)
 	}
 
@@ -321,6 +322,40 @@ func handleUpdatePreferencesWithPath(args map[string]any, path string, progress 
 		return nil, nil, err
 	}
 	return content, updated, nil
+}
+
+func preferenceUpdateLock(path string) *sync.Mutex {
+	lock, _ := preferenceUpdateLocks.LoadOrStore(path, &sync.Mutex{})
+	return lock.(*sync.Mutex)
+}
+
+func resolvePreferenceUpdatePath(path string) (string, error) {
+	if path == "" {
+		defaultPath, err := preferences.DefaultPath()
+		if err != nil {
+			return "", err
+		}
+		path = defaultPath
+	}
+
+	cleaned := filepath.Clean(path)
+	resolvedPath, err := filepath.EvalSymlinks(cleaned)
+	if err == nil {
+		return resolvedPath, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	resolvedParent, parentErr := filepath.EvalSymlinks(filepath.Dir(cleaned))
+	if parentErr == nil {
+		return filepath.Join(resolvedParent, filepath.Base(cleaned)), nil
+	}
+	if !os.IsNotExist(parentErr) {
+		return "", parentErr
+	}
+
+	return cleaned, nil
 }
 
 // mergePreferenceArgs applies only the fields present in args to the

--- a/mcp/tools_preferences_test.go
+++ b/mcp/tools_preferences_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/MikkoParkkola/trvl/internal/preferences"
@@ -213,9 +214,9 @@ func TestUpdatePreferences_InvalidFieldsIgnored(t *testing.T) {
 	path := setupTempPrefs(t, initial)
 
 	args := map[string]any{
-		"nonexistent_field":  "should be ignored",
-		"another_bad_field":  42,
-		"min_hotel_stars":    float64(4), // valid field mixed in
+		"nonexistent_field": "should be ignored",
+		"another_bad_field": 42,
+		"min_hotel_stars":   float64(4), // valid field mixed in
 	}
 
 	_, structured, err := handleUpdatePreferencesWithPath(args, path, nil)
@@ -242,8 +243,8 @@ func TestUpdatePreferences_BooleanFields(t *testing.T) {
 	path := setupTempPrefs(t, initial)
 
 	args := map[string]any{
-		"carry_on_only":   true,
-		"no_dormitories":  true,
+		"carry_on_only":  true,
+		"no_dormitories": true,
 		// prefer_direct NOT included — should stay true.
 	}
 
@@ -342,6 +343,134 @@ func TestUpdatePreferences_NoExistingFile_CreatesNew(t *testing.T) {
 	// File should exist on disk.
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		t.Error("preferences file was not created")
+	}
+}
+
+func TestUpdatePreferences_ConcurrentUpdatesPreserveDisjointFields(t *testing.T) {
+	initial := &preferences.Preferences{
+		DisplayCurrency: "EUR",
+		Locale:          "en",
+	}
+	path := setupTempPrefs(t, initial)
+
+	updateArgs := []map[string]any{
+		{"display_currency": "USD"},
+		{"locale": "fi-FI"},
+	}
+
+	for attempt := 0; attempt < 50; attempt++ {
+		if err := preferences.SaveTo(path, initial); err != nil {
+			t.Fatalf("reset preferences: %v", err)
+		}
+
+		start := make(chan struct{})
+		errs := make(chan error, len(updateArgs))
+
+		var wg sync.WaitGroup
+		for _, args := range updateArgs {
+			wg.Add(1)
+			go func(args map[string]any) {
+				defer wg.Done()
+				<-start
+				_, _, err := handleUpdatePreferencesWithPath(args, path, nil)
+				errs <- err
+			}(args)
+		}
+
+		close(start)
+		wg.Wait()
+		close(errs)
+
+		for err := range errs {
+			if err != nil {
+				t.Fatalf("concurrent update failed: %v", err)
+			}
+		}
+
+		reloaded, err := preferences.LoadFrom(path)
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		if reloaded.DisplayCurrency != "USD" || reloaded.Locale != "fi-FI" {
+			t.Fatalf("attempt %d: concurrent updates lost data: got currency=%q locale=%q", attempt, reloaded.DisplayCurrency, reloaded.Locale)
+		}
+	}
+}
+
+func TestUpdatePreferences_DefaultPathConcurrentUpdatesPreserveDisjointFields(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	initial := &preferences.Preferences{
+		DisplayCurrency: "EUR",
+		Locale:          "en",
+	}
+
+	updateArgs := []map[string]any{
+		{"display_currency": "USD"},
+		{"locale": "fi-FI"},
+	}
+
+	for attempt := 0; attempt < 50; attempt++ {
+		if err := preferences.Save(initial); err != nil {
+			t.Fatalf("reset preferences: %v", err)
+		}
+
+		start := make(chan struct{})
+		errs := make(chan error, len(updateArgs))
+
+		var wg sync.WaitGroup
+		for _, args := range updateArgs {
+			wg.Add(1)
+			go func(args map[string]any) {
+				defer wg.Done()
+				<-start
+				_, _, err := handleUpdatePreferencesWithPath(args, "", nil)
+				errs <- err
+			}(args)
+		}
+
+		close(start)
+		wg.Wait()
+		close(errs)
+
+		for err := range errs {
+			if err != nil {
+				t.Fatalf("concurrent update failed: %v", err)
+			}
+		}
+
+		reloaded, err := preferences.Load()
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		if reloaded.DisplayCurrency != "USD" || reloaded.Locale != "fi-FI" {
+			t.Fatalf("attempt %d: concurrent default-path updates lost data: got currency=%q locale=%q", attempt, reloaded.DisplayCurrency, reloaded.Locale)
+		}
+	}
+}
+
+func TestResolvePreferenceUpdatePath_ResolvesSymlinkedFilesToSharedLockKey(t *testing.T) {
+	targetPath := setupTempPrefs(t, preferences.Default())
+	symlinkPath := filepath.Join(t.TempDir(), "preferences-link.json")
+	if err := os.Symlink(targetPath, symlinkPath); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	resolvedTarget, err := resolvePreferenceUpdatePath(targetPath)
+	if err != nil {
+		t.Fatalf("resolve target path: %v", err)
+	}
+	resolvedSymlink, err := resolvePreferenceUpdatePath(symlinkPath)
+	if err != nil {
+		t.Fatalf("resolve symlink path: %v", err)
+	}
+
+	if resolvedTarget != resolvedSymlink {
+		t.Fatalf("resolved paths differ: target=%q symlink=%q", resolvedTarget, resolvedSymlink)
+	}
+	if preferenceUpdateLock(resolvedTarget) != preferenceUpdateLock(resolvedSymlink) {
+		t.Fatal("resolved symlink path should share the same mutex as the target path")
 	}
 }
 
@@ -448,8 +577,8 @@ func TestUpdatePreferences_TripTypesAndSeat(t *testing.T) {
 	path := setupTempPrefs(t, initial)
 
 	args := map[string]any{
-		"trip_types":      []any{"city_break", "adventure", "remote_work"},
-		"seat_preference": "window",
+		"trip_types":         []any{"city_break", "adventure", "remote_work"},
+		"seat_preference":    "window",
 		"default_companions": float64(1),
 	}
 
@@ -480,10 +609,10 @@ func TestUpdatePreferences_NotesAndContextFields(t *testing.T) {
 
 	args := map[string]any{
 		"notes":                "I have a fear of flying but manage with medication",
-		"previous_trips":      `["Japan","Spain","Germany"]`,
-		"bucket_list":         `["New Zealand","Iceland"]`,
+		"previous_trips":       `["Japan","Spain","Germany"]`,
+		"bucket_list":          `["New Zealand","Iceland"]`,
 		"activity_preferences": `["museums","food","nature"]`,
-		"dietary_needs":       `["vegetarian"]`,
+		"dietary_needs":        `["vegetarian"]`,
 	}
 
 	_, structured, err := handleUpdatePreferencesWithPath(args, path, nil)
@@ -540,10 +669,10 @@ func TestUpdatePreferences_FlightPreferences(t *testing.T) {
 func TestUpdatePreferences_NewFields_PreserveExisting(t *testing.T) {
 	t.Parallel()
 	initial := &preferences.Preferences{
-		HomeAirports:    []string{"HEL"},
-		DisplayCurrency: "EUR",
-		Locale:          "en-FI",
-		Nationality:     "FI",
+		HomeAirports:      []string{"HEL"},
+		DisplayCurrency:   "EUR",
+		Locale:            "en-FI",
+		Nationality:       "FI",
 		BudgetPerNightMax: 150,
 	}
 	path := setupTempPrefs(t, initial)

--- a/mcp/wrap_handler_clone_test.go
+++ b/mcp/wrap_handler_clone_test.go
@@ -1,0 +1,146 @@
+package mcp
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func TestWrapHandler_ConcurrentCallersGetPrivateStructuredContent(t *testing.T) {
+	t.Parallel()
+
+	carryOn := true
+	checkedBags := 1
+	shared := &models.FlightSearchResult{
+		Success:  true,
+		Count:    1,
+		TripType: "one_way",
+		Flights: []models.FlightResult{
+			{
+				Price:               123,
+				Currency:            "EUR",
+				Warnings:            []string{"Self-connect risk"},
+				Legs:                []models.FlightLeg{{AirlineCode: "AY"}},
+				CarryOnIncluded:     &carryOn,
+				CheckedBagsIncluded: &checkedBags,
+			},
+		},
+	}
+
+	s := NewServer()
+	handler := s.wrapHandler(func(context.Context, map[string]any, ElicitFunc, SamplingFunc, ProgressFunc) ([]ContentBlock, interface{}, error) {
+		return []ContentBlock{{
+			Type: "text",
+			Text: "ok",
+			Annotations: &ContentAnnotation{
+				Audience: []string{"user"},
+				Priority: 1,
+			},
+		}}, shared, nil
+	})
+
+	const callers = 2
+	contents := make([][]ContentBlock, callers)
+	results := make([]*models.FlightSearchResult, callers)
+	errs := make([]error, callers)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	args := map[string]any{
+		"origin":         "HEL",
+		"destination":    "NRT",
+		"departure_date": "2026-06-15",
+	}
+
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			content, structured, err := handler(context.Background(), args, nil, nil, nil)
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+			contents[idx] = content
+			results[idx] = structured.(*models.FlightSearchResult)
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("caller %d returned error: %v", i, err)
+		}
+	}
+
+	if results[0] == results[1] {
+		t.Fatal("concurrent callers received the same FlightSearchResult pointer")
+	}
+	if len(contents[0]) == 0 || len(contents[1]) == 0 {
+		t.Fatal("concurrent callers should both receive content blocks")
+	}
+	if &contents[0][0] == &contents[1][0] {
+		t.Fatal("concurrent callers reused the same ContentBlock backing storage")
+	}
+	if contents[0][0].Annotations == contents[1][0].Annotations {
+		t.Fatal("concurrent callers reused the same ContentAnnotation pointer")
+	}
+	if &contents[0][0].Annotations.Audience[0] == &contents[1][0].Annotations.Audience[0] {
+		t.Fatal("concurrent callers reused the same annotation audience backing storage")
+	}
+	if &results[0].Flights[0] == &results[1].Flights[0] {
+		t.Fatal("concurrent callers reused the same FlightResult backing storage")
+	}
+	if &results[0].Flights[0].Warnings[0] == &results[1].Flights[0].Warnings[0] {
+		t.Fatal("concurrent callers reused the same warnings backing storage")
+	}
+	if results[0].Flights[0].CarryOnIncluded == results[1].Flights[0].CarryOnIncluded {
+		t.Fatal("concurrent callers reused the same CarryOnIncluded pointer")
+	}
+	if results[0].Flights[0].CheckedBagsIncluded == results[1].Flights[0].CheckedBagsIncluded {
+		t.Fatal("concurrent callers reused the same CheckedBagsIncluded pointer")
+	}
+
+	contents[0][0].Text = "changed"
+	contents[0][0].Annotations.Audience[0] = "assistant"
+	contents[0] = contents[0][:0]
+	results[0].Count = 0
+	results[0].Flights[0].Warnings[0] = "changed"
+	results[0].Flights[0].Legs[0].AirlineCode = "JL"
+	*results[0].Flights[0].CarryOnIncluded = false
+	*results[0].Flights[0].CheckedBagsIncluded = 2
+	results[0].Flights = results[0].Flights[:0]
+
+	if len(contents[1]) == 0 {
+		t.Fatal("caller 1 content unexpectedly empty after caller 0 mutation")
+	}
+	if got := contents[1][0].Text; got != "ok" {
+		t.Fatalf("caller 1 text = %q, want %q", got, "ok")
+	}
+	if got := contents[1][0].Annotations.Audience[0]; got != "user" {
+		t.Fatalf("caller 1 audience = %q, want %q", got, "user")
+	}
+	if results[1].Count != 1 {
+		t.Fatalf("caller 1 Count = %d, want 1", results[1].Count)
+	}
+	if len(results[1].Flights) != 1 {
+		t.Fatalf("caller 1 len(Flights) = %d, want 1", len(results[1].Flights))
+	}
+	if got := results[1].Flights[0].Warnings[0]; got != "Self-connect risk" {
+		t.Fatalf("caller 1 warning = %q, want %q", got, "Self-connect risk")
+	}
+	if got := results[1].Flights[0].Legs[0].AirlineCode; got != "AY" {
+		t.Fatalf("caller 1 airline code = %q, want %q", got, "AY")
+	}
+	if got := *results[1].Flights[0].CarryOnIncluded; !got {
+		t.Fatalf("caller 1 CarryOnIncluded = %v, want true", got)
+	}
+	if got := *results[1].Flights[0].CheckedBagsIncluded; got != 1 {
+		t.Fatalf("caller 1 CheckedBagsIncluded = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Overview

Stack of four features + race-fix that landed in sequence. All build cleanly (`go build ./...` passes). Key new tests pass under `-race`.

---

### MIK-3074 — Typed FixHintCode classifier (base of stack)
Commits: `335a112`, `5c1a947`, `b1b7ecc`
- Typed `FixHintCode` constants for provider auth failures
- Eliminates data races in MCP handler tests
- Singleflight result cloning + hotel cache-key completeness + watch scheduler shutdown fix

### MIK-3062 — ProfileMatch multi-factor score ([ROI:50x])
Commits: `09a7c0a`, `625fbc4`, `8a629d9`
- `internal/scoring` package: 12-factor profile match (0–100), replaces `ValueScore`
- `--explain` flag on `trvl flights`, `hotels`, `optimize`, `trip-cost` — ASCII bar breakdown per factor
- Preferences struct gains `match_weights`, `airport_affinity`, `excluded_destinations`

### MIK-3065 — Opportunity Watch type ([ROI:35x])
Commit: `b499449`
- `internal/watch` gains `OpportunityWatch` with rolling window + favourite destination expansion
- `internal/match` (RequestMatch, 5 penalty axes) and `internal/dealquality` (p10/p20/p50 baselines)
- MCP tool `watch_opportunities` + CLI `trvl opportunities`

### MIK-3078 — Hidden-city matrix search + one-click booking (P1)
Commits: `c482f4c`, `fafddeb`
- `internal/hacks`: `ExpandMatrix` enumerates {origin×hub-beyond} permutations
- LayoverRisk score (carry-on, separate-ticket-baggage, connection-time)
- Direct booking URLs (KL/AF, AY, LH/OS/LX, fallback Google Flights)
- MCP tool `search_hidden_city` + CLI `trvl hidden-city`
- Fixture integration tests: AMS→HEL→RIX, AMS→FRA→MUC
- Tool count 56→57 in README/AGENTS/CHANGELOG

## Testing
```
go build ./...  # ✅ exit 0
go test -count=1 -run 'TestHiddenCity|TestSearchHiddenCity|TestProfileMatch|TestRequestMatch|TestDealQuality' ./internal/...  # ✅ all pass
```

## Merge order
Merge this PR **before** feat/mik-3081-awards (which also adds a tool and may need a rebase after this lands).

Closes #MIK-3062 #MIK-3065 #MIK-3074 #MIK-3078