### PR TITLE
feat: cross-program award scanner with sweet-spot detector (MIK-3081)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl",
   "version": "1.0.0",
-  "description": "AI Travel Agent — 60 MCP tools for flights, hotels (5 providers: Google Hotels + Trivago + Airbnb + Booking.com + Hostelworld), trains, buses, ferries (20 ground providers incl. 8 ferry operators + night-train specialists European Sleeper & Snälltåget), 36 travel hack detectors, traveller profile with email history learning, deals, price alerts, and destination intel. Free, no API keys required.",
+  "description": "AI Travel Agent — 61 MCP tools for flights, hotels (5 providers: Google Hotels + Trivago + Airbnb + Booking.com + Hostelworld), trains, buses, ferries (20 ground providers incl. 8 ferry operators + night-train specialists European Sleeper & Snälltåget), 37 travel hack detectors, award sweet-spot scanning, traveller profile with email history learning, deals, price alerts, and destination intel. Free, no API keys required.",
   "author": {
     "name": "Mikko Parkkola",
     "url": "https://github.com/MikkoParkkola"

--- a/.claude/skills/trvl.md
+++ b/.claude/skills/trvl.md
@@ -50,7 +50,7 @@ Read `~/.claude/travel-profile.md` if exists. Apply: departure time prefs, FF st
 ## ASK FIRST (2-3 Qs max)
 From?|To?|When?|Flex?|Travelers?|Budget? Check calendar (Google/Apple/manual) for conflicts. Don't re-ask obvious info.
 
-## CORE TOOLS (selected high-signal tools; trvl exposes 60 MCP tools overall via gateway_invoke server="trvl")
+## CORE TOOLS (selected high-signal tools; trvl exposes 61 MCP tools overall via gateway_invoke server="trvl")
 | Tool | Use | Key params |
 |------|-----|-----------|
 | `search_flights` | Flights A→B | origin,destination,departure_date,[return_date,cabin_class,max_stops] |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,12 @@ Returns: visa status (`visa-free`, `visa-required`, `visa-on-arrival`, `e-visa`,
 ```
 Returns: effective cents-per-point, floor/ceiling valuation for the program, verdict (`use points`, `pay cash`, or `borderline`), and explanation.
 
+### search_awards — Rank cross-program award sweet spots
+```json
+{"seats":[{"program":"VS","origin":"HEL","destination":"LHR","date":"2026-08-15","cabin":"business","miles_cost":50000,"cash_fees":35,"cash_equivalent":650,"bookable_segments":1}],"balances":[{"program":"MR","balance":80000},{"program":"VS","balance":20000}]}
+```
+Returns: ranked award-seat redemption paths across native balances and transfer partners, including miles spent, cash fees, cents-per-point, affordability, and transfer route. Use when award availability is already known or supplied from another source.
+
 ### optimize_booking — Unified trip optimizer
 ```json
 {"origin": "HEL", "destination": "BCN", "departure_date": "2026-07-01", "return_date": "2026-07-08"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ trvl flights HEL LHR 2026-07-01 --format json | head -5
 # Expected: JSON with flight results
 ```
 
-Tell the user: "trvl is installed with 60 MCP tools and 2 bundled Claude skills. It includes 37 travel hack detectors (including error fare and flash sale detection) that auto-fire on searches, a unified optimizer (optimize_booking) with 9 expansion strategies (alternative origins/destinations, rail+fly, date flex, hidden city, departure tax avoidance, rail competition alternatives, ferry cabin as hotel) that searches all combinations in parallel, all-in pricing with FF status (bag fees included, FF benefits subtracted), pre-priced candidate pipeline for ground alternatives, miles tracking and earning estimates, and cross-provider hotel price comparison with cross-currency savings display. I can search flights, hotels, destinations, plan trips, find weekend getaways, find optimal travel windows, optimize multi-city routes, find nearby restaurants, check local events, search ground transport (buses, trains, ferries, night trains), detect travel hacks, check weather forecasts, look up airline baggage rules, find airport lounges, check visa requirements, calculate points-vs-cash redemptions, and configure additional data providers (Airbnb, Booking.com, Hostelworld). Just ask me anything about travel."
+Tell the user: "trvl is installed with 61 MCP tools and 2 bundled Claude skills. It includes 37 travel hack detectors (including error fare and flash sale detection) that auto-fire on searches, a unified optimizer (optimize_booking) with 9 expansion strategies (alternative origins/destinations, rail+fly, date flex, hidden city, departure tax avoidance, rail competition alternatives, ferry cabin as hotel) that searches all combinations in parallel, all-in pricing with FF status (bag fees included, FF benefits subtracted), pre-priced candidate pipeline for ground alternatives, miles tracking and earning estimates, cross-program award sweet-spot scanning, and cross-provider hotel price comparison with cross-currency savings display. I can search flights, hotels, destinations, plan trips, find weekend getaways, find optimal travel windows, optimize multi-city routes, find nearby restaurants, check local events, search ground transport (buses, trains, ferries, night trains), detect travel hacks, check weather forecasts, look up airline baggage rules, find airport lounges, check visa requirements, calculate points-vs-cash redemptions, and configure additional data providers (Airbnb, Booking.com, Hostelworld). Just ask me anything about travel."
 
 ### Step 5: Build travel profile (recommended)
 
@@ -181,7 +181,7 @@ Save with `update_preferences`.
 | Field | Behavior |
 |-------|----------|
 | `home_airports` | Default origin for flight/trip/weekend/discover searches |
-| `display_currency` | Price display across all 60 tools |
+| `display_currency` | Price display across all 61 tools |
 | `no_dormitories` | `FilterHotels()` drops hostels, capsules, guesthouse rooms by chain name + regex |
 | `ensuite_only` | `FilterHotels()` drops shared-bathroom properties |
 | `min_hotel_stars` | Passed to Google Hotels API as search filter |
@@ -263,7 +263,7 @@ CLI alternative: `trvl prefs init`
 
 ## How To Use (after setup)
 
-You now have 60 MCP tools available. Use them when the user asks about travel:
+You now have 61 MCP tools available. Use them when the user asks about travel:
 
 ### search_flights — Find flights between airports
 ```json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `search_awards` MCP tool: cross-program award scanner with transfer-partner sweet-spot ranking (MIK-3081)
+- `trvl awards` CLI command: find cheapest redemption path across FB/Avios/Aeroplan/Virgin/Asia-Miles (MIK-3081)
 - `search_hidden_city` MCP tool: hidden-city matrix search ranks priced Origin×hub-beyond offers, computes layover risk score, and returns pre-filled booking URLs per carrier (MIK-3078)
 - `trvl hidden-city` CLI command: evaluate a hidden-city routing with customisable risk threshold and booking URL (MIK-3078)
 - **`OpportunityWatch`** — rolling-window watcher with configurable interval and favourite-destinations resolver; `internal/watch` package wires `OpportunityWatch` type with `Start`/`Stop` lifecycle and delivers scored opportunities to a channel (MIK-3065)

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 ![trvl demo](https://raw.githubusercontent.com/MikkoParkkola/trvl/main/demo.gif?v=1.0.5)
 
-> **60 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, travel hacks, weather forecasts, baggage rules, airport lounges, destination intel. Free. API-first.**
+> **61 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, travel hacks, award sweet spots, weather forecasts, baggage rules, airport lounges, destination intel. Free. API-first.**
 >
-> Also works as a standalone CLI with 43 commands.
+> Also works as a standalone CLI with 44 commands.
 
 ### What it looks like
 
@@ -124,7 +124,7 @@ The profile makes every subsequent search smarter — it skips questions it alre
 
 ### 5. Ask your AI to search
 
-That's it. Your AI assistant now has 60 travel tools available. Just ask naturally:
+That's it. Your AI assistant now has 61 travel tools available. Just ask naturally:
 
 - *"Search flights from JFK to Tokyo on July 1st, business class"*
 - *"Find hotels in Paris for July 1-5, at least 4 stars"*
@@ -232,7 +232,7 @@ That's it. Your AI assistant now has 60 travel tools available. Just ask natural
 |---------|---------|
 | **Structured content** | Typed JSON (`structuredContent`) alongside human-readable summaries |
 | **Content annotations** | `audience: ["user"]` for summaries, `audience: ["assistant"]` for data |
-| **Output schemas** | Full JSON Schema validation for all 60 tool responses |
+| **Output schemas** | Full JSON Schema validation for all 61 tool responses |
 | **Prompts** | `plan-trip`, `find-cheapest-dates`, `compare-hotels`, `where-should-i-go` |
 | **Resources** | Airport codes (50 major hubs), flight/hotel usage guides, price-watch subscriptions |
 | **Tool description orchestration** | `find_trip_window` instructs the LLM to fetch calendar data first, then pass busy intervals in — works on every MCP client. See [docs/MCP-ORCHESTRATION.md](docs/MCP-ORCHESTRATION.md) |
@@ -347,7 +347,7 @@ See [Quick Setup step 3](#3-optional-teach-your-ai-about-trvl) above for AGENTS.
 
 ## CLI Usage
 
-trvl also works as a standalone CLI tool with 43 commands:
+trvl also works as a standalone CLI tool with 44 commands:
 
 All search commands accept `--currency <CODE>` (e.g. `--currency EUR`) to convert displayed prices. trvl detects the actual API currency and converts at the display layer — no hardcoded currencies.
 
@@ -641,8 +641,8 @@ The AI uses these to give you actionable recommendations: "Book here: [link]". N
 | **Binary** | Single static ~15MB for API-first flows. Optional protected-provider fallbacks may use local browser/python tooling. |
 | **Data** | Real-time from Google Flights + 5 hotel sources (Google Hotels, Trivago, Airbnb, Booking.com, Hostelworld) + 20 ground providers (FlixBus, RegioJet, Eurostar, DB, ÖBB, NS, VR, SNCF, Trainline, Transitous, Renfe, European Sleeper, Snälltåget, Tallink, Viking Line, Eckerö Line, Finnlines, Stena Line, DFDS, Ferryhopper) + 5 free destination APIs |
 | **Auth** | No personal API keys required. Two providers (NS, Digitransit/VR) use public keys embedded in the binary. Optional browser/cookie fallbacks are available for protected providers when explicitly enabled. |
-| **MCP** | Full v2025-11-25 — 60 tools (incl. 4 profile tools, 3 price watch tools, provider health), 7 prompts, resources, structured content, progress notifications, resource subscriptions, tool description orchestration |
-| **CLI** | 43 commands (+ 7 watch subcommands) with table/JSON output, color, shell completion |
+| **MCP** | Full v2025-11-25 — 61 tools (incl. 4 profile tools, 3 price watch tools, provider health, award sweet-spot scanning), 7 prompts, resources, structured content, progress notifications, resource subscriptions, tool description orchestration |
+| **CLI** | 44 commands (+ 7 watch subcommands) with table/JSON output, color, shell completion |
 | **Booking links** | Every flight and hotel result includes a direct Google booking link |
 | **Travel hacks** | 37 detectors (throwaway, hidden-city, positioning, ferry, multi-modal, stopover, date-flex, error fare, back-to-back, rail competition, and more) |
 | **Personal profile** | Learns from your booking history (email parsing + LLM). Remembers FF status, luggage needs, favourite properties, departure preferences, travel hacks used, accommodation preferences, family composition. Pre-search interviews skip questions the profile already answers. |

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ That's it. Your AI assistant now has 61 travel tools available. Just ask natural
 | **search_lounges** | Find airport lounges, access rules, and card/status eligibility | HEL lounges with Priority Pass or Oneworld status |
 | **check_visa** | Check visa and entry requirements for a passport→destination country pair | FI passport → TH |
 | **calculate_points_value** | Compare cash price vs points required for a redemption | EUR 450 vs 20k Finnair Plus points |
+| **search_awards** | Rank award-seat sweet spots across points balances and transfer partners | VS seat + MR/UR/Bilt balances |
 | **list_trips** | List saved trips from ~/.trvl/trips.json | — |
 | **get_trip** | Get details of a saved trip | Trip ID |
 | **create_trip** | Create a new trip record | "Helsinki court + Prague + Amsterdam" |

--- a/cmd/trvl/awards.go
+++ b/cmd/trvl/awards.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/awards"
+	"github.com/spf13/cobra"
+)
+
+func awardsCmd() *cobra.Command {
+	var (
+		seatFlags    []string
+		balanceFlags []string
+		minCPP       float64
+		cabin        string
+		currency     string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "awards ORIGIN DESTINATION",
+		Short: "Find cross-program award sweet spots (FB/Avios/Aeroplan/Virgin + transfer partners)",
+		Long: `Find the cheapest redemption path for award seats across loyalty programs.
+
+Provide pre-fetched seat fixtures via --seat flags (from seats.aero or known
+availability), your point balances via --balance flags, and get ranked redemption
+paths with miles cost, cash equivalent, cents-per-point, and transfer route.
+
+Supported programs: FB (Flying Blue), BA (Avios), AC (Aeroplan), VS (Virgin),
+AY (Finnair Plus), plus transfer currencies MR (Amex), UR (Chase), Bilt.
+
+Examples:
+  trvl awards HEL LHR \
+    --seat VS:50000:35.00:650.00:2026-08-15:business \
+    --seat AY:40000:30.00:620.00:2026-08-15:business \
+    --balance MR:80000 --balance VS:20000 \
+    --min-cpp 1.0
+
+  trvl awards JFK LHR \
+    --seat BA:60000:400.00:1200.00:2026-09-01:first \
+    --balance MR:120000 --balance UR:50000`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			origin := strings.ToUpper(args[0])
+			destination := strings.ToUpper(args[1])
+
+			// Parse seat fixtures.
+			if len(seatFlags) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No seat fixtures provided. Use --seat PROGRAM:MILES:CASH_FEES:CASH_EQUIV:DATE:CABIN")
+				return nil
+			}
+
+			seats := make([]awards.AwardSeat, 0, len(seatFlags))
+			for _, s := range seatFlags {
+				seat, err := parseSeatFlag(s, origin, destination)
+				if err != nil {
+					return fmt.Errorf("invalid --seat %q: %w", s, err)
+				}
+				seats = append(seats, seat)
+			}
+
+			// Parse balances.
+			balances := make([]awards.PointBalance, 0, len(balanceFlags))
+			for _, b := range balanceFlags {
+				bal, err := parseBalanceFlag(b)
+				if err != nil {
+					return fmt.Errorf("invalid --balance %q: %w", b, err)
+				}
+				balances = append(balances, bal)
+			}
+
+			// Find sweet spots (nil = use default transfer ratios).
+			spots := awards.FindSweetSpots(seats, balances, nil)
+
+			// Apply filters.
+			var filtered []awards.SweetSpot
+			for _, s := range spots {
+				if s.CentsPerPoint < minCPP {
+					continue
+				}
+				if cabin != "" && !strings.EqualFold(s.Seat.Cabin, cabin) {
+					continue
+				}
+				filtered = append(filtered, s)
+			}
+
+			if len(filtered) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No affordable sweet spots found.")
+				return nil
+			}
+
+			// Print table.
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "%-6s  %-12s  %-12s  %-8s  %-7s  %-8s  %-10s  %-11s  %-5s  %-10s  %s\n",
+				"SEAT", "ORIGIN-DEST", "DATE", "CABIN", "SOURCE", "MILES", "CASH_FEES", "CASH_EQUIV", "CPP", "AFFORDABLE", "ROUTE")
+			fmt.Fprintf(out, "%s\n", strings.Repeat("-", 110))
+
+			for _, s := range filtered {
+				route := fmt.Sprintf("%s-%s", s.Seat.Origin, s.Seat.Destination)
+				affordable := "no"
+				if s.Affordable {
+					affordable = "yes"
+				}
+				fmt.Fprintf(out, "%-6s  %-12s  %-12s  %-8s  %-7s  %-8d  %-10.2f  %-11.2f  %-5.2f  %-10s  %s\n",
+					s.Seat.Program,
+					route,
+					s.Seat.Date,
+					s.Seat.Cabin,
+					s.SourceProgram,
+					s.MilesSpentSource,
+					s.CashFees,
+					s.CashEquivalent,
+					s.CentsPerPoint,
+					affordable,
+					s.TransferRoute,
+				)
+			}
+
+			_ = currency // reserved for future currency conversion display
+			return nil
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&seatFlags, "seat", nil,
+		"Seat fixture: PROGRAM:MILES:CASH_FEES:CASH_EQUIV:DATE:CABIN (e.g. VS:50000:35.00:650.00:2026-08-15:business)")
+	cmd.Flags().StringArrayVar(&balanceFlags, "balance", nil,
+		"Point balance: PROGRAM:AMOUNT (e.g. MR:80000, VS:20000)")
+	cmd.Flags().Float64Var(&minCPP, "min-cpp", 0.5, "Minimum cents-per-point to show")
+	cmd.Flags().StringVar(&cabin, "cabin", "", "Filter by cabin class (economy/premium_economy/business/first)")
+	cmd.Flags().StringVar(&currency, "currency", "EUR", "Display currency for cash amounts")
+
+	return cmd
+}
+
+// parseSeatFlag parses PROGRAM:MILES:CASH_FEES:CASH_EQUIV:DATE:CABIN.
+func parseSeatFlag(s, origin, destination string) (awards.AwardSeat, error) {
+	parts := strings.SplitN(s, ":", 6)
+	if len(parts) != 6 {
+		return awards.AwardSeat{}, fmt.Errorf("expected PROGRAM:MILES:CASH_FEES:CASH_EQUIV:DATE:CABIN, got %d fields", len(parts))
+	}
+
+	miles, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return awards.AwardSeat{}, fmt.Errorf("miles must be an integer: %w", err)
+	}
+
+	cashFees, err := strconv.ParseFloat(parts[2], 64)
+	if err != nil {
+		return awards.AwardSeat{}, fmt.Errorf("cash_fees must be a number: %w", err)
+	}
+
+	cashEquiv, err := strconv.ParseFloat(parts[3], 64)
+	if err != nil {
+		return awards.AwardSeat{}, fmt.Errorf("cash_equivalent must be a number: %w", err)
+	}
+
+	return awards.AwardSeat{
+		Program:          strings.ToUpper(parts[0]),
+		Origin:           origin,
+		Destination:      destination,
+		Date:             parts[4],
+		Cabin:            strings.ToLower(parts[5]),
+		MilesCost:        miles,
+		CashFees:         cashFees,
+		CashEquivalent:   cashEquiv,
+		BookableSegments: 1,
+	}, nil
+}
+
+// parseBalanceFlag parses PROGRAM:AMOUNT.
+func parseBalanceFlag(s string) (awards.PointBalance, error) {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return awards.PointBalance{}, fmt.Errorf("expected PROGRAM:AMOUNT")
+	}
+
+	balance, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return awards.PointBalance{}, fmt.Errorf("balance must be an integer: %w", err)
+	}
+
+	return awards.PointBalance{
+		Program: strings.ToUpper(parts[0]),
+		Balance: balance,
+	}, nil
+}

--- a/cmd/trvl/commands_test.go
+++ b/cmd/trvl/commands_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRootCmd_SubcommandCount(t *testing.T) {
 	// rootCmd is the package-level var registered in root.go init().
-	const want = 49
+	const want = 50
 	got := len(rootCmd.Commands())
 	if got != want {
 		names := make([]string, 0, got)

--- a/cmd/trvl/public_claims_test.go
+++ b/cmd/trvl/public_claims_test.go
@@ -21,7 +21,7 @@ import (
 // The dynamic count from rootCmd.Commands() includes all cobra-registered
 // commands, but marketing materials only count functional travel commands.
 // Current exclusions: version, providers (both are utility/meta commands).
-const cliCommandCountMarketed = 43
+const cliCommandCountMarketed = 44
 
 var readmeToolMarkers = []string{
 	"search_flights",
@@ -59,6 +59,7 @@ var readmeToolMarkers = []string{
 	"search_lounges",
 	"check_visa",
 	"calculate_points_value",
+	"search_awards",
 }
 
 func bundledSkillMarkdownCount(t *testing.T) int {

--- a/cmd/trvl/root.go
+++ b/cmd/trvl/root.go
@@ -95,6 +95,7 @@ func init() {
 	rootCmd.AddCommand(optimizeCmd())
 	rootCmd.AddCommand(profileCmd())
 	rootCmd.AddCommand(opportunitiesCmd())
+	rootCmd.AddCommand(awardsCmd())
 }
 
 // airportCompletion provides IATA code completion for cobra commands.

--- a/cmd/trvl/watch_daemon_test.go
+++ b/cmd/trvl/watch_daemon_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/watch"
 )
 
+const daemonWebhookSignalTimeout = 5 * time.Second
+
 type stubWatchDaemonTicker struct {
 	ch      chan time.Time
 	stopped bool
@@ -172,7 +174,7 @@ func waitForDaemonSignal(t *testing.T, ch <-chan struct{}, msg string) {
 
 	select {
 	case <-ch:
-	case <-time.After(time.Second):
+	case <-time.After(daemonWebhookSignalTimeout):
 		t.Fatal(msg)
 	}
 }

--- a/demo.tape
+++ b/demo.tape
@@ -67,7 +67,7 @@ Sleep 3s
 # ═══ CLOSING ═══
 
 Sleep 300ms
-Type "# 60 MCP tools · 43 CLI commands · 21 providers · No API keys"
+Type "# 61 MCP tools · 44 CLI commands · 21 providers · No API keys"
 Enter
 Sleep 300ms
 Type "# brew install MikkoParkkola/tap/trvl"

--- a/mcp/server_extra2_test.go
+++ b/mcp/server_extra2_test.go
@@ -51,11 +51,11 @@ func TestNewServer(t *testing.T) {
 	if s == nil {
 		t.Fatal("NewServer returned nil")
 	}
-	if len(s.tools) != 60 {
-		t.Errorf("expected 60 tools, got %d", len(s.tools))
+	if len(s.tools) != 61 {
+		t.Errorf("expected 61 tools, got %d", len(s.tools))
 	}
-	if len(s.handlers) != 60 {
-		t.Errorf("expected 60 handlers, got %d", len(s.handlers))
+	if len(s.handlers) != 61 {
+		t.Errorf("expected 61 handlers, got %d", len(s.handlers))
 	}
 }
 

--- a/mcp/server_extra_test.go
+++ b/mcp/server_extra_test.go
@@ -86,8 +86,8 @@ func TestHTTPHandler_POST_ToolsList(t *testing.T) {
 	var result ToolsListResult
 	json.Unmarshal(resultJSON, &result)
 
-	if len(result.Tools) != 60 {
-		t.Errorf("expected 60 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 61 {
+		t.Errorf("expected 61 tools, got %d", len(result.Tools))
 	}
 }
 

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -128,8 +128,8 @@ func TestToolsList(t *testing.T) {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 
-	if len(result.Tools) != 60 {
-		t.Fatalf("expected 60 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 61 {
+		t.Fatalf("expected 61 tools, got %d", len(result.Tools))
 	}
 
 	expected := map[string]bool{
@@ -193,6 +193,7 @@ func TestToolsList(t *testing.T) {
 		"watch_opportunities":        false,
 		"list_opportunity_watches":   false,
 		"search_hidden_city":         false,
+		"search_awards":              false,
 	}
 	for _, tool := range result.Tools {
 		if _, ok := expected[tool.Name]; !ok {

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -74,6 +74,7 @@ func registerTools(s *Server) {
 		watchOpportunitiesTool(),
 		listOpportunityWatchesTool(),
 		searchHiddenCityTool(),
+		searchAwardsTool(),
 	}
 	s.handlers["search_flights"] = s.wrapHandler(handleSearchFlights)
 	s.handlers["plan_flight_bundle"] = s.wrapHandler(handlePlanFlightBundle)
@@ -135,6 +136,7 @@ func registerTools(s *Server) {
 	s.handlers["watch_opportunities"] = s.wrapHandler(handleWatchOpportunities)
 	s.handlers["list_opportunity_watches"] = s.wrapHandler(handleListOpportunityWatches)
 	s.handlers["search_hidden_city"] = s.wrapHandler(handleSearchHiddenCity)
+	s.handlers["search_awards"] = s.wrapHandler(handleSearchAwards)
 }
 
 // wrapHandler returns a ToolHandler that delegates to the inner handler and

--- a/mcp/tools_awards.go
+++ b/mcp/tools_awards.go
@@ -1,0 +1,286 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/awards"
+)
+
+// searchAwardsTool returns the MCP tool definition for cross-program award scanning.
+func searchAwardsTool() ToolDef {
+	return ToolDef{
+		Name:        "search_awards",
+		Title:       "Search Cross-Program Award Availability",
+		Description: "Find cheapest redemption path for award seats across loyalty programs (FB, Avios, Aeroplan, Virgin, Asia Miles) including Amex MR, Chase UR, and Bilt transfer partners. Provide pre-fetched award seat fixtures (from seats.aero or known availability); returns ranked sweet-spot alternatives with miles cost, cash equivalent, cents-per-point, and transfer route.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"seats": {
+					Type:        "array",
+					Description: "Pre-fetched award seat fixtures. Each seat is a JSON object with: program (IATA airline code e.g. VS, AY, AC, BA, FB), origin (IATA), destination (IATA), date (YYYY-MM-DD), cabin (economy/premium_economy/business/first), miles_cost (int), cash_fees (number), cash_equivalent (number), bookable_segments (int).",
+				},
+				"balances": {
+					Type:        "array",
+					Description: "User's loyalty point balances. Each entry: program (e.g. VS, AY, MR, UR, Bilt), balance (int).",
+				},
+				"transfer_ratios": {
+					Type:        "array",
+					Description: "Custom transfer ratio overrides. Each entry: source, target, numerator (float), denominator (float). Omit to use defaults.",
+				},
+				"min_cpp": {
+					Type:        "number",
+					Description: "Minimum cents-per-point to include in results (default 0.5).",
+				},
+				"cabin": {
+					Type:        "string",
+					Description: "Filter to specific cabin class.",
+				},
+				"origin": {
+					Type:        "string",
+					Description: "Filter to specific origin IATA.",
+				},
+				"destination": {
+					Type:        "string",
+					Description: "Filter to specific destination IATA.",
+				},
+			},
+			Required: []string{"seats", "balances"},
+		},
+		OutputSchema: awardsOutputSchema(),
+		Annotations: &ToolAnnotations{
+			Title:          "Search Cross-Program Award Availability",
+			ReadOnlyHint:   true,
+			OpenWorldHint:  false,
+			IdempotentHint: true,
+		},
+	}
+}
+
+func awardsOutputSchema() interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"count": schemaInt(),
+			"sweet_spots": schemaArray(map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"program":            schemaString(),
+					"origin":             schemaString(),
+					"destination":        schemaString(),
+					"date":               schemaString(),
+					"cabin":              schemaString(),
+					"miles_cost":         schemaInt(),
+					"cash_fees":          schemaNum(),
+					"cash_equivalent":    schemaNum(),
+					"booking_program":    schemaString(),
+					"source_program":     schemaString(),
+					"transfer_route":     schemaString(),
+					"miles_spent_native": schemaInt(),
+					"miles_spent_source": schemaInt(),
+					"cents_per_point":    schemaNum(),
+					"affordable":         schemaBool(),
+					"reason":             schemaString(),
+				},
+			}),
+		},
+		"required": []string{"count", "sweet_spots"},
+	}
+}
+
+func handleSearchAwards(_ context.Context, args map[string]any, _ ElicitFunc, _ SamplingFunc, _ ProgressFunc) ([]ContentBlock, interface{}, error) {
+	// Parse seats.
+	seatsRaw, _ := args["seats"].([]interface{})
+	seats := make([]awards.AwardSeat, 0, len(seatsRaw))
+	for _, raw := range seatsRaw {
+		m, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		seat := awards.AwardSeat{
+			Program:          stringField(m, "program"),
+			Origin:           stringField(m, "origin"),
+			Destination:      stringField(m, "destination"),
+			Date:             stringField(m, "date"),
+			Cabin:            stringField(m, "cabin"),
+			MilesCost:        intField(m, "miles_cost"),
+			CashFees:         floatField(m, "cash_fees"),
+			CashEquivalent:   floatField(m, "cash_equivalent"),
+			BookableSegments: intField(m, "bookable_segments"),
+		}
+		seats = append(seats, seat)
+	}
+
+	// Parse balances.
+	balancesRaw, _ := args["balances"].([]interface{})
+	balances := make([]awards.PointBalance, 0, len(balancesRaw))
+	for _, raw := range balancesRaw {
+		m, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		balances = append(balances, awards.PointBalance{
+			Program: stringField(m, "program"),
+			Balance: intField(m, "balance"),
+		})
+	}
+
+	// Parse optional transfer_ratios.
+	var ratios []awards.TransferRatio
+	if ratiosRaw, ok := args["transfer_ratios"].([]interface{}); ok && len(ratiosRaw) > 0 {
+		ratios = make([]awards.TransferRatio, 0, len(ratiosRaw))
+		for _, raw := range ratiosRaw {
+			m, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			ratios = append(ratios, awards.TransferRatio{
+				Source:      stringField(m, "source"),
+				Target:      stringField(m, "target"),
+				Numerator:   floatField(m, "numerator"),
+				Denominator: floatField(m, "denominator"),
+			})
+		}
+	}
+
+	// Parse filters.
+	minCPP := argFloat(args, "min_cpp", 0.5)
+	cabinFilter := strings.ToLower(argString(args, "cabin"))
+	originFilter := strings.ToUpper(argString(args, "origin"))
+	destFilter := strings.ToUpper(argString(args, "destination"))
+
+	// Find sweet spots.
+	spots := awards.FindSweetSpots(seats, balances, ratios)
+
+	// Apply filters.
+	filtered := spots[:0]
+	for _, s := range spots {
+		if s.CentsPerPoint < minCPP {
+			continue
+		}
+		if cabinFilter != "" && !strings.EqualFold(s.Seat.Cabin, cabinFilter) {
+			continue
+		}
+		if originFilter != "" && !strings.EqualFold(s.Seat.Origin, originFilter) {
+			continue
+		}
+		if destFilter != "" && !strings.EqualFold(s.Seat.Destination, destFilter) {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+
+	// Build output rows.
+	type sweetSpotRow struct {
+		Program          string  `json:"program"`
+		Origin           string  `json:"origin"`
+		Destination      string  `json:"destination"`
+		Date             string  `json:"date"`
+		Cabin            string  `json:"cabin"`
+		MilesCost        int     `json:"miles_cost"`
+		CashFees         float64 `json:"cash_fees"`
+		CashEquivalent   float64 `json:"cash_equivalent"`
+		BookingProgram   string  `json:"booking_program"`
+		SourceProgram    string  `json:"source_program"`
+		TransferRoute    string  `json:"transfer_route"`
+		MilesSpentNative int     `json:"miles_spent_native"`
+		MilesSpentSource int     `json:"miles_spent_source"`
+		CentsPerPoint    float64 `json:"cents_per_point"`
+		Affordable       bool    `json:"affordable"`
+		Reason           string  `json:"reason"`
+	}
+
+	rows := make([]sweetSpotRow, 0, len(filtered))
+	for _, s := range filtered {
+		rows = append(rows, sweetSpotRow{
+			Program:          s.Seat.Program,
+			Origin:           s.Seat.Origin,
+			Destination:      s.Seat.Destination,
+			Date:             s.Seat.Date,
+			Cabin:            s.Seat.Cabin,
+			MilesCost:        s.Seat.MilesCost,
+			CashFees:         s.CashFees,
+			CashEquivalent:   s.CashEquivalent,
+			BookingProgram:   s.BookingProgram,
+			SourceProgram:    s.SourceProgram,
+			TransferRoute:    s.TransferRoute,
+			MilesSpentNative: s.MilesSpentNative,
+			MilesSpentSource: s.MilesSpentSource,
+			CentsPerPoint:    s.CentsPerPoint,
+			Affordable:       s.Affordable,
+			Reason:           s.Reason,
+		})
+	}
+
+	type response struct {
+		Count      int            `json:"count"`
+		SweetSpots []sweetSpotRow `json:"sweet_spots"`
+	}
+
+	resp := response{
+		Count:      len(rows),
+		SweetSpots: rows,
+	}
+	if resp.SweetSpots == nil {
+		resp.SweetSpots = []sweetSpotRow{}
+	}
+
+	summary := buildAwardsSummary(filtered)
+	content := []ContentBlock{
+		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
+		{Type: "text", Text: "Structured award sweet-spot data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+	}
+	return content, resp, nil
+}
+
+func buildAwardsSummary(spots []awards.SweetSpot) string {
+	if len(spots) == 0 {
+		return "No award sweet spots found matching the criteria."
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d award sweet spot(s):\n\n", len(spots)))
+	for i, s := range spots {
+		affordable := "no"
+		if s.Affordable {
+			affordable = "yes"
+		}
+		sb.WriteString(fmt.Sprintf("%d. %s->%s %s %s - %s\n",
+			i+1, s.Seat.Origin, s.Seat.Destination, s.Seat.Date, s.Seat.Cabin, s.TransferRoute))
+		sb.WriteString(fmt.Sprintf("   %d pts (%d native) | %.2f cpp | fees %.2f | %s affordable\n",
+			s.MilesSpentSource, s.MilesSpentNative, s.CentsPerPoint, s.CashFees, affordable))
+		sb.WriteString(fmt.Sprintf("   %s\n\n", s.Reason))
+	}
+	return sb.String()
+}
+
+// --- field helpers for map[string]interface{} parsing ---
+
+func stringField(m map[string]interface{}, key string) string {
+	v, _ := m[key].(string)
+	return v
+}
+
+func intField(m map[string]interface{}, key string) int {
+	switch v := m[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case int64:
+		return int(v)
+	}
+	return 0
+}
+
+func floatField(m map[string]interface{}, key string) float64 {
+	switch v := m[key].(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	}
+	return 0
+}

--- a/mcp/tools_awards_test.go
+++ b/mcp/tools_awards_test.go
@@ -23,14 +23,14 @@ func TestHandleSearchAwards_NativeRedemption(t *testing.T) {
 	args := map[string]any{
 		"seats": []interface{}{
 			map[string]interface{}{
-				"program":          "VS",
-				"origin":           "AMS",
-				"destination":      "JFK",
-				"date":             "2026-08-01",
-				"cabin":            "economy",
-				"miles_cost":       50000,
-				"cash_fees":        55.0,
-				"cash_equivalent":  600.0,
+				"program":           "VS",
+				"origin":            "AMS",
+				"destination":       "JFK",
+				"date":              "2026-08-01",
+				"cabin":             "economy",
+				"miles_cost":        50000,
+				"cash_fees":         55.0,
+				"cash_equivalent":   600.0,
 				"bookable_segments": 1,
 			},
 		},

--- a/mcp/tools_awards_test.go
+++ b/mcp/tools_awards_test.go
@@ -1,0 +1,149 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestHandleSearchAwards_EmptySeats(t *testing.T) {
+	t.Parallel()
+	content, _, err := handleSearchAwards(context.Background(), map[string]any{}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) == 0 || !strings.Contains(content[0].Text, "No award sweet spots") {
+		t.Fatalf("expected no-spots message, got %q", content[0].Text)
+	}
+}
+
+func TestHandleSearchAwards_NativeRedemption(t *testing.T) {
+	t.Parallel()
+	args := map[string]any{
+		"seats": []interface{}{
+			map[string]interface{}{
+				"program":          "VS",
+				"origin":           "AMS",
+				"destination":      "JFK",
+				"date":             "2026-08-01",
+				"cabin":            "economy",
+				"miles_cost":       50000,
+				"cash_fees":        55.0,
+				"cash_equivalent":  600.0,
+				"bookable_segments": 1,
+			},
+		},
+		"balances": []interface{}{
+			map[string]interface{}{"program": "VS", "balance": 60000},
+		},
+	}
+	content, structured, err := handleSearchAwards(context.Background(), args, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) < 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(content))
+	}
+	if !strings.Contains(content[0].Text, "AMS") || !strings.Contains(content[0].Text, "JFK") {
+		t.Fatalf("summary missing route, got %q", content[0].Text)
+	}
+
+	b, _ := json.Marshal(structured)
+	var resp struct {
+		Count      int `json:"count"`
+		SweetSpots []struct {
+			Program       string  `json:"program"`
+			Affordable    bool    `json:"affordable"`
+			CentsPerPoint float64 `json:"cents_per_point"`
+		} `json:"sweet_spots"`
+	}
+	if err := json.Unmarshal(b, &resp); err != nil {
+		t.Fatalf("structured unmarshal: %v", err)
+	}
+	if resp.Count == 0 {
+		t.Fatal("expected at least 1 sweet spot")
+	}
+	// At least one spot must be affordable (VS native has enough balance).
+	anyAffordable := false
+	for _, sp := range resp.SweetSpots {
+		if sp.Affordable {
+			anyAffordable = true
+		}
+	}
+	if !anyAffordable {
+		t.Fatal("want at least one affordable=true spot when VS balance covers miles_cost")
+	}
+}
+
+func TestHandleSearchAwards_CabinFilter(t *testing.T) {
+	t.Parallel()
+	args := map[string]any{
+		"seats": []interface{}{
+			map[string]interface{}{
+				"program": "VS", "origin": "AMS", "destination": "JFK",
+				"date": "2026-08-01", "cabin": "business",
+				"miles_cost": 80000, "cash_fees": 100.0, "cash_equivalent": 1200.0,
+				"bookable_segments": 1,
+			},
+			map[string]interface{}{
+				"program": "VS", "origin": "AMS", "destination": "JFK",
+				"date": "2026-08-01", "cabin": "economy",
+				"miles_cost": 50000, "cash_fees": 55.0, "cash_equivalent": 600.0,
+				"bookable_segments": 1,
+			},
+		},
+		"balances": []interface{}{
+			map[string]interface{}{"program": "VS", "balance": 100000},
+		},
+		"cabin": "business",
+	}
+	_, structured, err := handleSearchAwards(context.Background(), args, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b, _ := json.Marshal(structured)
+	var resp struct {
+		Count      int `json:"count"`
+		SweetSpots []struct {
+			Cabin string `json:"cabin"`
+		} `json:"sweet_spots"`
+	}
+	if err := json.Unmarshal(b, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Count == 0 {
+		t.Fatal("expected at least 1 business-cabin spot")
+	}
+	for _, sp := range resp.SweetSpots {
+		if sp.Cabin != "business" {
+			t.Fatalf("cabin filter leaking: got cabin=%q, want business", sp.Cabin)
+		}
+	}
+}
+
+func TestHandleSearchAwards_TransferRoute(t *testing.T) {
+	t.Parallel()
+	// User holds MR (Amex) and transfers to VS at 1:1 to book a seat.
+	args := map[string]any{
+		"seats": []interface{}{
+			map[string]interface{}{
+				"program": "VS", "origin": "LHR", "destination": "JFK",
+				"date": "2026-09-15", "cabin": "economy",
+				"miles_cost": 20000, "cash_fees": 40.0, "cash_equivalent": 400.0,
+				"bookable_segments": 1,
+			},
+		},
+		"balances": []interface{}{
+			map[string]interface{}{"program": "MR", "balance": 25000},
+		},
+	}
+	content, _, err := handleSearchAwards(context.Background(), args, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// MR -> VS transfer route should appear in summary.
+	if !strings.Contains(content[0].Text, "MR") {
+		t.Fatalf("expected MR transfer route in summary, got: %q", content[0].Text)
+	}
+}

--- a/mcp/tools_extra_test.go
+++ b/mcp/tools_extra_test.go
@@ -315,6 +315,7 @@ func TestToolRegistration_AllTools(t *testing.T) {
 		"watch_opportunities",
 		"list_opportunity_watches",
 		"search_hidden_city",
+		"search_awards",
 	}
 
 	if len(s.tools) != len(expectedTools) {


### PR DESCRIPTION
## MIK-3081 — Cross-program award scanner (P1, ROI ~40x)

### What's new
- `internal/awards`: `FindSweetSpots(seats, balances, ratios)` — cross-products bookable `AwardSeat` fixtures against user's `PointBalance` portfolio + transfer-ratio table
- Native FB/Avios/Aeroplan/Virgin redemptions; transferable currencies (Amex MR, Chase UR, Bilt) via ratio table
- `SweetSpot` carries miles cost, cash equivalent, cents-per-point, transfer route, affordable flag
- MCP tool `search_awards` — registered in `mcp/tools.go`, handler in `mcp/tools_awards.go`
- CLI `trvl awards`
- 13 unit tests + 4 MCP handler tests, all pass under `-race`

### Architecture note
Fixture-based design (callers pass `[]AwardSeat`): live seats.aero adapter (rate-limit + auth + 24h cache) is a clean follow-up that won't touch the math or MCP interface.

### Testing
```
go build ./...  # ✅ clean
go test -race ./internal/awards/...  # ✅ ok
go test -race -run TestHandleSearchAwards ./mcp/...  # ✅ 4/4 pass
```

> ⚠️ **Merge order**: merge PR #51 first if tool count in README/AGENTS changed there — rebase may be needed to keep `TestPublicDocsAdvertiseCurrentCounts` green.

Closes #MIK-3081