### PR TITLE
fix: remove unused calendar dayDelta helper

### DIFF
--- a/internal/calendar/free.go
+++ b/internal/calendar/free.go
@@ -166,17 +166,3 @@ func parseDate(s string) (time.Time, bool) {
 	}
 	return t, true
 }
-
-// dayDelta returns the absolute number of calendar days between two
-// dates (UTC), ignoring time-of-day.
-func dayDelta(a, b time.Time) int {
-	ay, am, ad := a.Date()
-	by, bm, bd := b.Date()
-	da := time.Date(ay, am, ad, 0, 0, 0, 0, time.UTC)
-	db := time.Date(by, bm, bd, 0, 0, 0, 0, time.UTC)
-	delta := int(db.Sub(da).Hours() / 24)
-	if delta < 0 {
-		delta = -delta
-	}
-	return delta
-}


### PR DESCRIPTION
## Summary
- remove the unused internal/calendar/free.go dayDelta helper flagged by staticcheck (U1000)
- restore the repo-wide Ubuntu CI lane inherited by open PRs
- keep the fix isolated from PR #53 and its MIK-3089 observability scope

## Why this slice
PR #53 is currently red because the base branch carries this pre-existing staticcheck failure outside that PR diff. Landing this tiny fix on main unblocks the whole review lane.

## Validation
- go build ./...
- go vet ./...
- staticcheck ./...
