### PR TITLE
Fix MCP HTTP and provider safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ trvl is part of a suite of MCP tools:
 
 **Hotel search shows 0 results?** Check your dates — Google Hotels requires check-in in the future and at least 1 night. Try: `trvl hotels "London" --checkin 2026-07-01 --checkout 2026-07-03`.
 
-**MCP server crashes on startup?** Run `trvl mcp` directly in your terminal to see the error. Common cause: port conflict when using `--http`. Try a different port with `--port 8081`.
+**MCP server crashes on startup?** Run `trvl mcp` directly in your terminal to see the error. Common cause: port conflict when using `--http`. Try a different port with `--port 8081`. HTTP mode listens on `127.0.0.1` by default and requires `Authorization: Bearer <token>`; set `TRVL_MCP_TOKEN` or use the generated startup token.
 
 ## Thanks
 

--- a/cmd/trvl/cli_consolidated_commands_test.go
+++ b/cmd/trvl/cli_consolidated_commands_test.go
@@ -1711,7 +1711,7 @@ func TestRunEvents_MissingAPIKeyV24(t *testing.T) {
 
 func TestMcpCmd_FlagsV24(t *testing.T) {
 	cmd := mcpCmd()
-	for _, name := range []string{"http", "port"} {
+	for _, name := range []string{"http", "host", "port", "token"} {
 		if f := cmd.Flags().Lookup(name); f == nil {
 			t.Errorf("expected --%s flag on mcpCmd", name)
 		}

--- a/cmd/trvl/cmd_extra_test.go
+++ b/cmd/trvl/cmd_extra_test.go
@@ -412,7 +412,9 @@ func TestMcpCmd_Flags(t *testing.T) {
 		defValue string
 	}{
 		{"http", "false"},
+		{"host", "127.0.0.1"},
 		{"port", "8080"},
+		{"token", ""},
 	}
 	for _, tt := range flags {
 		f := cmd.Flags().Lookup(tt.name)

--- a/cmd/trvl/mcp.go
+++ b/cmd/trvl/mcp.go
@@ -8,7 +8,9 @@ import (
 func mcpCmd() *cobra.Command {
 	var (
 		httpMode bool
+		host     string
 		port     int
+		token    string
 	)
 
 	cmd := &cobra.Command{
@@ -19,17 +21,22 @@ func mcpCmd() *cobra.Command {
 By default, runs in stdio mode (JSON-RPC over stdin/stdout) for use with
 Claude Code and other MCP-compatible clients.
 
-Use --http to start an HTTP server instead, suitable for gateway and remote access.`,
+Use --http to start an HTTP server instead. It listens on 127.0.0.1 by
+default; pass --host explicitly for gateway or remote access. HTTP mode
+requires bearer-token authentication, using --token, TRVL_MCP_TOKEN, or a
+random token generated at startup.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if httpMode {
-				return mcp.RunHTTP(port)
+				return mcp.RunHTTP(host, port, token)
 			}
 			return mcp.Run()
 		},
 	}
 
 	cmd.Flags().BoolVar(&httpMode, "http", false, "Run as HTTP server instead of stdio")
+	cmd.Flags().StringVar(&host, "host", "127.0.0.1", "HTTP server host (only used with --http)")
 	cmd.Flags().IntVar(&port, "port", 8080, "HTTP server port (only used with --http)")
+	cmd.Flags().StringVar(&token, "token", "", "Bearer token for HTTP mode (default: TRVL_MCP_TOKEN or generated)")
 
 	cmd.AddCommand(mcpInstallCmd())
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -185,7 +185,7 @@ Token bucket: 10 requests/second (matching fli's rate limit). Configurable via `
 
 Two transport modes:
 - **stdio**: `trvl mcp` — for Claude Code integration
-- **HTTP**: `trvl mcp --http --port 8000` — for gateway and remote use
+- **HTTP**: `trvl mcp --http --port 8000` — loopback by default with bearer-token auth; pass `--host` explicitly for gateway or remote use
 
 Four tools exposed:
 1. `search_flights` — search flights on a date
@@ -346,7 +346,7 @@ trvl prices <hotel_id> --checkin 2026-05-15 --checkout 2026-05-18
 trvl mcp
 
 # HTTP mode (for gateway)
-trvl mcp --http --port 8000
+TRVL_MCP_TOKEN="$(openssl rand -base64 32)" trvl mcp --http --host 127.0.0.1 --port 8000
 ```
 
 ## 8. Acceptance Criteria

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -2,6 +2,7 @@ package hotels
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"math"
@@ -172,9 +173,81 @@ const pageSize = 20
 // Known values: 3=highest rated, 4=most reviewed, 8=price low-to-high.
 var googleSortOrders = []string{"", "3", "8"}
 
-// hotelSearchKey builds a singleflight dedup key from the search parameters.
-func hotelSearchKey(location, checkIn, checkOut string, guests int) string {
-	return fmt.Sprintf("hotel|%s|%s|%s|%d", location, checkIn, checkOut, guests)
+// hotelSearchKey builds a singleflight dedup key from every option that can
+// affect fetched, enriched, or post-filtered hotel results.
+func hotelSearchKey(location string, opts HotelSearchOptions) string {
+	amenities := append([]string(nil), opts.Amenities...)
+	sort.Strings(amenities)
+	key := struct {
+		Location         string   `json:"location"`
+		CheckIn          string   `json:"check_in"`
+		CheckOut         string   `json:"check_out"`
+		Guests           int      `json:"guests"`
+		Stars            int      `json:"stars"`
+		Sort             string   `json:"sort"`
+		Currency         string   `json:"currency"`
+		MinPrice         float64  `json:"min_price"`
+		MaxPrice         float64  `json:"max_price"`
+		MinRating        float64  `json:"min_rating"`
+		MaxDistanceKm    float64  `json:"max_distance_km"`
+		Amenities        []string `json:"amenities,omitempty"`
+		CenterLat        float64  `json:"center_lat"`
+		CenterLon        float64  `json:"center_lon"`
+		EnrichAmenities  bool     `json:"enrich_amenities"`
+		EnrichLimit      int      `json:"enrich_limit"`
+		MaxPages         int      `json:"max_pages"`
+		FreeCancellation bool     `json:"free_cancellation"`
+		PropertyType     string   `json:"property_type"`
+		Brand            string   `json:"brand"`
+		EcoCertified     bool     `json:"eco_certified"`
+		MinBedrooms      int      `json:"min_bedrooms"`
+		MinBathrooms     int      `json:"min_bathrooms"`
+		MinBeds          int      `json:"min_beds"`
+		RoomType         string   `json:"room_type"`
+		Superhost        bool     `json:"superhost"`
+		InstantBook      bool     `json:"instant_book"`
+		MaxDistanceM     int      `json:"max_distance_m"`
+		Sustainable      bool     `json:"sustainable"`
+		MealPlan         bool     `json:"meal_plan"`
+		IncludeSoldOut   bool     `json:"include_sold_out"`
+	}{
+		Location:         location,
+		CheckIn:          opts.CheckIn,
+		CheckOut:         opts.CheckOut,
+		Guests:           opts.Guests,
+		Stars:            opts.Stars,
+		Sort:             opts.Sort,
+		Currency:         opts.Currency,
+		MinPrice:         opts.MinPrice,
+		MaxPrice:         opts.MaxPrice,
+		MinRating:        opts.MinRating,
+		MaxDistanceKm:    opts.MaxDistanceKm,
+		Amenities:        amenities,
+		CenterLat:        opts.CenterLat,
+		CenterLon:        opts.CenterLon,
+		EnrichAmenities:  opts.EnrichAmenities,
+		EnrichLimit:      opts.EnrichLimit,
+		MaxPages:         opts.MaxPages,
+		FreeCancellation: opts.FreeCancellation,
+		PropertyType:     opts.PropertyType,
+		Brand:            opts.Brand,
+		EcoCertified:     opts.EcoCertified,
+		MinBedrooms:      opts.MinBedrooms,
+		MinBathrooms:     opts.MinBathrooms,
+		MinBeds:          opts.MinBeds,
+		RoomType:         opts.RoomType,
+		Superhost:        opts.Superhost,
+		InstantBook:      opts.InstantBook,
+		MaxDistanceM:     opts.MaxDistanceM,
+		Sustainable:      opts.Sustainable,
+		MealPlan:         opts.MealPlan,
+		IncludeSoldOut:   opts.IncludeSoldOut,
+	}
+	data, err := json.Marshal(key)
+	if err != nil {
+		return fmt.Sprintf("hotel|%s|%s|%s|%d|%s", location, opts.CheckIn, opts.CheckOut, opts.Guests, opts.Currency)
+	}
+	return "hotel|" + string(data)
 }
 
 // SearchHotelsWithClient is like SearchHotels but reuses the provided client.
@@ -188,6 +261,8 @@ func SearchHotelsWithClient(ctx context.Context, client *batchexec.Client, locat
 	}
 	if opts.Currency == "" {
 		opts.Currency = "USD" // Google's default when no currency specified
+	} else {
+		opts.Currency = strings.ToUpper(opts.Currency)
 	}
 
 	// Validate dates.
@@ -200,7 +275,7 @@ func SearchHotelsWithClient(ctx context.Context, client *batchexec.Client, locat
 		return nil, fmt.Errorf("parse check-out date: %w", err)
 	}
 
-	key := hotelSearchKey(location, opts.CheckIn, opts.CheckOut, opts.Guests)
+	key := hotelSearchKey(location, opts)
 	v, sfErr, _ := hotelGroup.Do(key, func() (any, error) {
 		return searchHotelsCore(ctx, client, location, opts)
 	})

--- a/internal/hotels/singleflight_test.go
+++ b/internal/hotels/singleflight_test.go
@@ -54,12 +54,30 @@ func TestHotelSingleflight(t *testing.T) {
 // TestHotelSearchKey verifies that different parameter combinations produce
 // distinct keys, preventing incorrect deduplication.
 func TestHotelSearchKey(t *testing.T) {
-	k1 := hotelSearchKey("Paris", "2026-06-15", "2026-06-18", 2)
-	k2 := hotelSearchKey("Paris", "2026-06-16", "2026-06-18", 2) // different check-in
-	k3 := hotelSearchKey("London", "2026-06-15", "2026-06-18", 2) // different city
-	k4 := hotelSearchKey("Paris", "2026-06-15", "2026-06-18", 3)  // different guests
+	base := HotelSearchOptions{CheckIn: "2026-06-15", CheckOut: "2026-06-18", Guests: 2, Currency: "USD"}
+	changedCheckIn := base
+	changedCheckIn.CheckIn = "2026-06-16"
+	changedGuests := base
+	changedGuests.Guests = 3
+	changedCurrency := base
+	changedCurrency.Currency = "EUR"
+	changedStars := base
+	changedStars.Stars = 5
+	changedMaxPages := base
+	changedMaxPages.MaxPages = 1
+	changedFilter := base
+	changedFilter.MinPrice = 100
 
-	keys := []string{k1, k2, k3, k4}
+	k1 := hotelSearchKey("Paris", base)
+	k2 := hotelSearchKey("Paris", changedCheckIn)
+	k3 := hotelSearchKey("London", base)
+	k4 := hotelSearchKey("Paris", changedGuests)
+	k5 := hotelSearchKey("Paris", changedCurrency)
+	k6 := hotelSearchKey("Paris", changedStars)
+	k7 := hotelSearchKey("Paris", changedMaxPages)
+	k8 := hotelSearchKey("Paris", changedFilter)
+
+	keys := []string{k1, k2, k3, k4, k5, k6, k7, k8}
 	for i := range keys {
 		for j := i + 1; j < len(keys); j++ {
 			if keys[i] == keys[j] {
@@ -69,7 +87,7 @@ func TestHotelSearchKey(t *testing.T) {
 	}
 
 	// Same inputs must produce the same key.
-	k1again := hotelSearchKey("Paris", "2026-06-15", "2026-06-18", 2)
+	k1again := hotelSearchKey("Paris", base)
 	if k1 != k1again {
 		t.Errorf("same inputs produced different keys: %q vs %q", k1, k1again)
 	}

--- a/internal/providers/config.go
+++ b/internal/providers/config.go
@@ -7,8 +7,11 @@ package providers
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"time"
 )
+
+var providerIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
 
 // ProviderConfig is the main configuration for a single external provider.
 type ProviderConfig struct {
@@ -17,13 +20,13 @@ type ProviderConfig struct {
 	// field are treated as the v0 baseline and migrated forward at load time.
 	// Configs declaring a version newer than CurrentSchemaVersion are
 	// rejected with a clear error rather than loaded silently.
-	SchemaVersion   string            `json:"schema_version,omitempty"`
-	ID              string            `json:"id"`
-	Name            string            `json:"name"`
-	Category        string            `json:"category"` // "hotel", "transport", "restaurant", ...
-	Endpoint        string            `json:"endpoint"`
-	Method          string            `json:"method"` // "GET" or "POST"
-	Headers         map[string]string `json:"headers,omitempty"`
+	SchemaVersion string            `json:"schema_version,omitempty"`
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Category      string            `json:"category"` // "hotel", "transport", "restaurant", ...
+	Endpoint      string            `json:"endpoint"`
+	Method        string            `json:"method"` // "GET" or "POST"
+	Headers       map[string]string `json:"headers,omitempty"`
 	// HeaderOrder specifies the order in which request headers should be sent.
 	// When set, headers are added to the request in this order rather than
 	// map iteration order (which is random in Go). This is critical for
@@ -109,10 +112,10 @@ type ProviderConfig struct {
 // FilterComposite describes how to build a compound URL parameter from
 // individual filter variables. See ProviderConfig.FilterComposite.
 type FilterComposite struct {
-	TargetVar string             `json:"target_var"`                 // output variable name (e.g. "nflt")
-	Separator string             `json:"separator"`                  // URL-encoded separator (e.g. "%3B")
-	Parts     map[string]string  `json:"parts"`                      // filter_var → url_prefix mapping
-	Scales    map[string]float64 `json:"scales,omitempty"`           // filter_var → multiplier (e.g. min_rating × 10 for Booking's 0-100 scale)
+	TargetVar string             `json:"target_var"`       // output variable name (e.g. "nflt")
+	Separator string             `json:"separator"`        // URL-encoded separator (e.g. "%3B")
+	Parts     map[string]string  `json:"parts"`            // filter_var → url_prefix mapping
+	Scales    map[string]float64 `json:"scales,omitempty"` // filter_var → multiplier (e.g. min_rating × 10 for Booking's 0-100 scale)
 }
 
 // CityResolverConfig describes how to dynamically resolve a city name to a
@@ -153,22 +156,22 @@ type CityResolverConfig struct {
 
 // AuthConfig describes how to authenticate with the provider.
 type AuthConfig struct {
-	Type         string                `json:"type"` // "none", "header", "preflight"
-	PreflightURL string                `json:"preflight_url,omitempty"`
+	Type         string `json:"type"` // "none", "header", "preflight"
+	PreflightURL string `json:"preflight_url,omitempty"`
 	// PreflightMethod defaults to GET. Set to POST for OAuth2-style token exchange.
-	PreflightMethod string             `json:"preflight_method,omitempty"`
+	PreflightMethod string `json:"preflight_method,omitempty"`
 	// PreflightBody is the request body for POST preflights (supports ${var} substitution).
-	PreflightBody string               `json:"preflight_body,omitempty"`
+	PreflightBody string `json:"preflight_body,omitempty"`
 	// PreflightHeaders are additional headers for the preflight request.
-	PreflightHeaders map[string]string  `json:"preflight_headers,omitempty"`
-	Extractions  map[string]Extraction  `json:"extractions,omitempty"`
+	PreflightHeaders map[string]string     `json:"preflight_headers,omitempty"`
+	Extractions      map[string]Extraction `json:"extractions,omitempty"`
 	// BrowserEscapeHatch enables the Tier 4 browser-delegation fallback. When
 	// set and the caller has marked the context as interactive via
 	// WithInteractive, runPreflight will open the preflight URL in the user's
 	// browser so they can clear any JS challenge, then re-read cookies via
 	// kooky. Defaults to false for backwards compatibility — providers must
 	// opt in to avoid spontaneously launching browsers for every caller.
-	BrowserEscapeHatch bool             `json:"browser_escape_hatch,omitempty"`
+	BrowserEscapeHatch bool `json:"browser_escape_hatch,omitempty"`
 }
 
 // Extraction describes a regex extraction from a preflight response.
@@ -205,10 +208,10 @@ type Extraction struct {
 //     where the query key is `search({"input":{...giant-JSON...}})` and
 //     varies per request; the path becomes `.searchQueries.search*.results`.
 type ResponseMapping struct {
-	ResultsPath        string            `json:"results_path"`                    // dot-notation path to results array, supports `prefix*` segment wildcard
-	Fields             map[string]string `json:"fields"`                          // model field -> JSON path mapping
+	ResultsPath        string            `json:"results_path"`                   // dot-notation path to results array, supports `prefix*` segment wildcard
+	Fields             map[string]string `json:"fields"`                         // model field -> JSON path mapping
 	BodyExtractPattern string            `json:"body_extract_pattern,omitempty"` // optional regex applied to the HTTP body; capture group 1 becomes the JSON input
-	RatingScale        float64           `json:"rating_scale,omitempty"`          // multiply raw rating by this to normalize to 0-10 (e.g. 2.0 for Booking's 0-5 scale)
+	RatingScale        float64           `json:"rating_scale,omitempty"`         // multiply raw rating by this to normalize to 0-10 (e.g. 2.0 for Booking's 0-5 scale)
 }
 
 // RateLimitConfig controls request pacing.
@@ -224,7 +227,7 @@ type TLSConfig struct {
 
 // CookieConfig controls how cookies are obtained.
 type CookieConfig struct {
-	Source  string `json:"source"`           // "none", "preflight", "browser"
+	Source  string `json:"source"`            // "none", "preflight", "browser"
 	Browser string `json:"browser,omitempty"` // browser name when source is "browser"
 }
 
@@ -288,6 +291,9 @@ func (c *ProviderConfig) Validate() error {
 	if c.ID == "" {
 		return fmt.Errorf("provider config: id is required")
 	}
+	if !validProviderID(c.ID) {
+		return fmt.Errorf("provider config: id %q must match %s", c.ID, providerIDPattern.String())
+	}
 	if c.Name == "" {
 		return fmt.Errorf("provider config: name is required")
 	}
@@ -323,4 +329,8 @@ func (c *ProviderConfig) Validate() error {
 	}
 
 	return nil
+}
+
+func validProviderID(id string) bool {
+	return providerIDPattern.MatchString(id)
 }

--- a/internal/providers/providers_extra_test.go
+++ b/internal/providers/providers_extra_test.go
@@ -18,6 +18,17 @@ func TestValidate_MissingID(t *testing.T) {
 	}
 }
 
+func TestValidate_InvalidID(t *testing.T) {
+	for _, id := range []string{"../prefs", "bad/id", `bad\id`, "-bad", ""} {
+		t.Run(id, func(t *testing.T) {
+			cfg := ProviderConfig{ID: id, Name: "x", Category: "hotel", Endpoint: "https://api.example.com/search", ResponseMapping: ResponseMapping{ResultsPath: "results"}}
+			if err := cfg.Validate(); err == nil {
+				t.Error("expected error for invalid ID")
+			}
+		})
+	}
+}
+
 func TestValidate_MissingName(t *testing.T) {
 	cfg := ProviderConfig{ID: "x", Category: "hotel", Endpoint: "https://api.example.com/search", ResponseMapping: ResponseMapping{ResultsPath: "results"}}
 	if err := cfg.Validate(); err == nil {
@@ -65,7 +76,7 @@ func TestValidate_NegativeRateLimit(t *testing.T) {
 		ID: "x", Name: "x", Category: "hotel",
 		Endpoint:        "https://api.example.com/search",
 		ResponseMapping: ResponseMapping{ResultsPath: "results"},
-		RateLimit:        RateLimitConfig{RequestsPerSecond: -1},
+		RateLimit:       RateLimitConfig{RequestsPerSecond: -1},
 	}
 	if err := cfg.Validate(); err == nil {
 		t.Error("expected error for negative rate limit")
@@ -77,7 +88,7 @@ func TestValidate_ExcessiveRateLimit(t *testing.T) {
 		ID: "x", Name: "x", Category: "hotel",
 		Endpoint:        "https://api.example.com/search",
 		ResponseMapping: ResponseMapping{ResultsPath: "results"},
-		RateLimit:        RateLimitConfig{RequestsPerSecond: 200},
+		RateLimit:       RateLimitConfig{RequestsPerSecond: 200},
 	}
 	if err := cfg.Validate(); err == nil {
 		t.Error("expected error for rate limit > 100")
@@ -89,7 +100,7 @@ func TestValidate_ValidConfig(t *testing.T) {
 		ID: "test", Name: "Test Provider", Category: "hotel",
 		Endpoint:        "https://api.example.com/search",
 		ResponseMapping: ResponseMapping{ResultsPath: "results"},
-		RateLimit:        RateLimitConfig{RequestsPerSecond: 5, Burst: 1},
+		RateLimit:       RateLimitConfig{RequestsPerSecond: 5, Burst: 1},
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("unexpected error for valid config: %v", err)
@@ -294,6 +305,59 @@ func TestRegistry_ReloadMissing(t *testing.T) {
 	_, err = reg.Reload("nonexistent")
 	if err == nil {
 		t.Error("Reload nonexistent should return error")
+	}
+}
+
+func TestRegistry_SaveRejectsPathTraversalID(t *testing.T) {
+	dir := t.TempDir()
+	reg, err := NewRegistryAt(dir)
+	if err != nil {
+		t.Fatalf("NewRegistryAt: %v", err)
+	}
+	err = reg.Save(&ProviderConfig{
+		ID:              "../preferences",
+		Name:            "Bad",
+		Category:        "hotel",
+		Endpoint:        "https://api.example.com",
+		ResponseMapping: ResponseMapping{ResultsPath: "r"},
+	})
+	if err == nil {
+		t.Fatal("expected invalid ID error")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "..", "preferences.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("path traversal target exists or stat failed unexpectedly: %v", statErr)
+	}
+}
+
+func TestRegistry_SaveSecuresProviderFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	reg, err := NewRegistryAt(dir)
+	if err != nil {
+		t.Fatalf("NewRegistryAt: %v", err)
+	}
+	cfg := &ProviderConfig{
+		ID:              "secure-test",
+		Name:            "Secure",
+		Category:        "hotel",
+		Endpoint:        "https://api.example.com",
+		ResponseMapping: ResponseMapping{ResultsPath: "r"},
+	}
+	if err := reg.Save(cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("dir mode = %#o, want 0700", got)
+	}
+	info, err := os.Stat(filepath.Join(dir, "secure-test.json"))
+	if err != nil {
+		t.Fatalf("stat provider file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("file mode = %#o, want 0600", got)
 	}
 }
 
@@ -875,8 +939,8 @@ func TestJsonPath_WildcardSegment(t *testing.T) {
 func TestJsonPath_ArrayTraversal(t *testing.T) {
 	data := map[string]any{
 		"sections": []any{
-			map[string]any{"listings": []any{}},           // empty
-			map[string]any{"listings": []any{"a", "b"}},   // non-empty
+			map[string]any{"listings": []any{}},         // empty
+			map[string]any{"listings": []any{"a", "b"}}, // non-empty
 		},
 	}
 	got := jsonPath(data, "sections.listings")

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -32,8 +33,11 @@ func NewRegistry() (*Registry, error) {
 // NewRegistryAt creates a Registry backed by the given directory.
 // This is useful for testing with a temporary directory.
 func NewRegistryAt(dir string) (*Registry, error) {
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("providers: create dir: %w", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("providers: secure dir: %w", err)
 	}
 
 	r := &Registry{
@@ -65,6 +69,9 @@ func NewRegistryAt(dir string) (*Registry, error) {
 		// rather than loaded silently.
 		if err := Migrate(&cfg); err != nil {
 			return nil, fmt.Errorf("providers: migrate %s: %w", entry.Name(), err)
+		}
+		if !validProviderID(cfg.ID) {
+			return nil, fmt.Errorf("providers: invalid id %q in %s", cfg.ID, entry.Name())
 		}
 		r.configs[cfg.ID] = &cfg
 		if info, err := os.Stat(path); err == nil {
@@ -119,6 +126,9 @@ func (r *Registry) Save(config *ProviderConfig) error {
 }
 
 func (r *Registry) saveLocked(config *ProviderConfig) error {
+	if config == nil {
+		return fmt.Errorf("providers: nil config")
+	}
 	// MIK-3075: stamp the schema version on every save so freshly written
 	// configs always carry the version this binary supports. Older
 	// in-memory configs that have already passed Migrate are safe — the
@@ -130,8 +140,11 @@ func (r *Registry) saveLocked(config *ProviderConfig) error {
 	if err != nil {
 		return fmt.Errorf("providers: marshal %s: %w", config.ID, err)
 	}
-	path := filepath.Join(r.dir, config.ID+".json")
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	path, err := r.configPath(config.ID)
+	if err != nil {
+		return err
+	}
+	if err := writeProviderFile(path, r.dir, data); err != nil {
 		return fmt.Errorf("providers: write %s: %w", config.ID, err)
 	}
 	r.configs[config.ID] = config
@@ -153,7 +166,10 @@ func (r *Registry) Delete(id string) error {
 		return fmt.Errorf("providers: %s not found", id)
 	}
 
-	path := filepath.Join(r.dir, id+".json")
+	path, err := r.configPath(id)
+	if err != nil {
+		return err
+	}
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("providers: delete %s: %w", id, err)
 	}
@@ -186,7 +202,10 @@ func (r *Registry) Reload(id string) (*ProviderConfig, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	path := filepath.Join(r.dir, id+".json")
+	path, err := r.configPath(id)
+	if err != nil {
+		return nil, err
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("providers: reload %s: %w", id, err)
@@ -197,6 +216,9 @@ func (r *Registry) Reload(id string) (*ProviderConfig, error) {
 	}
 	if err := Migrate(&cfg); err != nil {
 		return nil, fmt.Errorf("providers: migrate %s: %w", id, err)
+	}
+	if !validProviderID(cfg.ID) {
+		return nil, fmt.Errorf("providers: invalid id %q in %s", cfg.ID, path)
 	}
 	r.configs[cfg.ID] = &cfg
 	if info, err := os.Stat(path); err == nil {
@@ -210,7 +232,10 @@ func (r *Registry) Reload(id string) (*ProviderConfig, error) {
 // in-memory config. Safe to call on every request — the common path is a
 // single os.Stat and no JSON parse or write-lock acquisition.
 func (r *Registry) ReloadIfChanged(id string) *ProviderConfig {
-	path := filepath.Join(r.dir, id+".json")
+	path, err := r.configPath(id)
+	if err != nil {
+		return nil
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		r.mu.RLock()
@@ -247,9 +272,56 @@ func (r *Registry) ReloadIfChanged(id string) *ProviderConfig {
 		// hot path; surface the migration error via slog only.
 		return r.configs[id]
 	}
+	if !validProviderID(cfg.ID) {
+		return r.configs[id]
+	}
 	r.configs[cfg.ID] = &cfg
 	r.loadedAt[cfg.ID] = info.ModTime()
 	return &cfg
+}
+
+func (r *Registry) configPath(id string) (string, error) {
+	if !validProviderID(id) {
+		return "", fmt.Errorf("providers: invalid id %q", id)
+	}
+	dir, err := filepath.Abs(r.dir)
+	if err != nil {
+		return "", fmt.Errorf("providers: resolve dir: %w", err)
+	}
+	path := filepath.Join(dir, id+".json")
+	rel, err := filepath.Rel(dir, path)
+	if err != nil {
+		return "", fmt.Errorf("providers: resolve path for %s: %w", id, err)
+	}
+	if rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("providers: invalid path for id %q", id)
+	}
+	return path, nil
+}
+
+func writeProviderFile(path, dir string, data []byte) error {
+	tmp, err := os.CreateTemp(dir, ".provider-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
 }
 
 // MarkSuccess records a successful request for the given provider.

--- a/internal/providers/runtime.go
+++ b/internal/providers/runtime.go
@@ -371,8 +371,8 @@ func (rt *Runtime) SearchHotels(ctx context.Context, location string, lat, lon f
 	// not appear in statuses (existing behavior preserved).
 	live := make([]*ProviderConfig, 0, len(providers))
 	for _, cfg := range providers {
-		if cfg.ErrorCount >= circuitBreakerThreshold && !cfg.LastSuccess.IsZero() &&
-			time.Since(cfg.LastSuccess) > circuitBreakerCooldown {
+		if cfg.ErrorCount >= circuitBreakerThreshold &&
+			(cfg.LastSuccess.IsZero() || time.Since(cfg.LastSuccess) > circuitBreakerCooldown) {
 			slog.Info("circuit breaker: skipping provider",
 				"provider", cfg.ID,
 				"errors", cfg.ErrorCount,
@@ -1347,4 +1347,3 @@ func (rt *Runtime) searchProvider(ctx context.Context, cfg *ProviderConfig, loca
 
 	return hotels, nil
 }
-

--- a/internal/providers/runtime_search_test.go
+++ b/internal/providers/runtime_search_test.go
@@ -55,6 +55,56 @@ func TestSearchHotelsProviderError(t *testing.T) {
 	}
 }
 
+func TestSearchHotelsCircuitBreaksNeverSuccessfulProvider(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		t.Error("circuit-broken provider should not be called")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	reg, err := NewRegistryAt(dir)
+	if err != nil {
+		t.Fatalf("NewRegistryAt: %v", err)
+	}
+
+	cfg := &ProviderConfig{
+		ID:         "never-success",
+		Name:       "Never Success",
+		Category:   "hotels",
+		Endpoint:   srv.URL + "/search",
+		Method:     "GET",
+		ErrorCount: circuitBreakerThreshold,
+		ResponseMapping: ResponseMapping{
+			ResultsPath: "results",
+		},
+		RateLimit: RateLimitConfig{
+			RequestsPerSecond: 100,
+			Burst:             10,
+		},
+	}
+	if err := reg.Save(cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	rt := NewRuntime(reg)
+	hotels, statuses, err := rt.SearchHotels(context.Background(), "Test", 0, 0, "2025-06-01", "2025-06-05", "USD", 2, nil)
+	if err != nil {
+		t.Fatalf("SearchHotels: %v", err)
+	}
+	if len(hotels) != 0 {
+		t.Fatalf("hotels = %d, want 0", len(hotels))
+	}
+	if len(statuses) != 0 {
+		t.Fatalf("statuses = %d, want 0", len(statuses))
+	}
+	if calls != 0 {
+		t.Fatalf("provider calls = %d, want 0", calls)
+	}
+}
+
 func TestSearchHotelsContextCanceled(t *testing.T) {
 	dir := t.TempDir()
 	reg, err := NewRegistryAt(dir)
@@ -471,4 +521,3 @@ func TestRunPreflight_POST(t *testing.T) {
 		t.Errorf("name = %q, want 'Token Hotel'", hotels[0].Name)
 	}
 }
-

--- a/mcp/http.go
+++ b/mcp/http.go
@@ -1,27 +1,54 @@
 package mcp
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 )
 
+const defaultHTTPHost = "127.0.0.1"
+
 // HTTPServer wraps an MCP Server with an HTTP transport.
 type HTTPServer struct {
 	server *Server
+	host   string
 	port   int
+	token  string
+}
+
+// HTTPServerOptions configures the HTTP MCP transport.
+type HTTPServerOptions struct {
+	Host  string
+	Port  int
+	Token string
 }
 
 // NewHTTPServer creates an HTTP transport for the MCP server on the given port.
 func NewHTTPServer(port int) *HTTPServer {
+	return NewHTTPServerWithOptions(HTTPServerOptions{Host: defaultHTTPHost, Port: port})
+}
+
+// NewHTTPServerWithOptions creates an HTTP transport for the MCP server.
+func NewHTTPServerWithOptions(opts HTTPServerOptions) *HTTPServer {
+	host := strings.TrimSpace(opts.Host)
+	if host == "" {
+		host = defaultHTTPHost
+	}
 	return &HTTPServer{
 		server: NewServer(),
-		port:   port,
+		host:   host,
+		port:   opts.Port,
+		token:  strings.TrimSpace(opts.Token),
 	}
 }
 
@@ -34,8 +61,8 @@ func (h *HTTPServer) ListenAndServe() error {
 	mux.HandleFunc("/mcp", h.handleMCP)
 	mux.HandleFunc("/health", h.handleHealth)
 
-	addr := fmt.Sprintf(":%d", h.port)
-	log.Printf("trvl MCP server listening on http://localhost%s/mcp", addr)
+	addr := net.JoinHostPort(h.host, strconv.Itoa(h.port))
+	log.Printf("trvl MCP server listening on http://%s/mcp", addr)
 	srv := &http.Server{
 		Addr:         addr,
 		Handler:      mux,
@@ -53,10 +80,15 @@ func (h *HTTPServer) handleMCP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 	}
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 
 	if r.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	if !h.authorize(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -97,6 +129,18 @@ func (h *HTTPServer) handleMCP(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
+func (h *HTTPServer) authorize(r *http.Request) bool {
+	if h.token == "" {
+		return true
+	}
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return false
+	}
+	return strings.TrimSpace(strings.TrimPrefix(auth, prefix)) == h.token
+}
+
 func (h *HTTPServer) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{
@@ -116,14 +160,47 @@ func isLocalhostOrigin(origin string) bool {
 	if err != nil {
 		return false
 	}
-	host := strings.Split(u.Host, ":")[0]
-	return host == "localhost" || host == "127.0.0.1" || host == "[::1]"
+	host := u.Hostname()
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
-// RunHTTP starts the MCP server in HTTP mode on the given port.
+// RunHTTP starts the MCP server in HTTP mode on the given host and port.
 //
 // Coverage exclusion: blocking HTTP server entry point.
 // Calls ListenAndServe, whose handler logic is tested via httptest in server_extra_test.go.
-func RunHTTP(port int) error {
-	return NewHTTPServer(port).ListenAndServe()
+func RunHTTP(host string, port int, token string) error {
+	generatedToken := false
+	if strings.TrimSpace(token) == "" {
+		token = strings.TrimSpace(os.Getenv("TRVL_MCP_TOKEN"))
+	}
+	if strings.TrimSpace(token) == "" {
+		generated, err := generateMCPToken()
+		if err != nil {
+			return fmt.Errorf("generate MCP HTTP token: %w", err)
+		}
+		token = generated
+		generatedToken = true
+	}
+	if generatedToken {
+		log.Printf("trvl MCP generated HTTP bearer token: %s", token)
+	} else {
+		log.Printf("trvl MCP HTTP auth enabled")
+	}
+	return NewHTTPServerWithOptions(HTTPServerOptions{
+		Host:  host,
+		Port:  port,
+		Token: token,
+	}).ListenAndServe()
+}
+
+func generateMCPToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
 }

--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -123,10 +123,10 @@ type ToolDef struct {
 // ToolAnnotations provides metadata hints about a tool's behavior.
 type ToolAnnotations struct {
 	Title           string `json:"title,omitempty"`
-	ReadOnlyHint    bool   `json:"readOnlyHint,omitempty"`
-	DestructiveHint bool   `json:"destructiveHint,omitempty"`
-	IdempotentHint  bool   `json:"idempotentHint,omitempty"`
-	OpenWorldHint   bool   `json:"openWorldHint,omitempty"`
+	ReadOnlyHint    bool   `json:"readOnlyHint"`
+	DestructiveHint bool   `json:"destructiveHint"`
+	IdempotentHint  bool   `json:"idempotentHint"`
+	OpenWorldHint   bool   `json:"openWorldHint"`
 }
 
 // InputSchema is a JSON Schema describing the tool's input parameters.

--- a/mcp/server_extra2_test.go
+++ b/mcp/server_extra2_test.go
@@ -70,6 +70,9 @@ func TestNewHTTPServer(t *testing.T) {
 	if hs.port != 8080 {
 		t.Errorf("port = %d, want 8080", hs.port)
 	}
+	if hs.host != defaultHTTPHost {
+		t.Errorf("host = %q, want %q", hs.host, defaultHTTPHost)
+	}
 	if hs.server == nil {
 		t.Error("server is nil")
 	}
@@ -173,6 +176,9 @@ func TestToolAnnotations(t *testing.T) {
 		"build_profile":           true,
 		"add_booking":             true,
 		"watch_price":             true,
+		"create_trip":             true,
+		"add_trip_leg":            true,
+		"mark_trip_booked":        true,
 	}
 
 	// Tools that create new resources on each call — not idempotent.
@@ -184,6 +190,9 @@ func TestToolAnnotations(t *testing.T) {
 		// find_interactive can trigger elicitation and sampling, whose replies
 		// are not reproducible across calls — flag it non-idempotent.
 		"find_interactive": true,
+		"create_trip":      true,
+		"add_trip_leg":     true,
+		"mark_trip_booked": true,
 	}
 
 	s := NewServer()

--- a/mcp/server_extra_test.go
+++ b/mcp/server_extra_test.go
@@ -41,6 +41,29 @@ func TestHTTPHandler_POST_Initialize(t *testing.T) {
 	}
 }
 
+func TestHTTPHandler_POST_RequiresBearerTokenWhenConfigured(t *testing.T) {
+	t.Parallel()
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{Port: 0, Token: "secret-token"})
+
+	req := Request{JSONRPC: "2.0", ID: float64(1), Method: "initialize"}
+	body, _ := json.Marshal(req)
+
+	rr := httptest.NewRecorder()
+	httpReq := httptest.NewRequest("POST", "/mcp", bytes.NewReader(body))
+	hs.handleMCP(rr, httpReq)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status without token = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+
+	rr = httptest.NewRecorder()
+	httpReq = httptest.NewRequest("POST", "/mcp", bytes.NewReader(body))
+	httpReq.Header.Set("Authorization", "Bearer secret-token")
+	hs.handleMCP(rr, httpReq)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status with token = %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
 func TestHTTPHandler_POST_ToolsList(t *testing.T) {
 	t.Parallel()
 	hs := NewHTTPServer(0)
@@ -513,4 +536,3 @@ func TestServeStdio_ManyEmptyLines(t *testing.T) {
 }
 
 // --- writeJSON ---
-

--- a/mcp/tools_hotels.go
+++ b/mcp/tools_hotels.go
@@ -11,6 +11,8 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/profile"
 )
 
+var searchHotelsFunc = hotels.SearchHotels
+
 // --- Output schema builders ---
 
 // hotelSearchOutputSchema returns the JSON Schema for HotelSearchResult.
@@ -23,18 +25,18 @@ func hotelSearchOutputSchema() interface{} {
 			"hotels": schemaArray(map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
-					"name":         schemaString(),
-					"hotel_id":     schemaString(),
-					"rating":       schemaNum(),
-					"review_count": schemaInt(),
-					"stars":        schemaInt(),
-					"price":        schemaNum(),
-					"currency":     schemaString(),
-					"address":      schemaString(),
-					"lat":          schemaNum(),
-					"lon":          schemaNum(),
-					"booking_url":  schemaString(),
-					"amenities":    schemaStringArray(),
+					"name":            schemaString(),
+					"hotel_id":        schemaString(),
+					"rating":          schemaNum(),
+					"review_count":    schemaInt(),
+					"stars":           schemaInt(),
+					"price":           schemaNum(),
+					"currency":        schemaString(),
+					"address":         schemaString(),
+					"lat":             schemaNum(),
+					"lon":             schemaNum(),
+					"booking_url":     schemaString(),
+					"amenities":       schemaStringArray(),
 					"eco_certified":   schemaBool(),
 					"savings":         schemaNumDesc("Price savings vs most expensive source"),
 					"cheapest_source": schemaStringDesc("Provider with lowest price"),
@@ -102,6 +104,7 @@ func searchHotelsTool() ToolDef {
 				"check_in":          {Type: "string", Description: "Check-in date in YYYY-MM-DD format"},
 				"check_out":         {Type: "string", Description: "Check-out date in YYYY-MM-DD format"},
 				"guests":            {Type: "integer", Description: "Number of guests (default: 2)"},
+				"currency":          {Type: "string", Description: "Currency code (e.g. USD, EUR). Defaults to display_currency preference, then USD"},
 				"stars":             {Type: "integer", Description: "Minimum star rating 1-5 (default: no filter)"},
 				"sort":              {Type: "string", Description: "Sort order: price, rating, distance, or stars (default: price)"},
 				"min_price":         {Type: "number", Description: "Minimum price per night (default: no filter)"},
@@ -192,6 +195,11 @@ func handleSearchHotels(ctx context.Context, args map[string]any, elicit ElicitF
 	// Load preferences early — used for guest count default and filter overrides.
 	prefs, _ := preferences.Load()
 
+	currency := strings.ToUpper(argString(args, "currency"))
+	if currency == "" && prefs != nil {
+		currency = strings.ToUpper(prefs.DisplayCurrency)
+	}
+
 	// Determine guest count: use the caller's explicit value, or fall back to
 	// DefaultCompanions + 1 (companions + the user), or the tool default (2).
 	guests := argInt(args, "guests", 0)
@@ -208,6 +216,7 @@ func handleSearchHotels(ctx context.Context, args map[string]any, elicit ElicitF
 		CheckIn:          checkIn,
 		CheckOut:         checkOut,
 		Guests:           guests,
+		Currency:         currency,
 		Stars:            argInt(args, "stars", 0),
 		Sort:             argString(args, "sort"),
 		MinPrice:         argFloat(args, "min_price", 0),
@@ -269,7 +278,7 @@ func handleSearchHotels(ctx context.Context, args map[string]any, elicit ElicitF
 		}
 	}
 
-	result, err := hotels.SearchHotels(ctx, location, opts)
+	result, err := searchHotelsFunc(ctx, location, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -649,4 +658,3 @@ func handleHotelRooms(ctx context.Context, args map[string]any, elicit ElicitFun
 
 	return content, availability, nil
 }
-

--- a/mcp/tools_hotels_currency_test.go
+++ b/mcp/tools_hotels_currency_test.go
@@ -1,0 +1,86 @@
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/hotels"
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+)
+
+func TestSearchHotelsTool_CurrencyProperty(t *testing.T) {
+	t.Parallel()
+	tool := searchHotelsTool()
+	prop, ok := tool.InputSchema.Properties["currency"]
+	if !ok {
+		t.Fatal("missing currency property")
+	}
+	if prop.Type != "string" {
+		t.Fatalf("currency type = %q, want string", prop.Type)
+	}
+}
+
+func TestHandleSearchHotels_DefaultsCurrencyFromPreferences(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	prefs := preferences.Default()
+	prefs.DisplayCurrency = "EUR"
+	if err := preferences.SaveTo(filepath.Join(tmp, ".trvl", "preferences.json"), prefs); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	orig := searchHotelsFunc
+	t.Cleanup(func() { searchHotelsFunc = orig })
+
+	var got hotels.HotelSearchOptions
+	searchHotelsFunc = func(_ context.Context, _ string, opts hotels.HotelSearchOptions) (*models.HotelSearchResult, error) {
+		got = opts
+		return &models.HotelSearchResult{Success: true}, nil
+	}
+
+	_, _, err := handleSearchHotels(context.Background(), map[string]any{
+		"location":  "Helsinki",
+		"check_in":  "2026-06-15",
+		"check_out": "2026-06-18",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleSearchHotels: %v", err)
+	}
+	if got.Currency != "EUR" {
+		t.Fatalf("Currency = %q, want EUR", got.Currency)
+	}
+}
+
+func TestHandleSearchHotels_ExplicitCurrencyOverridesPreferences(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	prefs := preferences.Default()
+	prefs.DisplayCurrency = "EUR"
+	if err := preferences.SaveTo(filepath.Join(tmp, ".trvl", "preferences.json"), prefs); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	orig := searchHotelsFunc
+	t.Cleanup(func() { searchHotelsFunc = orig })
+
+	var got hotels.HotelSearchOptions
+	searchHotelsFunc = func(_ context.Context, _ string, opts hotels.HotelSearchOptions) (*models.HotelSearchResult, error) {
+		got = opts
+		return &models.HotelSearchResult{Success: true}, nil
+	}
+
+	_, _, err := handleSearchHotels(context.Background(), map[string]any{
+		"location":  "Helsinki",
+		"check_in":  "2026-06-15",
+		"check_out": "2026-06-18",
+		"currency":  "gbp",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleSearchHotels: %v", err)
+	}
+	if got.Currency != "GBP" {
+		t.Fatalf("Currency = %q, want GBP", got.Currency)
+	}
+}

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -770,6 +770,7 @@ func TestIsLocalhostOrigin(t *testing.T) {
 		{"http://localhost:3000", true},
 		{"http://localhost:8080", true},
 		{"http://127.0.0.1:3000", true},
+		{"http://[::1]:3000", true},
 		{"https://evil.com", false},
 		{"", false},
 		{"http://example.com", false},

--- a/mcp/tools_trips.go
+++ b/mcp/tools_trips.go
@@ -122,8 +122,8 @@ func createTripTool() ToolDef {
 		},
 		Annotations: &ToolAnnotations{
 			Title:          "Create Trip",
-			ReadOnlyHint:   true,
-			IdempotentHint: true,
+			ReadOnlyHint:   false,
+			IdempotentHint: false,
 		},
 	}
 }
@@ -159,8 +159,8 @@ func addTripLegTool() ToolDef {
 		},
 		Annotations: &ToolAnnotations{
 			Title:          "Add Trip Leg",
-			ReadOnlyHint:   true,
-			IdempotentHint: true,
+			ReadOnlyHint:   false,
+			IdempotentHint: false,
 		},
 	}
 }
@@ -192,8 +192,8 @@ func markTripBookedTool() ToolDef {
 		},
 		Annotations: &ToolAnnotations{
 			Title:          "Mark Trip Booked",
-			ReadOnlyHint:   true,
-			IdempotentHint: true,
+			ReadOnlyHint:   false,
+			IdempotentHint: false,
 		},
 	}
 }
@@ -400,8 +400,8 @@ func exportICSTool() ToolDef {
 		OutputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
-				"ics":        schemaString(),
-				"trip_name":  schemaString(),
+				"ics":         schemaString(),
+				"trip_name":   schemaString(),
 				"event_count": schemaInt(),
 			},
 		},

--- a/npm/README.md
+++ b/npm/README.md
@@ -30,7 +30,7 @@ Add to `claude_desktop_config.json`:
 - Ground transport (buses, trains, ferries — 20 providers)
 - Destination intelligence (weather, safety, holidays, events)
 - Trip planning and price alerts
-- Travel hacks detection (36 strategies)
+- Travel hacks detection (37 detectors)
 
 ## License
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl-mcp",
   "version": "1.0.6",
-  "description": "AI travel agent — 54 MCP tools for flights, hotels, ground transport, price alerts. No API keys required.",
+  "description": "AI travel agent — 57 MCP tools for flights, hotels, ground transport, price alerts. No API keys required.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bind MCP HTTP to loopback by default, add explicit --host and bearer-token auth, and document HTTP token behavior.
- Validate provider IDs, enforce provider path containment, and write provider config files with private permissions.
- Fix hotel singleflight key coverage, MCP hotel currency defaults, mutating trip tool annotations, and provider circuit breaking for never-successful providers.
- Update npm/docs counts for 57 tools and 37 detectors.

## Validation
- go test ./...
- go test -short ./...
- go vet ./...
- git diff --check
- Local HTTP MCP smoke test: unauthenticated /mcp returns 401; authenticated initialize works; tools/list returns 57 tools; search_hotels exposes currency; create_trip serializes readOnlyHint=false and idempotentHint=false; calculate_points_value returns a sensible recommendation.