### PR TITLE
Fix canonical DoD follow-ups

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl",
   "version": "1.0.0",
-  "description": "AI Travel Agent — 57 MCP tools for flights, hotels (5 providers: Google Hotels + Trivago + Airbnb + Booking.com + Hostelworld), trains, buses, ferries (20 ground providers incl. 8 ferry operators + night-train specialists European Sleeper & Snälltåget), 36 travel hack detectors, traveller profile with email history learning, deals, price alerts, and destination intel. Free, no API keys required.",
+  "description": "AI Travel Agent — 60 MCP tools for flights, hotels (5 providers: Google Hotels + Trivago + Airbnb + Booking.com + Hostelworld), trains, buses, ferries (20 ground providers incl. 8 ferry operators + night-train specialists European Sleeper & Snälltåget), 36 travel hack detectors, traveller profile with email history learning, deals, price alerts, and destination intel. Free, no API keys required.",
   "author": {
     "name": "Mikko Parkkola",
     "url": "https://github.com/MikkoParkkola"

--- a/.claude/skills/trvl.md
+++ b/.claude/skills/trvl.md
@@ -50,7 +50,7 @@ Read `~/.claude/travel-profile.md` if exists. Apply: departure time prefs, FF st
 ## ASK FIRST (2-3 Qs max)
 From?|To?|When?|Flex?|Travelers?|Budget? Check calendar (Google/Apple/manual) for conflicts. Don't re-ask obvious info.
 
-## CORE TOOLS (selected high-signal tools; trvl exposes 57 MCP tools overall via gateway_invoke server="trvl")
+## CORE TOOLS (selected high-signal tools; trvl exposes 60 MCP tools overall via gateway_invoke server="trvl")
 | Tool | Use | Key params |
 |------|-----|-----------|
 | `search_flights` | Flights A→B | origin,destination,departure_date,[return_date,cabin_class,max_stops] |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ trvl flights HEL LHR 2026-07-01 --format json | head -5
 # Expected: JSON with flight results
 ```
 
-Tell the user: "trvl is installed with 57 MCP tools and 2 bundled Claude skills. It includes 37 travel hack detectors (including error fare and flash sale detection) that auto-fire on searches, a unified optimizer (optimize_booking) with 9 expansion strategies (alternative origins/destinations, rail+fly, date flex, hidden city, departure tax avoidance, rail competition alternatives, ferry cabin as hotel) that searches all combinations in parallel, all-in pricing with FF status (bag fees included, FF benefits subtracted), pre-priced candidate pipeline for ground alternatives, miles tracking and earning estimates, and cross-provider hotel price comparison with cross-currency savings display. I can search flights, hotels, destinations, plan trips, find weekend getaways, find optimal travel windows, optimize multi-city routes, find nearby restaurants, check local events, search ground transport (buses, trains, ferries, night trains), detect travel hacks, check weather forecasts, look up airline baggage rules, find airport lounges, check visa requirements, calculate points-vs-cash redemptions, and configure additional data providers (Airbnb, Booking.com, Hostelworld). Just ask me anything about travel."
+Tell the user: "trvl is installed with 60 MCP tools and 2 bundled Claude skills. It includes 37 travel hack detectors (including error fare and flash sale detection) that auto-fire on searches, a unified optimizer (optimize_booking) with 9 expansion strategies (alternative origins/destinations, rail+fly, date flex, hidden city, departure tax avoidance, rail competition alternatives, ferry cabin as hotel) that searches all combinations in parallel, all-in pricing with FF status (bag fees included, FF benefits subtracted), pre-priced candidate pipeline for ground alternatives, miles tracking and earning estimates, and cross-provider hotel price comparison with cross-currency savings display. I can search flights, hotels, destinations, plan trips, find weekend getaways, find optimal travel windows, optimize multi-city routes, find nearby restaurants, check local events, search ground transport (buses, trains, ferries, night trains), detect travel hacks, check weather forecasts, look up airline baggage rules, find airport lounges, check visa requirements, calculate points-vs-cash redemptions, and configure additional data providers (Airbnb, Booking.com, Hostelworld). Just ask me anything about travel."
 
 ### Step 5: Build travel profile (recommended)
 
@@ -181,7 +181,7 @@ Save with `update_preferences`.
 | Field | Behavior |
 |-------|----------|
 | `home_airports` | Default origin for flight/trip/weekend/discover searches |
-| `display_currency` | Price display across all 57 tools |
+| `display_currency` | Price display across all 60 tools |
 | `no_dormitories` | `FilterHotels()` drops hostels, capsules, guesthouse rooms by chain name + regex |
 | `ensuite_only` | `FilterHotels()` drops shared-bathroom properties |
 | `min_hotel_stars` | Passed to Google Hotels API as search filter |
@@ -263,7 +263,7 @@ CLI alternative: `trvl prefs init`
 
 ## How To Use (after setup)
 
-You now have 57 MCP tools available. Use them when the user asks about travel:
+You now have 60 MCP tools available. Use them when the user asks about travel:
 
 ### search_flights — Find flights between airports
 ```json

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ![trvl demo](https://raw.githubusercontent.com/MikkoParkkola/trvl/main/demo.gif?v=1.0.5)
 
-> **57 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, travel hacks, weather forecasts, baggage rules, airport lounges, destination intel. Free. API-first.**
+> **60 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, travel hacks, weather forecasts, baggage rules, airport lounges, destination intel. Free. API-first.**
 >
 > Also works as a standalone CLI with 43 commands.
 
@@ -124,7 +124,7 @@ The profile makes every subsequent search smarter — it skips questions it alre
 
 ### 5. Ask your AI to search
 
-That's it. Your AI assistant now has 57 travel tools available. Just ask naturally:
+That's it. Your AI assistant now has 60 travel tools available. Just ask naturally:
 
 - *"Search flights from JFK to Tokyo on July 1st, business class"*
 - *"Find hotels in Paris for July 1-5, at least 4 stars"*
@@ -232,7 +232,7 @@ That's it. Your AI assistant now has 57 travel tools available. Just ask natural
 |---------|---------|
 | **Structured content** | Typed JSON (`structuredContent`) alongside human-readable summaries |
 | **Content annotations** | `audience: ["user"]` for summaries, `audience: ["assistant"]` for data |
-| **Output schemas** | Full JSON Schema validation for all 57 tool responses |
+| **Output schemas** | Full JSON Schema validation for all 60 tool responses |
 | **Prompts** | `plan-trip`, `find-cheapest-dates`, `compare-hotels`, `where-should-i-go` |
 | **Resources** | Airport codes (50 major hubs), flight/hotel usage guides, price-watch subscriptions |
 | **Tool description orchestration** | `find_trip_window` instructs the LLM to fetch calendar data first, then pass busy intervals in — works on every MCP client. See [docs/MCP-ORCHESTRATION.md](docs/MCP-ORCHESTRATION.md) |
@@ -641,7 +641,7 @@ The AI uses these to give you actionable recommendations: "Book here: [link]". N
 | **Binary** | Single static ~15MB for API-first flows. Optional protected-provider fallbacks may use local browser/python tooling. |
 | **Data** | Real-time from Google Flights + 5 hotel sources (Google Hotels, Trivago, Airbnb, Booking.com, Hostelworld) + 20 ground providers (FlixBus, RegioJet, Eurostar, DB, ÖBB, NS, VR, SNCF, Trainline, Transitous, Renfe, European Sleeper, Snälltåget, Tallink, Viking Line, Eckerö Line, Finnlines, Stena Line, DFDS, Ferryhopper) + 5 free destination APIs |
 | **Auth** | No personal API keys required. Two providers (NS, Digitransit/VR) use public keys embedded in the binary. Optional browser/cookie fallbacks are available for protected providers when explicitly enabled. |
-| **MCP** | Full v2025-11-25 — 57 tools (incl. 4 profile tools, 3 price watch tools, provider health), 7 prompts, resources, structured content, progress notifications, resource subscriptions, tool description orchestration |
+| **MCP** | Full v2025-11-25 — 60 tools (incl. 4 profile tools, 3 price watch tools, provider health), 7 prompts, resources, structured content, progress notifications, resource subscriptions, tool description orchestration |
 | **CLI** | 43 commands (+ 7 watch subcommands) with table/JSON output, color, shell completion |
 | **Booking links** | Every flight and hotel result includes a direct Google booking link |
 | **Travel hacks** | 37 detectors (throwaway, hidden-city, positioning, ferry, multi-modal, stopover, date-flex, error fare, back-to-back, rail competition, and more) |

--- a/cmd/trvl/commands_test.go
+++ b/cmd/trvl/commands_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRootCmd_SubcommandCount(t *testing.T) {
 	// rootCmd is the package-level var registered in root.go init().
-	const want = 47
+	const want = 49
 	got := len(rootCmd.Commands())
 	if got != want {
 		names := make([]string, 0, got)

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -34,6 +34,8 @@ func flightsCmd() *cobra.Command {
 		targetCurrency string
 		compareCabins  bool
 		explain        bool
+		award          bool
+		awardCookies   string
 	)
 
 	cmd := &cobra.Command{
@@ -63,6 +65,13 @@ Examples:
 			origins := flights.ParseAirports(originArg)
 			destinations := flights.ParseAirports(args[1])
 			date := args[2]
+
+			if award {
+				if len(origins) != 1 || len(destinations) != 1 {
+					return fmt.Errorf("--award supports exactly one origin and one destination")
+				}
+				return runAwardScan(cmd.Context(), origins[0], destinations[0], date, awardCookies, format)
+			}
 
 			cabinClass, err := models.ParseCabinClass(cabin)
 			if err != nil {
@@ -154,6 +163,8 @@ Examples:
 	cmd.Flags().StringVar(&targetCurrency, "currency", "", "Convert prices to this currency (e.g. EUR, USD). Empty = show API default")
 	cmd.Flags().BoolVar(&compareCabins, "compare-cabins", false, "Compare prices across all cabin classes (economy, premium, business, first)")
 	cmd.Flags().BoolVar(&explain, "explain", false, "Show per-factor profile match breakdown for each result")
+	cmd.Flags().BoolVar(&award, "award", false, "Search Flying Blue award availability instead of cash fares")
+	cmd.Flags().StringVar(&awardCookies, "award-cookies", "", "KLM/Flying Blue Cookie header for --award (or set AFKL_KLM_COOKIES)")
 
 	cmd.ValidArgsFunction = airportCompletion
 
@@ -218,7 +229,7 @@ func printFlightsTable(ctx context.Context, origin, destination, targetCurrency 
 	allInData := make([]allInInfo, len(result.Flights))
 	showAllIn := false
 	prefs, _ := preferences.Load() //nolint:errcheck // default prefs on error
-	if prefs != nil { // all-in is self-gating: column only appears when allIn != basePrice for any flight
+	if prefs != nil {              // all-in is self-gating: column only appears when allIn != basePrice for any flight
 		needCheckedBag := !prefs.CarryOnOnly
 		needCarryOn := true
 		var ffStatuses []baggage.FFStatus

--- a/cmd/trvl/hiddencity.go
+++ b/cmd/trvl/hiddencity.go
@@ -103,15 +103,6 @@ Examples:
 	return cmd
 }
 
-// printHiddenCityTable is a helper for testing.
-func printHiddenCityTable(out interface{ Write([]byte) (int, error) }, candidates []hacks.HiddenCityCandidate) {
-	for _, c := range candidates {
-		fmt.Fprintf(out, "%s → %s (skip to %s) %s %.2f risk:%d %s\n",
-			c.Origin, c.HubBeyond, c.Hub,
-			c.Currency, c.Price, c.LayoverRisk, c.Reason)
-	}
-}
-
 // colorizeHiddenCityRisk returns a color-coded risk label.
 func colorizeHiddenCityRisk(risk int) string {
 	switch {

--- a/demo.tape
+++ b/demo.tape
@@ -67,7 +67,7 @@ Sleep 3s
 # ═══ CLOSING ═══
 
 Sleep 300ms
-Type "# 57 MCP tools · 43 CLI commands · 21 providers · No API keys"
+Type "# 60 MCP tools · 43 CLI commands · 21 providers · No API keys"
 Enter
 Sleep 300ms
 Type "# brew install MikkoParkkola/tap/trvl"

--- a/internal/ground/scraper.py
+++ b/internal/ground/scraper.py
@@ -17,16 +17,21 @@ import json
 import sys
 import re
 
-try:
-    from playwright_stealth import Stealth as _Stealth
-    _STEALTH_AVAILABLE = True
-except ImportError:
-    _Stealth = None
-    _STEALTH_AVAILABLE = False
+_Stealth = None
+_STEALTH_AVAILABLE = None
 
 
 def _apply_stealth(page):
     """Apply playwright-stealth patches to a page if available."""
+    global _Stealth, _STEALTH_AVAILABLE
+    if _STEALTH_AVAILABLE is None:
+        try:
+            from playwright_stealth import Stealth as _Stealth
+            _STEALTH_AVAILABLE = True
+        except ImportError:
+            _Stealth = None
+            _STEALTH_AVAILABLE = False
+
     if _STEALTH_AVAILABLE and _Stealth is not None:
         try:
             _Stealth().apply_stealth_sync(page)
@@ -35,12 +40,6 @@ def _apply_stealth(page):
 
 
 def main():
-    try:
-        from playwright.sync_api import sync_playwright, TimeoutError as PWTimeoutError
-    except ImportError:
-        out([], "playwright not installed: pip install playwright && playwright install chromium")
-        return
-
     raw = sys.stdin.read().strip()
     if not raw:
         out([], "no input on stdin")
@@ -58,9 +57,20 @@ def main():
     date = inp.get("date", "")
     currency = inp.get("currency", "EUR").upper()
 
+    def load_playwright():
+        try:
+            from playwright.sync_api import sync_playwright
+        except ImportError:
+            out([], "playwright not installed: pip install playwright && playwright install chromium")
+            return None
+        return sync_playwright
+
     # Token-capture modes: only need playwright, not from/to/date.
     # Output shape differs from route scrapers — callers handle these directly.
     if provider == "sncf_key":
+        sync_playwright = load_playwright()
+        if sync_playwright is None:
+            return
         try:
             with sync_playwright() as pw:
                 key = capture_sncf_key(pw)
@@ -70,6 +80,9 @@ def main():
         return
 
     if provider == "trainline_cookie":
+        sync_playwright = load_playwright()
+        if sync_playwright is None:
+            return
         try:
             with sync_playwright() as pw:
                 cookie = capture_trainline_cookie(pw)
@@ -92,6 +105,10 @@ def main():
     fn = scrapers.get(provider)
     if fn is None:
         out([], f"unsupported provider: {provider}")
+        return
+
+    sync_playwright = load_playwright()
+    if sync_playwright is None:
         return
 
     try:

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -179,7 +179,7 @@ var googleSortOrders = []string{"", "3", "8"}
 // hotelSearchKey builds a singleflight dedup key from every option that can
 // affect fetched, enriched, or post-filtered hotel results.
 func hotelSearchKey(location string, opts HotelSearchOptions) string {
-	amenities := append([]string(nil), opts.Amenities...)
+	amenities := normalizedHotelSearchAmenities(opts.Amenities)
 	sort.Strings(amenities)
 	key := struct {
 		Location         string   `json:"location"`
@@ -220,7 +220,7 @@ func hotelSearchKey(location string, opts HotelSearchOptions) string {
 		Guests:           opts.Guests,
 		Stars:            opts.Stars,
 		Sort:             opts.Sort,
-		Currency:         opts.Currency,
+		Currency:         strings.ToUpper(opts.Currency),
 		MinPrice:         opts.MinPrice,
 		MaxPrice:         opts.MaxPrice,
 		MinRating:        opts.MinRating,
@@ -230,10 +230,10 @@ func hotelSearchKey(location string, opts HotelSearchOptions) string {
 		CenterLon:        opts.CenterLon,
 		EnrichAmenities:  opts.EnrichAmenities,
 		EnrichLimit:      opts.EnrichLimit,
-		MaxPages:         opts.MaxPages,
+		MaxPages:         hotelPageLimit(opts.MaxPages),
 		FreeCancellation: opts.FreeCancellation,
 		PropertyType:     opts.PropertyType,
-		Brand:            opts.Brand,
+		Brand:            strings.ToLower(strings.TrimSpace(opts.Brand)),
 		EcoCertified:     opts.EcoCertified,
 		MinBedrooms:      opts.MinBedrooms,
 		MinBathrooms:     opts.MinBathrooms,
@@ -251,6 +251,17 @@ func hotelSearchKey(location string, opts HotelSearchOptions) string {
 		return fmt.Sprintf("hotel|%s|%s|%s|%d|%s", location, opts.CheckIn, opts.CheckOut, opts.Guests, opts.Currency)
 	}
 	return "hotel|" + string(data)
+}
+
+func normalizedHotelSearchAmenities(amenities []string) []string {
+	normalized := make([]string, 0, len(amenities))
+	for _, amenity := range amenities {
+		amenity = strings.ToLower(strings.TrimSpace(amenity))
+		if amenity != "" {
+			normalized = append(normalized, amenity)
+		}
+	}
+	return normalized
 }
 
 func hotelPageLimit(requested int) int {

--- a/internal/hotels/singleflight_test.go
+++ b/internal/hotels/singleflight_test.go
@@ -59,7 +59,13 @@ func TestHotelSingleflight(t *testing.T) {
 // TestHotelSearchKey verifies that different parameter combinations produce
 // distinct keys, preventing incorrect deduplication.
 func TestHotelSearchKey(t *testing.T) {
-	base := HotelSearchOptions{CheckIn: "2026-06-15", CheckOut: "2026-06-18", Guests: 2, Currency: "USD"}
+	base := HotelSearchOptions{
+		CheckIn:   "2026-06-15",
+		CheckOut:  "2026-06-18",
+		Guests:    2,
+		Currency:  "USD",
+		Amenities: []string{"pool", "wifi"},
+	}
 	changedCheckIn := base
 	changedCheckIn.CheckIn = "2026-06-16"
 	changedGuests := base

--- a/internal/providers/providers_extra_test.go
+++ b/internal/providers/providers_extra_test.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -330,6 +331,9 @@ func TestRegistry_SaveRejectsPathTraversalID(t *testing.T) {
 }
 
 func TestRegistry_SaveSecuresProviderFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not preserve POSIX permission bits in os.FileMode")
+	}
 	dir := t.TempDir()
 	reg, err := NewRegistryAt(dir)
 	if err != nil {

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -305,14 +305,16 @@ func writeProviderFile(path, dir string, data []byte) error {
 		return err
 	}
 	tmpName := tmp.Name()
-	defer os.Remove(tmpName)
+	defer func() {
+		_ = os.Remove(tmpName)
+	}()
 
 	if err := tmp.Chmod(0o600); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return err
 	}
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return err
 	}
 	if err := tmp.Close(); err != nil {

--- a/internal/providers/runtime.go
+++ b/internal/providers/runtime.go
@@ -97,16 +97,16 @@ type HotelFilterParams struct {
 	FreeCancellation bool
 
 	// Extended filters — wired to providers that support them.
-	MinBedrooms      int    // minimum bedrooms (Airbnb)
-	MinBathrooms     int    // minimum bathrooms (Airbnb)
-	MinBeds          int    // minimum beds (Airbnb)
-	RoomType         string // "entire_home", "private_room", "shared_room" (Airbnb)
-	Superhost        bool   // Superhost-only filter (Airbnb)
-	InstantBook      bool   // instant-bookable only (Airbnb)
-	MaxDistanceM     int    // max distance from center in meters (Booking)
-	Sustainable      bool   // eco/sustainable properties (Booking)
-	MealPlan         bool   // breakfast/meal included (Booking)
-	IncludeSoldOut   bool   // include sold-out properties in results (Booking)
+	MinBedrooms    int    // minimum bedrooms (Airbnb)
+	MinBathrooms   int    // minimum bathrooms (Airbnb)
+	MinBeds        int    // minimum beds (Airbnb)
+	RoomType       string // "entire_home", "private_room", "shared_room" (Airbnb)
+	Superhost      bool   // Superhost-only filter (Airbnb)
+	InstantBook    bool   // instant-bookable only (Airbnb)
+	MaxDistanceM   int    // max distance from center in meters (Booking)
+	Sustainable    bool   // eco/sustainable properties (Booking)
+	MealPlan       bool   // breakfast/meal included (Booking)
+	IncludeSoldOut bool   // include sold-out properties in results (Booking)
 }
 
 // Runtime is the generic HTTP execution engine for configured providers.
@@ -1025,7 +1025,12 @@ func (rt *Runtime) searchProvider(ctx context.Context, cfg *ProviderConfig, loca
 		"path", cfg.ResponseMapping.ResultsPath,
 		"resolved_type", fmt.Sprintf("%T", resultsRaw),
 		"is_array", ok,
-		"count", func() int { if ok { return len(arr) }; return -1 }())
+		"count", func() int {
+			if ok {
+				return len(arr)
+			}
+			return -1
+		}())
 	// For Apollo-cache providers (e.g. Booking), log empty-results at debug
 	// level so operators can diagnose SSR-vs-CSR rendering issues.
 	if ok && len(arr) == 0 {

--- a/internal/watch/webhook_test.go
+++ b/internal/watch/webhook_test.go
@@ -195,7 +195,7 @@ func TestCheckAllWithRooms_NilContextFallsBackToBackgroundForPriceChecks(t *test
 	}
 
 	checker := &contextRecordingPriceChecker{}
-	results := CheckAllWithRooms(nil, store, checker, nil)
+	results := CheckAllWithRooms(context.TODO(), store, checker, nil)
 	if len(results) != 1 {
 		t.Fatalf("got %d results, want 1", len(results))
 	}
@@ -222,7 +222,7 @@ func TestCheckAllWithRooms_NilContextFallsBackToBackgroundForRoomChecks(t *testi
 	}
 
 	roomChecker := &contextRecordingRoomChecker{}
-	results := CheckAllWithRooms(nil, store, &contextRecordingPriceChecker{}, roomChecker)
+	results := CheckAllWithRooms(context.TODO(), store, &contextRecordingPriceChecker{}, roomChecker)
 	if len(results) != 1 {
 		t.Fatalf("got %d results, want 1", len(results))
 	}

--- a/mcp/server_extra2_test.go
+++ b/mcp/server_extra2_test.go
@@ -51,11 +51,11 @@ func TestNewServer(t *testing.T) {
 	if s == nil {
 		t.Fatal("NewServer returned nil")
 	}
-	if len(s.tools) != 57 {
-		t.Errorf("expected 57 tools, got %d", len(s.tools))
+	if len(s.tools) != 60 {
+		t.Errorf("expected 60 tools, got %d", len(s.tools))
 	}
-	if len(s.handlers) != 57 {
-		t.Errorf("expected 57 handlers, got %d", len(s.handlers))
+	if len(s.handlers) != 60 {
+		t.Errorf("expected 60 handlers, got %d", len(s.handlers))
 	}
 }
 

--- a/mcp/server_extra_test.go
+++ b/mcp/server_extra_test.go
@@ -86,8 +86,8 @@ func TestHTTPHandler_POST_ToolsList(t *testing.T) {
 	var result ToolsListResult
 	json.Unmarshal(resultJSON, &result)
 
-	if len(result.Tools) != 57 {
-		t.Errorf("expected 57 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 60 {
+		t.Errorf("expected 60 tools, got %d", len(result.Tools))
 	}
 }
 

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -128,12 +128,14 @@ func TestToolsList(t *testing.T) {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 
-	if len(result.Tools) != 57 {
-		t.Fatalf("expected 57 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 60 {
+		t.Fatalf("expected 60 tools, got %d", len(result.Tools))
 	}
 
 	expected := map[string]bool{
 		"search_flights":             false,
+		"plan_flight_bundle":         false,
+		"find_interactive":           false,
 		"search_dates":               false,
 		"search_hotels":              false,
 		"search_hotel_by_name":       false,
@@ -165,6 +167,7 @@ func TestToolsList(t *testing.T) {
 		"create_trip":                false,
 		"add_trip_leg":               false,
 		"mark_trip_booked":           false,
+		"export_ics":                 false,
 		"get_weather":                false,
 		"get_baggage_rules":          false,
 		"find_trip_window":           false,
@@ -177,19 +180,19 @@ func TestToolsList(t *testing.T) {
 		"suggest_providers":          false,
 		"test_provider":              false,
 		"optimize_trip_dates":        false,
-		"assess_trip":               false,
-		"optimize_booking":          false,
-		"build_profile":             false,
-		"add_booking":               false,
-		"interview_trip":            false,
-		"onboard_profile":           false,
-		"provider_health":           false,
-		"watch_price":               false,
-		"list_watches":              false,
-		"check_watches":             false,
-		"watch_opportunities":       false,
-		"list_opportunity_watches":  false,
-		"search_hidden_city":        false,
+		"assess_trip":                false,
+		"optimize_booking":           false,
+		"build_profile":              false,
+		"add_booking":                false,
+		"interview_trip":             false,
+		"onboard_profile":            false,
+		"provider_health":            false,
+		"watch_price":                false,
+		"list_watches":               false,
+		"check_watches":              false,
+		"watch_opportunities":        false,
+		"list_opportunity_watches":   false,
+		"search_hidden_city":         false,
 	}
 	for _, tool := range result.Tools {
 		if _, ok := expected[tool.Name]; !ok {

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -15,6 +15,8 @@ import (
 func registerTools(s *Server) {
 	s.tools = []ToolDef{
 		searchFlightsTool(),
+		planFlightBundleTool(),
+		findInteractiveTool(),
 		searchDatesTool(),
 		searchHotelsTool(),
 		searchHotelByNameTool(),
@@ -46,6 +48,7 @@ func registerTools(s *Server) {
 		createTripTool(),
 		addTripLegTool(),
 		markTripBookedTool(),
+		exportICSTool(),
 		getWeatherTool(),
 		getBaggageRulesTool(),
 		findTripWindowTool(),
@@ -73,6 +76,8 @@ func registerTools(s *Server) {
 		searchHiddenCityTool(),
 	}
 	s.handlers["search_flights"] = s.wrapHandler(handleSearchFlights)
+	s.handlers["plan_flight_bundle"] = s.wrapHandler(handlePlanFlightBundle)
+	s.handlers["find_interactive"] = s.wrapHandler(handleFindInteractive)
 	s.handlers["search_dates"] = s.wrapHandler(handleSearchDates)
 	s.handlers["search_hotels"] = s.wrapHandler(handleSearchHotels)
 	s.handlers["search_hotel_by_name"] = s.wrapHandler(handleSearchHotelByName)
@@ -104,6 +109,7 @@ func registerTools(s *Server) {
 	s.handlers["create_trip"] = s.wrapHandler(handleCreateTrip)
 	s.handlers["add_trip_leg"] = s.wrapHandler(handleAddTripLeg)
 	s.handlers["mark_trip_booked"] = s.wrapHandler(handleMarkTripBooked)
+	s.handlers["export_ics"] = s.wrapHandler(handleExportICS)
 	s.handlers["get_weather"] = s.wrapHandler(handleGetWeather)
 	s.handlers["get_baggage_rules"] = s.wrapHandler(handleGetBaggageRules)
 	s.handlers["find_trip_window"] = s.wrapHandler(handleFindTripWindow)

--- a/mcp/tools_extra_test.go
+++ b/mcp/tools_extra_test.go
@@ -268,7 +268,8 @@ func TestToolRegistration_AllTools(t *testing.T) {
 	t.Parallel()
 	s := NewServer()
 	expectedTools := []string{
-		"search_flights", "search_dates", "search_hotels", "hotel_prices",
+		"search_flights", "plan_flight_bundle", "find_interactive",
+		"search_dates", "search_hotels", "hotel_prices",
 		"hotel_reviews", "destination_info", "calculate_trip_cost",
 		"weekend_getaway", "suggest_dates", "optimize_multi_city",
 		"nearby_places", "travel_guide", "local_events",
@@ -287,6 +288,7 @@ func TestToolRegistration_AllTools(t *testing.T) {
 		"create_trip",
 		"add_trip_leg",
 		"mark_trip_booked",
+		"export_ics",
 		"get_weather",
 		"get_baggage_rules",
 		"find_trip_window",

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # trvl-mcp
 
-AI travel agent MCP server. 54 tools for flights, hotels, ground transport, price alerts. No API keys required.
+AI travel agent MCP server. 60 tools for flights, hotels, ground transport, price alerts. No API keys required.
 
 ## Usage
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl-mcp",
   "version": "1.0.6",
-  "description": "AI travel agent — 57 MCP tools for flights, hotels, ground transport, price alerts. No API keys required.",
+  "description": "AI travel agent — 60 MCP tools for flights, hotels, ground transport, price alerts. No API keys required.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Fixes post-merge canonical DoD gaps from PR #55: gofmt drift, introduced errcheck findings, staticcheck failures, and brittle scraper invalid-input handling.
- Normalizes hotel singleflight keys to the effective search inputs used at runtime, and corrects the inconsistent amenity-order regression test.
- Wires previously defined MCP tools (`plan_flight_bundle`, `find_interactive`, `export_ics`) and the documented CLI `flights --award` path so public symbols are reachable from production.
- Updates public tool-count claims from 57 to 60 and fixes stale command-count coverage.

## KPI Impact
- Developer/operator impact: restores local canonical validation from red to green for the changed tree and fixes the Ubuntu CI `staticcheck ./...` failure class.
- User impact: invalid ground scraper input returns JSON errors without importing browser tooling; hotel singleflight keys no longer split identical effective searches or collide incorrectly across behavior-changing options; three existing MCP capabilities are now actually exposed.

## DoD Evidence
- `go test ./...`
- `go test ./cmd/trvl -count=1`
- `go test ./internal/hotels -count=1`
- `go test ./mcp -run 'TestToolsList|TestNewServer|TestToolAnnotations|TestPlanFlightBundleTool_SchemaShape|TestToolRegistration_AllTools|TestHTTPHandler_POST_ToolsList' -count=1`\n- `go test ./internal/ground -run 'TestScraperPy_(SyntaxCheck|MissingInputHandling|UnknownProvider|InvalidJSON)' -count=1 -v`\n- `go test ./internal/providers -run 'TestValidate_InvalidID|TestRegistry_SaveRejectsPathTraversalID|TestRegistry_SaveSecuresProviderFilePermissions|TestSearchHotelsCircuitBreaksNeverSuccessfulProvider' -count=1`\n- `go vet ./...`\n- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`\n- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run --new-from-rev=origin/main` -> 0 issues\n- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` -> No vulnerabilities found\n- `gofmt -l` on changed Go files -> no output\n- `git diff --check` -> no output\n- secret-pattern scan on changed files -> no matches\n- HTTP MCP smoke: unauthenticated `/mcp` = 401, `/health` reports 60 tools, `tools/list` reports 60 tools, `search_hotels.currency` schema present, `create_trip.readOnlyHint=false`, new tools present\n\n## Retro\n- What worked: canonical DoD caught real issues that the earlier shortcut check missed, including unwired public symbols and CI staticcheck failures.\n- What did not: PR #55 merged before the stricter pass finished, so this is a follow-up PR instead of an amended original PR.\n- Next: keep CI `staticcheck ./...` in the local DoD checklist, not just diff-only lint.\n