### PR TITLE
feat: wire 6 dormant math packages into CLI (MIK-3065/3080/3086/3087/3088/3090)

### DIFF
--- a/cmd/trvl/cabinarb.go
+++ b/cmd/trvl/cabinarb.go
@@ -1,0 +1,96 @@
+package main
+
+// MIK-3090: trvl cabin-arb — cabin-class arbitrage detector.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/cabinarb"
+	"github.com/spf13/cobra"
+)
+
+func cabinArbCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cabin-arb <cabin:price[:carrier]>...",
+		Short: "Detect near-flat cabin upgrades on the same itinerary",
+		Long: `cabin-arb inspects the fare ladder for an itinerary and flags every
+cabin-class upgrade whose upsell is within the threshold (default 15%).
+When premium-economy is within 15% of economy, the upgrade is a near-free
+step and the planner surfaces it as a recommendation.
+
+Each positional argument is a colon-separated triple:
+  cabin:price[:carrier]
+
+Valid cabin values: economy, premium_economy, business, first.
+
+Examples:
+  trvl cabin-arb economy:500 premium_economy:560
+  trvl cabin-arb economy:500 premium_economy:570 business:600 first:660
+  trvl cabin-arb economy:500:AY economy:480:KL premium_economy:550 --threshold 20
+  trvl cabin-arb economy:400 premium_economy:460 --format json`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: runCabinArb,
+	}
+	cmd.Flags().Float64("threshold", cabinarb.DefaultUpsellThresholdPct, "Upsell threshold in percent")
+	return cmd
+}
+
+func runCabinArb(cmd *cobra.Command, args []string) error {
+	threshold, _ := cmd.Flags().GetFloat64("threshold")
+	format, _ := cmd.Flags().GetString("format")
+	fares, err := parseCabinFares(args)
+	if err != nil {
+		return fmt.Errorf("cabin-arb: %w", err)
+	}
+	recs := cabinarb.DetectWithThreshold(fares, threshold)
+	if format == "json" {
+		return json.NewEncoder(os.Stdout).Encode(recs)
+	}
+	renderCabinArbTable(os.Stdout, recs, threshold)
+	return nil
+}
+
+func parseCabinFares(args []string) ([]cabinarb.CabinFare, error) {
+	out := make([]cabinarb.CabinFare, 0, len(args))
+	for _, arg := range args {
+		parts := strings.SplitN(arg, ":", 3)
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("invalid fare %q: expected cabin:price[:carrier]", arg)
+		}
+		cabin := strings.TrimSpace(parts[0])
+		if cabin == "" {
+			return nil, fmt.Errorf("invalid fare %q: cabin must not be empty", arg)
+		}
+		price, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid fare %q: price must be a number: %w", arg, err)
+		}
+		carrier := ""
+		if len(parts) == 3 {
+			carrier = strings.TrimSpace(parts[2])
+		}
+		out = append(out, cabinarb.CabinFare{Cabin: cabinarb.Cabin(cabin), Price: price, Carrier: carrier})
+	}
+	return out, nil
+}
+
+func renderCabinArbTable(out *os.File, recs []cabinarb.UpgradeRecommendation, threshold float64) {
+	if len(recs) == 0 {
+		fmt.Fprintf(out, "No upgrades within %.0f%% threshold.\n", threshold)
+		return
+	}
+	fmt.Fprintf(out, "Upgrade recommendations (threshold %.0f%%):\n", threshold)
+	fmt.Fprintf(out, "  %-16s %-16s %8s %8s %8s  %s\n", "Baseline", "Target", "Base", "Target", "Upsell%", "Reason")
+	fmt.Fprintf(out, "  %s\n", strings.Repeat("-", 80))
+	for _, r := range recs {
+		upsellStr := fmt.Sprintf("%.1f%%", r.UpsellPercent)
+		if r.UpsellPercent == 0 {
+			upsellStr = "0.0% (free!)"
+		}
+		fmt.Fprintf(out, "  %-16s %-16s %8.2f %8.2f %11s  %s\n", r.Baseline, r.Target, r.BaselinePrice, r.TargetPrice, upsellStr, r.Reason)
+	}
+}

--- a/cmd/trvl/commands_test.go
+++ b/cmd/trvl/commands_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRootCmd_SubcommandCount(t *testing.T) {
 	// rootCmd is the package-level var registered in root.go init().
-	const want = 50
+	const want = 56
 	got := len(rootCmd.Commands())
 	if got != want {
 		names := make([]string, 0, got)

--- a/cmd/trvl/expenses.go
+++ b/cmd/trvl/expenses.go
@@ -1,0 +1,130 @@
+package main
+
+// MIK-3088: trvl expenses — trip expense reconciler.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/expenses"
+	"github.com/spf13/cobra"
+)
+
+func expensesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "expenses <payer:amount[:traveller1,traveller2]>...",
+		Short: "Reconcile shared trip expenses — who owes whom",
+		Long: `expenses computes the minimum set of transfers that settles shared trip
+costs across a group of travellers. All amounts must use a single currency.
+
+Each positional argument encodes one booking:
+  payer:amount                   payer covers the full amount alone
+  payer:amount:t1,t2,t3          payer fronted; split equally among t1,t2,t3
+  payer:amount:t1=w1,t2=w2       weighted split (weights are relative, not %)
+
+Use --file with a JSON array of Booking objects for richer input.
+
+Examples:
+  trvl expenses alice:300:alice,bob,carol bob:150:bob,carol carol:90:carol
+  trvl expenses alice:500 bob:200:alice,bob
+  trvl expenses --file bookings.json --format json`,
+		Args: cobra.ArbitraryArgs,
+		RunE: runExpenses,
+	}
+	cmd.Flags().String("file", "", "Path to JSON file with bookings array")
+	return cmd
+}
+
+func runExpenses(cmd *cobra.Command, args []string) error {
+	filePath, _ := cmd.Flags().GetString("file")
+	format, _ := cmd.Flags().GetString("format")
+	var bookings []expenses.Booking
+	var err error
+	if filePath != "" {
+		bookings, err = loadBookingsFromFile(filePath)
+	} else {
+		if len(args) == 0 {
+			return fmt.Errorf("expenses: provide booking args or --file path")
+		}
+		bookings, err = parseBookingArgs(args)
+	}
+	if err != nil {
+		return fmt.Errorf("expenses: %w", err)
+	}
+	settlement := expenses.Reconcile(bookings)
+	if format == "json" {
+		return json.NewEncoder(os.Stdout).Encode(settlement)
+	}
+	fmt.Fprint(os.Stdout, expenses.Render(settlement))
+	return nil
+}
+
+func loadBookingsFromFile(path string) ([]expenses.Booking, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open file: %w", err)
+	}
+	defer f.Close()
+	var b []expenses.Booking
+	if err := json.NewDecoder(f).Decode(&b); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	return b, nil
+}
+
+func parseBookingArgs(args []string) ([]expenses.Booking, error) {
+	out := make([]expenses.Booking, 0, len(args))
+	for i, arg := range args {
+		parts := strings.SplitN(arg, ":", 3)
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("invalid booking %q: expected payer:amount[:travellers]", arg)
+		}
+		payer := strings.TrimSpace(parts[0])
+		if payer == "" {
+			return nil, fmt.Errorf("invalid booking %q: payer must not be empty", arg)
+		}
+		amount, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid booking %q: amount must be a number: %w", arg, err)
+		}
+		var split []expenses.ShareEntry
+		if len(parts) == 3 {
+			split, err = parseSplit(parts[2])
+			if err != nil {
+				return nil, fmt.Errorf("invalid booking %q split: %w", arg, err)
+			}
+		} else {
+			split = []expenses.ShareEntry{{Traveller: payer, Weight: 1}}
+		}
+		out = append(out, expenses.Booking{ID: fmt.Sprintf("booking-%d", i+1), Payer: payer, Amount: amount, Split: split})
+	}
+	return out, nil
+}
+
+func parseSplit(raw string) ([]expenses.ShareEntry, error) {
+	tokens := strings.Split(raw, ",")
+	out := make([]expenses.ShareEntry, 0, len(tokens))
+	for _, tok := range tokens {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		if idx := strings.Index(tok, "="); idx >= 0 {
+			name := strings.TrimSpace(tok[:idx])
+			w, err := strconv.ParseFloat(strings.TrimSpace(tok[idx+1:]), 64)
+			if err != nil {
+				return nil, fmt.Errorf("weight for %q must be a number", name)
+			}
+			out = append(out, expenses.ShareEntry{Traveller: name, Weight: w})
+		} else {
+			out = append(out, expenses.ShareEntry{Traveller: tok, Weight: 1})
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("split must contain at least one traveller")
+	}
+	return out, nil
+}

--- a/cmd/trvl/los.go
+++ b/cmd/trvl/los.go
@@ -1,0 +1,88 @@
+package main
+
+// MIK-3087: trvl los — length-of-stay rate-flip scanner.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/los"
+	"github.com/spf13/cobra"
+)
+
+func losCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "los <nights:total-price>...",
+		Short: "Detect length-of-stay rate flips — stay longer, pay less",
+		Long: `los scans hotel stay quotes and flags cases where extending or shortening
+the stay results in absolute savings or a lower per-night rate (>= 5% lower).
+
+Each positional argument is a nights:total-price pair. Append :r for refundable.
+The --baseline flag picks which nights value is the user's requested stay.
+
+Examples:
+  trvl los --baseline 7 5:420 6:480 7:560 8:530 9:495
+  trvl los --baseline 5 4:320 5:400 6:450 7:420:r --format json`,
+		Args: cobra.MinimumNArgs(2),
+		RunE: runLos,
+	}
+	cmd.Flags().Int("baseline", 0, "Baseline nights (the stay length the user requested) — required")
+	_ = cmd.MarkFlagRequired("baseline")
+	return cmd
+}
+
+func runLos(cmd *cobra.Command, args []string) error {
+	baseline, _ := cmd.Flags().GetInt("baseline")
+	format, _ := cmd.Flags().GetString("format")
+	quotes, err := parseLOSQuotes(args)
+	if err != nil {
+		return fmt.Errorf("los: %w", err)
+	}
+	flips := los.ScanLengthOfStay(baseline, quotes)
+	if format == "json" {
+		return json.NewEncoder(os.Stdout).Encode(flips)
+	}
+	renderLosTable(os.Stdout, baseline, flips)
+	return nil
+}
+
+func parseLOSQuotes(args []string) ([]los.LOSQuote, error) {
+	out := make([]los.LOSQuote, 0, len(args))
+	for _, arg := range args {
+		parts := strings.Split(arg, ":")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("invalid quote %q: expected nights:total-price[:r]", arg)
+		}
+		nights, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+		if err != nil || nights <= 0 {
+			return nil, fmt.Errorf("invalid quote %q: nights must be a positive integer", arg)
+		}
+		total, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid quote %q: price must be a number: %w", arg, err)
+		}
+		refundable := len(parts) >= 3 && strings.EqualFold(strings.TrimSpace(parts[2]), "r")
+		out = append(out, los.LOSQuote{Nights: nights, TotalPrice: total, Refundable: refundable})
+	}
+	return out, nil
+}
+
+func renderLosTable(out *os.File, baseline int, flips []los.Flip) {
+	if len(flips) == 0 {
+		fmt.Fprintf(out, "No rate flips detected for %d-night baseline.\n", baseline)
+		return
+	}
+	fmt.Fprintf(out, "Length-of-stay alternatives (baseline %d nights):\n", baseline)
+	fmt.Fprintf(out, "  %-20s %7s %7s %10s %10s %10s  %s\n", "Kind", "Base N", "Alt N", "Base Total", "Alt Total", "Delta", "Reason")
+	fmt.Fprintf(out, "  %s\n", strings.Repeat("-", 90))
+	for _, f := range flips {
+		refStr := ""
+		if f.Refundable {
+			refStr = " (refundable)"
+		}
+		fmt.Fprintf(out, "  %-20s %7d %7d %10.2f %10.2f %+10.2f  %s%s\n", f.Kind, f.BaselineNights, f.AlternativeNights, f.BaselineTotal, f.AlternativeTotal, f.TotalDelta, f.Reason, refStr)
+	}
+}

--- a/cmd/trvl/multidest.go
+++ b/cmd/trvl/multidest.go
@@ -1,0 +1,81 @@
+package main
+
+// MIK-3080: trvl multidest — multi-destination trip bundle ranker.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/multidest"
+	"github.com/spf13/cobra"
+)
+
+func multidestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "multidest",
+		Short: "Rank multi-destination city orderings by total trip cost",
+		Long: `multidest reads candidate city orderings from stdin or --file (JSON) and
+outputs the top-K bundles ranked by grand total (flights + hotels).
+
+Input JSON schema (array of Ordering objects):
+  [{"cities":["AMS","ROM"],"legs":[{"origin":"AMS","destination":"ROM","date":"2026-06-01","price":120}],"hotels":[{"city":"ROM","check_in":"2026-06-01","check_out":"2026-06-05","total_price":400}]}]
+
+Examples:
+  cat orderings.json | trvl multidest
+  trvl multidest --file orderings.json --top-k 5 --format json`,
+		Args: cobra.NoArgs,
+		RunE: runMultidest,
+	}
+	cmd.Flags().String("file", "", "Path to JSON file with orderings (default: read stdin)")
+	cmd.Flags().Int("top-k", 3, "Number of top bundles to show after drill-down")
+	cmd.Flags().Int("screen-k", 3, "Number of orderings to keep after flight-only screen")
+	return cmd
+}
+
+func runMultidest(cmd *cobra.Command, args []string) error {
+	filePath, _ := cmd.Flags().GetString("file")
+	topK, _ := cmd.Flags().GetInt("top-k")
+	screenK, _ := cmd.Flags().GetInt("screen-k")
+	format, _ := cmd.Flags().GetString("format")
+	var r *os.File
+	if filePath != "" {
+		f, err := os.Open(filePath)
+		if err != nil {
+			return fmt.Errorf("multidest: cannot open file: %w", err)
+		}
+		defer f.Close()
+		r = f
+	} else {
+		r = os.Stdin
+	}
+	var orderings []multidest.Ordering
+	if err := json.NewDecoder(r).Decode(&orderings); err != nil {
+		return fmt.Errorf("multidest: invalid JSON input: %w", err)
+	}
+	opt := multidest.ScreenOptions{TopKAfterScreen: screenK, TopKFinal: topK}
+	bundles := multidest.ScreenAndDrillDown(orderings, opt)
+	if format == "json" {
+		return json.NewEncoder(os.Stdout).Encode(bundles)
+	}
+	renderMultidestTable(os.Stdout, bundles)
+	return nil
+}
+
+func renderMultidestTable(out *os.File, bundles []multidest.Bundle) {
+	if len(bundles) == 0 {
+		fmt.Fprintln(out, "No bundles to rank — check input orderings.")
+		return
+	}
+	fmt.Fprintf(out, "Top %d multi-destination bundles:\n", len(bundles))
+	fmt.Fprintf(out, "  %-4s  %-28s %10s %10s %10s  %s\n", "Rank", "Cities", "Flights", "Hotels", "Total", "Notes")
+	fmt.Fprintf(out, "  %s\n", strings.Repeat("-", 78))
+	for _, b := range bundles {
+		cities := strings.Join(b.Cities, " -> ")
+		if len(cities) > 28 {
+			cities = cities[:25] + "..."
+		}
+		fmt.Fprintf(out, "  #%-3d  %-28s %10.2f %10.2f %10.2f  %s\n", b.Rank, cities, b.FlightTotal, b.HotelTotal, b.GrandTotal, b.Reason)
+	}
+}

--- a/cmd/trvl/opportunityscore.go
+++ b/cmd/trvl/opportunityscore.go
@@ -1,0 +1,111 @@
+package main
+
+// MIK-3065: trvl opportunity-score — opportunity signal scorer.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/opportunity"
+	"github.com/spf13/cobra"
+)
+
+func opportunityScoreCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "opportunity-score <dest:depart:return:profile:request:deal>...",
+		Short: "Rank travel opportunity candidates by weighted signal score",
+		Long: `opportunity-score scores candidates using 0.4*ProfileMatch + 0.2*RequestMatch + 0.4*DealQuality.
+Each candidate is a colon-separated sextuple:
+  destination:depart-date:return-date:profile-score:request-score:deal-score
+
+Signal scores are 0-100. Candidates below --min-score are dropped.
+Use --file with a JSON array of Candidate objects for richer input.
+
+Examples:
+  trvl opportunity-score PRG:2026-06-15:2026-06-22:90:70:95
+  trvl opportunity-score PRG:2026-06-15:2026-06-22:90:70:95 ROM:2026-07-01:2026-07-08:60:80:75 --min-score 70
+  trvl opportunity-score --file candidates.json --format json`,
+		Args: cobra.ArbitraryArgs,
+		RunE: runOpportunityScore,
+	}
+	cmd.Flags().Float64("min-score", 0, "Minimum overall score to include (0 = keep all)")
+	cmd.Flags().String("file", "", "Path to JSON file with candidates array")
+	return cmd
+}
+
+func runOpportunityScore(cmd *cobra.Command, args []string) error {
+	minScore, _ := cmd.Flags().GetFloat64("min-score")
+	filePath, _ := cmd.Flags().GetString("file")
+	format, _ := cmd.Flags().GetString("format")
+	var candidates []opportunity.Candidate
+	var err error
+	if filePath != "" {
+		candidates, err = loadCandidatesFromFile(filePath)
+	} else {
+		if len(args) == 0 {
+			return fmt.Errorf("opportunity-score: provide candidate args or --file path")
+		}
+		candidates, err = parseCandidateArgs(args)
+	}
+	if err != nil {
+		return fmt.Errorf("opportunity-score: %w", err)
+	}
+	ranked := opportunity.FilterAndRank(candidates, opportunity.Weights{}, minScore)
+	if format == "json" {
+		return json.NewEncoder(os.Stdout).Encode(ranked)
+	}
+	renderOpportunityTable(os.Stdout, ranked)
+	return nil
+}
+
+func loadCandidatesFromFile(path string) ([]opportunity.Candidate, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open file: %w", err)
+	}
+	defer f.Close()
+	var c []opportunity.Candidate
+	if err := json.NewDecoder(f).Decode(&c); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	return c, nil
+}
+
+func parseCandidateArgs(args []string) ([]opportunity.Candidate, error) {
+	out := make([]opportunity.Candidate, 0, len(args))
+	for _, arg := range args {
+		parts := strings.SplitN(arg, ":", 6)
+		if len(parts) != 6 {
+			return nil, fmt.Errorf("invalid candidate %q: expected dest:depart:return:profile:request:deal (6 fields)", arg)
+		}
+		profile, err := strconv.ParseFloat(strings.TrimSpace(parts[3]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid candidate %q: profile score must be a number", arg)
+		}
+		request, err := strconv.ParseFloat(strings.TrimSpace(parts[4]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid candidate %q: request score must be a number", arg)
+		}
+		deal, err := strconv.ParseFloat(strings.TrimSpace(parts[5]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid candidate %q: deal score must be a number", arg)
+		}
+		out = append(out, opportunity.Candidate{Destination: strings.TrimSpace(parts[0]), DepartDate: strings.TrimSpace(parts[1]), ReturnDate: strings.TrimSpace(parts[2]), Signals: opportunity.Signals{ProfileMatch: profile, RequestMatch: request, DealQuality: deal}})
+	}
+	return out, nil
+}
+
+func renderOpportunityTable(out *os.File, candidates []opportunity.Candidate) {
+	if len(candidates) == 0 {
+		fmt.Fprintln(out, "No candidates above minimum score threshold.")
+		return
+	}
+	fmt.Fprintf(out, "%-4s  %-8s  %-12s  %-12s  %7s  %7s  %7s  %7s  %s\n", "Rank", "Dest", "Depart", "Return", "Profile", "Request", "Deal", "Overall", "Verdict")
+	fmt.Fprintf(out, "%s\n", strings.Repeat("-", 88))
+	for i, c := range candidates {
+		fmt.Fprintf(out, "#%-3d  %-8s  %-12s  %-12s  %7.1f  %7.1f  %7.1f  %7.1f  %s\n", i+1, c.Destination, c.DepartDate, c.ReturnDate, c.Signals.ProfileMatch, c.Signals.RequestMatch, c.Signals.DealQuality, c.Overall, c.Reason)
+	}
+}

--- a/cmd/trvl/railpass.go
+++ b/cmd/trvl/railpass.go
@@ -1,0 +1,105 @@
+package main
+
+// MIK-3086: trvl rail-pass — rail-pass break-even advisor.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/railpass"
+	"github.com/spf13/cobra"
+)
+
+func railPassCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rail-pass <pass-cost> <leg-cost>...",
+		Short: "Rail-pass break-even: is the pass cheaper than point-to-point?",
+		Long: `rail-pass compares a rail pass cost against the stack of point-to-point
+segment prices and returns a verdict: buy_pass, skip_pass, or marginal.
+
+The first argument is the pass activation cost.
+Subsequent arguments are leg prices as a bare number (e.g. 120) or as
+operator:origin:destination:price[:reservation-fee] (e.g. DB:AMS:BRU:89:19).
+
+Examples:
+  trvl rail-pass 299 120 95 110
+  trvl rail-pass 349 DB:AMS:BRU:89:19 SNCF:PAR:LYS:45
+  trvl rail-pass 299 120 95 110 --pass-name "Interrail 4-in-1month" --format json`,
+		Args: cobra.MinimumNArgs(2),
+		RunE: runRailPass,
+	}
+	cmd.Flags().String("pass-name", "Rail Pass", "Name of the pass being evaluated")
+	cmd.Flags().Int("days", 0, "Number of travel days the pass covers")
+	cmd.Flags().Bool("res-included", false, "Reservation fees already included in pass cost")
+	return cmd
+}
+
+func runRailPass(cmd *cobra.Command, args []string) error {
+	format, _ := cmd.Flags().GetString("format")
+	passName, _ := cmd.Flags().GetString("pass-name")
+	days, _ := cmd.Flags().GetInt("days")
+	resIncluded, _ := cmd.Flags().GetBool("res-included")
+	passCost, err := strconv.ParseFloat(strings.TrimSpace(args[0]), 64)
+	if err != nil {
+		return fmt.Errorf("rail-pass: pass-cost must be a number: %w", err)
+	}
+	segments, err := parseRailSegments(args[1:])
+	if err != nil {
+		return fmt.Errorf("rail-pass: %w", err)
+	}
+	pass := railpass.PassOption{Name: passName, Cost: passCost, Days: days, ReservationsIncluded: resIncluded}
+	rec := railpass.EvaluatePass(pass, segments)
+	if format == "json" {
+		return json.NewEncoder(os.Stdout).Encode(rec)
+	}
+	renderRailPassTable(os.Stdout, rec)
+	return nil
+}
+
+func parseRailSegments(args []string) ([]railpass.PointToPointSegment, error) {
+	out := make([]railpass.PointToPointSegment, 0, len(args))
+	for _, arg := range args {
+		parts := strings.Split(arg, ":")
+		switch len(parts) {
+		case 1:
+			price, err := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid leg %q: must be a number", arg)
+			}
+			out = append(out, railpass.PointToPointSegment{Price: price})
+		case 4:
+			price, err := strconv.ParseFloat(strings.TrimSpace(parts[3]), 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid leg %q: price must be a number", arg)
+			}
+			out = append(out, railpass.PointToPointSegment{Operator: strings.TrimSpace(parts[0]), Origin: strings.TrimSpace(parts[1]), Destination: strings.TrimSpace(parts[2]), Price: price})
+		case 5:
+			price, err := strconv.ParseFloat(strings.TrimSpace(parts[3]), 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid leg %q: price must be a number", arg)
+			}
+			resFee, err := strconv.ParseFloat(strings.TrimSpace(parts[4]), 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid leg %q: reservation-fee must be a number", arg)
+			}
+			out = append(out, railpass.PointToPointSegment{Operator: strings.TrimSpace(parts[0]), Origin: strings.TrimSpace(parts[1]), Destination: strings.TrimSpace(parts[2]), Price: price, ReservationFee: resFee})
+		default:
+			return nil, fmt.Errorf("invalid leg %q: use number or operator:origin:destination:price[:fee]", arg)
+		}
+	}
+	return out, nil
+}
+
+func renderRailPassTable(out *os.File, rec railpass.Recommendation) {
+	fmt.Fprintf(out, "Rail pass evaluation: %s\n", rec.PassName)
+	fmt.Fprintf(out, "  Point-to-point total:  %.2f\n", rec.PointToPointTotal)
+	fmt.Fprintf(out, "  Pass effective cost:   %.2f\n", rec.PassTotalEffective)
+	fmt.Fprintf(out, "  Savings (p2p - pass):  %+.2f\n", rec.Savings)
+	fmt.Fprintf(out, "  Break-even segments:   %d\n", rec.BreakEvenSegments)
+	fmt.Fprintf(out, "  Segments scored:       %d\n", rec.SegmentsScored)
+	fmt.Fprintf(out, "  Verdict:               %s\n", rec.Verdict)
+	fmt.Fprintf(out, "  Reason:                %s\n", rec.Reason)
+}

--- a/cmd/trvl/root.go
+++ b/cmd/trvl/root.go
@@ -96,6 +96,12 @@ func init() {
 	rootCmd.AddCommand(profileCmd())
 	rootCmd.AddCommand(opportunitiesCmd())
 	rootCmd.AddCommand(awardsCmd())
+	rootCmd.AddCommand(cabinArbCmd())
+	rootCmd.AddCommand(multidestCmd())
+	rootCmd.AddCommand(losCmd())
+	rootCmd.AddCommand(railPassCmd())
+	rootCmd.AddCommand(expensesCmd())
+	rootCmd.AddCommand(opportunityScoreCmd())
 }
 
 // airportCompletion provides IATA code completion for cobra commands.


### PR DESCRIPTION
## Summary

- **cabin-arb** (`trvl cabin-arb`): cabin-class upgrade-ladder detector via `internal/cabinarb` (MIK-3090)
- **multidest** (`trvl multidest`): multi-destination bundle ranker via `internal/multidest` (MIK-3080)
- **los** (`trvl los`): length-of-stay rate-flip scanner via `internal/los` (MIK-3087)
- **rail-pass** (`trvl rail-pass`): rail-pass break-even advisor via `internal/railpass` (MIK-3086)
- **expenses** (`trvl expenses`): shared-trip expense reconciler via `internal/expenses` (MIK-3088)
- **opportunity-score** (`trvl opportunity-score`): opportunity signal scorer via `internal/opportunity` (MIK-3065)

All 6 commands follow the `forecast.go` wiring pattern. Root subcommand count updated 50 → 56. MCP tool wiring is out-of-scope (separate follow-up).

## Commit

- a1e79ed feat: wire 6 dormant math packages into CLI (MIK-3065/3080/3086/3087/3088/3090)

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go test -short ./internal/cabinarb ./internal/multidest ./internal/los ./internal/railpass ./internal/expenses ./internal/opportunity` — all 6 packages green
- [ ] `go test -short ./cmd/trvl -run TestRootCmd` — subcommand count (56) passes
- [ ] Pre-existing `TestPublicDocsAdvertiseCurrentCounts` failure is unrelated to this PR (in-flight work on awards branch, not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)