### PR TITLE
docs: sync advertised tool counts to live numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # trvl
 
-Travel MCP server + CLI. 57 MCP tools, 42 CLI commands. Go 1.26, no frameworks.
+Travel MCP server + CLI. 61 MCP tools, 50 CLI commands. Go 1.26, no frameworks.
 
 ## Product Vision
 
-trvl is a travel MCP server + CLI that gives any AI assistant (Claude, Cursor, Windsurf, Codex, …) direct access to flights, hotels, trains, buses, ferries, price alerts, travel hacks, weather, baggage rules, airport lounges, and destination intelligence — **without requiring personal API keys**. Single Go binary, MCP 2025-11-25 compliant, 57 MCP tools, 42 CLI commands, API-first with optional browser-assisted fallbacks for a handful of protected providers.
+trvl is a travel MCP server + CLI that gives any AI assistant (Claude, Cursor, Windsurf, Codex, …) direct access to flights, hotels, trains, buses, ferries, price alerts, travel hacks, weather, baggage rules, airport lounges, and destination intelligence — **without requiring personal API keys**. Single Go binary, MCP 2025-11-25 compliant, 61 MCP tools, 50 CLI commands, API-first with optional browser-assisted fallbacks for a handful of protected providers.
 
 ## Current Status
 
@@ -13,7 +13,7 @@ trvl is a travel MCP server + CLI that gives any AI assistant (Claude, Cursor, W
 - Flight providers: Google Flights (hand-rolled protobuf), Air France–KLM Offers API v3 (opt-in)
 - CI: build, vet, staticcheck, govulncheck, race tests, coverage ≥50% on ubuntu + windows
 - Latest release train: tag-triggered workflow + adhoc codesign identifier (PR #50)
-- npm wrapper, ICS calendar export, 55→57 tool bump landed in last ~90d
+- npm wrapper, ICS calendar export, 57→61 tool bump landed in last ~90d (MIK-3081/3082/3083/3084 + 6-package wiring batch in PR #57)
 
 ## Plan Forward (near-term, technical)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 > **61 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, travel hacks, award sweet spots, weather forecasts, baggage rules, airport lounges, destination intel. Free. API-first.**
 >
-> Also works as a standalone CLI with 44 commands.
+> Also works as a standalone CLI with 50 commands.
 
 ### What it looks like
 
@@ -348,7 +348,7 @@ See [Quick Setup step 3](#3-optional-teach-your-ai-about-trvl) above for AGENTS.
 
 ## CLI Usage
 
-trvl also works as a standalone CLI tool with 44 commands:
+trvl also works as a standalone CLI tool with 50 commands:
 
 All search commands accept `--currency <CODE>` (e.g. `--currency EUR`) to convert displayed prices. trvl detects the actual API currency and converts at the display layer — no hardcoded currencies.
 
@@ -643,7 +643,7 @@ The AI uses these to give you actionable recommendations: "Book here: [link]". N
 | **Data** | Real-time from Google Flights + 5 hotel sources (Google Hotels, Trivago, Airbnb, Booking.com, Hostelworld) + 20 ground providers (FlixBus, RegioJet, Eurostar, DB, ÖBB, NS, VR, SNCF, Trainline, Transitous, Renfe, European Sleeper, Snälltåget, Tallink, Viking Line, Eckerö Line, Finnlines, Stena Line, DFDS, Ferryhopper) + 5 free destination APIs |
 | **Auth** | No personal API keys required. Two providers (NS, Digitransit/VR) use public keys embedded in the binary. Optional browser/cookie fallbacks are available for protected providers when explicitly enabled. |
 | **MCP** | Full v2025-11-25 — 61 tools (incl. 4 profile tools, 3 price watch tools, provider health, award sweet-spot scanning), 7 prompts, resources, structured content, progress notifications, resource subscriptions, tool description orchestration |
-| **CLI** | 44 commands (+ 7 watch subcommands) with table/JSON output, color, shell completion |
+| **CLI** | 50 commands (+ 7 watch subcommands) with table/JSON output, color, shell completion |
 | **Booking links** | Every flight and hotel result includes a direct Google booking link |
 | **Travel hacks** | 37 detectors (throwaway, hidden-city, positioning, ferry, multi-modal, stopover, date-flex, error fare, back-to-back, rail competition, and more) |
 | **Personal profile** | Learns from your booking history (email parsing + LLM). Remembers FF status, luggage needs, favourite properties, departure preferences, travel hacks used, accommodation preferences, family composition. Pre-search interviews skip questions the profile already answers. |

--- a/cmd/trvl/public_claims_test.go
+++ b/cmd/trvl/public_claims_test.go
@@ -21,7 +21,7 @@ import (
 // The dynamic count from rootCmd.Commands() includes all cobra-registered
 // commands, but marketing materials only count functional travel commands.
 // Current exclusions: version, providers (both are utility/meta commands).
-const cliCommandCountMarketed = 44
+const cliCommandCountMarketed = 50
 
 var readmeToolMarkers = []string{
 	"search_flights",

--- a/demo.tape
+++ b/demo.tape
@@ -67,7 +67,7 @@ Sleep 3s
 # ═══ CLOSING ═══
 
 Sleep 300ms
-Type "# 61 MCP tools · 44 CLI commands · 21 providers · No API keys"
+Type "# 61 MCP tools · 50 CLI commands · 21 providers · No API keys"
 Enter
 Sleep 300ms
 Type "# brew install MikkoParkkola/tap/trvl"


### PR DESCRIPTION
## Summary
- After PR #57 wired 6 dormant math packages, public docs + the public-claims test still advertised pre-batch counts (44 CLI, 57 MCP).
- Updates 4 files the existing TestPublicDocsAdvertiseCurrentCounts enforces, plus the cliCommandCountMarketed constant.

## Evidence
- Live MCP tools list probe: **61 tools**
- rootCmd.Commands() count: **56** (50 marketed; 6 utility commands excluded — version, providers, help, completion, etc.)
- go test -short ./cmd ./mcp: green

## Changes
| File | Before | After |
|---|---|---|
| cmd public_claims_test.go | cliCommandCountMarketed = 44 | = 50 |
| CLAUDE.md (header + status) | 57 MCP, 42 CLI | 61 MCP, 50 CLI |
| README.md (3 places) | 44 commands | 50 commands |
| demo.tape | 61 MCP, 44 CLI | 61 MCP, 50 CLI |

## Test plan
- [x] go test -short -run TestPublicDocsAdvertiseCurrentCounts ./cmd ... — green
- [x] go test -short ./cmd ./mcp — green
- [x] Live tools-list probe confirms 61 tools

## Rollback
git revert 17f7965 — pure doc + test-constant change, zero behavior impact.

Generated with Claude Code
