### PR TITLE
docs: pre-release wip — providers skill, count drift to 61

### DIFF
--- a/.claude/skills/trvl.md
+++ b/.claude/skills/trvl.md
@@ -45,10 +45,15 @@ allowed-tools:
 # trvl — AI Travel Agent
 
 ## LOAD PROFILE
-Read `~/.claude/travel-profile.md` if exists. Apply: departure time prefs, FF status→airline preference, luggage costs, free layover cities, favourite accommodations, personal hacks.
+Read `~/.trvl/preferences.json` and `~/.trvl/profile.json` if they exist. Fallback to `~/.claude/travel-profile.md` only for older installs. Also call `get_preferences` before real searches so defaults reflect the live trvl store.
+
+Apply: home airports/cities, nationality for visas, display currency, carry-on/checked-bag needs, departure-time limits, FF status and lounge cards, hotel dealbreakers, preferred districts/properties, travel companions, previous trips, bucket list, and known personal hacks. Never print booking refs, loyalty numbers, passport data, emails, phone numbers, or private notes unless explicitly needed.
 
 ## ASK FIRST (2-3 Qs max)
-From?|To?|When?|Flex?|Travelers?|Budget? Check calendar (Google/Apple/manual) for conflicts. Don't re-ask obvious info.
+From?|To?|When?|Flex?|Travelers?|Budget? Check calendar (Google/Apple/manual) for conflicts when relevant. Do not re-ask facts already in the profile.
+
+## TOOL ROUTING
+Use `mcp__gateway__gateway_invoke` with `server="trvl"` and the tool name. Use `mcp__gateway__gateway_search_tools` only when the schema or tool availability is unclear.
 
 ## CORE TOOLS (selected high-signal tools; trvl exposes 61 MCP tools overall via gateway_invoke server="trvl")
 | Tool | Use | Key params |
@@ -58,7 +63,8 @@ From?|To?|When?|Flex?|Travelers?|Budget? Check calendar (Google/Apple/manual) fo
 | `search_hotels` | Hotels by city | location,check_in,check_out,[guests,stars,eco_certified] |
 | `hotel_prices` | Provider comparison | hotel_id,check_in,check_out |
 | `hotel_reviews` | Reviews for hotel | hotel_id,[limit,sort] |
-| `explore_destinations` | Where to go? | origin,[start_date,end_date] |
+| `hotel_rooms` | Room/rate details | hotel_name,check_in,check_out,[currency] |
+| `search_natural` | Natural-language travel search | query |
 | `destination_info` | Weather+safety+currency | location,[travel_dates] |
 | `calculate_trip_cost` | Total: flights+hotel | origin,destination,depart_date,return_date |
 | `suggest_dates` | Smart date advice | origin,destination,target_date,[flex_days] |
@@ -70,20 +76,37 @@ From?|To?|When?|Flex?|Travelers?|Budget? Check calendar (Google/Apple/manual) fo
 | `search_ground` | Bus/train/ferry (20 providers) | from,to,date,[currency,type,provider] |
 | `search_airport_transfers` | Airport→hotel or city transfers + taxi estimates | airport_code,destination,date,[provider] |
 | `search_restaurants` | Restaurants near location | location,[query,limit] |
+| `search_deals` | Cheap deal discovery | [origin,max_price,type] |
 | `plan_trip` | Flights + hotel in one parallel search | origin,destination,depart_date,[return_date,budget] |
 | `search_route` | Multi-modal routing across flights, trains, buses, and ferries | from,to,[depart_after,arrive_by] |
+| `plan_flight_bundle` | Best flight package / bundle candidates | origin,destination,departure_date,[return_date] |
+| `find_interactive` | Guided interactive finder | query,[context] |
 | `get_weather` | Weather forecast for a city | location,[travel_dates] |
 | `get_baggage_rules` | Airline carry-on and checked-bag rules | airline |
+| `search_lounges` | Airport lounge access | airport |
+| `check_visa` | Passport→destination entry requirement check | nationality,destination |
+| `calculate_points_value` | Points vs cash redemption value | program,points,cash_price |
 | `optimize_trip_dates` | Cheapest dates across range (1 API call) | origin,destination,from_date,to_date,trip_length |
 | `assess_trip` | GO/WAIT/NO_GO viability check | origin,destination,depart_date,return_date,[passport] |
 | `optimize_booking` | Unified optimizer: all combos | origin,destination,departure_date,[return_date,flex_days,carry_on_only] |
 | `detect_travel_hacks` | Run 37 parallel hack detectors | origin,destination,date,[return_date,carry_on] |
 | `detect_accommodation_hacks` | Split stay across hotels to save | city,check_in,check_out |
 | `search_hotel_by_name` | Find specific property across all providers | name,check_in,check_out,[location] |
+| `watch_room_availability` | Monitor specific room/property availability | hotel_name,check_in,check_out |
+| `get_preferences` | Read saved preferences | (none) |
+| `update_preferences` | Save confirmed preference changes | field/value updates |
+| `build_profile` | Build profile from booking history | source,[query] |
+| `add_booking` | Add a known booking to profile/history | type,provider,[reference,notes] |
+| `interview_trip` | Ask only missing pre-search questions | destination,[dates] |
 | `onboard_profile` | Progressive traveller interview (5 phases) | phase,[answers] |
+| `list_trips` / `get_trip` | Read persistent trip objects | [trip_id] |
+| `create_trip` / `add_trip_leg` / `mark_trip_booked` | Maintain trip state | trip_id,type,... |
+| `export_ics` | Export a trip as calendar ICS | trip_id |
 | `watch_price` | Create price alert with target | type,origin,destination,date,target_price |
 | `list_watches` | Show all active price watches | (none) |
 | `check_watches` | Re-check all watches for price drops | (none) |
+| `configure_provider` / `list_providers` | Configure or inspect optional providers | provider,config |
+| `suggest_providers` / `test_provider` / `remove_provider` | Provider catalog, validation, removal | provider |
 | `provider_health` | Provider success rate + latency | (none) |
 
 ## ALWAYS RUN THESE CHECKS
@@ -101,26 +124,25 @@ When the user asks about a trip, ALWAYS try optimize_booking first:
 3. For each option, explain which hacks were applied
 4. Show all-in costs (including bags adjusted for FF status)
 
+Fallback if `optimize_booking` is unavailable: run `search_dates`/`suggest_dates`, `search_flights`, `search_hotels` or `search_hotel_by_name`, `search_ground`/`search_route`, then `detect_travel_hacks` and `detect_accommodation_hacks`.
+
+## PROFILE WORKFLOW
+New user: run `onboard_profile` phases 1-5. Returning user: read profile first, then use `interview_trip` for only the missing constraints.
+
+If the user permits email/calendar scanning, run `build_profile` or collect booking confirmations and use `add_booking` to build evidence. Show inferred preferences as a draft and save only confirmed changes with `update_preferences`.
+
+Profile fields drive ranking and hack eligibility: `carry_on_only` gates hidden-city/throwaway ideas; `nationality` gates visa checks; FF status affects bag fees, lounge access, and points value; preferred districts and hotel floors affect lodging filters; home airports and nearby airports affect positioning searches.
+
 ## HACKS (37 detectors — apply when relevant)
-| Hack | When | Detection |
-|------|------|-----------|
-| Positioning flights | Long-haul expensive | explore→cheap hub→search(hub,dest) |
-| Hotel split | 4+ nights | Search weekday + weekend separately |
-| Hidden city | Expensive direct | Search A→C-via-B, compare. ⚠️Warn risks |
-| Throw-away return | One-way > round-trip | Compare, suggest skip return |
-| KLM/AF connections | Via AMS | 1-stop sometimes cheaper than nonstop |
-| Open-jaw | Multi-city | Fly in A, out of B, save backtracking |
-| Train+flight | Europe | Nearby city by train + cheaper flight |
-| Bus vs train | Short haul | search_ground both, compare FlixBus vs RegioJet vs Eurostar |
-| Overnight bus | Long routes | FlixBus night buses save hotel night |
-| Eurostar deals | London↔EU | search_ground London Paris — Eurostar auto-included |
-| Accommodation split | 4+ nights | detect_accommodation_hacks — saves 15%+ |
-| Cross-provider savings | Multi-source hotel | hotel search auto-shows cheapest source |
-| Flight combo | RT vs split airlines | DetectFlightCombo — compares RT vs 2x one-way |
-| Nested returns | 2+ trips same route | DetectFlightCombo — swaps return legs across trips |
-| Error fare | Price anomaly | haversine distance -> route tier -> floor comparison |
-| Flash sale | Below-floor price | Same as error_fare but above error threshold |
-| Trip viability | Before booking | assess_trip — GO/WAIT/NO_GO with cost breakdown |
+Use `detect_travel_hacks` for flight/ground opportunities and `detect_accommodation_hacks` for lodging. Always explain risk and eligibility.
+
+Flight pricing: throwaway, hidden_city, positioning, split, stopover, date_flex, open_jaw, multi_stop, currency_arbitrage, tuesday_booking, low_cost_carrier, advance_purchase, group_split, fare_breakpoint, destination_airport, departure_tax, back_to_back, mileage_run, error_fare.
+
+Multimodal/ground: night_transport, ferry_positioning, multimodal_skip_flight, multimodal_positioning, multimodal_open_jaw_ground, multimodal_return_split, rail_fly_arbitrage, throwaway_ground, eurostar_return, cross_border_rail, ferry_cabin, self_transfer, regional_pass, rail_competition.
+
+Context/risk/value: calendar_conflict, eu261, day_use, hotel split, cross-provider accommodation savings.
+
+Risk rules: hidden-city/throwaway only when carry-on-only; self-transfer/positioning needs buffer time; overnight buffer for expensive long-haul or separate tickets; error fares require urgency plus cancellation risk warning; visas/passport/health/legal/current purchase facts need authoritative verification.
 
 ## OUTPUT FORMAT
 Be DECISIVE — 1 recommendation, not 50 options. Show exact details:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,18 +39,19 @@ claude mcp add trvl --transport stdio -- trvl mcp
 
 ```bash
 mkdir -p ~/.claude/skills
-for s in trvl; do
+for s in trvl providers; do
   curl -fsSL "https://raw.githubusercontent.com/MikkoParkkola/trvl/main/.claude/skills/$s.md" -o "$HOME/.claude/skills/$s.md"
 done
 ```
 
-The skill at `.claude/skills/trvl.md` teaches you how to:
+The skills at `.claude/skills/trvl.md` and `.claude/skills/providers.md` teach you how to:
 - Ask the right questions (From? To? When? Flex? Budget?)
 - Run hack detectors automatically after every search
 - Use the unified optimizer (`optimize_booking`) for trip planning
 - Show the "Naive -> Optimized -> Saved" comparison after every plan
 - Use all-in pricing with FF benefits (bag fees included, status benefits subtracted)
 - Apply 37 travel hack detectors to find savings opportunities
+- Configure optional hotel/restaurant/ground providers only after verified source-code research and user consent
 
 ### Step 4: Verify
 

--- a/README.md
+++ b/README.md
@@ -102,12 +102,14 @@ claude mcp add trvl --transport stdio -- trvl mcp
 
 ### 3. (Optional) Teach your AI about trvl
 
-If you used the one-command setup above, the skill is already installed. Otherwise, install the bundled skill that teaches Claude how to use trvl optimally:
+If you used the one-command setup above, the skill is already installed. Otherwise, install the bundled skill that teaches Claude how to use trvl optimally, plus the provider-helper skill for safe optional provider setup:
 
 ```bash
-# Install the bundled skill (Claude Code)
+# Install the bundled skills (Claude Code)
 mkdir -p ~/.claude/skills
-curl -fsSL "https://raw.githubusercontent.com/MikkoParkkola/trvl/main/.claude/skills/trvl.md" -o "$HOME/.claude/skills/trvl.md"
+for s in trvl providers; do
+  curl -fsSL "https://raw.githubusercontent.com/MikkoParkkola/trvl/main/.claude/skills/$s.md" -o "$HOME/.claude/skills/$s.md"
+done
 ```
 
 Reference docs for other clients: [AGENTS.md](https://raw.githubusercontent.com/MikkoParkkola/trvl/main/AGENTS.md) (full) · [llms.txt](https://raw.githubusercontent.com/MikkoParkkola/trvl/main/llms.txt) (compact)

--- a/llms.txt
+++ b/llms.txt
@@ -19,11 +19,11 @@ Claude Desktop: Add {"mcpServers":{"trvl":{"command":"trvl","args":["mcp"]}}} to
 ## Skills (install after MCP setup)
 
 mkdir -p ~/.claude/skills
-for s in trvl travel-hacks travel-agent travel-agent-compact; do
+for s in trvl providers; do
   curl -fsSL "https://raw.githubusercontent.com/MikkoParkkola/trvl/main/.claude/skills/$s.md" -o "$HOME/.claude/skills/$s.md"
 done
 
-## MCP Tools (54 total)
+## MCP Tools (61 total)
 
 - search_flights(origin, destination, departure_date, [return_date, cabin_class, max_stops, sort_by, alliances, depart_after, depart_before, less_emissions, carry_on_bags, checked_bags, require_checked_bag, max_price, max_duration, exclude_basic, airlines])
   - checked_bags: HIDDEN GOOGLE FEATURE — server-side filter not exposed in Google's own UI
@@ -37,6 +37,7 @@ done
 - hotel_prices(hotel_id, check_in, check_out, [currency])
 - hotel_reviews(hotel_id, [limit, sort])
 - hotel_rooms(hotel_name, check_in, check_out, [currency])
+- watch_room_availability(hotel_name, check_in, check_out, [currency])
 - search_hotel_by_name(name, check_in, check_out, [location, currency])
   - Searches for a specific hotel by name across all providers (Google Hotels, Trivago, Booking, Airbnb, Hostelworld). Fuzzy-matches results to the search name. Ideal for finding a known property.
 - destination_info(location, [travel_dates])
@@ -66,6 +67,7 @@ done
 - create_trip(name)
 - add_trip_leg(trip_id, type, ...)
 - mark_trip_booked(trip_id, leg_index)
+- export_ics(trip_id)
 - get_baggage_rules(airline, [type])
 - build_profile() — build traveller profile from booking history (email parsing + LLM)
 - add_booking(type, provider, [reference], [notes]) — add a booking to the profile
@@ -86,12 +88,20 @@ done
   - Re-check all active watches against current prices. Returns which prices dropped below target.
 - provider_health()
   - Show per-provider health summary: total calls, success rate, average latency, last error. Read from ~/.trvl/health.jsonl.
+- plan_flight_bundle(origin, destination, departure_date, [return_date])
+  - Finds efficient flight package/bundle candidates.
+- find_interactive(query, [context])
+  - Guided interactive trip finder for under-specified travel searches.
 
 ## MCP Prompts
 
 - plan-trip(origin, destination, departure_date, return_date, [budget])
 - find-cheapest-dates(origin, destination, month)
 - compare-hotels(location, check_in, check_out, [priorities])
+- where-should-i-go(origin, [month, budget])
+- packing-list(destination, dates, [trip_type, activities])
+- setup_profile()
+- setup_providers()
 
 ## CLI (14 commands)
 

--- a/mcp/prompts.go
+++ b/mcp/prompts.go
@@ -254,11 +254,16 @@ func promptWhereShouldIGo(args map[string]any) (*PromptsGetResult, error) {
 		monthLine = fmt.Sprintf(" in %s", month)
 	}
 
+	destinationStep := fmt.Sprintf("Use search_deals with origin=%s to discover affordable destinations and their prices. Note the cheapest 10-15 options.", origin)
+	if month != "" {
+		destinationStep += fmt.Sprintf("\n   - Also run weekend_getaway with origin=%s and month=%s as a second pass for weekend-sized options.", origin, month)
+	}
+
 	prompt := fmt.Sprintf(`I want to travel from %s%s but I'm not sure where to go.%s
 
 Follow these steps:
 
-1. **Explore destinations**: Use explore_destinations with origin=%s to discover available destinations and their prices. Note the cheapest 10-15 options.
+1. **Explore destinations**: %s
 
 2. **Filter and rank**: From the results:
    - Filter by budget if specified
@@ -275,7 +280,7 @@ Follow these steps:
    - A "Premium pick" (best destination if budget allows)
 
 5. **Next steps**: Suggest searching hotels at the top pick, or checking flexible dates with search_dates for the recommended destination.`,
-		origin, monthLine, budgetLine, origin)
+		origin, monthLine, budgetLine, destinationStep)
 
 	desc := fmt.Sprintf("Destination discovery from %s", origin)
 	if month != "" {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl-mcp",
   "version": "1.0.6",
-  "description": "AI travel agent — 60 MCP tools for flights, hotels, ground transport, price alerts. No API keys required.",
+  "description": "AI travel agent — 61 MCP tools for flights, hotels, ground transport, price alerts. No API keys required.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Recovered from pre-release stash. Doc-only updates.
- Adds `providers` skill alongside `trvl` in AGENTS.md and llms.txt
- Mentions watch_room_availability tool in llms.txt
- Bumps inline count references (npm description + llms tools count) to 61 to match PR #58 single-source-of-truth

## Evidence
- `go test -short -run TestPublicDocsAdvertiseCurrentCounts` green
- `go build` green
- No behavior changes (only docs and copy)

## Rollback
git revert 6e1e630 — pure doc change.

Generated with Claude Code
