### PR TITLE
ci: pin release workflow actions to SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       # step. v2.2.4 is the widely-deployed version used by goreleaser's
       # own release pipeline and is fully compatible with our signs: block.
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
         with:
           cosign-release: 'v2.2.4'
 
@@ -58,7 +58,7 @@ jobs:
         # "does not contain cert"). v6.4.0 skips that pre-flight check;
         # our own signs: block in .goreleaser.yaml still uses the
         # cosign-installer cosign for signing release artifacts correctly.
-        uses: goreleaser/goreleaser-action@v6.4.0
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
## Summary
- pin the remaining tag-pinned release workflow actions to full commit SHAs
- preserve version comments for Dependabot/review readability

## Validation
- YAML parse for `.github/workflows/release.yml`
- `actionlint .github/workflows/release.yml`
- scan confirms no unpinned remote `uses:` remain in `.github/workflows`
- `git diff --check`
- focused code review found no blocking issues

MIK-2922