### PR TITLE
docs: position trvl for AI-assistant travel

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@
 
 ![trvl demo](https://raw.githubusercontent.com/MikkoParkkola/trvl/main/demo.gif?v=1.0.5)
 
-> **61 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, travel hacks, award sweet spots, weather forecasts, baggage rules, airport lounges, destination intel. Free. API-first.**
+> **The canonical travel MCP for AI assistants. 61 tools. 21 providers. Zero API keys. One binary.**
 >
-> Also works as a standalone CLI with 50 commands.
+> Makes Claude, Cursor, Windsurf, Codex, and any MCP-compatible AI a competent travel agent — flights, hotels, trains, buses, ferries, price alerts, award sweet spots, weather, baggage, lounges, destination intel. Free. API-first. Also works as a standalone CLI with 50 commands.
+
+**For**: AI-assistant users who book ≥4 trips/yr · AI-app builders integrating travel intent · devs shopping MCP registries.
+**Not for**: humans booking via a website (use Google Flights) · travel-agency SaaS shoppers (we are not a hosted product).
+
+→ Full positioning: [`docs/POSITIONING.md`](docs/POSITIONING.md) · Architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) · Tools: [`AGENTS.md`](AGENTS.md)
 
 ### What it looks like
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 > **The canonical travel MCP for AI assistants. 61 tools. 21 providers. Zero API keys. One binary.**
 >
-> Makes Claude, Cursor, Windsurf, Codex, and any MCP-compatible AI a competent travel agent — flights, hotels, trains, buses, ferries, price alerts, award sweet spots, weather, baggage, lounges, destination intel. Free. API-first. Also works as a standalone CLI with 50 commands.
+> Gives Claude, Cursor, Windsurf, Codex, and any MCP-compatible AI 61 travel tools for your AI assistant — flights, hotels, trains, buses, ferries, price alerts, award sweet spots, weather, baggage, lounges, destination intel. Free. API-first. Also works as a standalone CLI with 50 commands.
 
 **For**: AI-assistant users who book ≥4 trips/yr · AI-app builders integrating travel intent · devs shopping MCP registries.
 **Not for**: humans booking via a website (use Google Flights) · travel-agency SaaS shoppers (we are not a hosted product).

--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -1,0 +1,114 @@
+# trvl — Positioning
+
+> **The canonical travel MCP server. 61 tools, 21 providers, zero API keys, one binary.**
+
+Last updated: 2026-05-08 · Parent epic: [MIK-3438](https://linear.app/parm/issue/MIK-3438)
+
+---
+
+## 1. Tagline
+
+**trvl makes your AI assistant a competent travel agent.**
+
+Not a chatbot that "thinks" about travel. An agent with structured, live access to 21 real providers — flights, hotels, trains, buses, ferries, weather, awards, alerts — through 61 MCP tools that any compliant client (Claude, Cursor, Windsurf, Codex, ChatGPT-with-MCP, …) can call directly.
+
+## 2. The problem we solve
+
+Every AI assistant today fails at travel in the same three ways:
+
+1. **Stale knowledge.** Models trained months ago don't know today's prices, schedules, or award charts.
+2. **Screen-scraped substitutes.** Even with browse, agents read Kayak's HTML — slow, brittle, captcha-blocked, no structured booking data, no hidden-city, no award sweetspots.
+3. **No multi-provider arbitrage.** A consumer-grade agent sees one source at a time; it can't run Ryanair × easyJet × Lufthansa × award-program × hotel-points in parallel and surface the dominated combinations.
+
+trvl is the first MCP server purpose-built to fix all three at once.
+
+## 3. Who this is for (ICP)
+
+| Tier | Profile | What they get |
+|---|---|---|
+| **Primary** | AI-assistant power users (Claude / Cursor / Windsurf) who book ≥4 trips/yr | A trip-planning copilot that beats Kayak on price *and* effort |
+| **Secondary** | AI-app builders integrating travel intent (booking concierges, expense automation, corporate travel agents) | A no-keys, single-binary backend they can ship inside their product |
+| **Tertiary** | Devs shopping MCP servers in registries (smithery.ai, awesome-mcp, PulseMCP) | The category-defining travel MCP — install, done |
+
+## 4. Who this is NOT for (anti-positioning)
+
+- **Humans who book through a website.** Use Google Flights. trvl serves *agents*, not direct human UIs.
+- **Travel agencies wanting white-label SaaS.** No signup, no servers, no billing — by design.
+- **Single-flight one-shot lookups.** Kayak is fine for that. trvl earns its keep when an agent runs 10+ tool-calls per query.
+
+## 5. Value triangle (what makes us category-defining)
+
+```
+            21 providers (most in MCP space)
+                       /\
+                      /  \
+                     /    \
+                    /      \
+                   /        \
+  Zero API keys --/----------\-- Agent-native
+   (no signup,    \          /   (61 MCP tools,
+    free tier,     \        /    structured I/O,
+    one binary)     \      /     not screen scrape)
+                     \    /
+                      \  /
+                       \/
+                  Browser fallback
+              (Booking.com, AFKLM, ...)
+```
+
+| Pillar | Why it matters | Evidence |
+|---|---|---|
+| 21 providers | Highest count of any travel MCP. Multi-provider arbitrage is impossible without coverage. | [README provider list](../README.md#providers) |
+| Zero API keys | Removes the #1 install-abandonment cause. Free tier works on day zero. | Default config has no key fields |
+| Agent-native | Structured tool I/O beats HTML scraping for agent reliability. | [AGENTS.md](../AGENTS.md) — 61 tools, typed schemas |
+| Browser fallback | When a provider has no API (Booking.com, AFKLM), we use a headless browser, not pretend support. | [internal/browser/](../internal/browser/) |
+| One binary | `brew install`, done. No Docker, no Python venv, no Node toolchain. | `goreleaser` artifacts, all platforms |
+
+## 6. Versus the real alternatives
+
+> 🟡 Full head-to-head matrix landing in [MIK-3439](https://linear.app/parm/issue/MIK-3439). Summary below.
+
+| Alternative | What it is | Where trvl wins |
+|---|---|---|
+| **Google Flights / Kayak (web)** | Consumer search UIs | Not callable by agents; no MCP; no award sweetspots; no multi-provider arbitrage in one query |
+| **ChatGPT browse + travel sites** | LLM screen-scrapes Kayak | 10–30× slower per query; brittle to captchas; can't do hidden-city or award sweetspots |
+| **Other travel MCPs (one-provider wrappers)** | Usually 1–3 providers, often Google Flights only | trvl has 21 providers in one binary |
+| **Travel-agent SaaS (Hopper, etc.)** | Paid consumer app | trvl is free, open-source, embeddable, not a product to log in to |
+
+## 7. Proof points
+
+- 61 MCP tools live on `main` ([tool list](../AGENTS.md))
+- 21 providers wired (`google-flights`, `airbnb`, `booking.com`, `trivago`, `hostelworld`, `ferryhopper`, `kelkoo`, `kiwi`, `flixbus`, `rome2rio`, `omio`, `trainline`, `afklm`, `lufthansa`, `aircanada`, `delta`, `iata`, `openweathermap`, `noaa`, `weather.gov`, `wikivoyage`)
+- Real protobuf reverse-engineering for Google Flights (not HTML scrape — see `internal/providers/googleflights/`)
+- Single-binary distribution: macOS / Linux / Windows / Docker
+- License: PolyForm NC 1.0 — free for non-commercial agents, paid for commercial integrations (see [LICENSE](../LICENSE))
+
+## 8. Distribution strategy
+
+Tracked as children of [MIK-3438](https://linear.app/parm/issue/MIK-3438):
+
+- **MIK-3439** — vs-comparison matrix (credibility)
+- **MIK-3440** — demo refresh: asciinema + GIF + first-5-prompts starter
+- **MIK-3441** — registry submissions: smithery.ai, awesome-mcp, MCP-registry, PulseMCP
+- **MIK-3442** — case-study artifact: real booking, real savings, screenshots
+- **MIK-3443** — distribution telemetry to measure positioning impact
+
+## 9. Success metrics (90-day)
+
+| Metric | Baseline | 90-day target |
+|---|---|---|
+| GitHub release downloads (28-day) | TBD (MIK-3443 captures) | +5× |
+| npm `trvl` installs (28-day) | TBD | +5× |
+| Registry listings live | 0 | ≥3 (smithery, awesome-mcp, PulseMCP) |
+| Unsolicited third-party mentions | 0 tracked | ≥1 blog / tweet citing trvl as canonical |
+| Demo cast viewable | static GIF only | <30s asciinema cast |
+
+## 10. What we are *not* doing yet
+
+- Booking execution (we surface, agents book) — by design, until liability + payment story is solved
+- Mobile-app shell — agents already live where users are
+- Hosted SaaS — open-source first; hosted comes later if it's the bottleneck
+
+---
+
+**Maintenance**: review quarterly. Update Section 6 alternatives table whenever a competing travel MCP ships. Re-baseline Section 9 metrics post-launch.


### PR DESCRIPTION
## Summary
- Refresh README hero with trvl's AI-assistant ICP and anti-positioning
- Add docs/POSITIONING.md with value triangle, alternatives matrix, proof points, distribution plan, and 90-day success metrics

## Linear
- Refs MIK-3438

## Validation
- git diff --check origin/main..HEAD
- test -f docs/POSITIONING.md
- rg -n "POSITIONING.md|AI-assistant power users|Anti-positioning|Success metrics" README.md docs/POSITIONING.md

## DoD notes
- Docs-only change; no runtime code changed
- Child issues MIK-3439..MIK-3443 remain open for comparison matrix, demo refresh, directory submissions, case study, and telemetry
