### PR TITLE
ci: bump Go and restore release distribution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.26.2"]
+        go-version: ["1.26.3"]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -106,7 +106,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
       # Register QEMU user-static interpreters so buildx can emit
       # linux/arm64 images on the amd64 GitHub-hosted runner.
       - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,14 @@ on:
 
 permissions:
   contents: write
+  packages: write
   id-token: write  # cosign keyless signing via Sigstore needs OIDC token
 
 jobs:
   goreleaser:
     runs-on: macos-14
+    env:
+      HAS_HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,7 +52,8 @@ jobs:
         with:
           cosign-release: 'v2.2.4'
 
-      - name: Run GoReleaser
+      - name: Run GoReleaser with Homebrew tap
+        if: env.HAS_HOMEBREW_TAP_TOKEN == 'true'
         # Pin to v6.4.0: goreleaser-action@v7 introduced a cosign-based
         # self-verification of the downloaded goreleaser binary, which is
         # incompatible with the new sigstore-bundle-v0.3 format goreleaser
@@ -62,17 +66,57 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          # Skip docker (macos-14 runners don't have Docker) and homebrew
-          # (requires HOMEBREW_TAP_TOKEN PAT with write access to
-          # MikkoParkkola/homebrew-tap — the default GITHUB_TOKEN cannot push
-          # to another repo). Remove these skips once:
-          #   - docker: a separate Linux job handles it, OR
-          #   - homebrew: HOMEBREW_TAP_TOKEN secret is configured.
-          args: release --clean --skip=docker --skip=homebrew
+          # Docker is published by the Linux docker job below. Homebrew is
+          # published here when HOMEBREW_TAP_TOKEN can push to the tap repo.
+          args: release --clean --skip=docker
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           # Hybrid PQC signing: ML-DSA-65 private key. Pubkey is embedded
           # in trvl at build time from internal/selfupdate/keys/. Fingerprint
           # of the active trust anchor is shown by `trvl version --verify`.
           TRVL_MLDSA_PRIVKEY_V1: ${{ secrets.TRVL_MLDSA_PRIVKEY_V1 }}
+
+      - name: Run GoReleaser without Homebrew tap
+        if: env.HAS_HOMEBREW_TAP_TOKEN != 'true'
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --skip=docker --skip=homebrew
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRVL_MLDSA_PRIVKEY_V1: ${{ secrets.TRVL_MLDSA_PRIVKEY_V1 }}
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: goreleaser
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          docker buildx create --use --name trvl-release
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg VERSION="${VERSION}" \
+            --tag "ghcr.io/mikkoparkkola/trvl:${VERSION}" \
+            --tag "ghcr.io/mikkoparkkola/trvl:latest" \
+            --file Dockerfile.release \
+            --push \
+            .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,3 +120,33 @@ jobs:
             --file Dockerfile.release \
             --push \
             .
+
+  mcp-registry:
+    runs-on: ubuntu-latest
+    needs: docker
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Stamp server.json for release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "${VERSION}" '
+            .version = $v |
+            .packages[0].identifier = "ghcr.io/mikkoparkkola/trvl:" + $v |
+            .packages[0].version = $v
+          ' server.json > server.tmp
+          mv server.tmp server.json
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       # Install cosign for hybrid release signing — see signs: block in
       # .goreleaser.yaml. Keyless mode uses the workflow's OIDC token

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -16,6 +16,12 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
     -o /out/trvl ./cmd/trvl
 
 FROM alpine:3.23
+ARG VERSION=dev
+LABEL org.opencontainers.image.title="trvl" \
+      org.opencontainers.image.description="AI travel agent MCP server for flights, hotels, ground transport, price alerts, and award travel" \
+      org.opencontainers.image.source="https://github.com/MikkoParkkola/trvl" \
+      org.opencontainers.image.version="${VERSION}" \
+      io.modelcontextprotocol.server.name="io.github.mikkoparkkola/trvl"
 RUN apk add --no-cache ca-certificates
 COPY --from=build /out/trvl /usr/local/bin/trvl
 ENTRYPOINT ["trvl"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,21 @@
+FROM golang:1.26.3-alpine AS build
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+
+RUN apk add --no-cache ca-certificates git
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
+    -ldflags="-s -w -X main.Version=${VERSION} -X github.com/MikkoParkkola/trvl/mcp.serverVersion=${VERSION}" \
+    -o /out/trvl ./cmd/trvl
+
+FROM alpine:3.23
+RUN apk add --no-cache ca-certificates
+COPY --from=build /out/trvl /usr/local/bin/trvl
+ENTRYPOINT ["trvl"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MikkoParkkola/trvl
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/andybalholm/brotli v1.2.1

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.mikkoparkkola/trvl",
+  "title": "trvl",
+  "description": "AI travel agent for flights, hotels, ground transport, price alerts, and award travel.",
+  "version": "1.2.1",
+  "repository": {
+    "url": "https://github.com/MikkoParkkola/trvl",
+    "source": "github"
+  },
+  "websiteUrl": "https://github.com/MikkoParkkola/trvl",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/mikkoparkkola/trvl:1.2.1",
+      "version": "1.2.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Bump the Go toolchain pin from 1.26.2 to 1.26.3 in go.mod and CI/release workflows
- Fix the shared Dependabot PR failure where govulncheck reports standard-library vulnerabilities fixed in Go 1.26.3
- Stop always skipping Homebrew in the tag Release workflow; publish the tap when HOMEBREW_TAP_TOKEN is configured
- Add a Linux multi-arch GHCR publish job using Dockerfile.release

## Issues / PRs
- Helps unblock #74, #75, #76, #77, #78 by moving CI to Go 1.26.3
- Addresses the release automation side of #73; the Homebrew tap was also manually bumped to v1.2.0 in MikkoParkkola/homebrew-tap@e7cc54b

## Validation
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- go run golang.org/x/vuln/cmd/govulncheck@latest ./... — No vulnerabilities found
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml syntax ok"'\n- git diff --check\n- rg -n "1\\.26\\.2" go.mod .github || true\n\n## Validation gap\n- Local Docker build could not run because Docker daemon is not running in this session. The release Docker job will be validated by GitHub Actions.\n\n## DoD notes\n- CI/release/config-only changes; no runtime code changed\n- Security gate: govulncheck passes locally under Go 1.26.3\n