### PR TITLE
fix: remove OCI package version from MCP manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
           jq --arg v "${VERSION}" '
             .version = $v |
             .packages[0].identifier = "ghcr.io/mikkoparkkola/trvl:" + $v |
-            .packages[0].version = $v
+            del(.packages[0].version)
           ' server.json > server.tmp
           mv server.tmp server.json
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
   "description": "AI travel agent for flights, hotels, ground transport, price alerts, and award travel.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",
     "source": "github"
@@ -12,8 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mikkoparkkola/trvl:1.2.2",
-      "version": "1.2.2",
+      "identifier": "ghcr.io/mikkoparkkola/trvl:1.2.3",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Fixes the next MCP Registry publish blocker found by the v1.2.2 release. The registry accepted the canonical `io.github.MikkoParkkola/trvl` namespace from PR #82, then rejected the manifest because OCI packages must not include a package-level `version` field.

Changes:
- remove `packages[0].version` from `server.json`
- make release stamping delete the package-level version while still stamping the server `version` and OCI tag identifier
- bump manifest version/tag to `1.2.3` for the next release attempt

## Evidence

v1.2.2 Release run `25728107763`:
- GoReleaser: passed
- Docker/GHCR: passed
- MCP Registry: failed with `OCI packages must not have 'version' field - include version in 'identifier' instead`

Local validation:
- `jq empty server.json`
- `git diff --check -- .github/workflows/release.yml server.json`
- `mcp-publisher validate server.json`
- `goreleaser check`
- `go test ./cmd/trvl -run TestPublicDocsAdvertiseCurrentCounts`
- jq release-stamping simulation confirms package `version` is absent

Related: #19, #73, MIK-3441.
