### PR TITLE
docs: update distribution status

### DIFF
--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -24,14 +24,29 @@ Re-check with:
 gh api repos/MikkoParkkola/trvl/traffic/popular/referrers
 ```
 
+## Automated Distribution Metrics
+
+MIK-3443 added weekly aggregate metrics collection:
+
+```bash
+make distribution-metrics
+```
+
+The generated dashboard is tracked at [docs/internal/distribution-metrics.md](internal/distribution-metrics.md). Weekly JSON snapshots are written under ignored `.internal/metrics/` files:
+
+- `.internal/metrics/downloads-$YYYYWW.json` for GitHub release asset downloads by version and asset
+- `.internal/metrics/npm-$YYYYWW.json` for npm download counts
+
+The 2026-05-12 baseline captured 337 GitHub release asset downloads and 0 npm `trvl` downloads because the npm downloads API returned `npm package or range not found`.
+
 ## Registry Matrix
 
 | Channel | Status | Evidence / Next Action |
 | --- | --- | --- |
 | Smithery | Not live | `https://smithery.ai/servers/@MikkoParkkola/trvl` returned 404 on 2026-05-12. `smithery mcp publish . -n @MikkoParkkola/trvl` failed because the current CLI attempted to bundle the repo path as an shttp server. Smithery now expects a public Streamable HTTP endpoint or an MCPB bundle. |
 | awesome-mcp-servers | PR open, blocked | [punkpeye/awesome-mcp-servers#5137](https://github.com/punkpeye/awesome-mcp-servers/pull/5137) is open and clean, but maintainer automation requires a live Glama listing and score badge. |
-| Official MCP Registry | Release path prepared; not live | `server.json`, the OCI image label, and the release workflow publish step are present. `https://registry.modelcontextprotocol.io/v0/servers?search=trvl` returned an empty list and the direct `io.github.MikkoParkkola/trvl` lookup returned 404 on 2026-05-12. The v1.2.1 publish job authenticated successfully, then failed with a namespace case mismatch (`io.github.MikkoParkkola/*` allowed, lowercase owner attempted); `server.json` and the OCI label now use the authorized GitHub owner casing for the next tagged publish. |
-| PulseMCP | Not verified live | Simple unauthenticated curl to PulseMCP returned 403 on 2026-05-12. Re-check after the official MCP Registry publication, since PulseMCP participates in the registry ecosystem. |
+| Official MCP Registry | Live | The v1.2.3 release published successfully. Public registry search for `io.github.MikkoParkkola/trvl` returns an active latest entry with version `1.2.3` and OCI package `ghcr.io/mikkoparkkola/trvl:1.2.3`. Release run: https://github.com/MikkoParkkola/trvl/actions/runs/25729860435. |
+| PulseMCP | Not verified live | Simple unauthenticated curl to PulseMCP returned 403 on 2026-05-12. Re-check periodically now that the official MCP Registry entry is live. |
 | mcp.so | Submitted, not live | [chatmcp/mcpso#2288](https://github.com/chatmcp/mcpso/issues/2288) tracks the submission. `https://mcp.so/server/trvl` returned "Project not found" on 2026-05-12. |
 | Glama | Not live; repo metadata fixed | `https://glama.ai/api/mcp/v1/servers/MikkoParkkola/trvl` returned 404 on 2026-05-12. `glama.json` is now tracked so the repo exposes the maintainer manifest. Manual "Add Server" flow may still be required. |
 


### PR DESCRIPTION
## Summary
- Updates `docs/DISTRIBUTION.md` now that the v1.2.3 official MCP Registry publish is live.
- Links the MIK-3443 distribution metrics dashboard and records the 2026-05-12 baseline.
- Keeps the remaining external blockers explicit: Smithery, Glama, mcp.so, PulseMCP, and awesome-mcp.

## Validation
- `git diff --check -- docs/DISTRIBUTION.md`
- secret/path scan across `docs/DISTRIBUTION.md` returned no matches
- `go test ./cmd/trvl -run TestPublicDocsAdvertiseCurrentCounts`
