### PR TITLE
test: harden coverage gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,7 +718,7 @@ The AI uses these to give you actionable recommendations: "Book here: [link]". N
 | **Personal profile** | Learns from your booking history (email parsing + LLM). Remembers FF status, luggage needs, favourite properties, departure preferences, travel hacks used, accommodation preferences, family composition. Pre-search interviews skip questions the profile already answers. |
 | **Output** | Pretty tables with color (default) or JSON (`--format json`) |
 | **Platforms** | Linux, macOS (amd64, arm64). Windows CI in progress. |
-| **Code** | 622 Go files, 203K LOC, 32 packages, 6400+ tests, 82% coverage |
+| **Code** | Go codebase with CI race/coverage gates and a documented local test matrix in [docs/TESTING.md](docs/TESTING.md) |
 | **License** | PolyForm Noncommercial 1.0 |
 
 ## Attribution

--- a/cmd/distribution-metrics/main.go
+++ b/cmd/distribution-metrics/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -12,48 +13,61 @@ import (
 )
 
 func main() {
+	if err := run(context.Background(), os.Args[1:], os.Stdout, os.Stderr, distributionmetrics.Collect); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type collectFunc func(context.Context, distributionmetrics.Config) (distributionmetrics.Report, error)
+
+func run(ctx context.Context, args []string, stdout, stderr io.Writer, collect collectFunc) error {
 	cfg := distributionmetrics.DefaultConfig()
 	var now string
 	var launchDate string
 
-	flag.StringVar(&cfg.Owner, "owner", cfg.Owner, "GitHub repository owner")
-	flag.StringVar(&cfg.Repo, "repo", cfg.Repo, "GitHub repository name")
-	flag.StringVar(&cfg.NPMPackage, "npm-package", cfg.NPMPackage, "npm package name to query")
-	flag.StringVar(&cfg.MetricsDir, "metrics-dir", cfg.MetricsDir, "directory for weekly JSON snapshots")
-	flag.StringVar(&cfg.DashboardPath, "dashboard", cfg.DashboardPath, "markdown dashboard path")
-	flag.IntVar(&cfg.Weeks, "weeks", cfg.Weeks, "rolling npm window in weeks")
-	flag.StringVar(&now, "date", "", "capture date in YYYY-MM-DD format; defaults to today UTC")
-	flag.StringVar(&launchDate, "launch-date", cfg.LaunchDate.Format(time.DateOnly), "positioning launch date in YYYY-MM-DD format")
-	flag.Parse()
+	fs := flag.NewFlagSet("distribution-metrics", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&cfg.Owner, "owner", cfg.Owner, "GitHub repository owner")
+	fs.StringVar(&cfg.Repo, "repo", cfg.Repo, "GitHub repository name")
+	fs.StringVar(&cfg.NPMPackage, "npm-package", cfg.NPMPackage, "npm package name to query")
+	fs.StringVar(&cfg.MetricsDir, "metrics-dir", cfg.MetricsDir, "directory for weekly JSON snapshots")
+	fs.StringVar(&cfg.DashboardPath, "dashboard", cfg.DashboardPath, "markdown dashboard path")
+	fs.IntVar(&cfg.Weeks, "weeks", cfg.Weeks, "rolling npm window in weeks")
+	fs.StringVar(&now, "date", "", "capture date in YYYY-MM-DD format; defaults to today UTC")
+	fs.StringVar(&launchDate, "launch-date", cfg.LaunchDate.Format(time.DateOnly), "positioning launch date in YYYY-MM-DD format")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
 
 	if now != "" {
 		parsed, err := time.Parse(time.DateOnly, now)
 		if err != nil {
-			log.Fatalf("invalid -date: %v", err)
+			return fmt.Errorf("invalid -date: %w", err)
 		}
 		cfg.Now = parsed
 	}
 	if launchDate != "" {
 		parsed, err := time.Parse(time.DateOnly, launchDate)
 		if err != nil {
-			log.Fatalf("invalid -launch-date: %v", err)
+			return fmt.Errorf("invalid -launch-date: %w", err)
 		}
 		cfg.LaunchDate = parsed
 	}
 
 	if err := distributionmetrics.ValidateConfig(cfg); err != nil {
-		log.Fatal(err)
+		return err
 	}
-	report, err := distributionmetrics.Collect(context.Background(), cfg)
+	report, err := collect(ctx, cfg)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
-	_, _ = fmt.Fprintf(os.Stdout, "week=%s\n", report.WeekKey)
-	_, _ = fmt.Fprintf(os.Stdout, "github_snapshot=%s total_downloads=%d\n", report.GitHubPath, report.GitHubTotal)
-	_, _ = fmt.Fprintf(os.Stdout, "npm_snapshot=%s total_downloads=%d\n", report.NPMPath, report.NPMTotal)
+	_, _ = fmt.Fprintf(stdout, "week=%s\n", report.WeekKey)
+	_, _ = fmt.Fprintf(stdout, "github_snapshot=%s total_downloads=%d\n", report.GitHubPath, report.GitHubTotal)
+	_, _ = fmt.Fprintf(stdout, "npm_snapshot=%s total_downloads=%d\n", report.NPMPath, report.NPMTotal)
 	if report.NPMError != "" {
-		_, _ = fmt.Fprintf(os.Stdout, "npm_note=%s\n", report.NPMError)
+		_, _ = fmt.Fprintf(stdout, "npm_note=%s\n", report.NPMError)
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "dashboard=%s\n", report.DashboardPath)
+	_, _ = fmt.Fprintf(stdout, "dashboard=%s\n", report.DashboardPath)
+	return nil
 }

--- a/cmd/distribution-metrics/main_test.go
+++ b/cmd/distribution-metrics/main_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/distributionmetrics"
+)
+
+func TestRunParsesFlagsAndPrintsReport(t *testing.T) {
+	var gotCfg distributionmetrics.Config
+	collect := func(_ context.Context, cfg distributionmetrics.Config) (distributionmetrics.Report, error) {
+		gotCfg = cfg
+		return distributionmetrics.Report{
+			WeekKey:       "2026-W20",
+			GitHubPath:    "/tmp/github.json",
+			NPMPath:       "/tmp/npm.json",
+			DashboardPath: "/tmp/dashboard.md",
+			GitHubTotal:   42,
+			NPMTotal:      7,
+			NPMError:      "npm range unavailable",
+		}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"--owner", "example",
+		"--repo", "repo",
+		"--npm-package", "@example/trvl",
+		"--metrics-dir", "/tmp/metrics",
+		"--dashboard", "/tmp/dashboard.md",
+		"--weeks", "4",
+		"--date", "2026-05-13",
+		"--launch-date", "2026-05-01",
+	}, &stdout, &stderr, collect)
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+
+	if gotCfg.Owner != "example" || gotCfg.Repo != "repo" || gotCfg.NPMPackage != "@example/trvl" {
+		t.Fatalf("parsed repo config = %#v", gotCfg)
+	}
+	if gotCfg.Weeks != 4 {
+		t.Fatalf("Weeks = %d, want 4", gotCfg.Weeks)
+	}
+	if got := gotCfg.Now.Format(time.DateOnly); got != "2026-05-13" {
+		t.Fatalf("Now = %s, want 2026-05-13", got)
+	}
+	if got := gotCfg.LaunchDate.Format(time.DateOnly); got != "2026-05-01" {
+		t.Fatalf("LaunchDate = %s, want 2026-05-01", got)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"week=2026-W20",
+		"github_snapshot=/tmp/github.json total_downloads=42",
+		"npm_snapshot=/tmp/npm.json total_downloads=7",
+		"npm_note=npm range unavailable",
+		"dashboard=/tmp/dashboard.md",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, out)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunRejectsInvalidDateBeforeCollect(t *testing.T) {
+	called := false
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{"--date", "May 13"}, &stdout, &stderr,
+		func(context.Context, distributionmetrics.Config) (distributionmetrics.Report, error) {
+			called = true
+			return distributionmetrics.Report{}, nil
+		})
+	if err == nil || !strings.Contains(err.Error(), "invalid -date") {
+		t.Fatalf("run() error = %v, want invalid -date", err)
+	}
+	if called {
+		t.Fatal("collector was called after invalid date")
+	}
+}
+
+func TestRunPropagatesCollectorError(t *testing.T) {
+	wantErr := errors.New("collector failed")
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), nil, &stdout, &stderr,
+		func(context.Context, distributionmetrics.Config) (distributionmetrics.Report, error) {
+			return distributionmetrics.Report{}, wantErr
+		})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("run() error = %v, want %v", err, wantErr)
+	}
+}

--- a/cmd/e2e-verify/main.go
+++ b/cmd/e2e-verify/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -24,64 +25,84 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/selfupdate"
 )
 
-func main() {
-	const (
-		dir          = "/tmp/trvl-e2e"
-		tarballName  = "trvl_1.2.0_darwin_arm64.tar.gz"
-		tarballPath  = dir + "/tarball.tar.gz"
-		sigPath      = dir + "/tarball.tar.gz.mldsa65.sig"
-		checksumPath = dir + "/checksums.txt"
-	)
+type verifyFunc func(io.Reader, []byte) error
 
-	// 1. SHA-256 verify against checksums.txt.
-	got, err := sha256OfFile(tarballPath)
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "FAIL: sha256 read: %v\n", err)
+type verifyConfig struct {
+	TarballName  string
+	TarballPath  string
+	SigPath      string
+	ChecksumPath string
+}
+
+func main() {
+	const dir = "/tmp/trvl-e2e"
+	cfg := verifyConfig{
+		TarballName:  "trvl_1.2.0_darwin_arm64.tar.gz",
+		TarballPath:  dir + "/tarball.tar.gz",
+		SigPath:      dir + "/tarball.tar.gz.mldsa65.sig",
+		ChecksumPath: dir + "/checksums.txt",
+	}
+	if err := run(cfg, os.Stdout, os.Stderr, selfupdate.VerifyMLDSA65); err != nil {
 		os.Exit(1)
 	}
-	checksumsBytes, err := os.ReadFile(checksumPath)
+}
+
+func run(cfg verifyConfig, stdout, stderr io.Writer, verify verifyFunc) error {
+	// 1. SHA-256 verify against checksums.txt.
+	got, err := sha256OfFile(cfg.TarballPath)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "FAIL: read checksums: %v\n", err)
-		os.Exit(1)
+		_, _ = fmt.Fprintf(stderr, "FAIL: sha256 read: %v\n", err)
+		return err
+	}
+	checksumsBytes, err := os.ReadFile(cfg.ChecksumPath)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "FAIL: read checksums: %v\n", err)
+		return err
 	}
 	expected := ""
 	for _, line := range strings.Split(string(checksumsBytes), "\n") {
 		fields := strings.Fields(line)
-		if len(fields) >= 2 && fields[len(fields)-1] == tarballName {
+		if len(fields) >= 2 && fields[len(fields)-1] == cfg.TarballName {
 			expected = strings.ToLower(fields[0])
 			break
 		}
 	}
 	if expected == "" {
-		_, _ = fmt.Fprintf(os.Stderr, "FAIL: %s not found in checksums.txt\n", tarballName)
-		os.Exit(1)
+		err := fmt.Errorf("%s not found in checksums.txt", cfg.TarballName)
+		_, _ = fmt.Fprintf(stderr, "FAIL: %v\n", err)
+		return err
 	}
 	if !strings.EqualFold(got, expected) {
-		_, _ = fmt.Fprintf(os.Stderr, "FAIL: sha256 mismatch: got %s, want %s\n", got, expected)
-		os.Exit(1)
+		err := fmt.Errorf("sha256 mismatch: got %s, want %s", got, expected)
+		_, _ = fmt.Fprintf(stderr, "FAIL: %v\n", err)
+		return err
 	}
-	fmt.Printf("OK   sha256: %s matches checksums.txt entry for %s\n", got, tarballName)
+	_, _ = fmt.Fprintf(stdout, "OK   sha256: %s matches checksums.txt entry for %s\n", got, cfg.TarballName)
 
 	// 2. ML-DSA-65 verify against embedded trust anchor.
-	sig, err := os.ReadFile(sigPath)
+	sig, err := os.ReadFile(cfg.SigPath)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "FAIL: read sig: %v\n", err)
-		os.Exit(1)
+		_, _ = fmt.Fprintf(stderr, "FAIL: read sig: %v\n", err)
+		return err
 	}
-	tarball, err := os.Open(tarballPath)
+	tarball, err := os.Open(cfg.TarballPath)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "FAIL: open tarball: %v\n", err)
-		os.Exit(1)
+		_, _ = fmt.Fprintf(stderr, "FAIL: open tarball: %v\n", err)
+		return err
 	}
 	defer func() { _ = tarball.Close() }()
-	if err := selfupdate.VerifyMLDSA65(tarball, sig); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "FAIL: ml-dsa: %v\n", err)
-		os.Exit(1)
+	if verify == nil {
+		verify = func(io.Reader, []byte) error { return errors.New("missing verifier") }
 	}
-	fmt.Printf("OK   ml-dsa-65: signature verified against trust anchor %s\n",
+	if err := verify(tarball, sig); err != nil {
+		_, _ = fmt.Fprintf(stderr, "FAIL: ml-dsa: %v\n", err)
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "OK   ml-dsa-65: signature verified against trust anchor %s\n",
 		selfupdate.MLDSA65PubkeyFingerprint())
 
-	fmt.Println("\nE2E VERIFY PASSED — production v1.2.0 artifacts pass the same chain trvl self-update would run.")
+	_, _ = fmt.Fprintln(stdout, "\nE2E VERIFY PASSED — production v1.2.0 artifacts pass the same chain trvl self-update would run.")
+	return nil
 }
 
 func sha256OfFile(path string) (string, error) {

--- a/cmd/e2e-verify/main_test.go
+++ b/cmd/e2e-verify/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunVerifiesChecksumAndSignature(t *testing.T) {
+	dir := t.TempDir()
+	tarball := filepath.Join(dir, "tarball.tar.gz")
+	sigPath := filepath.Join(dir, "tarball.tar.gz.mldsa65.sig")
+	checksums := filepath.Join(dir, "checksums.txt")
+	tarballName := "trvl_1.2.0_darwin_arm64.tar.gz"
+	body := []byte("release archive bytes")
+	sig := []byte("signature bytes")
+
+	if err := os.WriteFile(tarball, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sigPath, sig, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(body)
+	if err := os.WriteFile(checksums, []byte(fmt.Sprintf("%x  %s\n", sum, tarballName)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := run(verifyConfig{
+		TarballName:  tarballName,
+		TarballPath:  tarball,
+		SigPath:      sigPath,
+		ChecksumPath: checksums,
+	}, &stdout, &stderr, func(r io.Reader, gotSig []byte) error {
+		gotBody, err := io.ReadAll(r)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(gotBody, body) {
+			t.Fatalf("verifier read body %q, want %q", gotBody, body)
+		}
+		if !bytes.Equal(gotSig, sig) {
+			t.Fatalf("verifier got sig %q, want %q", gotSig, sig)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "OK   sha256:") || !strings.Contains(out, "E2E VERIFY PASSED") {
+		t.Fatalf("stdout missing success markers:\n%s", out)
+	}
+}
+
+func TestRunRejectsChecksumMismatch(t *testing.T) {
+	dir := t.TempDir()
+	tarball := filepath.Join(dir, "tarball.tar.gz")
+	sigPath := filepath.Join(dir, "tarball.tar.gz.mldsa65.sig")
+	checksums := filepath.Join(dir, "checksums.txt")
+	if err := os.WriteFile(tarball, []byte("release archive bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sigPath, []byte("signature"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(checksums, []byte("deadbeef  trvl_1.2.0_darwin_arm64.tar.gz\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := run(verifyConfig{
+		TarballName:  "trvl_1.2.0_darwin_arm64.tar.gz",
+		TarballPath:  tarball,
+		SigPath:      sigPath,
+		ChecksumPath: checksums,
+	}, &stdout, &stderr, func(io.Reader, []byte) error {
+		t.Fatal("verifier should not run after checksum mismatch")
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Fatalf("run() error = %v, want checksum mismatch", err)
+	}
+	if !strings.Contains(stderr.String(), "FAIL: sha256 mismatch") {
+		t.Fatalf("stderr missing mismatch:\n%s", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestSha256OfFileMissingFile(t *testing.T) {
+	if _, err := sha256OfFile(filepath.Join(t.TempDir(), "missing.tar.gz")); err == nil {
+		t.Fatal("sha256OfFile() error = nil, want missing file error")
+	}
+}

--- a/cmd/keygen-mldsa/main.go
+++ b/cmd/keygen-mldsa/main.go
@@ -20,67 +20,103 @@
 package main
 
 import (
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/cloudflare/circl/sign/mldsa/mldsa65"
 )
 
 func main() {
-	priv := flag.String("priv", "", "path to write privkey hex (0600)")
-	pub := flag.String("pub", "", "path to write pubkey hex (0644)")
-	flag.Parse()
+	if err := run(os.Args[1:], os.Stderr, cryptorand.Reader); err != nil {
+		if _, ok := err.(usageError); !ok {
+			_, _ = fmt.Fprintf(os.Stderr, "keygen-mldsa: %v\n", err)
+		}
+		os.Exit(exitCode(err))
+	}
+}
+
+type usageError struct {
+	msg string
+}
+
+func (e usageError) Error() string { return e.msg }
+func (e usageError) ExitCode() int { return 2 }
+
+type exitCoder interface {
+	ExitCode() int
+}
+
+func exitCode(err error) int {
+	if e, ok := err.(exitCoder); ok {
+		return e.ExitCode()
+	}
+	return 1
+}
+
+func run(args []string, stderr io.Writer, random io.Reader) error {
+	fs := flag.NewFlagSet("keygen-mldsa", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	priv := fs.String("priv", "", "path to write privkey hex (0600)")
+	pub := fs.String("pub", "", "path to write pubkey hex (0644)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
 	if *priv == "" || *pub == "" {
-		_, _ = fmt.Fprintln(os.Stderr, "usage: keygen-mldsa --priv <path> --pub <path>")
-		os.Exit(2)
+		_, _ = fmt.Fprintln(stderr, "usage: keygen-mldsa --priv <path> --pub <path>")
+		return usageError{msg: "missing required --priv or --pub"}
+	}
+	if random == nil {
+		random = cryptorand.Reader
 	}
 
-	pk, sk, err := mldsa65.GenerateKey(rand.Reader)
+	pk, sk, err := mldsa65.GenerateKey(random)
 	if err != nil {
-		die("keygen: %v", err)
+		return fmt.Errorf("keygen: %w", err)
 	}
 	pkb, err := pk.MarshalBinary()
 	if err != nil {
-		die("marshal pub: %v", err)
+		return fmt.Errorf("marshal pub: %w", err)
 	}
 	skb, err := sk.MarshalBinary()
 	if err != nil {
-		die("marshal priv: %v", err)
+		return fmt.Errorf("marshal priv: %w", err)
 	}
 
 	// Roundtrip: ensure the serialized bytes re-parse and sign+verify
 	// before we hand the privkey off to durable storage.
 	var pk2 mldsa65.PublicKey
 	if err := pk2.UnmarshalBinary(pkb); err != nil {
-		die("pub roundtrip: %v", err)
+		return fmt.Errorf("pub roundtrip: %w", err)
 	}
 	var sk2 mldsa65.PrivateKey
 	if err := sk2.UnmarshalBinary(skb); err != nil {
-		die("priv roundtrip: %v", err)
+		return fmt.Errorf("priv roundtrip: %w", err)
 	}
 	canary := []byte("trvl-keygen-roundtrip-canary")
 	sig := make([]byte, mldsa65.SignatureSize)
 	if err := mldsa65.SignTo(&sk2, canary, nil, false, sig); err != nil {
-		die("roundtrip sign: %v", err)
+		return fmt.Errorf("roundtrip sign: %w", err)
 	}
 	if !mldsa65.Verify(&pk2, canary, nil, sig) {
-		die("roundtrip verify: failed")
+		return fmt.Errorf("roundtrip verify: failed")
 	}
 
 	if err := writeFileExclusive(*priv, []byte(hex.EncodeToString(skb)+"\n"), 0o600); err != nil {
-		die("write priv: %v", err)
+		return fmt.Errorf("write priv: %w", err)
 	}
 	if err := writeFileExclusive(*pub, []byte(hex.EncodeToString(pkb)+"\n"), 0o644); err != nil {
-		die("write pub: %v", err)
+		return fmt.Errorf("write pub: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(os.Stderr, "ML-DSA-65 keypair written.\n")
-	_, _ = fmt.Fprintf(os.Stderr, "  pubkey:  %s (%d bytes binary, %d hex chars)\n", *pub, len(pkb), len(pkb)*2)
-	_, _ = fmt.Fprintf(os.Stderr, "  privkey: %s (mode 0600, %d bytes binary, %d hex chars)\n", *priv, len(skb), len(skb)*2)
-	_, _ = fmt.Fprintf(os.Stderr, "  roundtrip: sign + verify OK\n")
+	_, _ = fmt.Fprintf(stderr, "ML-DSA-65 keypair written.\n")
+	_, _ = fmt.Fprintf(stderr, "  pubkey:  %s (%d bytes binary, %d hex chars)\n", *pub, len(pkb), len(pkb)*2)
+	_, _ = fmt.Fprintf(stderr, "  privkey: %s (mode 0600, %d bytes binary, %d hex chars)\n", *priv, len(skb), len(skb)*2)
+	_, _ = fmt.Fprintf(stderr, "  roundtrip: sign + verify OK\n")
+	return nil
 }
 
 func writeFileExclusive(path string, data []byte, mode os.FileMode) error {
@@ -93,9 +129,4 @@ func writeFileExclusive(path string, data []byte, mode os.FileMode) error {
 	defer func() { _ = f.Close() }()
 	_, err = f.Write(data)
 	return err
-}
-
-func die(format string, a ...any) {
-	_, _ = fmt.Fprintf(os.Stderr, "keygen-mldsa: "+format+"\n", a...)
-	os.Exit(1)
 }

--- a/cmd/keygen-mldsa/main_test.go
+++ b/cmd/keygen-mldsa/main_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -90,6 +91,9 @@ func readHexFile(t *testing.T, path string) []byte {
 
 func assertMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose POSIX file modes through os.FileMode")
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/keygen-mldsa/main_test.go
+++ b/cmd/keygen-mldsa/main_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	cryptorand "crypto/rand"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudflare/circl/sign/mldsa/mldsa65"
+)
+
+func TestRunWritesKeypairWithSafeModes(t *testing.T) {
+	dir := t.TempDir()
+	priv := filepath.Join(dir, "mldsa.priv.hex")
+	pub := filepath.Join(dir, "mldsa.pub.hex")
+	var stderr bytes.Buffer
+
+	if err := run([]string{"--priv", priv, "--pub", pub}, &stderr, cryptorand.Reader); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+
+	privHex := readHexFile(t, priv)
+	pubHex := readHexFile(t, pub)
+	if len(privHex) != mldsa65.PrivateKeySize {
+		t.Fatalf("priv key bytes = %d, want %d", len(privHex), mldsa65.PrivateKeySize)
+	}
+	if len(pubHex) != mldsa65.PublicKeySize {
+		t.Fatalf("pub key bytes = %d, want %d", len(pubHex), mldsa65.PublicKeySize)
+	}
+	assertMode(t, priv, 0o600)
+	assertMode(t, pub, 0o644)
+
+	out := stderr.String()
+	if !strings.Contains(out, "roundtrip: sign + verify OK") {
+		t.Fatalf("stderr missing roundtrip marker:\n%s", out)
+	}
+	if strings.Contains(out, hex.EncodeToString(privHex[:32])) {
+		t.Fatal("stderr leaked private key material")
+	}
+}
+
+func TestRunRejectsMissingPaths(t *testing.T) {
+	var stderr bytes.Buffer
+	err := run(nil, &stderr, cryptorand.Reader)
+	var usage usageError
+	if !errors.As(err, &usage) {
+		t.Fatalf("run() error = %T %[1]v, want usageError", err)
+	}
+	if exitCode(err) != 2 {
+		t.Fatalf("exitCode = %d, want 2", exitCode(err))
+	}
+	if !strings.Contains(stderr.String(), "usage: keygen-mldsa") {
+		t.Fatalf("stderr missing usage:\n%s", stderr.String())
+	}
+}
+
+func TestWriteFileExclusiveRefusesOverwrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "existing")
+	if err := os.WriteFile(path, []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFileExclusive(path, []byte("new"), 0o600); err == nil {
+		t.Fatal("writeFileExclusive() error = nil, want overwrite refusal")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "existing" {
+		t.Fatalf("file content = %q, want existing", got)
+	}
+}
+
+func readHexFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := hex.DecodeString(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	return decoded
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %04o, want %04o", path, got, want)
+	}
+}

--- a/cmd/sign-mldsa/main.go
+++ b/cmd/sign-mldsa/main.go
@@ -52,55 +52,72 @@ const (
 )
 
 func main() {
-	in := flag.String("in", "", "path to the artifact to sign")
-	out := flag.String("out", "", "output signature path (default: <in>.mldsa65.sig)")
-	flag.Parse()
+	if err := run(os.Args[1:], os.Stderr, os.Getenv); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "sign-mldsa: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type getenvFunc func(string) string
+
+func run(args []string, stderr io.Writer, getenv getenvFunc) error {
+	fs := flag.NewFlagSet("sign-mldsa", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	in := fs.String("in", "", "path to the artifact to sign")
+	out := fs.String("out", "", "output signature path (default: <in>.mldsa65.sig)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
 	if *in == "" {
-		die("usage: sign-mldsa --in <artifact> [--out <sig>]")
+		return fmt.Errorf("usage: sign-mldsa --in <artifact> [--out <sig>]")
 	}
 	outPath := *out
 	if outPath == "" {
 		outPath = *in + sigSuffix
 	}
 
-	privHex := os.Getenv(envPrivkey)
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	privHex := getenv(envPrivkey)
 	if privHex == "" {
-		die("env %s is empty; cannot sign without privkey", envPrivkey)
+		return fmt.Errorf("env %s is empty; cannot sign without privkey", envPrivkey)
 	}
 	skBytes, err := hex.DecodeString(privHex)
 	if err != nil {
-		die("decode privkey hex: %v", err)
+		return fmt.Errorf("decode privkey hex: %w", err)
 	}
 	if len(skBytes) != mldsa65.PrivateKeySize {
-		die("privkey wrong length: got %d, want %d", len(skBytes), mldsa65.PrivateKeySize)
+		return fmt.Errorf("privkey wrong length: got %d, want %d", len(skBytes), mldsa65.PrivateKeySize)
 	}
 	var sk mldsa65.PrivateKey
 	if err := sk.UnmarshalBinary(skBytes); err != nil {
-		die("unmarshal privkey: %v", err)
+		return fmt.Errorf("unmarshal privkey: %w", err)
 	}
 
 	digest, err := sha256File(*in)
 	if err != nil {
-		die("sha256 %s: %v", *in, err)
+		return fmt.Errorf("sha256 %s: %w", *in, err)
 	}
 
 	sig := make([]byte, mldsa65.SignatureSize)
 	if err := mldsa65.SignTo(&sk, digest, nil, false, sig); err != nil {
-		die("sign: %v", err)
+		return fmt.Errorf("sign: %w", err)
 	}
 
 	// Sanity: verify the signature we just produced before writing it.
 	// Catches a corrupted privkey-in-secret before it lands in a release.
 	pk := sk.Public().(*mldsa65.PublicKey)
 	if !mldsa65.Verify(pk, digest, nil, sig) {
-		die("self-verify failed; refusing to ship a signature that does not verify")
+		return fmt.Errorf("self-verify failed; refusing to ship a signature that does not verify")
 	}
 
 	if err := writeFileExcl(outPath, sig, 0o644); err != nil {
-		die("write sig %s: %v", outPath, err)
+		return fmt.Errorf("write sig %s: %w", outPath, err)
 	}
-	_, _ = fmt.Fprintf(os.Stderr, "sign-mldsa: %s -> %s (sha256=%x, sig=%d bytes)\n",
+	_, _ = fmt.Fprintf(stderr, "sign-mldsa: %s -> %s (sha256=%x, sig=%d bytes)\n",
 		*in, outPath, digest[:8], len(sig))
+	return nil
 }
 
 func sha256File(path string) ([]byte, error) {
@@ -125,9 +142,4 @@ func writeFileExcl(path string, data []byte, mode os.FileMode) error {
 	defer func() { _ = f.Close() }()
 	_, err = f.Write(data)
 	return err
-}
-
-func die(format string, a ...any) {
-	_, _ = fmt.Fprintf(os.Stderr, "sign-mldsa: "+format+"\n", a...)
-	os.Exit(1)
 }

--- a/cmd/sign-mldsa/main_test.go
+++ b/cmd/sign-mldsa/main_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	cryptorand "crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudflare/circl/sign/mldsa/mldsa65"
+)
+
+func TestRunSignsArtifactAndDoesNotLeakPrivkey(t *testing.T) {
+	privHex, pub := generatePrivateKeyHex(t)
+	dir := t.TempDir()
+	artifact := filepath.Join(dir, "trvl.tar.gz")
+	if err := os.WriteFile(artifact, []byte("archive bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	if err := run([]string{"--in", artifact}, &stderr, func(name string) string {
+		if name == envPrivkey {
+			return privHex
+		}
+		return ""
+	}); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+
+	sigPath := artifact + sigSuffix
+	sig, err := os.ReadFile(sigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sig) != mldsa65.SignatureSize {
+		t.Fatalf("sig bytes = %d, want %d", len(sig), mldsa65.SignatureSize)
+	}
+	digest, err := sha256File(artifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mldsa65.Verify(pub, digest, nil, sig) {
+		t.Fatal("signature does not verify with generated public key")
+	}
+	if strings.Contains(stderr.String(), privHex[:64]) {
+		t.Fatal("stderr leaked private key material")
+	}
+	if !strings.Contains(stderr.String(), "sign-mldsa:") {
+		t.Fatalf("stderr missing success marker:\n%s", stderr.String())
+	}
+}
+
+func TestRunRejectsMissingPrivateKey(t *testing.T) {
+	dir := t.TempDir()
+	artifact := filepath.Join(dir, "trvl.tar.gz")
+	if err := os.WriteFile(artifact, []byte("archive bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	err := run([]string{"--in", artifact}, &stderr, func(string) string { return "" })
+	if err == nil || !strings.Contains(err.Error(), envPrivkey) {
+		t.Fatalf("run() error = %v, want missing env key", err)
+	}
+	if _, statErr := os.Stat(artifact + sigSuffix); !os.IsNotExist(statErr) {
+		t.Fatalf("signature file exists after failed sign: %v", statErr)
+	}
+}
+
+func TestRunRefusesToOverwriteSignature(t *testing.T) {
+	privHex, _ := generatePrivateKeyHex(t)
+	dir := t.TempDir()
+	artifact := filepath.Join(dir, "trvl.tar.gz")
+	out := filepath.Join(dir, "trvl.sig")
+	if err := os.WriteFile(artifact, []byte("archive bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(out, []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	err := run([]string{"--in", artifact, "--out", out}, &stderr, func(name string) string {
+		if name == envPrivkey {
+			return privHex
+		}
+		return ""
+	})
+	if err == nil || !strings.Contains(err.Error(), "write sig") {
+		t.Fatalf("run() error = %v, want overwrite refusal", err)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "existing" {
+		t.Fatalf("sig content = %q, want existing", got)
+	}
+}
+
+func generatePrivateKeyHex(t *testing.T) (string, *mldsa65.PublicKey) {
+	t.Helper()
+	pk, sk, err := mldsa65.GenerateKey(cryptorand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skb, err := sk.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(skb), pk
+}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,34 @@
+# Testing
+
+This repo treats test coverage as a release gate, not a vanity metric. Use this
+matrix when changing behaviour or before claiming Definition of Done.
+
+## Local Matrix
+
+| Test type | Command | Notes |
+| --- | --- | --- |
+| Unit and regression | `go test -short ./...` | Default local pass for pure logic, command helpers, MCP schemas, parsers, and storage. |
+| Race and coverage | `go test -short -p=1 -race -coverprofile coverage.out ./...` | Mirrors CI's low-parallelism path for constrained runners. |
+| Coverage summary | `go tool cover -func=coverage.out` | Use the `total:` row in handoffs. |
+| Full integration | `TRVL_LIVE_INTEGRATION=1 go test ./...` | Runs tests guarded by `testutil.RequireLiveIntegration`; requires network and may hit provider rate limits. |
+| E2E CLI smoke | `go test -short ./cmd/trvl ./mcp` | Covers CLI/MCP wiring and user-facing tool surfaces without live providers. |
+| Fuzz seed corpus | `go test ./internal/nlsearch -run FuzzHeuristicKeepsStructuredFieldsValid` | Runs fuzz seeds as a normal test; use `-fuzz=FuzzHeuristicKeepsStructuredFieldsValid` for deeper campaigns. |
+| Chaos | `go test ./internal/chaos ./internal/providers -run 'Chaos|Circuit|Timeout|Retry'` | Exercises deterministic failure injection, provider cooldown, timeout, and retry paths. |
+| UAT-style travel workspace | `go test -short ./internal/trips ./internal/imports ./internal/evidence ./internal/itinerary ./internal/fareintel ./mcp -run 'Workspace|Reservation|Booking|Evidence|Itinerary|Fare'` | Proves the user workflow from import to booking-readiness remains wired. |
+
+## Coverage Expectations
+
+- Add positive, negative, and corner-case tests for every changed behaviour.
+- Add regression tests for every bug fix before or alongside the fix.
+- Use fuzz/property-style tests for untrusted free-text input, date parsing,
+  price parsing, schema validation, and trip import/merge logic.
+- Use `httptest` or injectable functions for command and integration coverage;
+  tests must not require production secrets or live bookings.
+- Record exact skipped or blocked evidence when local disk, network, provider
+  rate limits, or credentials prevent a full run.
+
+## CI
+
+`.github/workflows/ci.yaml` runs `go test` with race detection and coverage.
+The local low-parallelism command above is the closest reproduction path for
+machines with limited disk or memory.

--- a/internal/nlsearch/parser.go
+++ b/internal/nlsearch/parser.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -174,7 +175,9 @@ func extractNaturalDate(query string) string {
 			d := 0
 			_, _ = fmt.Sscanf(day, "%d", &d)
 			if d >= 1 && d <= 31 {
-				return fmt.Sprintf("%s-%02d-%02d", year, month, d)
+				if date := fmt.Sprintf("%s-%02d-%02d", year, month, d); validISODate(date) {
+					return date
+				}
 			}
 		}
 	}
@@ -186,11 +189,18 @@ func extractNaturalDate(query string) string {
 			d := 0
 			_, _ = fmt.Sscanf(day, "%d", &d)
 			if d >= 1 && d <= 31 {
-				return fmt.Sprintf("%s-%02d-%02d", year, month, d)
+				if date := fmt.Sprintf("%s-%02d-%02d", year, month, d); validISODate(date) {
+					return date
+				}
 			}
 		}
 	}
 	return ""
+}
+
+func validISODate(date string) bool {
+	parsed, err := time.Parse(time.DateOnly, date)
+	return err == nil && parsed.Format(time.DateOnly) == date
 }
 
 // Heuristic extracts travel intent and parameters from a free-form query
@@ -268,11 +278,19 @@ func Heuristic(query, today string) Params {
 
 	// 3a. ISO 8601 dates.
 	if dates := isoDatePattern.FindAllString(query, -1); len(dates) > 0 {
-		p.Date = dates[0]
-		p.CheckIn = dates[0]
-		if len(dates) >= 2 {
-			p.ReturnDate = dates[1]
-			p.CheckOut = dates[1]
+		validDates := make([]string, 0, len(dates))
+		for _, date := range dates {
+			if validISODate(date) {
+				validDates = append(validDates, date)
+			}
+		}
+		if len(validDates) > 0 {
+			p.Date = validDates[0]
+			p.CheckIn = validDates[0]
+			if len(validDates) >= 2 {
+				p.ReturnDate = validDates[1]
+				p.CheckOut = validDates[1]
+			}
 		}
 	}
 

--- a/internal/nlsearch/parser_fuzz_test.go
+++ b/internal/nlsearch/parser_fuzz_test.go
@@ -1,0 +1,60 @@
+package nlsearch
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func FuzzHeuristicKeepsStructuredFieldsValid(f *testing.F) {
+	for _, seed := range []string{
+		"flight from HEL to BCN on 2026-07-01",
+		"hotels in Tokyo 7 May 2026",
+		"cheap route from Helsinki to Prague next weekend",
+		"need a room under 120 EUR",
+		"",
+		strings.Repeat("A", 256),
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, query string) {
+		if len(query) > 4096 {
+			t.Skip("keep normal test-mode fuzz corpus bounded")
+		}
+		p := Heuristic(query, "2026-05-13")
+
+		switch p.Intent {
+		case "route", "hotel", "flight", "deals":
+		default:
+			t.Fatalf("unexpected intent %q for query %q", p.Intent, query)
+		}
+		for name, date := range map[string]string{
+			"date":        p.Date,
+			"return_date": p.ReturnDate,
+			"check_in":    p.CheckIn,
+			"check_out":   p.CheckOut,
+		} {
+			if date == "" {
+				continue
+			}
+			if _, err := time.Parse(time.DateOnly, date); err != nil {
+				t.Fatalf("%s = %q is not an ISO date for query %q: %v", name, date, query, err)
+			}
+		}
+		for name, code := range map[string]string{
+			"origin":      p.Origin,
+			"destination": p.Destination,
+		} {
+			if code == "" {
+				continue
+			}
+			if len(code) != 3 || code != strings.ToUpper(code) {
+				t.Fatalf("%s = %q, want uppercase IATA-like code for query %q", name, code, query)
+			}
+		}
+		if p.MaxBudget < 0 {
+			t.Fatalf("MaxBudget = %f, want non-negative for query %q", p.MaxBudget, query)
+		}
+	})
+}

--- a/internal/nlsearch/parser_test.go
+++ b/internal/nlsearch/parser_test.go
@@ -87,6 +87,13 @@ func TestHeuristic_ISODateRange(t *testing.T) {
 	}
 }
 
+func TestHeuristic_IgnoresInvalidISODate(t *testing.T) {
+	p := Heuristic("from HEL to BCN on 0000-00-00", "2026-04-12")
+	if p.Date != "" || p.CheckIn != "" {
+		t.Fatalf("invalid ISO date populated date fields: %#v", p)
+	}
+}
+
 func TestHeuristic_NextWeekend(t *testing.T) {
 	// 2026-04-12 is a Sunday. Next Saturday = 2026-04-18.
 	p := Heuristic("anywhere next weekend", "2026-04-12")

--- a/internal/nlsearch/testdata/fuzz/FuzzHeuristicKeepsStructuredFieldsValid/7bb6e996514d692d
+++ b/internal/nlsearch/testdata/fuzz/FuzzHeuristicKeepsStructuredFieldsValid/7bb6e996514d692d
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("000aaaAAAAA0from AAA to AAA000 0000-00-00")


### PR DESCRIPTION
## Summary
- Refactors the four previously 0%-covered command packages into thin `main()` wrappers with injectable `run(...)` helpers.
- Adds positive/negative tests for distribution metrics, e2e verification, ML-DSA key generation, and ML-DSA signing without live network or production secrets.
- Adds a fuzz/property-style NL parser test, keeps the failing corpus that exposed invalid ISO-shaped dates, and fixes the parser to ignore invalid calendar dates.
- Adds `docs/TESTING.md` and replaces the stale README coverage number with a link to the maintained local/CI test matrix.

Fixes #98

## DoR
- PASS: issue #98 captures testable ACs, scoped targets, ROI, duplicate scan result, risks, and validation plan.

## DoD Evidence
- `go test ./cmd/distribution-metrics ./cmd/e2e-verify ./cmd/keygen-mldsa ./cmd/sign-mldsa ./internal/nlsearch`
- `go test ./internal/nlsearch -run=^$ -fuzz=FuzzHeuristicKeepsStructuredFieldsValid -fuzztime=5s`
- `GOTMPDIR=$PWD/.gotmp go test -p=1 -race -coverprofile=/tmp/trvl-race-coverage.out ./...`
- `go tool cover -func=/tmp/trvl-race-coverage.out`: total 78.9%
- `go build ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`: No vulnerabilities found.
- `git diff --check`

## Notes
- Earlier race+coverage attempts hit local disk pressure (`errno=28`) while linking large test binaries. After cleanup and rerun with repo-local `GOTMPDIR`, the final CI-style pass completed successfully.
