### PR TITLE
feat: enrich provider health metrics

### DIFF
--- a/.claude/skills/trvl.md
+++ b/.claude/skills/trvl.md
@@ -208,7 +208,7 @@ The full compatibility surface is below.
 | Tool | Use |
 |---|---|
 | `list_providers` | List all configured providers + status |
-| `provider_health` | Per-provider success rate, latency, last error/hint code |
+| `provider_health` | Per-provider success rate, latency, freshness, result counts, last error class, circuit state, next retry, and fix hint |
 | `suggest_providers` | Catalogue of optional providers to enable (with auth pattern, OSS reference) |
 | `configure_provider` | Enable a provider (requires user consent) |
 | `test_provider` | Validate a provider's config |
@@ -565,7 +565,7 @@ Offer 2-3 refinements: "Other dates?" · "Nearby airports?" · "Different hotel?
 - **"What €X gets you"** → budget→destination mapping via `search_dates` fan-out.
 - **"Calendar hole"** → `find_trip_window` with calendar busy-intervals → flight savings for free weeks.
 - **"Award sweet spot"** → `search_awards` with the user's MR / UR / Bilt / FB / VS / AS balances.
-- **"Provider audit"** → `provider_health` + `list_providers` to diagnose flaky upstream sources.
+- **"Provider audit"** → `provider_health` + `list_providers` to diagnose stale, sparse, circuit-broken, or flaky upstream sources.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,7 +489,7 @@ Stores watch in `~/.trvl/watches.json`. Use `check_watches` to re-check prices, 
 ```json
 {}
 ```
-Shows per-provider success rate, average latency, and last error from `~/.trvl/health.jsonl`. Use to diagnose why a provider isn't returning results.
+Shows per-provider success rate, average latency, result-count quality, freshness, last error class, circuit-break state, next retry time, and fix hint from the redacted `~/.trvl/health.jsonl` log plus provider config state. Use to diagnose stale, sparse, blocked, or failing providers without exposing provider credentials.
 
 ### detect_travel_hacks — Find savings opportunities
 ```json

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ That's it. Your AI assistant now has 1 smart travel tool available. The old 63 t
 | **search_route** | Multi-modal routing combining flights, trains, buses and ferries | Helsinki → Dubrovnik, arrive by 2026-04-10 |
 | **get_weather** | Get a weather forecast for any city (Open-Meteo, up to 14 days) | Prague, weekend forecast |
 | **get_preferences** | Read user travel preferences (FF status, bag rules, seat preferences) | — |
+| **provider_health** | Diagnose configured providers with success rate, freshness, result counts, error class, circuit state, next retry, and fix hints | "why is Booking.com failing?" |
 | **detect_travel_hacks** | Run 18 parallel detectors for flight and ground savings opportunities | HEL → AMS, Apr 13, carry-on only |
 | **detect_accommodation_hacks** | Find hotel split savings (e.g. 2-city stay cheaper than 1 hotel) | Prague, Jun 15-22 |
 | **search_natural** | Natural language search using keyword heuristics — dispatches to the right tool automatically | "cheapest weekend in July from Helsinki" |

--- a/internal/providers/circuit_health.go
+++ b/internal/providers/circuit_health.go
@@ -1,0 +1,60 @@
+package providers
+
+import (
+	"fmt"
+	"time"
+)
+
+// CircuitHealth is the user-facing state of the provider circuit breaker.
+type CircuitHealth struct {
+	State       string `json:"state"` // closed, open, half_open
+	ErrorCount  int    `json:"error_count,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+	NextRetryAt string `json:"next_retry_at,omitempty"`
+	FixHint     string `json:"fix_hint,omitempty"`
+}
+
+// CircuitBreakerHealth mirrors the runtime's circuit-break decision so
+// provider_health can explain whether a provider will be tried, skipped, or
+// allowed through as a half-open recovery probe.
+func CircuitBreakerHealth(cfg *ProviderConfig, now time.Time) CircuitHealth {
+	if cfg == nil {
+		return CircuitHealth{State: "unknown"}
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if cfg.ErrorCount < circuitBreakerThreshold {
+		return CircuitHealth{State: "closed", ErrorCount: cfg.ErrorCount}
+	}
+
+	tripAt := cfg.LastErrorAt
+	if tripAt.IsZero() {
+		tripAt = cfg.LastSuccess
+	}
+	if tripAt.IsZero() {
+		return CircuitHealth{
+			State:      "open",
+			ErrorCount: cfg.ErrorCount,
+			Reason:     fmt.Sprintf("tripped after %d consecutive failures; no failure timestamp recorded", cfg.ErrorCount),
+			FixHint:    "fix the upstream credential, cookie, or endpoint, then run `trvl provider reset <id>` to clear the breaker",
+		}
+	}
+
+	retryAt := tripAt.Add(circuitBreakerCooldown)
+	if now.Sub(tripAt) < circuitBreakerCooldown {
+		return CircuitHealth{
+			State:       "open",
+			ErrorCount:  cfg.ErrorCount,
+			Reason:      fmt.Sprintf("tripped after %d consecutive failures", cfg.ErrorCount),
+			NextRetryAt: retryAt.UTC().Format(time.RFC3339),
+			FixHint:     "wait for cooldown to elapse, or run `trvl provider reset <id>` to retry immediately",
+		}
+	}
+	return CircuitHealth{
+		State:      "half_open",
+		ErrorCount: cfg.ErrorCount,
+		Reason:     "cooldown elapsed; the next search will probe this provider",
+		FixHint:    "run a provider search to test recovery, or reset the provider with `trvl provider reset <id>` after fixing credentials",
+	}
+}

--- a/internal/providers/health_log.go
+++ b/internal/providers/health_log.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"time"
 )
@@ -13,7 +14,15 @@ import (
 const (
 	healthLogMaxBytes = 1 * 1024 * 1024 // 1 MB rotate threshold
 	healthLogBufSize  = 256             // channel buffer
+	healthFreshWindow = 24 * time.Hour
 )
+
+var healthSecretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)(authorization:\s*bearer\s+)[^\s,;]+`),
+	regexp.MustCompile(`(?i)\b(bearer\s+)[A-Za-z0-9._~+/\-]+=*`),
+	regexp.MustCompile(`(?i)([?&][^=\s&]*(?:api[_-]?key|token|secret|password|auth|session|csrf)[^=\s&]*=)[^&\s]+`),
+	regexp.MustCompile(`(?i)\b([A-Za-z0-9_.-]*(?:api[_-]?key|token|secret|password|auth|session|csrf)[A-Za-z0-9_.-]*\s*[:=]\s*)[^\s,;&]+`),
+}
 
 // HealthEntry records a single external provider API call outcome.
 type HealthEntry struct {
@@ -21,25 +30,36 @@ type HealthEntry struct {
 	Provider  string `json:"provider"`
 	// Operation is "search", "preflight", or "auth".
 	Operation string `json:"op"`
-	// Status is "ok", "error", or "timeout".
+	// Status is "ok", "error", "timeout", or "circuit_broken".
 	Status    string `json:"status"`
 	LatencyMs int64  `json:"latency_ms"`
 	Results   int    `json:"results,omitempty"`
 	Error     string `json:"error,omitempty"`
-	HintCode  string `json:"hint_code,omitempty"` // typed root-cause code when status != "ok"
+	// ErrorClass is a stable root-cause category such as RATE_LIMITED,
+	// TLS_TIMEOUT, or CIRCUIT_BROKEN. HintCode is retained for older readers.
+	ErrorClass string `json:"error_class,omitempty"`
+	HintCode   string `json:"hint_code,omitempty"` // typed root-cause code when status != "ok"
 }
 
 // ProviderHealth is the per-provider aggregate computed by HealthSummary.
 type ProviderHealth struct {
-	Provider     string  `json:"provider"`
-	TotalCalls   int     `json:"total_calls"`
-	SuccessCount int     `json:"success_count"`
-	ErrorCount   int     `json:"error_count"`
-	TimeoutCount int     `json:"timeout_count"`
-	SuccessRate  float64 `json:"success_rate"`
-	AvgLatencyMs int64   `json:"avg_latency_ms"`
-	LastError    string  `json:"last_error,omitempty"`
-	LastHintCode string  `json:"last_hint_code,omitempty"` // most recent root-cause code for failures
+	Provider       string  `json:"provider"`
+	TotalCalls     int     `json:"total_calls"`
+	SuccessCount   int     `json:"success_count"`
+	ErrorCount     int     `json:"error_count"`
+	TimeoutCount   int     `json:"timeout_count"`
+	SuccessRate    float64 `json:"success_rate"`
+	AvgLatencyMs   int64   `json:"avg_latency_ms"`
+	TotalResults   int     `json:"total_results"`
+	AvgResults     float64 `json:"avg_results"`
+	LastResults    int     `json:"last_results"`
+	LastSeen       string  `json:"last_seen,omitempty"`
+	LastSuccess    string  `json:"last_success,omitempty"`
+	LastFailure    string  `json:"last_failure,omitempty"`
+	Freshness      string  `json:"freshness"`
+	LastError      string  `json:"last_error,omitempty"`
+	LastErrorClass string  `json:"last_error_class,omitempty"`
+	LastHintCode   string  `json:"last_hint_code,omitempty"` // most recent root-cause code for failures
 }
 
 // healthWriter is the package-level singleton that owns the write goroutine.
@@ -102,7 +122,7 @@ func appendHealthEntry(entry HealthEntry) error {
 	}
 	defer func() { _ = f.Close() }()
 
-	line, err := json.Marshal(entry)
+	line, err := json.Marshal(sanitizeHealthEntry(entry))
 	if err != nil {
 		return err
 	}
@@ -118,11 +138,27 @@ func LogHealth(entry HealthEntry) {
 	if entry.Timestamp == "" {
 		entry.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	}
+	entry = sanitizeHealthEntry(entry)
 	select {
 	case healthCh <- entry:
 	default:
 		// channel full — drop silently
 	}
+}
+
+func sanitizeHealthEntry(entry HealthEntry) HealthEntry {
+	entry.Error = redactHealthText(entry.Error)
+	if entry.ErrorClass == "" {
+		entry.ErrorClass = entry.HintCode
+	}
+	return entry
+}
+
+func redactHealthText(s string) string {
+	for _, pattern := range healthSecretPatterns {
+		s = pattern.ReplaceAllString(s, "${1}<redacted>")
+	}
+	return s
 }
 
 // ReadHealthLog reads the last N entries from the health log in dir.
@@ -150,6 +186,7 @@ func ReadHealthLog(dir string, last int) ([]HealthEntry, error) {
 		if err := json.Unmarshal(line, &e); err != nil {
 			continue // skip malformed lines
 		}
+		e = sanitizeHealthEntry(e)
 		entries = append(entries, e)
 	}
 	if err := scanner.Err(); err != nil {
@@ -171,13 +208,20 @@ func HealthSummary(dir string) map[string]ProviderHealth {
 	}
 
 	type agg struct {
-		total        int
-		successes    int
-		errors       int
-		timeouts     int
-		latSum       int64
-		lastErr      string
-		lastHintCode string
+		total          int
+		successes      int
+		errors         int
+		timeouts       int
+		latSum         int64
+		totalResults   int
+		resultSamples  int
+		lastResults    int
+		lastSeen       time.Time
+		lastSuccess    time.Time
+		lastFailure    time.Time
+		lastErr        string
+		lastErrorClass string
+		lastHintCode   string
 	}
 	m := make(map[string]*agg)
 
@@ -189,29 +233,48 @@ func HealthSummary(dir string) map[string]ProviderHealth {
 		}
 		a.total++
 		a.latSum += e.LatencyMs
+		ts, hasTS := parseHealthTimestamp(e.Timestamp)
+		if hasTS && ts.After(a.lastSeen) {
+			a.lastSeen = ts
+		}
 		switch e.Status {
 		case "ok":
 			a.successes++
+			a.totalResults += e.Results
+			a.resultSamples++
+			a.lastResults = e.Results
+			if hasTS && ts.After(a.lastSuccess) {
+				a.lastSuccess = ts
+			}
 		case "timeout":
 			a.timeouts++
+			if hasTS && ts.After(a.lastFailure) {
+				a.lastFailure = ts
+			}
 			if e.Error != "" {
 				a.lastErr = e.Error
 			}
-			if e.HintCode != "" {
-				a.lastHintCode = e.HintCode
+			if code := healthErrorClass(e); code != "" {
+				a.lastErrorClass = code
+				a.lastHintCode = code
 			}
 		default:
 			a.errors++
+			if hasTS && ts.After(a.lastFailure) {
+				a.lastFailure = ts
+			}
 			if e.Error != "" {
 				a.lastErr = e.Error
 			}
-			if e.HintCode != "" {
-				a.lastHintCode = e.HintCode
+			if code := healthErrorClass(e); code != "" {
+				a.lastErrorClass = code
+				a.lastHintCode = code
 			}
 		}
 	}
 
 	result := make(map[string]ProviderHealth, len(m))
+	now := time.Now().UTC()
 	for provider, a := range m {
 		var avgLat int64
 		if a.total > 0 {
@@ -221,17 +284,64 @@ func HealthSummary(dir string) map[string]ProviderHealth {
 		if a.total > 0 {
 			rate = float64(a.successes) / float64(a.total)
 		}
+		var avgResults float64
+		if a.resultSamples > 0 {
+			avgResults = float64(a.totalResults) / float64(a.resultSamples)
+		}
 		result[provider] = ProviderHealth{
-			Provider:     provider,
-			TotalCalls:   a.total,
-			SuccessCount: a.successes,
-			ErrorCount:   a.errors,
-			TimeoutCount: a.timeouts,
-			SuccessRate:  rate,
-			AvgLatencyMs: avgLat,
-			LastError:    a.lastErr,
-			LastHintCode: a.lastHintCode,
+			Provider:       provider,
+			TotalCalls:     a.total,
+			SuccessCount:   a.successes,
+			ErrorCount:     a.errors,
+			TimeoutCount:   a.timeouts,
+			SuccessRate:    rate,
+			AvgLatencyMs:   avgLat,
+			TotalResults:   a.totalResults,
+			AvgResults:     avgResults,
+			LastResults:    a.lastResults,
+			LastSeen:       formatHealthTime(a.lastSeen),
+			LastSuccess:    formatHealthTime(a.lastSuccess),
+			LastFailure:    formatHealthTime(a.lastFailure),
+			Freshness:      healthFreshness(a.lastSeen, now),
+			LastError:      a.lastErr,
+			LastErrorClass: a.lastErrorClass,
+			LastHintCode:   a.lastHintCode,
 		}
 	}
 	return result
+}
+
+func healthErrorClass(e HealthEntry) string {
+	if e.ErrorClass != "" {
+		return e.ErrorClass
+	}
+	return e.HintCode
+}
+
+func parseHealthTimestamp(raw string) (time.Time, bool) {
+	if raw == "" {
+		return time.Time{}, false
+	}
+	ts, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return ts.UTC(), true
+}
+
+func formatHealthTime(ts time.Time) string {
+	if ts.IsZero() {
+		return ""
+	}
+	return ts.UTC().Format(time.RFC3339)
+}
+
+func healthFreshness(lastSeen, now time.Time) string {
+	if lastSeen.IsZero() {
+		return "unknown"
+	}
+	if now.Sub(lastSeen) > healthFreshWindow {
+		return "stale"
+	}
+	return "fresh"
 }

--- a/internal/providers/health_log_test.go
+++ b/internal/providers/health_log_test.go
@@ -87,12 +87,13 @@ func TestReadHealthLog_Last(t *testing.T) {
 func TestHealthSummary_Aggregation(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "health.jsonl")
+	now := time.Now().UTC()
 
 	entries := []HealthEntry{
-		{Provider: "agoda", Operation: "search", Status: "ok", LatencyMs: 100},
-		{Provider: "agoda", Operation: "search", Status: "ok", LatencyMs: 200},
-		{Provider: "agoda", Operation: "search", Status: "error", LatencyMs: 50, Error: "http 403"},
-		{Provider: "booking", Operation: "search", Status: "timeout", LatencyMs: 30000, Error: "deadline exceeded"},
+		{Timestamp: now.Add(-3 * time.Hour).Format(time.RFC3339), Provider: "agoda", Operation: "search", Status: "ok", LatencyMs: 100, Results: 4},
+		{Timestamp: now.Add(-2 * time.Hour).Format(time.RFC3339), Provider: "agoda", Operation: "search", Status: "ok", LatencyMs: 200, Results: 8},
+		{Timestamp: now.Add(-1 * time.Hour).Format(time.RFC3339), Provider: "agoda", Operation: "search", Status: "error", LatencyMs: 50, Error: "http 403", HintCode: string(FixHintAkamaiBlock)},
+		{Timestamp: now.Add(-48 * time.Hour).Format(time.RFC3339), Provider: "booking", Operation: "search", Status: "timeout", LatencyMs: 30000, Error: "deadline exceeded", ErrorClass: string(FixHintTLSTimeout)},
 	}
 
 	f, _ := os.Create(path)
@@ -128,6 +129,21 @@ func TestHealthSummary_Aggregation(t *testing.T) {
 	if agoda.LastError != "http 403" {
 		t.Errorf("agoda last_error: got %q", agoda.LastError)
 	}
+	if agoda.TotalResults != 12 {
+		t.Errorf("agoda total_results: got %d, want 12", agoda.TotalResults)
+	}
+	if agoda.AvgResults != 6 {
+		t.Errorf("agoda avg_results: got %f, want 6", agoda.AvgResults)
+	}
+	if agoda.LastResults != 8 {
+		t.Errorf("agoda last_results: got %d, want 8", agoda.LastResults)
+	}
+	if agoda.Freshness != "fresh" {
+		t.Errorf("agoda freshness: got %q, want fresh", agoda.Freshness)
+	}
+	if agoda.LastErrorClass != string(FixHintAkamaiBlock) {
+		t.Errorf("agoda last_error_class: got %q, want %q", agoda.LastErrorClass, FixHintAkamaiBlock)
+	}
 
 	booking := summary["booking"]
 	if booking.TimeoutCount != 1 {
@@ -135,6 +151,48 @@ func TestHealthSummary_Aggregation(t *testing.T) {
 	}
 	if booking.ErrorCount != 0 {
 		t.Errorf("booking error_count: got %d, want 0", booking.ErrorCount)
+	}
+	if booking.Freshness != "stale" {
+		t.Errorf("booking freshness: got %q, want stale", booking.Freshness)
+	}
+	if booking.LastErrorClass != string(FixHintTLSTimeout) {
+		t.Errorf("booking last_error_class: got %q, want %q", booking.LastErrorClass, FixHintTLSTimeout)
+	}
+}
+
+func TestSanitizeHealthEntryRedactsSecrets(t *testing.T) {
+	entry := sanitizeHealthEntry(HealthEntry{
+		Provider: "secret-provider",
+		Status:   "error",
+		Error:    "GET https://api.example/search?api_key=secret123&session_token=tok456 failed Authorization: Bearer abc.def",
+		HintCode: string(FixHintRateLimited),
+	})
+	if strings.Contains(entry.Error, "secret123") || strings.Contains(entry.Error, "tok456") || strings.Contains(entry.Error, "abc.def") {
+		t.Fatalf("secret leaked after redaction: %s", entry.Error)
+	}
+	if entry.ErrorClass != string(FixHintRateLimited) {
+		t.Fatalf("ErrorClass = %q, want %q", entry.ErrorClass, FixHintRateLimited)
+	}
+}
+
+func TestCircuitBreakerHealthStates(t *testing.T) {
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	if got := CircuitBreakerHealth(&ProviderConfig{ErrorCount: 1}, now); got.State != "closed" {
+		t.Fatalf("state = %q, want closed", got.State)
+	}
+	open := CircuitBreakerHealth(&ProviderConfig{
+		ErrorCount:  circuitBreakerThreshold,
+		LastErrorAt: now.Add(-time.Minute),
+	}, now)
+	if open.State != "open" || open.NextRetryAt == "" || open.FixHint == "" {
+		t.Fatalf("open circuit health = %#v", open)
+	}
+	half := CircuitBreakerHealth(&ProviderConfig{
+		ErrorCount:  circuitBreakerThreshold,
+		LastErrorAt: now.Add(-(circuitBreakerCooldown + time.Minute)),
+	}, now)
+	if half.State != "half_open" {
+		t.Fatalf("state = %q, want half_open", half.State)
 	}
 }
 

--- a/internal/providers/runtime.go
+++ b/internal/providers/runtime.go
@@ -347,6 +347,14 @@ func (rt *Runtime) SearchHotels(ctx context.Context, location string, lat, lon f
 					Error:   fmt.Sprintf("circuit breaker tripped after %d consecutive failures (never succeeded; awaiting cooldown)", cfg.ErrorCount),
 					FixHint: "fix the upstream credential / cookie / endpoint, then run `trvl provider reset <id>` to clear the breaker",
 				})
+				LogHealth(HealthEntry{
+					Provider:   cfg.ID,
+					Operation:  "search",
+					Status:     "circuit_broken",
+					Error:      fmt.Sprintf("circuit breaker tripped after %d consecutive failures (never succeeded; awaiting cooldown)", cfg.ErrorCount),
+					ErrorClass: "CIRCUIT_BROKEN",
+					HintCode:   "CIRCUIT_BROKEN",
+				})
 				continue
 			}
 			if now.Sub(tripAt) < circuitBreakerCooldown {
@@ -367,6 +375,14 @@ func (rt *Runtime) SearchHotels(ctx context.Context, location string, lat, lon f
 						cfg.LastError,
 						recoveryAt.Format(time.RFC3339)),
 					FixHint: "wait for cooldown to elapse, or run `trvl provider reset <id>` to retry immediately",
+				})
+				LogHealth(HealthEntry{
+					Provider:   cfg.ID,
+					Operation:  "search",
+					Status:     "circuit_broken",
+					Error:      fmt.Sprintf("circuit breaker tripped after %d consecutive failures; last error: %s; recovery probe at %s", cfg.ErrorCount, cfg.LastError, recoveryAt.Format(time.RFC3339)),
+					ErrorClass: "CIRCUIT_BROKEN",
+					HintCode:   "CIRCUIT_BROKEN",
 				})
 				continue
 			}

--- a/mcp/tools_provider_health_test.go
+++ b/mcp/tools_provider_health_test.go
@@ -1,0 +1,125 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/providers"
+)
+
+func TestProviderHealthSurfacesFreshnessResultsAndCircuitState(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	reg, err := providers.NewRegistryAt(filepath.Join(tmp, "providers"))
+	if err != nil {
+		t.Fatalf("NewRegistryAt: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := reg.Save(&providers.ProviderConfig{
+		ID:          "flaky",
+		Name:        "Flaky Provider",
+		Category:    "hotel",
+		Endpoint:    "https://example.com/search",
+		Method:      "GET",
+		ErrorCount:  5,
+		LastError:   "http 429",
+		LastErrorAt: now.Add(-time.Minute),
+		ResponseMapping: providers.ResponseMapping{
+			ResultsPath: "items",
+		},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	healthPath := filepath.Join(tmp, ".trvl", "health.jsonl")
+	if err := os.MkdirAll(filepath.Dir(healthPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	entries := []providers.HealthEntry{
+		{
+			Timestamp: now.Add(-2 * time.Minute).Format(time.RFC3339),
+			Provider:  "flaky",
+			Operation: "search",
+			Status:    "ok",
+			LatencyMs: 120,
+			Results:   6,
+		},
+		{
+			Timestamp:  now.Add(-time.Minute).Format(time.RFC3339),
+			Provider:   "flaky",
+			Operation:  "search",
+			Status:     "error",
+			LatencyMs:  250,
+			Error:      "http 429 for https://example.com?api_key=secret123",
+			ErrorClass: string(providers.FixHintRateLimited),
+			HintCode:   string(providers.FixHintRateLimited),
+		},
+	}
+	f, err := os.Create(healthPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		line, _ := json.Marshal(entry)
+		_, _ = f.Write(append(line, '\n'))
+	}
+	_ = f.Close()
+
+	content, structured, err := handleProviderHealth(context.Background(), nil, nil, nil, nil, reg, nil)
+	if err != nil {
+		t.Fatalf("handleProviderHealth: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("expected text content")
+	}
+	text := content[0].Text
+	for _, want := range []string{"flaky", "freshness fresh", "results total 6", "circuit open", string(providers.FixHintRateLimited)} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("provider_health text missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "secret123") {
+		t.Fatalf("provider_health text leaked secret:\n%s", text)
+	}
+
+	var parsed struct {
+		Providers []struct {
+			Provider           string  `json:"provider"`
+			Name               string  `json:"name"`
+			TotalResults       int     `json:"total_results"`
+			AvgResults         float64 `json:"avg_results"`
+			Freshness          string  `json:"freshness"`
+			LastErrorClass     string  `json:"last_error_class"`
+			CircuitState       string  `json:"circuit_state"`
+			CircuitNextRetryAt string  `json:"circuit_next_retry_at"`
+			FixHint            string  `json:"fix_hint"`
+		} `json:"providers"`
+	}
+	data, _ := json.Marshal(structured)
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal structured: %v", err)
+	}
+	if len(parsed.Providers) != 1 {
+		t.Fatalf("providers = %d, want 1: %s", len(parsed.Providers), data)
+	}
+	row := parsed.Providers[0]
+	if row.Provider != "flaky" || row.Name != "Flaky Provider" {
+		t.Fatalf("row identity = %#v", row)
+	}
+	if row.TotalResults != 6 || row.AvgResults != 6 {
+		t.Fatalf("result metrics = total %d avg %f, want 6/6", row.TotalResults, row.AvgResults)
+	}
+	if row.Freshness != "fresh" || row.LastErrorClass != string(providers.FixHintRateLimited) {
+		t.Fatalf("freshness/error class = %#v", row)
+	}
+	if row.CircuitState != "open" || row.CircuitNextRetryAt == "" || row.FixHint == "" {
+		t.Fatalf("circuit fields = %#v", row)
+	}
+}

--- a/mcp/tools_providers.go
+++ b/mcp/tools_providers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -827,48 +828,126 @@ func providerHealthTool() ToolDef {
 }
 
 // handleProviderHealth processes a provider_health tool call.
-func handleProviderHealth(_ context.Context, _ map[string]any, _ ElicitFunc, _ SamplingFunc, _ ProgressFunc, _ *providers.Registry, _ *providers.Runtime) ([]ContentBlock, interface{}, error) {
+func handleProviderHealth(_ context.Context, _ map[string]any, _ ElicitFunc, _ SamplingFunc, _ ProgressFunc, reg *providers.Registry, _ *providers.Runtime) ([]ContentBlock, interface{}, error) {
 	dir, err := providers.HealthLogDir()
 	if err != nil {
 		return nil, nil, fmt.Errorf("provider_health: %w", err)
 	}
 
 	summary := providers.HealthSummary(dir)
-	if len(summary) == 0 {
+	configs := map[string]*providers.ProviderConfig{}
+	if reg != nil {
+		for _, cfg := range reg.List() {
+			configs[cfg.ID] = cfg
+		}
+	}
+	if len(summary) == 0 && len(configs) == 0 {
 		return textContent("No health data recorded yet. Health entries are written after provider searches."), nil, nil
 	}
 
 	type row struct {
-		Provider     string  `json:"provider"`
-		TotalCalls   int     `json:"total_calls"`
-		SuccessCount int     `json:"success_count"`
-		ErrorCount   int     `json:"error_count"`
-		TimeoutCount int     `json:"timeout_count"`
-		SuccessRate  float64 `json:"success_rate"`
-		AvgLatencyMs int64   `json:"avg_latency_ms"`
-		LastError    string  `json:"last_error,omitempty"`
+		Provider           string  `json:"provider"`
+		Name               string  `json:"name,omitempty"`
+		TotalCalls         int     `json:"total_calls"`
+		SuccessCount       int     `json:"success_count"`
+		ErrorCount         int     `json:"error_count"`
+		TimeoutCount       int     `json:"timeout_count"`
+		SuccessRate        float64 `json:"success_rate"`
+		AvgLatencyMs       int64   `json:"avg_latency_ms"`
+		TotalResults       int     `json:"total_results"`
+		AvgResults         float64 `json:"avg_results"`
+		LastResults        int     `json:"last_results"`
+		LastSeen           string  `json:"last_seen,omitempty"`
+		LastSuccess        string  `json:"last_success,omitempty"`
+		LastFailure        string  `json:"last_failure,omitempty"`
+		Freshness          string  `json:"freshness"`
+		LastError          string  `json:"last_error,omitempty"`
+		LastErrorClass     string  `json:"last_error_class,omitempty"`
+		LastHintCode       string  `json:"last_hint_code,omitempty"`
+		CircuitState       string  `json:"circuit_state"`
+		CircuitErrorCount  int     `json:"circuit_error_count,omitempty"`
+		CircuitReason      string  `json:"circuit_reason,omitempty"`
+		CircuitNextRetryAt string  `json:"circuit_next_retry_at,omitempty"`
+		FixHint            string  `json:"fix_hint,omitempty"`
 	}
 
-	rows := make([]row, 0, len(summary))
-	var lines []string
-	for _, h := range summary {
-		rows = append(rows, row{
-			Provider:     h.Provider,
-			TotalCalls:   h.TotalCalls,
-			SuccessCount: h.SuccessCount,
-			ErrorCount:   h.ErrorCount,
-			TimeoutCount: h.TimeoutCount,
-			SuccessRate:  h.SuccessRate,
-			AvgLatencyMs: h.AvgLatencyMs,
-			LastError:    h.LastError,
-		})
-		line := fmt.Sprintf("- %s: %d calls, %.0f%% ok, avg %dms",
-			h.Provider, h.TotalCalls, h.SuccessRate*100, h.AvgLatencyMs)
-		if h.ErrorCount > 0 || h.TimeoutCount > 0 {
-			line += fmt.Sprintf(", %d errors, %d timeouts", h.ErrorCount, h.TimeoutCount)
+	providerIDs := make(map[string]bool, len(summary)+len(configs))
+	for id := range summary {
+		providerIDs[id] = true
+	}
+	for id := range configs {
+		providerIDs[id] = true
+	}
+
+	rows := make([]row, 0, len(providerIDs))
+	now := time.Now()
+	for id := range providerIDs {
+		h := summary[id]
+		if h.Provider == "" {
+			h.Provider = id
+			h.Freshness = "unknown"
 		}
-		if h.LastError != "" {
-			line += fmt.Sprintf(", last error: %s", h.LastError)
+		cfg := configs[id]
+		circuit := providers.CircuitBreakerHealth(cfg, now)
+		name := ""
+		if cfg != nil {
+			name = cfg.Name
+		}
+		rows = append(rows, row{
+			Provider:           h.Provider,
+			Name:               name,
+			TotalCalls:         h.TotalCalls,
+			SuccessCount:       h.SuccessCount,
+			ErrorCount:         h.ErrorCount,
+			TimeoutCount:       h.TimeoutCount,
+			SuccessRate:        h.SuccessRate,
+			AvgLatencyMs:       h.AvgLatencyMs,
+			TotalResults:       h.TotalResults,
+			AvgResults:         h.AvgResults,
+			LastResults:        h.LastResults,
+			LastSeen:           h.LastSeen,
+			LastSuccess:        h.LastSuccess,
+			LastFailure:        h.LastFailure,
+			Freshness:          h.Freshness,
+			LastError:          h.LastError,
+			LastErrorClass:     h.LastErrorClass,
+			LastHintCode:       h.LastHintCode,
+			CircuitState:       circuit.State,
+			CircuitErrorCount:  circuit.ErrorCount,
+			CircuitReason:      circuit.Reason,
+			CircuitNextRetryAt: circuit.NextRetryAt,
+			FixHint:            circuit.FixHint,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Provider < rows[j].Provider })
+
+	var lines []string
+	for _, r := range rows {
+		label := r.Provider
+		if r.Name != "" && r.Name != r.Provider {
+			label = fmt.Sprintf("%s (%s)", r.Provider, r.Name)
+		}
+		line := fmt.Sprintf("- %s: %d calls, %.0f%% ok, avg %dms, freshness %s, results total %d avg %.1f, circuit %s",
+			label, r.TotalCalls, r.SuccessRate*100, r.AvgLatencyMs, r.Freshness, r.TotalResults, r.AvgResults, r.CircuitState)
+		if r.ErrorCount > 0 || r.TimeoutCount > 0 {
+			line += fmt.Sprintf(", %d errors, %d timeouts", r.ErrorCount, r.TimeoutCount)
+		}
+		if r.LastErrorClass != "" {
+			line += fmt.Sprintf(", class %s", r.LastErrorClass)
+		}
+		if r.LastError != "" {
+			line += fmt.Sprintf(", last error: %s", r.LastError)
+		}
+		if r.CircuitState == "open" || r.CircuitState == "half_open" {
+			if r.CircuitReason != "" {
+				line += fmt.Sprintf(", reason: %s", r.CircuitReason)
+			}
+			if r.CircuitNextRetryAt != "" {
+				line += fmt.Sprintf(", next retry: %s", r.CircuitNextRetryAt)
+			}
+			if r.FixHint != "" {
+				line += fmt.Sprintf(", fix: %s", r.FixHint)
+			}
 		}
 		lines = append(lines, line)
 	}


### PR DESCRIPTION
## Summary
- Extends provider health logging with redacted error text, stable error classes, result-count aggregates, freshness, and last-seen timestamps.
- Adds circuit-break health projection to `provider_health`, including open/half-open state, next retry time, and fix hints for agents.
- Updates README, AGENTS.md, and the bundled trvl skill so provider audit guidance matches the new output.

## Acceptance Criteria
- GH-92.PROVIDERS.1: Provider search health entries now carry timestamp, latency, result count on success, error class on failure, and are sanitized before write/read.
- GH-92.PROVIDERS.2: `provider_health` returns success rate, freshness, average latency, last error class, result metrics, and circuit state.
- GH-92.PROVIDERS.3: README/AGENTS/skill docs describe the rendered metrics and redacted health log behavior.
- GH-92.PROVIDERS.4: Circuit-broken providers surface typed state, next retry, and actionable reset/fix hints.

## DoD Evidence
- `go test -short ./internal/providers -run 'Health|Circuit' -count=1`
- `go test -short ./mcp -run 'ProviderHealth|HandleProviderHealth' -count=1`
- `go test -short ./internal/providers ./mcp ./cmd/trvl`
- `go test -short -race ./internal/providers ./mcp`
- `GOTMPDIR=$PWD/.gotmp go test -short -p=1 -race -coverprofile=/tmp/trvl-provider-health-coverage.out ./...` (total coverage 78.2%)
- `go build ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` (No vulnerabilities found)
- `/Users/mikko/.claude/bin/mcp-security-scan --json .`
- `gofmt -l $(git ls-files '*.go')`
- `git diff --check`
- diff secret scan found only redaction regexes and synthetic redaction-test strings, no real credentials

Fixes #92
