### PR TITLE
build(goreleaser): shorten brew desc — fix homebrew-tap CI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -138,7 +138,7 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
     homepage: https://github.com/MikkoParkkola/trvl
-    description: "AI travel agent — 55 MCP tools for flights, hotels, ground transport, price alerts. Free, no API keys."
+    description: "Travel MCP server — flights, hotels, ground transport, no API keys for search"
     license: "PolyForm-Noncommercial-1.0.0"
     install: |
       bin.install "trvl"


### PR DESCRIPTION
## Summary

Shortens GoReleaser-generated brew description from 102 chars (rubocop violation) to 79 chars.

## Root cause

`homebrew-tap` CI has been red since the v1.2.x train started (failures on 2026-05-18, 2026-05-12). `rubocop FormulaAudit/Desc` rules:
- Description must be < 80 characters (was 102)
- Description must not end with a full stop (was "...no API keys.")

Both violations come from `.goreleaser.yaml:141` which generates `Formula/trvl.rb` in `MikkoParkkola/homebrew-tap` on each tagged release.

## Fix

`.goreleaser.yaml:141`:
- Before: `"AI travel agent — 55 MCP tools for flights, hotels, ground transport, price alerts. Free, no API keys."` (102 chars, full stop)
- After: `"Travel MCP server — flights, hotels, ground transport, no API keys for search"` (79 chars, no full stop)

## Test plan

- [x] String length verified < 80 chars
- [x] No trailing full stop
- [ ] Next tagged release will regenerate Formula/trvl.rb with the new desc
- [ ] homebrew-tap CI returns to green after that release

## Linked
- MIK-4390 (public-repo health sweep) — clears 3rd of 3 red flags
  (PR #104 for nab + PR #199 for mcp-gateway already in queue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
