### PR TITLE
ci: add top-level least-privilege permissions block

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     permissions:


### PR DESCRIPTION
## Summary
- Add a workflow-level `permissions: contents: read` block to `.github/workflows/ci.yaml`.
- Keeps `GITHUB_TOKEN` read-only by default so any job without an explicit grant can't write.
- The `test` job retains its per-job `contents: write` for the coverage-badge push; `release`/`npm-publish` keep their existing per-job grants.

## Why
Least-privilege hardening keeps the token scope honest and prevents accidental write access drifting into new jobs.

## Test plan
- [ ] CI green on ubuntu + windows (build, vet, staticcheck, govulncheck, race tests, coverage >=50%)
- [ ] Coverage badge push still succeeds on main

Generated with Claude Code