### PR TITLE
ci: pin goreleaser-action back to v6.4.0 (fix v1.4.0 release failure)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,14 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "UTC"
+    ignore:
+      # Pin goreleaser-action to v6.x. v7 adds a cosign self-verification of
+      # the downloaded goreleaser binary that is incompatible with the
+      # sigstore-bundle-v0.3 format goreleaser v2.4+ ships (cosign rejects
+      # the bundle: "does not contain cert"). PR #108 auto-bumped to v7.2.2
+      # and broke the v1.4.0 release. See the comment in release.yml.
+      - dependency-name: "goreleaser/goreleaser-action"
+        versions: [">=7"]
 
   - package-ecosystem: "gomod"
     directory: "/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         # "does not contain cert"). v6.4.0 skips that pre-flight check;
         # our own signs: block in .goreleaser.yaml still uses the
         # cosign-installer cosign for signing release artifacts correctly.
-        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -79,7 +79,7 @@ jobs:
 
       - name: Run GoReleaser without Homebrew tap
         if: env.HAS_HOMEBREW_TAP_TOKEN != 'true'
-        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
## Problem
The `v1.4.0` release run failed in the `goreleaser` job before producing any artifacts:
```
Verifying checksums.txt signature with cosign ...
Error: bundle does not contain cert for verification, please provide public key
```

## Root cause
Dependabot #108 auto-bumped `goreleaser/goreleaser-action` 6.4.0 -> 7.2.2 — the exact bump the in-repo comment (release.yml:57-64) warns against. v7 self-verifies the downloaded goreleaser binary with cosign and passes `--bundle` without `--new-bundle-format`, so cosign rejects goreleaser v2.16.0's sigstore-bundle-v0.3 format. v1.3.0 shipped green on v6.4.0 earlier the same day.

## Fix
- Revert both `uses:` lines to `goreleaser-action@v6.4.0` (pinned SHA `e435ccd`).
- Add a dependabot `ignore` for `goreleaser-action >=7` so the regression cannot recur.

## Acceptance criteria
- TRVL.CI.1: CI build/vet/staticcheck/test pass on this branch.
- TRVL.CI.2: After merge, re-tagging `v1.4.0` triggers a green release.yml run that publishes the GH release + homebrew formula.

## ROI
Unblocks the v1.4.0 release (new providers HomeToGo/WizzAir/Transavia/Travelpayouts + air-quality/sun/bike-share). Value: restored release channel; Cost: 2-line revert. Fail-fast: tag re-run is the proof.

## Source
release.yml:57-64 cautionary comment; failed run 26418877955.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>