### PR TITLE
ci(release): npm publish via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,27 +151,30 @@ jobs:
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish
 
-  # Publishes the npm wrapper (trvl-mcp) which downloads the release binary on
-  # install. Opt-in: only runs when an NPM_TOKEN secret is configured, mirroring
-  # the HOMEBREW_TAP_TOKEN gating on the goreleaser job. The version is stamped
-  # from the release tag so npm never drifts from the GitHub release.
+  # Publishes the trvl-mcp npm wrapper via npm Trusted Publishing (OIDC) — no
+  # stored token. One-time npmjs.com setup required: package trvl-mcp ->
+  # Settings -> Trusted Publisher -> GitHub Actions, repo MikkoParkkola/trvl,
+  # workflow release.yml, environment (none). Until that's configured this job
+  # fails loudly, but the GitHub release itself is already published by the
+  # goreleaser job above, so the release is not blocked.
   npm:
     runs-on: ubuntu-latest
     needs: goreleaser
-    env:
-      HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' }}
+    permissions:
+      contents: read
+      id-token: write  # OIDC token for npm trusted publishing + provenance
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Stamp version from tag and publish
-        if: env.HAS_NPM_TOKEN == 'true'
+      # OIDC trusted publishing needs npm >= 11.5.1; ubuntu-latest may ship older.
+      - name: Use recent npm
+        run: npm install -g npm@latest
+
+      - name: Stamp version from tag and publish (OIDC, no token)
         working-directory: npm
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           npm version "${VERSION}" --no-git-tag-version --allow-same-version
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          npm publish --access public
+          npm publish --provenance --access public
 


### PR DESCRIPTION
## Summary
- Replaces the `NPM_TOKEN`-gated npm publish job with **keyless OIDC Trusted Publishing** (`id-token: write` + `npm publish --provenance`).
- No long-lived npm secret to store or rotate — matches the cosign keyless signing already in this workflow and the mcp-gateway sibling's npm setup.
- Version is stamped from the release tag so npm never drifts from the GitHub release.

## One-time setup required (npmjs.com)
Configure Trusted Publisher for package `trvl-mcp`: Settings → Trusted Publisher → GitHub Actions → repo `MikkoParkkola/trvl`, workflow `release.yml`. Until then the npm job fails loudly, but the GitHub release itself is unaffected (published by the goreleaser job).

## Test plan
- [ ] CI test matrix green (ubuntu + windows)
- [ ] On next `v*` tag after npmjs Trusted Publisher is configured, npm job publishes `trvl-mcp` with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)