### PR TITLE
feat: time + location awareness by default (CLI + MCP) + update-checker fix

### DIFF
--- a/cmd/trvl/cli_cmds_split6_test.go
+++ b/cmd/trvl/cli_cmds_split6_test.go
@@ -188,11 +188,13 @@ func TestDatesCmd_FlagsV5(t *testing.T) {
 }
 
 func TestDatesCmd_RequiresTwoArgsV5(t *testing.T) {
+	// Origin is now optional; dates needs at least DESTINATION. Zero args
+	// must still fail cobra's RangeArgs(1,2).
 	cmd := datesCmd()
-	cmd.SetArgs([]string{"HEL"})
+	cmd.SetArgs([]string{})
 	err := cmd.Execute()
 	if err == nil {
-		t.Error("expected error with one arg")
+		t.Error("expected error with zero args")
 	}
 }
 

--- a/cmd/trvl/cli_consolidated_config_test.go
+++ b/cmd/trvl/cli_consolidated_config_test.go
@@ -430,6 +430,9 @@ func TestPrefsSetCmd_UnknownKeyV21(t *testing.T) {
 func TestWhenCmd_MissingOriginNoPrefsV22(t *testing.T) {
 	tmp := t.TempDir()
 	setTestHome(t, tmp)
+	// Disable geo-IP so origin resolution can't silently succeed off the
+	// network; with no home airport and no explicit --origin it must error.
+	t.Setenv("TRVL_NO_GEO", "1")
 	cmd := whenCmd()
 	cmd.SetArgs([]string{"--to", "BCN", "--from", "2026-07-01", "--until", "2026-07-31"})
 	err := cmd.Execute()

--- a/cmd/trvl/cmd_test.go
+++ b/cmd/trvl/cmd_test.go
@@ -589,7 +589,7 @@ func TestExploreCmd_RequiresOneArg(t *testing.T) {
 	// no home airport, an explicit origin is still required — assert that
 	// path rather than a cobra arg-count error.
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	setTestHome(t, tmp)
 	t.Setenv("TRVL_NO_GEO", "1")
 	cmd := exploreCmd()
 	cmd.SilenceUsage = true

--- a/cmd/trvl/cmd_test.go
+++ b/cmd/trvl/cmd_test.go
@@ -66,7 +66,9 @@ func TestRootCmd_HelpContainsExamples(t *testing.T) {
 // flights command
 // ---------------------------------------------------------------------------
 
-func TestFlightsCmd_RequiresThreeArgs(t *testing.T) {
+func TestFlightsCmd_RequiresTwoArgs(t *testing.T) {
+	// Origin is now optional (resolved from prefs/geo), so the minimum is
+	// DESTINATION + DATE. A single arg must still be rejected by cobra.
 	cmd := flightsCmd()
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
@@ -76,13 +78,21 @@ func TestFlightsCmd_RequiresThreeArgs(t *testing.T) {
 	}
 }
 
-func TestFlightsCmd_TooFewArgsTwo(t *testing.T) {
+func TestFlightsCmd_AcceptsTwoArgs(t *testing.T) {
+	// DEST + DATE (no origin) must pass cobra arg validation. We disable the
+	// network geo path so the run is deterministic and offline; with no
+	// resolvable origin it returns a clear "no origin" error rather than an
+	// arg-count error. Either a nil error (origin resolved from prefs) or a
+	// non-arg-count error is acceptable here — what we assert is that cobra's
+	// RangeArgs(2,3) does NOT reject the 2-arg form.
+	t.Setenv("TRVL_NO_GEO", "1")
 	cmd := flightsCmd()
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
-	cmd.SetArgs([]string{"HEL", "NRT"})
-	if err := cmd.Execute(); err == nil {
-		t.Error("expected error with only 2 args")
+	cmd.SetArgs([]string{"NRT", "2099-01-01"})
+	err := cmd.Execute()
+	if err != nil && strings.Contains(err.Error(), "accepts") {
+		t.Errorf("2-arg form should pass cobra arg validation, got arg-count error: %v", err)
 	}
 }
 
@@ -114,7 +124,7 @@ func TestFlightsCmd_Flags(t *testing.T) {
 
 func TestFlightsCmd_UseLine(t *testing.T) {
 	cmd := flightsCmd()
-	if cmd.Use != "flights ORIGIN DESTINATION DATE" {
+	if cmd.Use != "flights [ORIGIN] DESTINATION DATE" {
 		t.Errorf("flights Use = %q", cmd.Use)
 	}
 }
@@ -533,12 +543,14 @@ func TestWatchDaemonCmd_Flags(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDatesCmd_RequiresTwoArgs(t *testing.T) {
+	// Origin is now optional; the minimum is DESTINATION. Zero args must
+	// still be rejected by cobra's RangeArgs(1,2).
 	cmd := datesCmd()
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
-	cmd.SetArgs([]string{"HEL"})
+	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err == nil {
-		t.Error("expected error with only 1 arg")
+		t.Error("expected error with 0 args")
 	}
 }
 
@@ -573,12 +585,18 @@ func TestDatesCmd_Flags(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestExploreCmd_RequiresOneArg(t *testing.T) {
+	// Origin is now optional (resolved from prefs/geo). With geo disabled and
+	// no home airport, an explicit origin is still required — assert that
+	// path rather than a cobra arg-count error.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("TRVL_NO_GEO", "1")
 	cmd := exploreCmd()
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
 	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err == nil {
-		t.Error("expected error with 0 args")
+		t.Error("expected error when no origin and none resolvable")
 	}
 }
 

--- a/cmd/trvl/dates.go
+++ b/cmd/trvl/dates.go
@@ -23,28 +23,41 @@ func datesCmd() *cobra.Command {
 		format         string
 		legacy         bool
 		targetCurrency string
+		noGeo          bool
 	)
 
 	cmd := &cobra.Command{
-		Use:   "dates ORIGIN DESTINATION",
+		Use:   "dates [ORIGIN] DESTINATION",
 		Short: "Find cheapest flight dates across a range",
 		Long: `Search for the cheapest flight prices across a date range.
 
-ORIGIN and DESTINATION are IATA airport codes (e.g. HEL, NRT, JFK).
+ORIGIN and DESTINATION are IATA airport codes (e.g. HEL, NRT, JFK). ORIGIN is
+optional: omit it and trvl resolves it from your saved home airport or, failing
+that, your current location (geo-IP, best-effort; disable with --no-geo).
 
 By default, uses Google's CalendarGraph API for fast single-request results.
 Falls back to per-date search automatically if CalendarGraph fails.
 Use --legacy to force the per-date search approach.
 
 Examples:
+  trvl dates NRT --from 2026-06-01 --to 2026-06-30
   trvl dates HEL NRT --from 2026-06-01 --to 2026-06-30
   trvl dates HEL NRT --from 2026-06-01 --to 2026-06-30 --round-trip --duration 7
   trvl dates HEL NRT --from 2026-06-01 --to 2026-06-07 --format json
   trvl dates HEL NRT --from 2026-06-01 --to 2026-06-30 --legacy`,
-		Args: cobra.ExactArgs(2),
+		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			origin := strings.ToUpper(args[0])
-			destination := strings.ToUpper(args[1])
+			var originArg, destination string
+			if len(args) == 2 {
+				originArg = args[0]
+				destination = strings.ToUpper(args[1])
+			} else {
+				destination = strings.ToUpper(args[0])
+			}
+			origin, err := resolveCLIOrigin(cmd.Context(), originArg, format, noGeo)
+			if err != nil {
+				return err
+			}
 
 			if legacy {
 				// Legacy: per-date N-call approach.
@@ -97,6 +110,7 @@ Examples:
 	cmd.Flags().StringVar(&format, "format", "table", "Output format: table, json")
 	cmd.Flags().BoolVar(&legacy, "legacy", false, "Use legacy per-date search (slower, more requests)")
 	cmd.Flags().StringVar(&targetCurrency, "currency", "", "Convert prices to this currency (e.g. EUR, USD). Empty = show API default")
+	cmd.Flags().BoolVar(&noGeo, "no-geo", false, "Disable geo-IP origin detection (also via TRVL_NO_GEO=1)")
 
 	cmd.ValidArgsFunction = airportCompletion
 

--- a/cmd/trvl/explore.go
+++ b/cmd/trvl/explore.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
@@ -23,24 +22,35 @@ func exploreCmd() *cobra.Command {
 		stops          string
 		format         string
 		targetCurrency string
+		noGeo          bool
 	)
 
 	cmd := &cobra.Command{
-		Use:   "explore ORIGIN",
+		Use:   "explore [ORIGIN]",
 		Short: "Discover cheapest destinations from an airport",
 		Long: `Explore flight destinations from an airport, sorted by price.
 
-ORIGIN is an IATA airport code (e.g. HEL, JFK, NRT).
+ORIGIN is an IATA airport code (e.g. HEL, JFK, NRT). It is optional: omit it
+and trvl resolves it from your saved home airport or current location (geo-IP,
+best-effort; disable with --no-geo).
 Returns a list of destinations with the cheapest available prices.
 
 Examples:
+  trvl explore
   trvl explore HEL
   trvl explore HEL --from 2026-07-01 --to 2026-07-14
   trvl explore JFK --type one-way
   trvl explore HEL --format json`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			origin := strings.ToUpper(args[0])
+			originArg := ""
+			if len(args) == 1 {
+				originArg = args[0]
+			}
+			origin, err := resolveCLIOrigin(cmd.Context(), originArg, format, noGeo)
+			if err != nil {
+				return err
+			}
 
 			if err := models.ValidateIATA(origin); err != nil {
 				return fmt.Errorf("invalid origin: %w", err)
@@ -117,6 +127,7 @@ Examples:
 	cmd.Flags().StringVar(&stops, "stops", "any", "Stops filter: any, nonstop")
 	cmd.Flags().StringVar(&format, "format", "table", "Output format: table, json")
 	cmd.Flags().StringVar(&targetCurrency, "currency", "", "Convert prices to this currency (e.g. EUR, USD). Empty = show API default")
+	cmd.Flags().BoolVar(&noGeo, "no-geo", false, "Disable geo-IP origin detection (also via TRVL_NO_GEO=1)")
 
 	cmd.ValidArgsFunction = airportCompletion
 

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -20,6 +20,7 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/points"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
 	"github.com/MikkoParkkola/trvl/internal/scoring"
+	"github.com/MikkoParkkola/trvl/internal/travelctx"
 	"github.com/spf13/cobra"
 )
 
@@ -36,13 +37,14 @@ func flightsCmd() *cobra.Command {
 		compareCabins  bool
 		explain        bool
 		award          bool
+		noGeo          bool
 		awardCookies   string
 		provider       string
 		flightRailFly  bool
 	)
 
 	cmd := &cobra.Command{
-		Use:   "flights ORIGIN DESTINATION DATE",
+		Use:   "flights [ORIGIN] DESTINATION DATE",
 		Short: "Search flights between airports (supports multi-airport)",
 		Long: `Search flights between airports on a specific date.
 
@@ -54,20 +56,67 @@ Examples:
   trvl flights AMS,EIN,ANR HEL,TKU,TLL 2026-06-15
   trvl flights HEL NRT 2026-06-15 --return 2026-06-22
   trvl flights HEL NRT 2026-06-15 --cabin business --stops nonstop`,
-		Args: cobra.ExactArgs(3),
+		Args: cobra.RangeArgs(2, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			originArg := args[0]
+			// Accept both "ORIGIN DEST DATE" (explicit) and "DEST DATE"
+			// (origin auto-resolved from location/time context).
+			var originArg, destArg, date string
+			switch len(args) {
+			case 3:
+				originArg, destArg, date = args[0], args[1], args[2]
+			default: // 2 args
+				destArg, date = args[0], args[1]
+			}
 
-			// If the user passes "home" as origin, resolve from preferences.
+			// Resolve the ambient search context (current time + best-available
+			// origin). Precedence: explicit ORIGIN > "home" keyword / saved home
+			// airport > geo-IP (best-effort, opt-out via --no-geo / TRVL_NO_GEO).
+			prefs, _ := preferences.Load() //nolint:errcheck // default prefs on error
+			explicitForCtx := originArg
 			if strings.EqualFold(strings.TrimSpace(originArg), "home") {
-				if prefs, err := preferences.Load(); err == nil && prefs.HomeAirport() != "" {
-					originArg = prefs.HomeAirport()
+				explicitForCtx = "" // fall through to prefs/home resolution
+			}
+			tctx := travelctx.Resolve(cmd.Context(), prefs, travelctx.Options{
+				ExplicitOrigin: explicitForCtx,
+				AllowGeoIP:     !noGeo,
+			})
+
+			// Auto-fill the origin when the user didn't pass an explicit code
+			// (2-arg form or the "home" keyword).
+			autoResolved := false
+			if explicitForCtx == "" && tctx.Origin.HasAirport() {
+				originArg = tctx.Origin.Airport
+				autoResolved = true
+			}
+			if strings.TrimSpace(originArg) == "" {
+				return fmt.Errorf("no origin given and none could be resolved from your preferences or location; pass ORIGIN explicitly, e.g. `trvl flights HEL %s %s`", destArg, date)
+			}
+			if autoResolved && format != "json" {
+				origName := tctx.Origin.City
+				if origName == "" {
+					origName = tctx.Origin.Airport
+				}
+				switch tctx.Origin.Source {
+				case travelctx.SourcePrefs:
+					_, _ = fmt.Fprintf(os.Stderr, "Origin %s (%s) — from your saved home airport.\n", tctx.Origin.Airport, origName)
+				case travelctx.SourceGeoIP:
+					_, _ = fmt.Fprintf(os.Stderr, "Origin %s (%s) — detected from your current location. Override with an explicit code or --no-geo.\n", tctx.Origin.Airport, origName)
 				}
 			}
 
 			origins := flights.ParseAirports(originArg)
-			destinations := flights.ParseAirports(args[1])
-			date := args[2]
+			destinations := flights.ParseAirports(destArg)
+
+			// Surface the booking window: lead time is one of the strongest fare
+			// levers, and trvl knows "now", so it can flag last-minute / too-early
+			// searches without being asked.
+			if format != "json" {
+				if dep, derr := time.Parse("2006-01-02", date); derr == nil {
+					if adv := travelctx.ClassifyWindow(tctx.LeadTimeDays(dep)).Advisory(); adv != "" {
+						_, _ = fmt.Fprintf(os.Stderr, "%s\n", adv)
+					}
+				}
+			}
 
 			// Validate IATA codes up-front so invalid input fails fast with a
 			// deterministic error, not via downstream provider HTTP calls. This
@@ -82,7 +131,7 @@ Examples:
 				}
 			}
 			if len(destinations) == 0 {
-				return fmt.Errorf("invalid destination: %q: at least one IATA code required", args[1])
+				return fmt.Errorf("invalid destination: %q: at least one IATA code required", destArg)
 			}
 			for _, code := range destinations {
 				if err := models.ValidateIATA(code); err != nil {
@@ -201,6 +250,7 @@ Examples:
 	cmd.Flags().StringVar(&awardCookies, "award-cookies", "", "KLM/Flying Blue Cookie header for --award (or set AFKL_KLM_COOKIES)")
 	cmd.Flags().StringVar(&provider, "provider", "", "Flight provider: empty = default (Google Flights + Kiwi + Skiplagged merge), skiplagged = Skiplagged MCP only (hidden-city + virtual-interlining defaults)")
 	cmd.Flags().BoolVar(&flightRailFly, "rail-fly", false, "Expand the search to rail-connected origins (KL/AF Air&Rail), surfacing cheaper rail+fly bundles even when the origin is outside the default hub list")
+	cmd.Flags().BoolVar(&noGeo, "no-geo", false, "Disable geo-IP origin detection (also honored via TRVL_NO_GEO=1). Origin then resolves only from an explicit code or your saved home airport.")
 
 	cmd.ValidArgsFunction = airportCompletion
 

--- a/cmd/trvl/grid.go
+++ b/cmd/trvl/grid.go
@@ -21,24 +21,37 @@ func gridCmd() *cobra.Command {
 		returnTo       string
 		format         string
 		targetCurrency string
+		noGeo          bool
 	)
 
 	cmd := &cobra.Command{
-		Use:   "grid ORIGIN DESTINATION",
+		Use:   "grid [ORIGIN] DESTINATION",
 		Short: "Show a departure x return price grid",
 		Long: `Show a 2D price grid of departure date x return date combinations.
 
-ORIGIN and DESTINATION are IATA airport codes (e.g. HEL, NRT, JFK).
+ORIGIN and DESTINATION are IATA airport codes (e.g. HEL, NRT, JFK). ORIGIN is
+optional: omit it and trvl resolves it from your saved home airport or current
+location (geo-IP, best-effort; disable with --no-geo).
 The grid shows the cheapest round-trip price for each date combination.
 
 Examples:
+  trvl grid NRT --depart-from 2026-07-01 --depart-to 2026-07-07 --return-from 2026-07-08 --return-to 2026-07-14
   trvl grid HEL NRT --depart-from 2026-07-01 --depart-to 2026-07-07 --return-from 2026-07-08 --return-to 2026-07-14
   trvl grid HEL BCN --depart-from 2026-06-15 --depart-to 2026-06-20 --return-from 2026-06-22 --return-to 2026-06-28
   trvl grid HEL NRT --format json`,
-		Args: cobra.ExactArgs(2),
+		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			origin := strings.ToUpper(args[0])
-			destination := strings.ToUpper(args[1])
+			var originArg, destination string
+			if len(args) == 2 {
+				originArg = args[0]
+				destination = strings.ToUpper(args[1])
+			} else {
+				destination = strings.ToUpper(args[0])
+			}
+			origin, err := resolveCLIOrigin(cmd.Context(), originArg, format, noGeo)
+			if err != nil {
+				return err
+			}
 
 			if err := models.ValidateIATA(origin); err != nil {
 				return fmt.Errorf("invalid origin: %w", err)
@@ -73,6 +86,7 @@ Examples:
 	cmd.Flags().StringVar(&returnTo, "return-to", "", "End of return range (YYYY-MM-DD); default: return-from + 6 days")
 	cmd.Flags().StringVar(&format, "format", "table", "Output format: table, json")
 	cmd.Flags().StringVar(&targetCurrency, "currency", "", "Convert prices to this currency (e.g. EUR, USD). Empty = show API default")
+	cmd.Flags().BoolVar(&noGeo, "no-geo", false, "Disable geo-IP origin detection (also via TRVL_NO_GEO=1)")
 
 	cmd.ValidArgsFunction = airportCompletion
 

--- a/cmd/trvl/origin.go
+++ b/cmd/trvl/origin.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/travelctx"
+)
+
+// resolveCLIOrigin resolves a possibly-omitted CLI origin argument the same
+// way across every flight-search command. Precedence: an explicit code (or
+// the "home" keyword, which routes to the saved home airport) > saved home
+// airport > best-effort geo-IP location.
+//
+// explicit is the raw ORIGIN arg ("" when the user omitted it). noGeo mirrors
+// the per-command --no-geo flag / TRVL_NO_GEO env. format gates the human
+// notice (suppressed for json). It returns the resolved IATA code, or an
+// actionable error when nothing could be determined.
+//
+// The one-line provenance notice ("from your saved home airport" / "detected
+// from your current location") is written to stderr so it never pollutes
+// machine-readable stdout.
+func resolveCLIOrigin(ctx context.Context, explicit, format string, noGeo bool) (string, error) {
+	explicitForCtx := explicit
+	if strings.EqualFold(strings.TrimSpace(explicit), "home") {
+		explicitForCtx = "" // fall through to prefs/home resolution
+	}
+	prefs, _ := preferences.Load() //nolint:errcheck // default prefs on error
+	tctx := travelctx.Resolve(ctx, prefs, travelctx.Options{
+		ExplicitOrigin: explicitForCtx,
+		AllowGeoIP:     !noGeo,
+	})
+	if !tctx.Origin.HasAirport() {
+		return "", fmt.Errorf("no origin given and none could be resolved from your preferences or location; pass ORIGIN explicitly or set a home airport via `trvl prefs`")
+	}
+	// Only narrate when we actually filled in an origin the user didn't type.
+	if explicitForCtx == "" && format != "json" {
+		name := tctx.Origin.City
+		if name == "" {
+			name = tctx.Origin.Airport
+		}
+		switch tctx.Origin.Source {
+		case travelctx.SourcePrefs:
+			_, _ = fmt.Fprintf(os.Stderr, "Origin %s (%s) — from your saved home airport.\n", tctx.Origin.Airport, name)
+		case travelctx.SourceGeoIP:
+			_, _ = fmt.Fprintf(os.Stderr, "Origin %s (%s) — detected from your current location. Override with an explicit code or --no-geo.\n", tctx.Origin.Airport, name)
+		}
+	}
+	return tctx.Origin.Airport, nil
+}

--- a/cmd/trvl/rune_validation_test.go
+++ b/cmd/trvl/rune_validation_test.go
@@ -23,7 +23,7 @@ func TestExploreCmd_RequiresOneArg_Extra(t *testing.T) {
 	// explore now accepts 0 args (origin auto-resolved). With geo disabled and
 	// no home airport, it must still error on an unresolvable origin.
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	setTestHome(t, tmp)
 	t.Setenv("TRVL_NO_GEO", "1")
 	cmd := exploreCmd()
 	cmd.SilenceUsage = true

--- a/cmd/trvl/rune_validation_test.go
+++ b/cmd/trvl/rune_validation_test.go
@@ -8,22 +8,29 @@ import "testing"
 // ---------------------------------------------------------------------------
 
 func TestDatesCmd_RequiresThreeArgs(t *testing.T) {
+	// Origin is now optional; dates needs at least DESTINATION. Zero args
+	// must still fail cobra's RangeArgs(1,2).
 	cmd := datesCmd()
-	cmd.SilenceUsage = true
-	cmd.SilenceErrors = true
-	cmd.SetArgs([]string{"HEL"})
-	if err := cmd.Execute(); err == nil {
-		t.Error("expected error with 1 arg")
-	}
-}
-
-func TestExploreCmd_RequiresOneArg_Extra(t *testing.T) {
-	cmd := exploreCmd()
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
 	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err == nil {
 		t.Error("expected error with 0 args")
+	}
+}
+
+func TestExploreCmd_RequiresOneArg_Extra(t *testing.T) {
+	// explore now accepts 0 args (origin auto-resolved). With geo disabled and
+	// no home airport, it must still error on an unresolvable origin.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("TRVL_NO_GEO", "1")
+	cmd := exploreCmd()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when no origin and none resolvable")
 	}
 }
 

--- a/cmd/trvl/when.go
+++ b/cmd/trvl/when.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
-	"github.com/MikkoParkkola/trvl/internal/preferences"
 	"github.com/MikkoParkkola/trvl/internal/tripwindow"
 	"github.com/spf13/cobra"
 )
@@ -24,6 +23,7 @@ func whenCmd() *cobra.Command {
 		maxCandidates int
 		budgetEUR     float64
 		formatOut     string
+		noGeo         bool
 	)
 
 	cmd := &cobra.Command{
@@ -57,15 +57,13 @@ Examples:
 				return fmt.Errorf("--until YYYY-MM-DD is required")
 			}
 
-			// Resolve origin from flag or preferences.
-			if origin == "" {
-				if prefs, err := preferences.Load(); err == nil && prefs != nil && len(prefs.HomeAirports) > 0 {
-					origin = prefs.HomeAirports[0]
-				}
+			// Resolve origin: explicit --origin flag, else saved home airport,
+			// else best-effort geo-IP location (disable with --no-geo).
+			resolved, err := resolveCLIOrigin(cmd.Context(), origin, formatOut, noGeo)
+			if err != nil {
+				return fmt.Errorf("--origin is required (or set home_airports in ~/.trvl/preferences.json): %w", err)
 			}
-			if origin == "" {
-				return fmt.Errorf("--origin is required (or set home_airports in ~/.trvl/preferences.json)")
-			}
+			origin = resolved
 
 			// Validate origin IATA.
 			if err := models.ValidateIATA(origin); err != nil {
@@ -153,6 +151,7 @@ Examples:
 	cmd.Flags().String("to", "", "Destination city or IATA code (required)")
 	_ = cmd.MarkFlagRequired("to")
 	cmd.Flags().StringVar(&origin, "origin", "", "Origin IATA code (default: first home_airport from preferences)")
+	cmd.Flags().BoolVar(&noGeo, "no-geo", false, "Disable geo-IP origin detection (also via TRVL_NO_GEO=1)")
 	cmd.Flags().StringVar(&windowStart, "from", "", "Earliest departure date YYYY-MM-DD (required)")
 	_ = cmd.MarkFlagRequired("from")
 	cmd.Flags().StringVar(&windowEnd, "until", "", "Latest return date YYYY-MM-DD (required)")

--- a/internal/selfupdate/check.go
+++ b/internal/selfupdate/check.go
@@ -25,8 +25,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/MikkoParkkola/trvl/internal/upgrade"
 )
 
 const (
@@ -160,7 +158,7 @@ func (c *Checker) Check(ctx context.Context, disableForCI bool) (UpdateInfo, err
 		// changed since the cache was written (user upgraded out of
 		// band — e.g. brew — and the cache hasn't expired yet).
 		cached.CurrentVersion = c.currentVer
-		cached.UpdateAvailable = upgrade.CompareSemver(cached.LatestVersion, c.currentVer) > 0
+		cached.UpdateAvailable = isUpdateAvailable(cached.LatestVersion, c.currentVer)
 		return cached, nil
 	}
 
@@ -171,7 +169,7 @@ func (c *Checker) Check(ctx context.Context, disableForCI bool) (UpdateInfo, err
 		// rather than nothing.
 		if cached, ok := c.readCache(); ok {
 			cached.CurrentVersion = c.currentVer
-			cached.UpdateAvailable = upgrade.CompareSemver(cached.LatestVersion, c.currentVer) > 0
+			cached.UpdateAvailable = isUpdateAvailable(cached.LatestVersion, c.currentVer)
 			return cached, nil
 		}
 		return UpdateInfo{CurrentVersion: c.currentVer}, nil
@@ -217,7 +215,7 @@ func (c *Checker) fetchLatest(ctx context.Context) (UpdateInfo, error) {
 	return UpdateInfo{
 		CurrentVersion:  c.currentVer,
 		LatestVersion:   latest,
-		UpdateAvailable: upgrade.CompareSemver(latest, c.currentVer) > 0,
+		UpdateAvailable: isUpdateAvailable(latest, c.currentVer),
 		ReleaseURL:      raw.HTMLURL,
 		CheckedAt:       time.Now().UTC(),
 	}, nil

--- a/internal/selfupdate/notify.go
+++ b/internal/selfupdate/notify.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -15,6 +16,38 @@ import (
 // throughout trvl for version ordering.
 func semverCmp(a, b string) int {
 	return upgrade.CompareSemver(a, b)
+}
+
+// gitDescribeSuffix matches a `git describe --tags` suffix of the form
+// "-<commits>-g<hash>" (with an optional "-dirty" marker). Such a suffix
+// means the binary was built N commits AHEAD of its base tag, so it is
+// strictly newer than that tag — NOT an older pre-release of it. Real
+// semver pre-releases ("-rc.1", "-beta.2") do not match this shape.
+var gitDescribeSuffix = regexp.MustCompile(`-[0-9]+-g[0-9a-f]+(-dirty)?$`)
+
+// baseTag strips a git-describe suffix, returning the underlying tag and
+// whether a suffix was present. "v1.5.0-3-gabc123" -> ("v1.5.0", true);
+// "v1.5.0-rc.1" -> ("v1.5.0-rc.1", false).
+func baseTag(v string) (string, bool) {
+	if loc := gitDescribeSuffix.FindStringIndex(v); loc != nil {
+		return v[:loc[0]], true
+	}
+	return v, false
+}
+
+// isUpdateAvailable reports whether the latest upstream release is strictly
+// newer than the running build. It is git-describe-aware: a development
+// build N commits ahead of tag X ("vX-N-ghash") already CONTAINS release X,
+// so it is treated as >= X and never nags about "updating" to a release the
+// local binary has already surpassed. Plain releases and real pre-releases
+// fall through to the standard semver comparison.
+func isUpdateAvailable(latest, current string) bool {
+	if base, ok := baseTag(current); ok {
+		// Ahead-of-tag build: an update exists only if the latest release
+		// is newer than the base tag this build descends from.
+		return upgrade.CompareSemver(latest, base) > 0
+	}
+	return upgrade.CompareSemver(latest, current) > 0
 }
 
 // IsCIEnv heuristically detects continuous-integration / sandboxed
@@ -73,8 +106,14 @@ func NotifyAvailable(w io.Writer, info UpdateInfo) {
 	if current == "" {
 		current = "dev"
 	}
+	// Normalize a leading "v" on both fields so the "v%s" formatting below
+	// never produces a doubled prefix (e.g. "vv1.5.0"). LatestVersion is
+	// stored without "v" by the checker, but CurrentVersion comes straight
+	// from main.Version, which goreleaser/git-describe stamps WITH a "v".
+	latest := strings.TrimPrefix(info.LatestVersion, "v")
+	current = strings.TrimPrefix(current, "v")
 	msg := fmt.Sprintf("trvl: v%s available (you have v%s). Release notes: %s\n",
-		info.LatestVersion, current, info.ReleaseURL)
+		latest, current, info.ReleaseURL)
 	_, _ = io.WriteString(w, msg)
 }
 
@@ -120,7 +159,7 @@ func CheckInBackground(ctx context.Context, currentVer string, notifyW io.Writer
 		cached.CurrentVersion = currentVer
 		// Recompute against the running binary version in case the
 		// user upgraded out of band since the cache was written.
-		cached.UpdateAvailable = compareVersions(cached.LatestVersion, currentVer) > 0
+		cached.UpdateAvailable = isUpdateAvailable(cached.LatestVersion, currentVer)
 		if notifyW != nil {
 			NotifyAvailable(notifyW, cached)
 		}

--- a/internal/selfupdate/notify.go
+++ b/internal/selfupdate/notify.go
@@ -12,12 +12,6 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/upgrade"
 )
 
-// semverCmp delegates to the upgrade package — same comparison used
-// throughout trvl for version ordering.
-func semverCmp(a, b string) int {
-	return upgrade.CompareSemver(a, b)
-}
-
 // gitDescribeSuffix matches a `git describe --tags` suffix of the form
 // "-<commits>-g<hash>" (with an optional "-dirty" marker). Such a suffix
 // means the binary was built N commits AHEAD of its base tag, so it is
@@ -175,12 +169,6 @@ func CheckInBackground(ctx context.Context, currentVer string, notifyW io.Writer
 		defer cancel()
 		_, _ = c.Check(bgCtx, false)
 	}()
-}
-
-// compareVersions wraps the upgrade package's CompareSemver to avoid
-// re-importing it at every callsite.
-func compareVersions(a, b string) int {
-	return semverCmp(a, b)
 }
 
 // LoadCachedInfo returns the most recently cached UpdateInfo, or the

--- a/internal/selfupdate/notify_describe_test.go
+++ b/internal/selfupdate/notify_describe_test.go
@@ -1,0 +1,109 @@
+package selfupdate
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestIsUpdateAvailable_GitDescribe verifies the git-describe-aware update
+// gate: a build N commits ahead of its base tag must NOT be told to "update"
+// to the release it already contains, while genuinely older builds and real
+// pre-releases still behave per semver.
+func TestIsUpdateAvailable_GitDescribe(t *testing.T) {
+	cases := []struct {
+		name    string
+		latest  string // release tag from GitHub, "v"-stripped as the checker stores it
+		current string // running binary's main.Version (git-describe, carries "v")
+		want    bool
+	}{
+		{
+			name:    "ahead of tag: 3 commits past v1.5.0 is not an update",
+			latest:  "1.5.0",
+			current: "v1.5.0-3-gfb1d4e4",
+			want:    false,
+		},
+		{
+			name:    "ahead of tag, dirty tree: still not an update",
+			latest:  "1.5.0",
+			current: "v1.5.0-3-gfb1d4e4-dirty",
+			want:    false,
+		},
+		{
+			name:    "ahead of OLD tag but newer release exists: update IS available",
+			latest:  "1.6.0",
+			current: "v1.5.0-3-gfb1d4e4",
+			want:    true,
+		},
+		{
+			name:    "clean older release: update available",
+			latest:  "1.5.0",
+			current: "v1.4.1",
+			want:    true,
+		},
+		{
+			name:    "clean equal release: no update",
+			latest:  "1.5.0",
+			current: "v1.5.0",
+			want:    false,
+		},
+		{
+			name:    "real pre-release is older than its release: update available",
+			latest:  "1.5.0",
+			current: "v1.5.0-rc.1",
+			want:    true,
+		},
+		{
+			name:    "local ahead of latest release: no update",
+			latest:  "1.4.0",
+			current: "v1.5.0",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUpdateAvailable(tc.latest, tc.current); got != tc.want {
+				t.Fatalf("isUpdateAvailable(%q, %q) = %v, want %v",
+					tc.latest, tc.current, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNotifyAvailable_NoDoubleV ensures the notice never prints a doubled
+// "v" prefix even when CurrentVersion already carries one (main.Version is
+// stamped as "v1.5.0-..." by git-describe / goreleaser).
+func TestNotifyAvailable_NoDoubleV(t *testing.T) {
+	var buf bytes.Buffer
+	NotifyAvailable(&buf, UpdateInfo{
+		LatestVersion:   "1.6.0",
+		CurrentVersion:  "v1.5.0",
+		UpdateAvailable: true,
+		ReleaseURL:      "https://example.test/releases/v1.6.0",
+	})
+	out := buf.String()
+	if strings.Contains(out, "vv") {
+		t.Fatalf("notice contains doubled v prefix: %q", out)
+	}
+	if !strings.Contains(out, "v1.6.0 available") {
+		t.Fatalf("notice missing latest version: %q", out)
+	}
+	if !strings.Contains(out, "you have v1.5.0") {
+		t.Fatalf("notice missing/garbled current version: %q", out)
+	}
+}
+
+// TestNotifyAvailable_NoDoubleV_LatestWithV guards the symmetric case where
+// LatestVersion unexpectedly carries a "v" too (defensive normalization).
+func TestNotifyAvailable_NoDoubleV_LatestWithV(t *testing.T) {
+	var buf bytes.Buffer
+	NotifyAvailable(&buf, UpdateInfo{
+		LatestVersion:   "v1.6.0",
+		CurrentVersion:  "v1.5.0",
+		UpdateAvailable: true,
+		ReleaseURL:      "https://example.test/releases/v1.6.0",
+	})
+	if out := buf.String(); strings.Contains(out, "vv") {
+		t.Fatalf("notice contains doubled v prefix: %q", out)
+	}
+}

--- a/internal/travelctx/airport_lookup.go
+++ b/internal/travelctx/airport_lookup.go
@@ -1,0 +1,63 @@
+package travelctx
+
+import (
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// countryPrimaryAirport maps an ISO 3166-1 alpha-2 country code to that
+// country's primary international gateway IATA code. This is a coarse
+// last-resort fallback: used only when geo-IP gives us a country but the city
+// could not be mapped to an airport. It covers the countries trvl's airport
+// table already knows; unknown countries simply yield "" and the caller
+// degrades to "no origin resolved".
+//
+// Scope is deliberately the busiest hub per country (the one a traveler is
+// most likely to actually depart from), not every airport. Kept in sync by
+// hand with models.AirportNames.
+var countryPrimaryAirport = map[string]string{
+	"FI": "HEL", "GB": "LHR", "FR": "CDG", "NL": "AMS", "DE": "FRA",
+	"ES": "MAD", "IT": "FCO", "CH": "ZRH", "AT": "VIE", "BE": "BRU",
+	"DK": "CPH", "NO": "OSL", "SE": "ARN", "IE": "DUB", "PT": "LIS",
+	"GR": "ATH", "PL": "WAW", "CZ": "PRG", "HU": "BUD", "RO": "OTP",
+	"BG": "SOF", "TR": "IST", "HR": "ZAG", "RS": "BEG", "EE": "TLL",
+	"LV": "RIX", "LT": "VNO", "IS": "KEF",
+	"US": "JFK", "CA": "YYZ", "MX": "MEX",
+	"JP": "HND", "KR": "ICN", "CN": "PEK", "HK": "HKG", "TW": "TPE",
+	"SG": "SIN", "TH": "BKK", "MY": "KUL", "ID": "CGK", "PH": "MNL",
+	"VN": "SGN", "IN": "DEL", "LK": "CMB", "NP": "KTM", "KH": "PNH",
+	"MM": "RGN",
+	"AE": "DXB", "QA": "DOH", "SA": "RUH", "IL": "TLV", "JO": "AMM",
+	"BH": "BAH", "OM": "MCT", "KW": "KWI",
+	"ZA": "JNB", "KE": "NBO", "EG": "CAI", "MA": "CMN", "ET": "ADD",
+	"NG": "LOS", "GH": "ACC", "SN": "DSS", "TN": "TUN",
+	"AU": "SYD", "NZ": "AKL", "FJ": "NAN",
+	"BR": "GRU", "AR": "EZE", "CL": "SCL", "CO": "BOG", "PE": "LIM",
+	"EC": "UIO", "VE": "CCS", "UY": "MVD", "PA": "PTY", "CR": "SJO",
+	"CU": "HAV", "DO": "SDQ", "JM": "MBJ",
+}
+
+// airportForLocation maps a resolved (city, country) pair to a best-guess
+// origin airport IATA code. It tries, in order:
+//
+//  1. City name → airports serving it (models.ResolveCityToAirports), taking
+//     the alphabetically-first for determinism. This reuses trvl's existing
+//     243-airport table, so no new data to maintain for cities.
+//  2. Country code → that country's primary hub (countryPrimaryAirport).
+//
+// Returns "" when neither yields a match — the caller treats that as
+// "origin unresolved" and falls back to requiring an explicit argument.
+func airportForLocation(city, country string) string {
+	if c := strings.TrimSpace(city); c != "" {
+		if codes := models.ResolveCityToAirports(c); len(codes) > 0 {
+			return codes[0] // sorted; deterministic
+		}
+	}
+	if cc := strings.ToUpper(strings.TrimSpace(country)); cc != "" {
+		if code, ok := countryPrimaryAirport[cc]; ok {
+			return code
+		}
+	}
+	return ""
+}

--- a/internal/travelctx/resolve.go
+++ b/internal/travelctx/resolve.go
@@ -1,0 +1,296 @@
+package travelctx
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+)
+
+// Clock supplies the current time. The system clock is the default; tests
+// inject a fixed clock for determinism.
+type Clock interface {
+	Now() time.Time
+}
+
+// systemClock returns the real wall clock in the host's local timezone.
+type systemClock struct{}
+
+func (systemClock) Now() time.Time { return time.Now() }
+
+// GeoResolver discovers the user's approximate physical location. The
+// production implementation calls a free, keyless geo-IP endpoint; tests
+// inject a stub. Implementations MUST be best-effort: a non-nil error means
+// "could not determine", never a hard failure for the caller.
+type GeoResolver interface {
+	Resolve(ctx context.Context) (Location, error)
+}
+
+// Options tune a single Resolve call.
+type Options struct {
+	// ExplicitOrigin, when non-empty, wins outright (precedence rule 1).
+	// This is the CLI ORIGIN argument; passing it means the user already
+	// said where they are, so no detection runs.
+	ExplicitOrigin string
+
+	// AllowGeoIP gates the network detection path (precedence rule 3).
+	// When false, resolution stops at preferences. Callers pass false in
+	// the deterministic test suite, in CI, or when the user opted out.
+	AllowGeoIP bool
+
+	// Clock overrides the time source (tests). nil => system clock.
+	Clock Clock
+
+	// Geo overrides the location source (tests). nil => httpGeoResolver.
+	Geo GeoResolver
+}
+
+// geoDisabledByEnv reports whether the environment forbids the network geo
+// path: explicit opt-out, or a detected CI/sandbox where outbound calls are
+// noise. Mirrors the kill-switch philosophy of the selfupdate checker.
+func geoDisabledByEnv() bool {
+	if v := os.Getenv("TRVL_NO_GEO"); v != "" && v != "0" && v != "false" {
+		return true
+	}
+	for _, name := range []string{"CI", "GITHUB_ACTIONS", "GITLAB_CI"} {
+		if v := os.Getenv(name); v != "" && v != "0" && v != "false" {
+			return true
+		}
+	}
+	return false
+}
+
+// timezoneName returns the IANA zone name for t's location. Go's time.Local
+// stringifies as "Local", which is useless to a caller trying to display or
+// reason about the zone. When we hit that, fall back to the TZ env var (set
+// on most Unix hosts) and finally to the zone abbreviation from the timestamp
+// (e.g. "EEST"), so the field is always meaningful rather than "Local".
+func timezoneName(t time.Time) string {
+	name := t.Location().String()
+	if name != "" && name != "Local" {
+		return name
+	}
+	if tz := strings.TrimSpace(os.Getenv("TZ")); tz != "" {
+		return tz
+	}
+	if abbr, _ := t.Zone(); abbr != "" {
+		return abbr
+	}
+	return name
+}
+
+// Resolve assembles the ambient search Context: current time + timezone
+// (always), and the best-available origin per the precedence in the package
+// doc. It never returns an error — every source degrades gracefully, because
+// a search must still run with partial context.
+func Resolve(ctx context.Context, prefs *preferences.Preferences, opts Options) Context {
+	clk := opts.Clock
+	if clk == nil {
+		clk = systemClock{}
+	}
+	now := clk.Now()
+
+	out := Context{
+		Now:        now,
+		Timezone:   timezoneName(now),
+		TimeSource: SourceClock,
+	}
+
+	// Precedence 1: explicit caller value wins, no detection.
+	if code := normalizeIATA(opts.ExplicitOrigin); code != "" {
+		out.Origin = Location{
+			Airport: code,
+			City:    models.LookupAirportName(code),
+			Source:  SourceExplicit,
+		}
+		return out
+	}
+
+	// Precedence 2: configured home airport — zero network, zero privacy cost.
+	if prefs != nil {
+		if home := normalizeIATA(prefs.HomeAirport()); home != "" {
+			loc := Location{Airport: home, City: models.LookupAirportName(home), Source: SourcePrefs}
+			if len(prefs.HomeCities) > 0 {
+				loc.City = prefs.HomeCities[0]
+			}
+			out.Origin = loc
+			return out
+		}
+	}
+
+	// Precedence 3: geo-IP, best-effort and gated.
+	if opts.AllowGeoIP && !geoDisabledByEnv() {
+		geo := opts.Geo
+		if geo == nil {
+			geo = newHTTPGeoResolver()
+		}
+		if loc, err := geo.Resolve(ctx); err == nil {
+			// Fill the airport from city/country if the resolver didn't.
+			if loc.Airport == "" {
+				loc.Airport = airportForLocation(loc.City, loc.Country)
+			}
+			loc.Airport = normalizeIATA(loc.Airport)
+			if loc.Source == SourceUnknown {
+				loc.Source = SourceGeoIP
+			}
+			out.Origin = loc
+			return out
+		}
+	}
+
+	// Nothing resolved — Origin stays zero; callers must handle (and the CLI
+	// falls back to requiring an explicit ORIGIN, as before).
+	return out
+}
+
+// --- network geo resolver (free, keyless, best-effort) ---
+
+const (
+	// geoEndpoint is ipinfo.io's anonymous JSON endpoint. Keyless, no signup,
+	// generous unauthenticated allowance — consistent with trvl's
+	// "no API keys on the default path" rule. Failure is non-fatal.
+	geoEndpoint    = "https://ipinfo.io/json"
+	geoUserAgent   = "trvl-travelctx/1"
+	geoHTTPTimeout = 3 * time.Second
+)
+
+type httpGeoResolver struct {
+	client   *http.Client
+	endpoint string
+}
+
+func newHTTPGeoResolver() *httpGeoResolver {
+	return &httpGeoResolver{
+		client:   &http.Client{Timeout: geoHTTPTimeout},
+		endpoint: geoEndpoint,
+	}
+}
+
+// ipinfoResponse is the subset of ipinfo.io's payload we consume. "loc" is
+// "lat,lon" as a single string.
+type ipinfoResponse struct {
+	City    string `json:"city"`
+	Country string `json:"country"`
+	Loc     string `json:"loc"`
+}
+
+func (r *httpGeoResolver) Resolve(ctx context.Context) (Location, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.endpoint, nil)
+	if err != nil {
+		return Location{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", geoUserAgent)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return Location{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return Location{}, &geoStatusError{code: resp.StatusCode}
+	}
+
+	var raw ipinfoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return Location{}, err
+	}
+	lat, lon := parseLatLon(raw.Loc)
+	return Location{
+		City:    strings.TrimSpace(raw.City),
+		Country: strings.ToUpper(strings.TrimSpace(raw.Country)),
+		Lat:     lat,
+		Lon:     lon,
+		Source:  SourceGeoIP,
+	}, nil
+}
+
+type geoStatusError struct{ code int }
+
+func (e *geoStatusError) Error() string {
+	return "travelctx: geo endpoint returned status " + itoa(e.code)
+}
+
+// itoa is a tiny dependency-free int->string (avoids importing strconv just
+// for one error path).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}
+
+// parseLatLon splits ipinfo's "lat,lon" string into two floats. Returns
+// (0,0) on any parse problem — coordinates are advisory, never load-bearing.
+func parseLatLon(s string) (lat, lon float64) {
+	parts := strings.SplitN(strings.TrimSpace(s), ",", 2)
+	if len(parts) != 2 {
+		return 0, 0
+	}
+	lat = atof(parts[0])
+	lon = atof(parts[1])
+	return lat, lon
+}
+
+// atof is a minimal, tolerant float parser for decimal-degree strings.
+func atof(s string) float64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	var neg bool
+	if s[0] == '-' {
+		neg = true
+		s = s[1:]
+	} else if s[0] == '+' {
+		s = s[1:]
+	}
+	var intPart, fracPart float64
+	var fracDiv float64 = 1
+	seenDot := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '.':
+			if seenDot {
+				return 0
+			}
+			seenDot = true
+		case c >= '0' && c <= '9':
+			d := float64(c - '0')
+			if seenDot {
+				fracDiv *= 10
+				fracPart += d / fracDiv
+			} else {
+				intPart = intPart*10 + d
+			}
+		default:
+			return 0
+		}
+	}
+	v := intPart + fracPart
+	if neg {
+		v = -v
+	}
+	return v
+}

--- a/internal/travelctx/resolve.go
+++ b/internal/travelctx/resolve.go
@@ -124,9 +124,16 @@ func Resolve(ctx context.Context, prefs *preferences.Preferences, opts Options) 
 	}
 
 	// Precedence 3: geo-IP, best-effort and gated.
-	if opts.AllowGeoIP && !geoDisabledByEnv() {
+	if opts.AllowGeoIP {
 		geo := opts.Geo
+		// The env kill-switch (CI / TRVL_NO_GEO) only suppresses the REAL
+		// network resolver. An explicitly injected resolver (tests, or a
+		// caller supplying its own location source) is never gated — the
+		// gate exists to avoid outbound calls, not to disable injection.
 		if geo == nil {
+			if geoDisabledByEnv() {
+				return out
+			}
 			geo = newHTTPGeoResolver()
 		}
 		if loc, err := geo.Resolve(ctx); err == nil {

--- a/internal/travelctx/travelctx.go
+++ b/internal/travelctx/travelctx.go
@@ -1,0 +1,140 @@
+// Package travelctx resolves the ambient context every trvl search runs
+// inside: the current time, the user's timezone, and their likely origin
+// (airport / city / country). trvl is location- and time-aware by default
+// so that answers and recommendations reflect *where* and *when* the search
+// happens — booking lead time and day-of-week are real price levers, and a
+// sensible default origin removes a mandatory argument from the common case.
+//
+// Design constraints honored (see trvl CLAUDE.md "Decisions Locked"):
+//
+//   - No API keys on the default path. Geo-IP uses a free, keyless endpoint
+//     and is strictly best-effort: any failure degrades silently to prefs.
+//   - Deterministic default test suite. Time and geo are injected via the
+//     Clock and GeoResolver interfaces; the network resolver is never hit in
+//     tests. IsCIEnv / TRVL_NO_GEO disable the network path entirely.
+//   - Unidirectional imports. travelctx depends only on internal/models and
+//     internal/preferences, never the reverse.
+//
+// Resolution precedence for origin (highest wins):
+//
+//  1. Explicit caller value (the CLI ORIGIN arg) — never overridden.
+//  2. Configured home airport (preferences.HomeAirports[0]) — zero network.
+//  3. Geo-IP → nearest known airport — best-effort, cached, kill-switchable.
+//
+// Time is always available (system clock); it has no privacy cost and is
+// never gated.
+package travelctx
+
+import (
+	"strings"
+	"time"
+)
+
+// Source records how a resolved field was obtained, so output can be honest
+// about provenance ("origin HEL — detected from your location" vs "from your
+// saved home airport").
+type Source string
+
+const (
+	SourceUnknown  Source = ""
+	SourceExplicit Source = "explicit"    // caller supplied it directly
+	SourcePrefs    Source = "preferences" // from ~/.trvl/preferences.json
+	SourceGeoIP    Source = "geoip"       // detected from network location
+	SourceClock    Source = "clock"       // system clock
+)
+
+// Location is a resolved physical origin. Any field may be zero if it could
+// not be determined; callers must tolerate partial data.
+type Location struct {
+	Airport string  // IATA code, e.g. "HEL" (uppercase)
+	City    string  // e.g. "Helsinki"
+	Country string  // ISO 3166-1 alpha-2, e.g. "FI"
+	Lat     float64 // decimal degrees, 0 if unknown
+	Lon     float64 // decimal degrees, 0 if unknown
+	Source  Source  // how Airport was resolved
+}
+
+// HasAirport reports whether an origin airport was resolved.
+func (l Location) HasAirport() bool { return l.Airport != "" }
+
+// Context is the ambient state a search executes in.
+type Context struct {
+	// Now is the moment the search is running, in the user's timezone.
+	Now time.Time
+	// Timezone is the IANA name of Now's location, e.g. "Europe/Helsinki".
+	Timezone string
+	// Origin is the user's resolved current/home location.
+	Origin Location
+	// TimeSource is always SourceClock today; reserved for future overrides
+	// (e.g. a --now flag for reproducible runs).
+	TimeSource Source
+}
+
+// LeadTimeDays returns whole days from Now until the given departure date.
+// Negative values mean the date is in the past. Booking lead time is one of
+// the strongest single predictors of fare level, so callers surface this to
+// the user and may weight recommendations on it.
+func (c Context) LeadTimeDays(departure time.Time) int {
+	// Compare calendar days in the context's timezone, not raw 24h spans, so
+	// "tomorrow" reads as 1 regardless of the clock time of day.
+	loc := c.Now.Location()
+	n := time.Date(c.Now.Year(), c.Now.Month(), c.Now.Day(), 0, 0, 0, 0, loc)
+	d := departure.In(loc)
+	dd := time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, loc)
+	return int(dd.Sub(n).Hours() / 24)
+}
+
+// BookingWindow classifies how far out a departure is, for advisory copy.
+type BookingWindow string
+
+const (
+	WindowPast      BookingWindow = "past"       // departure already gone
+	WindowLastMin   BookingWindow = "last_min"   // 0–3 days: fares typically peak
+	WindowShort     BookingWindow = "short"      // 4–13 days: limited room to optimize
+	WindowSweetSpot BookingWindow = "sweet_spot" // 14–60 days: usual best-fare zone (short/medium haul)
+	WindowEarly     BookingWindow = "early"      // 61–120 days: book or watch
+	WindowVeryEarly BookingWindow = "very_early" // 120+ days: prices often not yet keen
+)
+
+// ClassifyWindow maps a lead time in days to a BookingWindow. The bands are
+// deliberately coarse, advisory heuristics — not a pricing model.
+func ClassifyWindow(leadDays int) BookingWindow {
+	switch {
+	case leadDays < 0:
+		return WindowPast
+	case leadDays <= 3:
+		return WindowLastMin
+	case leadDays <= 13:
+		return WindowShort
+	case leadDays <= 60:
+		return WindowSweetSpot
+	case leadDays <= 120:
+		return WindowEarly
+	default:
+		return WindowVeryEarly
+	}
+}
+
+// Advisory returns a one-line, human-facing note about the booking window,
+// or "" for the neutral sweet-spot case where no nudge is warranted.
+func (w BookingWindow) Advisory() string {
+	switch w {
+	case WindowPast:
+		return "That departure date is in the past — double-check the year."
+	case WindowLastMin:
+		return "Last-minute window (≤3 days): fares are usually at their peak; flexibility on dates rarely helps now."
+	case WindowShort:
+		return "Short lead time (under 2 weeks): limited room to optimize — book once you see a fair fare."
+	case WindowEarly:
+		return "Booking early (2–4 months out): fares may still soften; worth a price watch before committing."
+	case WindowVeryEarly:
+		return "Very early (4+ months out): airlines often haven't released keen fares yet; watch rather than commit."
+	default:
+		return ""
+	}
+}
+
+// normalizeIATA upper-cases and trims an airport code.
+func normalizeIATA(s string) string {
+	return strings.ToUpper(strings.TrimSpace(s))
+}

--- a/internal/travelctx/travelctx_test.go
+++ b/internal/travelctx/travelctx_test.go
@@ -1,0 +1,267 @@
+package travelctx
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+)
+
+// fixedClock is a deterministic Clock for tests.
+type fixedClock struct{ t time.Time }
+
+func (f fixedClock) Now() time.Time { return f.t }
+
+// stubGeo is a deterministic GeoResolver for tests; never touches the network.
+type stubGeo struct {
+	loc Location
+	err error
+}
+
+func (s stubGeo) Resolve(context.Context) (Location, error) { return s.loc, s.err }
+
+func helsinki() *time.Location {
+	loc, err := time.LoadLocation("Europe/Helsinki")
+	if err != nil {
+		return time.UTC
+	}
+	return loc
+}
+
+func TestResolve_ExplicitOriginWins(t *testing.T) {
+	prefs := &preferences.Preferences{HomeAirports: []string{"AMS"}}
+	clk := fixedClock{t: time.Date(2026, 5, 31, 19, 0, 0, 0, helsinki())}
+	// Even with prefs set and geo allowed, an explicit origin must win and
+	// must NOT trigger any detection (geo stub would error if consulted).
+	got := Resolve(context.Background(), prefs, Options{
+		ExplicitOrigin: "hel",
+		AllowGeoIP:     true,
+		Clock:          clk,
+		Geo:            stubGeo{err: errors.New("geo must not be called")},
+	})
+	if got.Origin.Airport != "HEL" {
+		t.Fatalf("airport = %q, want HEL", got.Origin.Airport)
+	}
+	if got.Origin.Source != SourceExplicit {
+		t.Fatalf("source = %q, want explicit", got.Origin.Source)
+	}
+}
+
+func TestResolve_PrefsBeatsGeo(t *testing.T) {
+	prefs := &preferences.Preferences{
+		HomeAirports: []string{"HEL"},
+		HomeCities:   []string{"Helsinki"},
+	}
+	clk := fixedClock{t: time.Now()}
+	got := Resolve(context.Background(), prefs, Options{
+		AllowGeoIP: true,
+		Clock:      clk,
+		Geo:        stubGeo{loc: Location{Airport: "AMS", City: "Amsterdam"}},
+	})
+	if got.Origin.Airport != "HEL" {
+		t.Fatalf("airport = %q, want HEL (prefs beats geo)", got.Origin.Airport)
+	}
+	if got.Origin.Source != SourcePrefs {
+		t.Fatalf("source = %q, want preferences", got.Origin.Source)
+	}
+	if got.Origin.City != "Helsinki" {
+		t.Fatalf("city = %q, want Helsinki", got.Origin.City)
+	}
+}
+
+func TestResolve_GeoFallbackWhenNoPrefs(t *testing.T) {
+	clk := fixedClock{t: time.Now()}
+	got := Resolve(context.Background(), &preferences.Preferences{}, Options{
+		AllowGeoIP: true,
+		Clock:      clk,
+		Geo:        stubGeo{loc: Location{City: "Barcelona", Country: "ES"}},
+	})
+	if got.Origin.Airport != "BCN" {
+		t.Fatalf("airport = %q, want BCN (city->airport)", got.Origin.Airport)
+	}
+	if got.Origin.Source != SourceGeoIP {
+		t.Fatalf("source = %q, want geoip", got.Origin.Source)
+	}
+}
+
+func TestResolve_GeoCountryFallback(t *testing.T) {
+	clk := fixedClock{t: time.Now()}
+	// City unknown to the airport table, but country maps to a primary hub.
+	got := Resolve(context.Background(), nil, Options{
+		AllowGeoIP: true,
+		Clock:      clk,
+		Geo:        stubGeo{loc: Location{City: "Espoo", Country: "FI"}},
+	})
+	if got.Origin.Airport != "HEL" {
+		t.Fatalf("airport = %q, want HEL (country->hub)", got.Origin.Airport)
+	}
+}
+
+func TestResolve_GeoDisabledStopsAtPrefs(t *testing.T) {
+	clk := fixedClock{t: time.Now()}
+	// AllowGeoIP=false: with no prefs, origin must be unresolved and geo
+	// must never be consulted (stub errors if it is).
+	got := Resolve(context.Background(), nil, Options{
+		AllowGeoIP: false,
+		Clock:      clk,
+		Geo:        stubGeo{err: errors.New("geo must not be called when disabled")},
+	})
+	if got.Origin.HasAirport() {
+		t.Fatalf("airport = %q, want empty (geo disabled, no prefs)", got.Origin.Airport)
+	}
+}
+
+func TestResolve_GeoErrorDegradesGracefully(t *testing.T) {
+	clk := fixedClock{t: time.Now()}
+	got := Resolve(context.Background(), nil, Options{
+		AllowGeoIP: true,
+		Clock:      clk,
+		Geo:        stubGeo{err: errors.New("network down")},
+	})
+	if got.Origin.HasAirport() {
+		t.Fatalf("airport = %q, want empty on geo error", got.Origin.Airport)
+	}
+	// Time must still be populated even when location fails entirely.
+	if got.Now.IsZero() {
+		t.Fatal("Now is zero; time must be available regardless of geo")
+	}
+}
+
+func TestResolve_TimeAlwaysPresent(t *testing.T) {
+	want := time.Date(2026, 5, 31, 19, 48, 0, 0, helsinki())
+	got := Resolve(context.Background(), nil, Options{Clock: fixedClock{t: want}})
+	if !got.Now.Equal(want) {
+		t.Fatalf("Now = %v, want %v", got.Now, want)
+	}
+	if got.Timezone != "Europe/Helsinki" {
+		t.Fatalf("Timezone = %q, want Europe/Helsinki", got.Timezone)
+	}
+	if got.TimeSource != SourceClock {
+		t.Fatalf("TimeSource = %q, want clock", got.TimeSource)
+	}
+}
+
+func TestLeadTimeDays(t *testing.T) {
+	now := time.Date(2026, 5, 31, 19, 0, 0, 0, helsinki())
+	c := Context{Now: now}
+	cases := []struct {
+		name string
+		dep  time.Time
+		want int
+	}{
+		{"same day", time.Date(2026, 5, 31, 6, 0, 0, 0, helsinki()), 0},
+		{"tomorrow regardless of clock", time.Date(2026, 6, 1, 1, 0, 0, 0, helsinki()), 1},
+		{"two weeks", time.Date(2026, 6, 14, 12, 0, 0, 0, helsinki()), 14},
+		{"past", time.Date(2026, 5, 28, 12, 0, 0, 0, helsinki()), -3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.LeadTimeDays(tc.dep); got != tc.want {
+				t.Fatalf("LeadTimeDays = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyWindow(t *testing.T) {
+	cases := []struct {
+		lead int
+		want BookingWindow
+	}{
+		{-1, WindowPast},
+		{0, WindowLastMin},
+		{3, WindowLastMin},
+		{4, WindowShort},
+		{13, WindowShort},
+		{14, WindowSweetSpot},
+		{60, WindowSweetSpot},
+		{61, WindowEarly},
+		{120, WindowEarly},
+		{121, WindowVeryEarly},
+	}
+	for _, tc := range cases {
+		if got := ClassifyWindow(tc.lead); got != tc.want {
+			t.Errorf("ClassifyWindow(%d) = %q, want %q", tc.lead, got, tc.want)
+		}
+	}
+}
+
+func TestAdvisory_SweetSpotIsSilent(t *testing.T) {
+	if a := WindowSweetSpot.Advisory(); a != "" {
+		t.Fatalf("sweet-spot advisory = %q, want empty (no nudge)", a)
+	}
+	if a := WindowLastMin.Advisory(); a == "" {
+		t.Fatal("last-min advisory should be non-empty")
+	}
+}
+
+func TestAirportForLocation(t *testing.T) {
+	cases := []struct {
+		city, country, want string
+	}{
+		{"Amsterdam", "NL", "AMS"},
+		{"Prague", "CZ", "PRG"},
+		{"", "FI", "HEL"},        // country-only fallback
+		{"Nowhereville", "", ""}, // nothing resolvable
+		{"Nowhereville", "ZZ", ""},
+	}
+	for _, tc := range cases {
+		if got := airportForLocation(tc.city, tc.country); got != tc.want {
+			t.Errorf("airportForLocation(%q,%q) = %q, want %q", tc.city, tc.country, got, tc.want)
+		}
+	}
+}
+
+func TestParseLatLon(t *testing.T) {
+	lat, lon := parseLatLon("60.1695,24.9354")
+	if lat < 60.16 || lat > 60.17 {
+		t.Errorf("lat = %v, want ~60.1695", lat)
+	}
+	if lon < 24.93 || lon > 24.94 {
+		t.Errorf("lon = %v, want ~24.9354", lon)
+	}
+	// Negative + malformed.
+	lat2, lon2 := parseLatLon("-33.8688,151.2093")
+	if lat2 > -33.0 {
+		t.Errorf("lat2 = %v, want negative ~-33.87", lat2)
+	}
+	if lon2 < 151.0 {
+		t.Errorf("lon2 = %v, want ~151.21", lon2)
+	}
+	if l1, l2 := parseLatLon("garbage"); l1 != 0 || l2 != 0 {
+		t.Errorf("garbage parse = (%v,%v), want (0,0)", l1, l2)
+	}
+}
+
+func TestTimezoneName_PrefersIANAOverLocal(t *testing.T) {
+	// A named zone is returned verbatim.
+	hel := helsinki()
+	if hel.String() != "UTC" { // skip if zoneinfo unavailable
+		got := timezoneName(time.Date(2026, 5, 31, 12, 0, 0, 0, hel))
+		if got != "Europe/Helsinki" {
+			t.Fatalf("named zone = %q, want Europe/Helsinki", got)
+		}
+	}
+
+	// time.Local stringifies as "Local"; timezoneName must do better,
+	// falling back to TZ env or the zone abbreviation rather than "Local".
+	t.Setenv("TZ", "Europe/Helsinki")
+	got := timezoneName(time.Date(2026, 5, 31, 12, 0, 0, 0, time.Local))
+	if got == "Local" || got == "" {
+		t.Fatalf("local-zone fallback = %q, want a meaningful zone name", got)
+	}
+}
+
+func TestGeoDisabledByEnv(t *testing.T) {
+	t.Setenv("TRVL_NO_GEO", "1")
+	if !geoDisabledByEnv() {
+		t.Fatal("TRVL_NO_GEO=1 should disable geo")
+	}
+	t.Setenv("TRVL_NO_GEO", "")
+	t.Setenv("CI", "true")
+	if !geoDisabledByEnv() {
+		t.Fatal("CI=true should disable geo")
+	}
+}

--- a/mcp/coverage_push_split3_test.go
+++ b/mcp/coverage_push_split3_test.go
@@ -138,10 +138,13 @@ func TestReadResource_Watches_EmptyStore(t *testing.T) {
 // --- handleSearchFlights validation (26.2% coverage) ---
 
 func TestHandleSearchFlights_MissingOriginDest_Push(t *testing.T) {
+	// Origin is now optional (resolved from prefs/geo), so an empty args map
+	// fails on the still-required destination. Disable geo for determinism.
+	t.Setenv("TRVL_NO_GEO", "1")
 	_, _, err := handleSearchFlights(context.Background(),
 		map[string]any{}, nil, nil, nil)
-	if err == nil || !contains(err.Error(), "origin and destination") {
-		t.Errorf("expected origin/dest error, got: %v", err)
+	if err == nil || !contains(err.Error(), "destination is required") {
+		t.Errorf("expected destination-required error, got: %v", err)
 	}
 }
 
@@ -149,8 +152,11 @@ func TestHandleSearchFlights_InvalidOriginIATA(t *testing.T) {
 	_, _, err := handleSearchFlights(context.Background(),
 		map[string]any{"origin": "TOOLONG", "destination": "BCN", "departure_date": "2026-06-15"},
 		nil, nil, nil)
-	if err == nil || !contains(err.Error(), "invalid origin") {
-		t.Errorf("expected invalid origin error, got: %v", err)
+	// An explicitly-supplied bad origin is still rejected; the message now
+	// reads "resolved origin ... is invalid" since origin flows through the
+	// optional-origin resolver.
+	if err == nil || !contains(err.Error(), "origin") {
+		t.Errorf("expected origin validation error, got: %v", err)
 	}
 }
 

--- a/mcp/origin_context.go
+++ b/mcp/origin_context.go
@@ -1,0 +1,47 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/travelctx"
+)
+
+// resolveDestOriginOptional validates the destination (always required) and
+// resolves the origin from, in precedence order: the explicit origin
+// argument, the user's saved home airport, then best-effort geo-IP location.
+// This makes trvl location-aware by default on the MCP surface: an AI agent
+// can call search_flights with only a destination and trvl fills in the
+// origin the same way the CLI does.
+//
+// originSource reports how the origin was obtained (travelctx.SourceExplicit
+// / SourcePrefs / SourceGeoIP) so the handler can disclose it to the agent.
+// geoOK gates the network path; pass false to stay offline (tests, CI).
+func resolveDestOriginOptional(ctx context.Context, args map[string]any, geoOK bool) (origin, dest string, originSource travelctx.Source, err error) {
+	dest = strings.TrimSpace(argString(args, "destination"))
+	if dest == "" {
+		return "", "", travelctx.SourceUnknown, fmt.Errorf("destination is required")
+	}
+	dest = resolveMCPLocation(dest)
+	if verr := models.ValidateIATA(dest); verr != nil {
+		return "", "", travelctx.SourceUnknown, fmt.Errorf("invalid destination %q: %w", dest, verr)
+	}
+
+	explicit := strings.TrimSpace(argString(args, "origin"))
+	prefs, _ := preferences.Load() //nolint:errcheck // default prefs on nil/err
+	tctx := travelctx.Resolve(ctx, prefs, travelctx.Options{
+		ExplicitOrigin: explicit,
+		AllowGeoIP:     geoOK,
+	})
+	if !tctx.Origin.HasAirport() {
+		return "", "", travelctx.SourceUnknown, fmt.Errorf("origin is required: none supplied and none could be resolved from preferences or location; pass origin, or set a home airport via preferences")
+	}
+	origin = resolveMCPLocation(tctx.Origin.Airport)
+	if verr := models.ValidateIATA(origin); verr != nil {
+		return "", "", travelctx.SourceUnknown, fmt.Errorf("resolved origin %q is invalid: %w", origin, verr)
+	}
+	return origin, dest, tctx.Origin.Source, nil
+}

--- a/mcp/origin_context_test.go
+++ b/mcp/origin_context_test.go
@@ -1,0 +1,110 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/travelctx"
+)
+
+// TestResolveDestOriginOptional_ExplicitWins verifies the explicit origin
+// argument is honored and reported as the source, with no network needed.
+func TestResolveDestOriginOptional_ExplicitWins(t *testing.T) {
+	args := map[string]any{"origin": "AMS", "destination": "BCN"}
+	origin, dest, src, err := resolveDestOriginOptional(context.Background(), args, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if origin != "AMS" {
+		t.Errorf("origin = %q, want AMS", origin)
+	}
+	if dest != "BCN" {
+		t.Errorf("dest = %q, want BCN", dest)
+	}
+	if src != travelctx.SourceExplicit {
+		t.Errorf("source = %q, want explicit", src)
+	}
+}
+
+// TestResolveDestOriginOptional_CityNameOrigin verifies a city-name origin is
+// resolved to an IATA code.
+func TestResolveDestOriginOptional_CityNameOrigin(t *testing.T) {
+	args := map[string]any{"origin": "Amsterdam", "destination": "Barcelona"}
+	origin, dest, _, err := resolveDestOriginOptional(context.Background(), args, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if origin != "AMS" {
+		t.Errorf("origin = %q, want AMS", origin)
+	}
+	if dest != "BCN" {
+		t.Errorf("dest = %q, want BCN", dest)
+	}
+}
+
+// TestResolveDestOriginOptional_DestRequired verifies destination is still
+// mandatory even though origin is now optional.
+func TestResolveDestOriginOptional_DestRequired(t *testing.T) {
+	args := map[string]any{"origin": "HEL"}
+	if _, _, _, err := resolveDestOriginOptional(context.Background(), args, false); err == nil {
+		t.Fatal("expected error when destination is missing")
+	}
+}
+
+// TestResolveDestOriginOptional_NoOriginNoGeoErrors verifies that with no
+// explicit origin, no resolvable home airport, and geo disabled, the helper
+// returns a clear actionable error rather than proceeding with empty origin.
+func TestResolveDestOriginOptional_NoOriginNoGeoErrors(t *testing.T) {
+	// Point HOME at an empty dir so preferences.Load() yields no home airport,
+	// and disable geo so no network is consulted.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("TRVL_NO_GEO", "1")
+	args := map[string]any{"destination": "BCN"}
+	_, _, src, err := resolveDestOriginOptional(context.Background(), args, false)
+	if err == nil {
+		t.Fatal("expected error when no origin can be resolved")
+	}
+	if src != travelctx.SourceUnknown {
+		t.Errorf("source = %q, want unknown on failure", src)
+	}
+}
+
+// TestBuildBookingContext_LeadTimeAndWindow verifies the time context attached
+// to a result carries a sane window classification and is never nil for a
+// valid date.
+func TestBuildBookingContext_LeadTimeAndWindow(t *testing.T) {
+	// A date ~2 years out is unambiguously in the very-early or early band,
+	// regardless of when this test runs.
+	bc := buildBookingContext("2099-01-01", "HEL", travelctx.SourcePrefs)
+	if bc == nil {
+		t.Fatal("booking context is nil for a valid date")
+	}
+	if bc.OriginSource != string(travelctx.SourcePrefs) {
+		t.Errorf("origin_source = %q, want preferences", bc.OriginSource)
+	}
+	if bc.LeadTimeDays <= 0 {
+		t.Errorf("lead_time_days = %d, want positive for a far-future date", bc.LeadTimeDays)
+	}
+	if bc.BookingWindow == "" {
+		t.Error("booking_window is empty")
+	}
+	if bc.Timezone == "" {
+		t.Error("timezone is empty")
+	}
+}
+
+// TestBuildBookingContext_BadDateStillReturnsTime verifies a malformed date
+// degrades gracefully: time context present, lead-time math skipped.
+func TestBuildBookingContext_BadDateStillReturnsTime(t *testing.T) {
+	bc := buildBookingContext("not-a-date", "HEL", travelctx.SourceExplicit)
+	if bc == nil {
+		t.Fatal("booking context should be non-nil even for a bad date")
+	}
+	if bc.SearchedAt == "" {
+		t.Error("searched_at should be populated regardless of date parse")
+	}
+	if bc.BookingWindow != "" {
+		t.Errorf("booking_window = %q, want empty for unparseable date", bc.BookingWindow)
+	}
+}

--- a/mcp/origin_context_test.go
+++ b/mcp/origin_context_test.go
@@ -59,6 +59,7 @@ func TestResolveDestOriginOptional_NoOriginNoGeoErrors(t *testing.T) {
 	// and disable geo so no network is consulted.
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	t.Setenv("TRVL_NO_GEO", "1")
 	args := map[string]any{"destination": "BCN"}
 	_, _, src, err := resolveDestOriginOptional(context.Background(), args, false)

--- a/mcp/tools_flights.go
+++ b/mcp/tools_flights.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/baggage"
 	"github.com/MikkoParkkola/trvl/internal/flights"
@@ -13,6 +14,7 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/points"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
 	"github.com/MikkoParkkola/trvl/internal/profile"
+	"github.com/MikkoParkkola/trvl/internal/travelctx"
 )
 
 // --- Output schema builders ---
@@ -146,7 +148,7 @@ func searchFlightsTool() ToolDef {
 		InputSchema: InputSchema{
 			Type: "object",
 			Properties: map[string]Property{
-				"origin":              {Type: "string", Description: "Departure airport IATA code or city name (e.g., HEL, JFK, Paris, Tokyo). City names resolve to primary airport."},
+				"origin":              {Type: "string", Description: "Departure airport IATA code or city name (e.g., HEL, JFK, Paris, Tokyo). OPTIONAL: if omitted, trvl resolves the origin from the user's saved home airport, then best-effort from their current location (geo-IP). City names resolve to primary airport."},
 				"destination":         {Type: "string", Description: "Arrival airport IATA code or city name (e.g., NRT, LAX, London, Barcelona). City names resolve to primary airport."},
 				"departure_date":      {Type: "string", Description: "Departure date in YYYY-MM-DD format"},
 				"return_date":         {Type: "string", Description: "Return date in YYYY-MM-DD format for round-trip (omit for one-way)"},
@@ -173,7 +175,7 @@ func searchFlightsTool() ToolDef {
 				"first_result":        {Type: "boolean", Description: "Return only the first result with a valid price after sorting. Combine with sort_by to get e.g. the shortest priced flight (duration) or cheapest. Default: false."},
 				"provider":            {Type: "string", Description: "Flight provider: empty (default) = Google Flights + Kiwi + Skiplagged merge, 'skiplagged' = Skiplagged MCP only (hidden-city + virtual-interlining defaults). Use the solo provider when you want to cross-validate hidden-city candidates."},
 			},
-			Required: []string{"origin", "destination", "departure_date"},
+			Required: []string{"destination", "departure_date"},
 		},
 		OutputSchema: flightSearchOutputSchema(),
 		Annotations: &ToolAnnotations{
@@ -215,7 +217,11 @@ func searchDatesTool() ToolDef {
 // --- Tool handlers ---
 
 func handleSearchFlights(ctx context.Context, args map[string]any, elicit ElicitFunc, sampling SamplingFunc, progress ProgressFunc) ([]ContentBlock, interface{}, error) {
-	origin, dest, err := validateOriginDest(args)
+	// Origin is optional: resolve from explicit arg > saved home airport >
+	// geo-IP. This makes the MCP surface location-aware by default, matching
+	// the CLI. Geo network lookup is gated by the same env kill-switches as
+	// the rest of trvl (TRVL_NO_GEO / CI detection) via travelctx.
+	origin, dest, originSource, err := resolveDestOriginOptional(ctx, args, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -479,22 +485,24 @@ func handleSearchFlights(ctx context.Context, args map[string]any, elicit Elicit
 
 	// Build structured response.
 	type enrichedFlightSearchResult struct {
-		Success     bool             `json:"success"`
-		Count       int              `json:"count"`
-		TripType    string           `json:"trip_type"`
-		Flights     []enrichedFlight `json:"flights"`
-		Error       string           `json:"error,omitempty"`
-		Suggestions []Suggestion     `json:"suggestions,omitempty"`
-		Hacks       []hacks.Hack     `json:"hacks,omitempty"`
+		Success        bool             `json:"success"`
+		Count          int              `json:"count"`
+		TripType       string           `json:"trip_type"`
+		Flights        []enrichedFlight `json:"flights"`
+		Error          string           `json:"error,omitempty"`
+		Suggestions    []Suggestion     `json:"suggestions,omitempty"`
+		Hacks          []hacks.Hack     `json:"hacks,omitempty"`
+		BookingContext *bookingContext  `json:"booking_context,omitempty"`
 	}
 	resp := enrichedFlightSearchResult{
-		Success:     result.Success,
-		Count:       result.Count,
-		TripType:    result.TripType,
-		Flights:     enrichedFlights,
-		Error:       result.Error,
-		Suggestions: suggestions,
-		Hacks:       flightHacks,
+		Success:        result.Success,
+		Count:          result.Count,
+		TripType:       result.TripType,
+		Flights:        enrichedFlights,
+		Error:          result.Error,
+		Suggestions:    suggestions,
+		Hacks:          flightHacks,
+		BookingContext: buildBookingContext(date, origin, originSource),
 	}
 
 	content, err := buildAnnotatedContentBlocks(flightSummary(result, origin, dest), resp)
@@ -503,6 +511,53 @@ func handleSearchFlights(ctx context.Context, args map[string]any, elicit Elicit
 	}
 
 	return content, resp, nil
+}
+
+// bookingContext is the time-and-place context attached to a flight search
+// result so an AI agent can reason about WHEN the search happened (booking
+// lead time materially affects fares) and HOW the origin was determined.
+type bookingContext struct {
+	// SearchedAt is the local time the search ran (RFC3339).
+	SearchedAt string `json:"searched_at"`
+	// Timezone is the IANA name for SearchedAt.
+	Timezone string `json:"timezone"`
+	// LeadTimeDays is whole days from now to departure (negative = past).
+	LeadTimeDays int `json:"lead_time_days"`
+	// BookingWindow is the coarse band: last_min / short / sweet_spot / ...
+	BookingWindow string `json:"booking_window"`
+	// Advisory is a one-line human-facing nudge, empty for the neutral case.
+	Advisory string `json:"advisory,omitempty"`
+	// OriginSource reports how the origin was resolved: explicit / preferences
+	// / geoip. Lets the agent disclose "I used your home airport" vs "detected
+	// from your location".
+	OriginSource string `json:"origin_source,omitempty"`
+}
+
+// buildBookingContext assembles the time/place context for a search. It uses
+// the system clock (no network) and the date string already validated by the
+// caller. Returns nil only if the date cannot be parsed, in which case the
+// field is simply omitted.
+func buildBookingContext(date, origin string, originSource travelctx.Source) *bookingContext {
+	tctx := travelctx.Resolve(context.Background(), nil, travelctx.Options{
+		ExplicitOrigin: origin,
+		AllowGeoIP:     false, // time only; origin already resolved upstream
+	})
+	bc := &bookingContext{
+		SearchedAt:   tctx.Now.Format(time.RFC3339),
+		Timezone:     tctx.Timezone,
+		OriginSource: string(originSource),
+	}
+	dep, derr := time.ParseInLocation("2006-01-02", date, tctx.Now.Location())
+	if derr != nil {
+		// No lead-time math possible; still return the time context.
+		return bc
+	}
+	lead := tctx.LeadTimeDays(dep)
+	window := travelctx.ClassifyWindow(lead)
+	bc.LeadTimeDays = lead
+	bc.BookingWindow = string(window)
+	bc.Advisory = window.Advisory()
+	return bc
 }
 
 // dispatchFlightSearch routes a search_flights call to the right


### PR DESCRIPTION
## Summary

Makes trvl **time- and location-aware by default** across both surfaces, so answers and recommendations reflect *where* and *when* a search happens — booking lead time materially affects fares, and a sensible default origin removes a mandatory argument from the common case.

Two logical commits:

1. **`fix(selfupdate)`** — git-describe-aware update check. A version like `v1.5.0-3-gfb1d4e4` (3 commits ahead of tag) was parsed as a *pre-release* of 1.5.0, so the checker reported the release as "newer" — a false update nag on every run, plus a doubled-`v` formatting bug. Fixed with describe-suffix detection + prefix normalization.
2. **`feat(travelctx)`** — new `internal/travelctx` package + wiring.

## What's new

**`internal/travelctx`** resolves ambient search context:
- Current time + IANA timezone (always).
- Origin precedence: explicit arg -> saved home airport -> best-effort geo-IP (keyless ipinfo, honoring the "no API keys on the default path" decision; degrades silently to prefs).
- Booking-window classifier (last_min / short / sweet_spot / early / very_early) + advisory copy from lead time.
- Deterministic: Clock + GeoResolver are injectable; network path gated by TRVL_NO_GEO / CI detection, never runs in the default test suite.

**CLI** — flights, dates, grid, explore, when accept an optional origin (cobra RangeArgs), narrate provenance on stderr, surface the booking-window advisory. Shared resolveCLIOrigin helper + per-command --no-geo.

**MCP** — search_flights makes origin optional (resolved the same way) and attaches a booking_context block (searched_at, timezone, lead_time_days, booking_window, advisory, origin_source) so agents can reason about timing and disclose how origin was determined.

## Verification

- Full suite green (47 packages), go vet clean, gofmt clean.
- New tests: travelctx 18, mcp origin/context 6, selfupdate describe 11.
- Updated existing arg-count tests whose contracts legitimately changed (origin now optional).
- Live-verified: 2-arg CLI search and MCP search_flights both auto-resolve HEL and return real fares with booking context.

## Notes

- Backward compatible: explicit ORIGIN DEST DATE still works everywhere.
- Privacy: geo-IP is opt-out via --no-geo / TRVL_NO_GEO=1, and auto-disabled in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)