### PR TITLE
docs: add commercial license sponsor rail

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [MikkoParkkola]

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,39 @@
+# Commercial Use
+
+`trvl` is free for personal, research, educational, and noncommercial use under the PolyForm Noncommercial 1.0.0 license.
+
+Commercial use requires a separate commercial license.
+
+Examples that require a commercial license:
+
+- A company uses `trvl` internally for agent workflows, travel search, travel operations, demos, or consulting.
+- `trvl` is forked, wrapped, or modified for business use.
+- `trvl` is run as a hosted, shared, or managed service.
+- `trvl` powers a paid app, SaaS, agent platform, travel product, internal business tool, or data product.
+- Search results, integrations, or provider-specific behavior from `trvl` create revenue or business value.
+
+## Standard commercial license
+
+Companies can buy a standard commercial-use license through GitHub Sponsors:
+
+- EUR 500/month per named project.
+- Covers one company or organization using this project while sponsorship remains active.
+- Covers routine internal business use, private forks, wrappers, private integrations, and shared internal services for that organization.
+- Requires the sponsoring company to identify the licensed project, such as `trvl`, in the sponsor note or by email.
+- Does not include support, SLA, custom development, indemnity, trademark rights, sublicensing, resale, or the right to offer `trvl` as a hosted or managed service to third parties unless separately agreed in writing.
+
+The standard license is intended to be simple enough for normal team, department, or manager-level purchasing. It is not a blanket license for all Mikko Parkkola projects.
+
+## Custom commercial terms
+
+Custom terms are available for larger or unusual deployments, including:
+
+- Multiple projects or portfolio-wide use.
+- External-facing SaaS, hosted, managed-service, or resale use.
+- Redistribution to customers, subsidiaries, contractors, or channel partners.
+- High-scale deployments, regulated environments, procurement-specific contract terms, indemnity, support, SLA, or custom development.
+- Strategic partnerships, revenue share, attribution plus upstream collaboration, or annual invoicing.
+
+Sponsor link: https://github.com/sponsors/MikkoParkkola
+
+Annual invoicing, procurement terms, custom terms, or resale rights can be agreed by email: mikko.parkkola@iki.fi

--- a/README.md
+++ b/README.md
@@ -762,4 +762,8 @@ trvl is part of a suite of MCP tools:
 
 ## License
 
-[PolyForm Noncommercial 1.0.0](LICENSE) — free for personal and noncommercial use. Commercial use requires a separate license.
+[PolyForm Noncommercial 1.0.0](LICENSE) — free for personal and noncommercial use.
+
+Commercial use requires a separate license. That includes company-internal use, forks used for business workflows, hosted/shared-service deployments, embedding in commercial agent platforms, or using `trvl` to power paid travel, consulting, automation, or data products.
+
+Companies can buy a standard commercial-use license via [GitHub Sponsors](https://github.com/sponsors/MikkoParkkola) at EUR 500/month per named project. See [COMMERCIAL.md](COMMERCIAL.md) for scope, exclusions, and custom terms.


### PR DESCRIPTION
## Summary

Adds GitHub Sponsors funding metadata and clarifies the standard commercial-license path for business use.

## Acceptance criteria

- AC-001: `.github/FUNDING.yml` points to `MikkoParkkola` so GitHub can show the Sponsor button after merge.
- AC-002: README/license docs describe the standard EUR 500/month per named project commercial-use path.
- AC-003: Annual invoicing and custom terms are clearly handled by email agreement.
- AC-004: Existing open-source license grants are preserved; Enterprise Edition/commercial boundaries are clarified where applicable.

## ROI

P1 / high leverage: makes the payment path visible at the point where companies evaluate the repo, while keeping normal noncommercial and core open-source use clear.

## Fail-fast

If GitHub does not render the Sponsor button after merge, verify the default-branch `.github/FUNDING.yml` path and GitHub Sponsors profile status before changing licensing text.

## Source

Requested by @MikkoParkkola to make Sponsor buttons appear where commercial licensing makes sense and to clarify per-project licensing terms.
