### PR TITLE
feat(transfer): Leave-By Scheduler engine (Phase 3, MIK-5734 B.2)

### DIFF
--- a/internal/models/transfer.go
+++ b/internal/models/transfer.go
@@ -42,3 +42,22 @@ type TransferComparison struct {
 	BestValue   string           `json:"best_value_mode,omitempty"`
 	LuggageBest string           `json:"most_luggage_friendly_mode,omitempty"`
 }
+
+// ScheduleTimeline is the Leave-By backward plan: when to leave home so the
+// traveller reaches the gate comfortably, with the buffer surfaced, a
+// confidence band, and (when available) a tighter fallback. Computed by
+// backward induction from the flight departure; never optimistic.
+type ScheduleTimeline struct {
+	LeaveHomeBy   string     `json:"leave_home_by"` // local "HH:MM"
+	Steps         []SchedRow `json:"steps"`
+	BufferMinutes int        `json:"airport_buffer_minutes"`
+	Assumptions   []string   `json:"assumptions"`
+	Confidence    string     `json:"confidence"` // high | medium | low
+	Fallback      string     `json:"fallback,omitempty"`
+}
+
+// SchedRow is one timed row of the Leave-By timeline.
+type SchedRow struct {
+	Time string `json:"time"` // local "HH:MM"
+	Text string `json:"text"`
+}

--- a/internal/transfer/schedule.go
+++ b/internal/transfer/schedule.go
@@ -1,0 +1,146 @@
+package transfer
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/transfer/airportkb"
+)
+
+// Default conservative buffers (minutes) used when the airport KB has no entry.
+// Deliberately generous: the scheduler errs toward "leave earlier", never
+// optimistic. A missing profile lowers confidence, never shortens the buffer.
+const (
+	defaultIntlBufferMin     = 150 // 2h30 — conservative when airport unknown
+	defaultDomesticBufferMin = 90
+	safetyMarginMin          = 15 // fixed floor added on top of everything
+)
+
+// transferVarianceMin returns a padding (minutes) for the chosen ground mode,
+// reflecting real-world reliability: rail is steady, road is not.
+func transferVarianceMin(mode string) int {
+	switch mode {
+	case "train", "metro", "airport_express":
+		return 5
+	case "bus", "transit", "mixed":
+		return 12
+	case "taxi", "ride_hail":
+		return 20 // traffic-exposed
+	case "private_transfer":
+		return 10
+	default:
+		return 12
+	}
+}
+
+// ScheduleInput configures a Leave-By computation for the outbound airport leg.
+type ScheduleInput struct {
+	DepartureLocal time.Time // flight (or train) scheduled departure, local time
+	AirportCode    string    // IATA, for the curated buffer KB
+	International  bool      // intl vs domestic check-in/security buffer
+	GroundMinutes  int       // chosen ground option door-to-door minutes (home -> airport)
+	GroundMode     string    // chosen ground mode (for variance)
+	OriginWalkMin  int       // walk from door to the first stop, if any
+	GroundLabel    string    // e.g. "Train I to Helsinki Airport"
+}
+
+// BuildSchedule computes the Leave-By timeline by backward induction from the
+// departure anchor. Every term is grounded or conservative and surfaced in
+// Assumptions; the result is never optimistic (see invariant test).
+func BuildSchedule(in ScheduleInput) models.ScheduleTimeline {
+	buffer, bufferGrounded := airportBuffer(in.AirportCode, in.International)
+	variance := transferVarianceMin(in.GroundMode)
+
+	totalLead := buffer + in.GroundMinutes + variance + in.OriginWalkMin + safetyMarginMin
+	leaveBy := in.DepartureLocal.Add(-time.Duration(totalLead) * time.Minute)
+	arriveAirport := in.DepartureLocal.Add(-time.Duration(buffer) * time.Minute)
+
+	rows := []models.SchedRow{
+		{Time: clock(leaveBy), Text: "Leave home" + labelSuffix(in.GroundLabel)},
+	}
+	if in.OriginWalkMin > 0 {
+		rows = append(rows, models.SchedRow{
+			Time: clock(leaveBy.Add(time.Duration(in.OriginWalkMin) * time.Minute)),
+			Text: fmt.Sprintf("Reach first stop (%d-min walk)", in.OriginWalkMin),
+		})
+	}
+	rows = append(rows,
+		models.SchedRow{Time: clock(arriveAirport), Text: fmt.Sprintf("Arrive at airport — allow %d min for %s", buffer, checkinPhrase(in.International))},
+		models.SchedRow{Time: clock(in.DepartureLocal), Text: "Scheduled departure"},
+	)
+
+	assumptions := []string{
+		fmt.Sprintf("%d-min airport buffer (%s)", buffer, checkinPhrase(in.International)),
+		fmt.Sprintf("%d-min ground transfer + %d-min variance (%s)", in.GroundMinutes, variance, modeWord(in.GroundMode)),
+		fmt.Sprintf("%d-min safety margin", safetyMarginMin),
+	}
+	if in.OriginWalkMin > 0 {
+		assumptions = append(assumptions, fmt.Sprintf("%d-min walk to first stop", in.OriginWalkMin))
+	}
+
+	conf := confidence(bufferGrounded, in.GroundMode)
+
+	return models.ScheduleTimeline{
+		LeaveHomeBy:   clock(leaveBy),
+		Steps:         rows,
+		BufferMinutes: buffer,
+		Assumptions:   assumptions,
+		Confidence:    conf,
+		Fallback:      "", // populated by the journey planner when a later departure still clears a reduced buffer
+	}
+}
+
+// airportBuffer returns the recommended check-in+security buffer and whether it
+// came from the curated KB (grounded) vs a conservative default.
+func airportBuffer(code string, intl bool) (minutes int, grounded bool) {
+	if p, ok := airportkb.Lookup(code); ok {
+		if intl && p.IntlBufferMin > 0 {
+			return p.IntlBufferMin, true
+		}
+		if !intl && p.DomesticBufferMin > 0 {
+			return p.DomesticBufferMin, true
+		}
+	}
+	if intl {
+		return defaultIntlBufferMin, false
+	}
+	return defaultDomesticBufferMin, false
+}
+
+func confidence(bufferGrounded bool, mode string) string {
+	lowVariance := mode == "train" || mode == "metro" || mode == "airport_express"
+	switch {
+	case bufferGrounded && lowVariance:
+		return "high"
+	case bufferGrounded || lowVariance:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+func checkinPhrase(intl bool) string {
+	if intl {
+		return "check-in + security (international)"
+	}
+	return "check-in + security (domestic)"
+}
+
+func modeWord(mode string) string {
+	if mode == "" {
+		return "transfer"
+	}
+	return mode
+}
+
+func labelSuffix(label string) string {
+	if label == "" {
+		return ""
+	}
+	return " — " + label
+}
+
+func clock(t time.Time) string {
+	return t.Format("15:04")
+}

--- a/internal/transfer/schedule_test.go
+++ b/internal/transfer/schedule_test.go
@@ -1,0 +1,88 @@
+package transfer
+
+import (
+	"testing"
+	"time"
+)
+
+func mustParse(t *testing.T, s string) time.Time {
+	t.Helper()
+	tm, err := time.Parse("2006-01-02 15:04", s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return tm
+}
+
+func TestBuildSchedule_Success_GroundedAirport(t *testing.T) {
+	// HEL is in the KB (intl buffer 120). Train ground leg, low variance.
+	in := ScheduleInput{
+		DepartureLocal: mustParse(t, "2026-07-18 09:40"),
+		AirportCode:    "HEL",
+		International:  true,
+		GroundMinutes:  30,
+		GroundMode:     "train",
+		OriginWalkMin:  5,
+		GroundLabel:    "Train I to Helsinki Airport",
+	}
+	s := BuildSchedule(in)
+
+	if s.BufferMinutes != 120 {
+		t.Errorf("buffer = %d, want 120 (HEL intl KB)", s.BufferMinutes)
+	}
+	if s.Confidence != "high" {
+		t.Errorf("confidence = %q, want high (grounded buffer + low-variance train)", s.Confidence)
+	}
+	// leave_by = 09:40 - (120 + 30 + 5 variance + 5 walk + 15 safety) = -175 min => 06:45
+	if s.LeaveHomeBy != "06:45" {
+		t.Errorf("leave_home_by = %q, want 06:45", s.LeaveHomeBy)
+	}
+	if len(s.Steps) < 3 {
+		t.Errorf("expected >=3 timeline rows, got %d", len(s.Steps))
+	}
+	if s.Steps[len(s.Steps)-1].Time != "09:40" {
+		t.Errorf("last row should be the departure at 09:40, got %q", s.Steps[len(s.Steps)-1].Time)
+	}
+}
+
+// TestBuildSchedule_NeverOptimistic is the safety invariant: leave_by must
+// always be earlier than departure minus the airport buffer alone — i.e. the
+// schedule never assumes you can arrive later than the check-in buffer allows.
+func TestBuildSchedule_NeverOptimistic(t *testing.T) {
+	cases := []ScheduleInput{
+		{DepartureLocal: mustParse(t, "2026-07-18 09:40"), AirportCode: "HEL", International: true, GroundMinutes: 30, GroundMode: "train"},
+		{DepartureLocal: mustParse(t, "2026-07-18 23:55"), AirportCode: "ZZZ", International: true, GroundMinutes: 50, GroundMode: "taxi", OriginWalkMin: 3},
+		{DepartureLocal: mustParse(t, "2026-07-18 06:10"), AirportCode: "BCN", International: false, GroundMinutes: 20, GroundMode: "bus"},
+	}
+	for i, in := range cases {
+		s := BuildSchedule(in)
+		leaveBy := mustParse(t, "2026-07-18 "+s.LeaveHomeBy)
+		latestSafe := in.DepartureLocal.Add(-time.Duration(s.BufferMinutes) * time.Minute).Add(-time.Duration(in.GroundMinutes) * time.Minute)
+		if !leaveBy.Before(latestSafe) && !leaveBy.Equal(latestSafe) {
+			t.Errorf("case %d: leave_by %s is optimistic — not earlier than departure - buffer - ground (%s)", i, s.LeaveHomeBy, latestSafe.Format("15:04"))
+		}
+	}
+}
+
+func TestBuildSchedule_UnknownAirportIsConservativeAndLowerConfidence(t *testing.T) {
+	in := ScheduleInput{
+		DepartureLocal: mustParse(t, "2026-07-18 12:00"),
+		AirportCode:    "ZZZ", // not in KB
+		International:  true,
+		GroundMinutes:  40,
+		GroundMode:     "taxi",
+	}
+	s := BuildSchedule(in)
+	if s.BufferMinutes != defaultIntlBufferMin {
+		t.Errorf("unknown airport must use conservative default %d, got %d", defaultIntlBufferMin, s.BufferMinutes)
+	}
+	if s.Confidence == "high" {
+		t.Errorf("unknown buffer + taxi must not be high confidence, got %q", s.Confidence)
+	}
+}
+
+func TestTransferVariance_RailSteadierThanRoad(t *testing.T) {
+	if transferVarianceMin("train") >= transferVarianceMin("taxi") {
+		t.Errorf("train variance (%d) must be less than taxi (%d)", transferVarianceMin("train"), transferVarianceMin("taxi"))
+	}
+}


### PR DESCRIPTION
## What

Phase 3 of the door-to-door epic (MIK-5734 AC B.2): the Leave-By Scheduler engine — the "when do I leave home to reach the gate comfortably, not last-minute" calculation the user asked for directly.

## The model

Backward induction from the flight departure anchor. The leave-by time is the departure time minus the airport check-in and security buffer (from the curated airport KB), minus the chosen ground transfer time, minus a mode variance pad (rail steadier than road), minus the origin walk, minus a fixed safety margin.

Every term is grounded (curated airport KB) or conservatively defaulted, and surfaced in the timeline assumptions. Output: a timed timeline (leave home, reach stop, arrive airport with buffer, departure), a confidence band (from data quality plus mode variance), and room for a tighter fallback.

## Safety guarantees (tested)

- Never optimistic: an invariant test asserts the leave-by time is always earlier than departure minus the airport buffer minus ground time, across grounded, unknown-airport, and late-night cases.
- Unknown airport degrades safely: conservative default buffer plus lowered confidence, never a shortened buffer.
- Rail variance is smaller than road variance (reliability-aware padding).

## Scope

This PR ships the tested engine (internal transfer scheduler plus ScheduleTimeline and SchedRow model types). MCP exposure lands with the journey intent (Option B), which adds the home-to-airport stitcher and would bump the advertised alias count — deliberately kept out of this focused PR to avoid a premature doc-count cascade.

## Verification

go build, go vet, staticcheck all clean. go test with the race detector on internal transfer passes (scheduler plus existing comparison-card tests).

Tracking: MIK-5734 (epic), AC B.2.

Generated with Claude Code
