### PR TITLE
feat(mcp): plan_journey intent exposes Leave-By Scheduler (MIK-5734 B.1)

### DIFF
--- a/cmd/trvl/public_claims_test.go
+++ b/cmd/trvl/public_claims_test.go
@@ -127,7 +127,21 @@ func registeredMCPCompatibilityAliasCount(t *testing.T) int {
 		t.Fatal("mcp.Server should expose an internal handlers field")
 	}
 
-	return handlers.Len() - 1 // Exclude the primary travel smart router.
+	// Exclude the primary travel smart router and any non-alias smart
+	// capabilities (e.g. plan_journey) — these are reachable via the travel
+	// router intent but are NOT legacy compatibility aliases, so they must not
+	// inflate the marketed "compatibility aliases" count.
+	nonAliasCapabilities := map[string]bool{
+		"travel":       true, // the smart router itself
+		"plan_journey": true, // Leave-By Scheduler capability (MIK-5734 B)
+	}
+	count := 0
+	for _, key := range handlers.MapKeys() {
+		if !nonAliasCapabilities[key.String()] {
+			count++
+		}
+	}
+	return count
 }
 
 func TestPublicDocsAdvertiseCurrentCounts(t *testing.T) {

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -86,6 +86,10 @@ func registerTools(s *Server) {
 	}
 	s.tools = advertisedToolSurface(legacyTools)
 	s.handlers["travel"] = s.handleTravel
+	// plan_journey is a smart capability reachable via the travel router intent,
+	// not a legacy compatibility alias — registered as a handler but kept out of
+	// the advertised legacyTools surface (see registeredMCPCompatibilityAliasCount).
+	s.handlers["plan_journey"] = s.wrapHandler("plan_journey", handleJourney)
 	s.handlers["search_flights"] = s.wrapHandler("search_flights", handleSearchFlights)
 	s.handlers["plan_flight_bundle"] = s.wrapHandler("plan_flight_bundle", handlePlanFlightBundle)
 	s.handlers["find_interactive"] = s.wrapHandler("find_interactive", handleFindInteractive)

--- a/mcp/tools_journey.go
+++ b/mcp/tools_journey.go
@@ -1,0 +1,65 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/transfer"
+)
+
+// handleJourney exposes the Leave-By Scheduler: given a flight departure and how
+// the traveller reaches the airport, it answers "when do I leave home to be
+// comfortably (not last-minute) at the gate?" with a grounded, conservative
+// timeline. It is a smart capability reachable via the `travel` router intent
+// `plan_journey`; it is deliberately NOT advertised as a compatibility alias
+// (it is a capability, not a legacy tool name).
+func handleJourney(ctx context.Context, args map[string]any, elicit ElicitFunc, sampling SamplingFunc, progress ProgressFunc) ([]ContentBlock, interface{}, error) {
+	airport := argString(args, "airport_code")
+	date := argString(args, "date")
+	depTime := argString(args, "departure_time")
+	if airport == "" || date == "" || depTime == "" {
+		return nil, nil, fmt.Errorf("airport_code, date, and departure_time are required")
+	}
+	groundMin := argInt(args, "ground_minutes", 0)
+	groundMode := argString(args, "ground_mode")
+	if groundMin <= 0 || groundMode == "" {
+		return nil, nil, fmt.Errorf("ground_minutes (>0) and ground_mode are required; pick a mode from a transfer search first")
+	}
+
+	departure, err := time.Parse("2006-01-02 15:04", date+" "+depTime)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid date/departure_time (want YYYY-MM-DD and HH:MM): %w", err)
+	}
+
+	intl := argBool(args, "international", true)
+	schedule := transfer.BuildSchedule(transfer.ScheduleInput{
+		DepartureLocal: departure,
+		AirportCode:    airport,
+		International:   intl,
+		GroundMinutes:  groundMin,
+		GroundMode:     groundMode,
+		OriginWalkMin:  argInt(args, "origin_walk_min", 0),
+		GroundLabel:    argString(args, "ground_label"),
+	})
+
+	summary := fmt.Sprintf("Leave home by %s to reach %s comfortably for your %s departure (confidence: %s).",
+		schedule.LeaveHomeBy, airport, depTime, schedule.Confidence)
+	for _, row := range schedule.Steps {
+		summary += fmt.Sprintf("\n  %s  %s", row.Time, row.Text)
+	}
+	if len(schedule.Assumptions) > 0 {
+		summary += "\n\nAssumptions: "
+		for i, a := range schedule.Assumptions {
+			if i > 0 {
+				summary += "; "
+			}
+			summary += a
+		}
+	}
+
+	content := []ContentBlock{
+		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
+	}
+	return content, schedule, nil
+}

--- a/mcp/tools_journey_test.go
+++ b/mcp/tools_journey_test.go
@@ -1,0 +1,83 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestHandleJourney_Success(t *testing.T) {
+	args := map[string]any{
+		"airport_code":    "HEL",
+		"date":            "2026-07-18",
+		"departure_time":  "09:40",
+		"international":   true,
+		"ground_minutes":  float64(30),
+		"ground_mode":     "train",
+		"origin_walk_min": float64(5),
+		"ground_label":    "Train I to Helsinki Airport",
+	}
+	content, structured, err := handleJourney(context.Background(), args, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleJourney error: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("expected user-facing content")
+	}
+
+	data, _ := json.Marshal(structured)
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal schedule: %v", err)
+	}
+	if got["leave_home_by"] != "06:45" {
+		t.Errorf("leave_home_by = %v, want 06:45 (HEL intl 120 buffer + 30 ground + 5 var + 5 walk + 15 safety)", got["leave_home_by"])
+	}
+	if got["confidence"] != "high" {
+		t.Errorf("confidence = %v, want high", got["confidence"])
+	}
+}
+
+func TestHandleJourney_RequiresGroundChoice(t *testing.T) {
+	args := map[string]any{
+		"airport_code":   "HEL",
+		"date":           "2026-07-18",
+		"departure_time": "09:40",
+		// missing ground_minutes/ground_mode
+	}
+	if _, _, err := handleJourney(context.Background(), args, nil, nil, nil); err == nil {
+		t.Fatal("expected error when ground option is missing")
+	}
+}
+
+func TestHandleJourney_BadDate(t *testing.T) {
+	args := map[string]any{
+		"airport_code":   "HEL",
+		"date":           "July 18",
+		"departure_time": "09:40",
+		"ground_minutes": float64(30),
+		"ground_mode":    "train",
+	}
+	if _, _, err := handleJourney(context.Background(), args, nil, nil, nil); err == nil {
+		t.Fatal("expected error on unparseable date")
+	}
+}
+
+// TestPlanJourney_CallableViaIntent_NotAdvertised verifies plan_journey is a
+// reachable capability (registered handler) but not part of the advertised
+// legacy compatibility-alias surface in either mode.
+func TestPlanJourney_CallableViaIntent_NotAdvertised(t *testing.T) {
+	s := NewServer()
+	if _, ok := s.handlers["plan_journey"]; !ok {
+		t.Fatal("plan_journey handler must be registered (callable via travel intent)")
+	}
+	if toolRegistered(s.tools, "plan_journey") {
+		t.Error("plan_journey must NOT be advertised in the default compact surface")
+	}
+
+	t.Setenv("TRVL_MCP_TOOL_MODE", "legacy")
+	legacy := NewServer()
+	if toolRegistered(legacy.tools, "plan_journey") {
+		t.Error("plan_journey must NOT be advertised among the legacy compatibility aliases")
+	}
+}


### PR DESCRIPTION
## What

MIK-5734 B.1: exposes the Leave-By Scheduler through MCP as the `plan_journey` smart capability, so an assistant can finally answer the user's question end-to-end — "when do I leave home to reach the gate comfortably, not last-minute?"

## How it is reached

`plan_journey` is callable via the `travel` router intent (registered handler), taking airport_code, date, departure_time, and the chosen ground option (ground_minutes + ground_mode from a transfer search). It returns the grounded leave-by timeline (ScheduleTimeline) with surfaced assumptions and a confidence band.

## Surface taxonomy (deliberate)

plan_journey is a NEW capability, not a legacy compatibility alias. It is therefore:
- registered as a handler (callable via intent), but
- NOT added to the advertised legacy tool surface (default stays 1 advertised tool; legacy mode stays exactly 64 aliases), and
- excluded from the marketed "compatibility aliases" count via registeredMCPCompatibilityAliasCount, so the count stays an honest 64 with zero doc cascade.

This keeps the 1-advertised-tool token-efficiency property and the marketed counts intact.

## Tests

- handler success (HEL intl, train -> leave by 06:45), required-ground-choice error, bad-date error.
- plan_journey is registered (callable) but NOT advertised in either compact or legacy mode.
- existing public-claims + legacy-count guards stay green (alias count held at 64).

## Verification

go build, go vet, staticcheck all clean. go test on mcp, cmd/trvl, internal/transfer passes.

Tracking: MIK-5734 (epic), AC B.1.

Generated with Claude Code
