### PR TITLE
feat(mcp): proactively surface door-to-door transfer after flight search (MIK-5734 A.1)

### DIFF
--- a/mcp/coverage_boost2_test.go
+++ b/mcp/coverage_boost2_test.go
@@ -417,6 +417,30 @@ func TestFlightSuggestions_WithMultiStop(t *testing.T) {
 	}
 }
 
+func TestFlightSuggestions_SurfacesDoorToDoorTransfer(t *testing.T) {
+	t.Parallel()
+	result := &models.FlightSearchResult{
+		Success: true, Count: 1,
+		Flights: []models.FlightResult{{Price: 200, Stops: 0}},
+	}
+	suggestions := flightSuggestions(result, "HEL", "BCN", "2026-07-18", flightsOptsEmpty())
+	var hasTransfer, hasJourney bool
+	for _, s := range suggestions {
+		if s.Action == "search_airport_transfers" && s.Params["airport_code"] == "BCN" {
+			hasTransfer = true
+		}
+		if s.Action == "plan_journey" && s.Params["airport_code"] == "HEL" {
+			hasJourney = true
+		}
+	}
+	if !hasTransfer {
+		t.Error("should proactively surface the arrival airport transfer (A.1)")
+	}
+	if !hasJourney {
+		t.Error("should proactively surface the departure leave-by schedule (A.1)")
+	}
+}
+
 func TestFlightSuggestions_WidelyVaryingPrices(t *testing.T) {
 	t.Parallel()
 	result := &models.FlightSearchResult{

--- a/mcp/tools_flights.go
+++ b/mcp/tools_flights.go
@@ -794,5 +794,22 @@ func flightSuggestions(result *models.FlightSearchResult, origin, dest, date str
 		})
 	}
 
+	// Proactively surface the door-to-door transfer (MIK-5734 A.1): once a
+	// flight is found, the next question is always "how do I get from the
+	// airport to where I'm staying, and when do I leave home?". Offer both the
+	// arrival-side transfer comparison and the departure-side leave-by schedule.
+	if dest != "" {
+		suggestions = append(suggestions, Suggestion{
+			Action:      "search_airport_transfers",
+			Description: fmt.Sprintf("Plan the airport transfer from %s to your accommodation (compare public transport, taxi, express)", dest),
+			Params:      map[string]any{"airport_code": dest, "destination": "YOUR_HOTEL_OR_ADDRESS", "date": date},
+		})
+		suggestions = append(suggestions, Suggestion{
+			Action:      "plan_journey",
+			Description: fmt.Sprintf("Get a leave-by schedule for the %s departure (when to leave home for check-in + security)", origin),
+			Params:      map[string]any{"airport_code": origin, "date": date, "departure_time": "HH:MM", "ground_minutes": 0, "ground_mode": "train"},
+		})
+	}
+
 	return suggestions
 }


### PR DESCRIPTION
## What

MIK-5734 A.1: proactively surface the door-to-door transfer. Once search_flights finds a flight, the response now includes two suggestions, because the next question is always "how do I get from the airport to where I'm staying, and when do I leave home?":

- search_airport_transfers at the arrival airport (compare public transport / taxi / express).
- plan_journey for the departure airport (leave-by schedule with check-in + security buffer).

This fixes the discoverability gap from the original user feedback: the transfer + leave-by capabilities existed but were never offered in the natural flow.

## How

Extends the existing flightSuggestions mechanism (same shape as the round-trip / nonstop / cheaper-dates suggestions already returned). Additive — no new tool, no schema change, no count change.

## Tests

TestFlightSuggestions_SurfacesDoorToDoorTransfer asserts both the arrival-transfer and departure leave-by suggestions appear with the correct airport codes.

## Verification

go build, go vet, staticcheck clean. go test on mcp passes.

Tracking: MIK-5734 (epic), AC A.1.

Generated with Claude Code
