### PR TITLE
feat(mcp): auto-stitch home-to-airport leg in plan_journey via origin (MIK-5734 B.1-phase2)

### DIFF
--- a/mcp/tools_journey.go
+++ b/mcp/tools_journey.go
@@ -8,7 +8,14 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/calendar"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/transfer"
+	"github.com/MikkoParkkola/trvl/internal/trip"
 )
+
+// journeyTransferSearch is a test seam over the home->airport ground search so
+// the default suite stays deterministic (no live network). Production points at
+// trip.SearchAirportTransfers, which already resolves airport codes to cities
+// and merges transit + ground providers + a taxi estimate.
+var journeyTransferSearch = trip.SearchAirportTransfers
 
 // handleJourney exposes the Leave-By Scheduler: given a flight departure and how
 // the traveller reaches the airport, it answers "when do I leave home to be
@@ -16,6 +23,12 @@ import (
 // timeline. It is a smart capability reachable via the `travel` router intent
 // `plan_journey`; it is deliberately NOT advertised as a compatibility alias
 // (it is a capability, not a legacy tool name).
+//
+// Ground leg: pass ground_minutes + ground_mode explicitly (from a transfer
+// search), OR pass origin to auto-compute the home->airport leg — when origin is
+// set and no explicit ground option is given, plan_journey searches the leg,
+// returns the full comparison card (so the traveller can still choose), and
+// schedules from the best-value option.
 func handleJourney(ctx context.Context, args map[string]any, elicit ElicitFunc, sampling SamplingFunc, progress ProgressFunc) ([]ContentBlock, interface{}, error) {
 	airport := argString(args, "airport_code")
 	date := argString(args, "date")
@@ -25,13 +38,38 @@ func handleJourney(ctx context.Context, args map[string]any, elicit ElicitFunc, 
 	}
 	groundMin := argInt(args, "ground_minutes", 0)
 	groundMode := argString(args, "ground_mode")
+	groundLabel := argString(args, "ground_label")
+
+	// Auto-stitch the home->airport leg (B.1-phase2) when an origin is given and
+	// no explicit ground option was passed.
+	var comparison *models.TransferComparison
+	if origin := argString(args, "origin"); origin != "" && (groundMin <= 0 || groundMode == "") {
+		res, serr := journeyTransferSearch(ctx, trip.AirportTransferInput{
+			AirportCode: airport,
+			Destination: origin,
+			Date:        date,
+			Currency:    argString(args, "currency"),
+		})
+		if serr == nil && res != nil && res.Success && len(res.Routes) > 0 {
+			card := transfer.BuildOptions(res.Routes, airport, origin, airport)
+			comparison = &card
+			if best := pickScheduledOption(card); best != nil {
+				groundMin = best.DoorToDoorMin
+				groundMode = best.Mode
+				if groundLabel == "" {
+					groundLabel = best.Label
+				}
+			}
+		}
+	}
+
 	if groundMin <= 0 || groundMode == "" {
-		return nil, nil, fmt.Errorf("ground_minutes (>0) and ground_mode are required; pick a mode from a transfer search first")
+		return nil, nil, fmt.Errorf("provide ground_minutes (>0) + ground_mode from a transfer search, or pass origin to auto-compute the home-to-airport leg")
 	}
 
 	departure, err := time.Parse("2006-01-02 15:04", date+" "+depTime)
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid date/departure_time (want YYYY-MM-DD and HH:MM): %w", err)
+		return nil, nil, fmt.Errorf("invalid date or departure_time (date as 4-digit-year-month-day, time as HH:MM): %w", err)
 	}
 
 	intl := argBool(args, "international", true)
@@ -42,7 +80,7 @@ func handleJourney(ctx context.Context, args map[string]any, elicit ElicitFunc, 
 		GroundMinutes:  groundMin,
 		GroundMode:     groundMode,
 		OriginWalkMin:  argInt(args, "origin_walk_min", 0),
-		GroundLabel:    argString(args, "ground_label"),
+		GroundLabel:    groundLabel,
 	})
 
 	summary := fmt.Sprintf("Leave home by %s to reach %s comfortably for your %s departure (confidence: %s).",
@@ -59,6 +97,9 @@ func handleJourney(ctx context.Context, args map[string]any, elicit ElicitFunc, 
 			summary += a
 		}
 	}
+	if comparison != nil && len(comparison.Options) > 1 {
+		summary += "\n\nGround leg scheduled with the best-value option; the full comparison is attached so you can choose another."
+	}
 
 	content := []ContentBlock{
 		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
@@ -67,24 +108,46 @@ func handleJourney(ctx context.Context, args map[string]any, elicit ElicitFunc, 
 	// Optional calendar handoff (F.1): when as_ics is set, attach an iCalendar
 	// "Leave home" event with a reminder alarm so the user can drop it straight
 	// into Apple/Google/Outlook. Additive — does not change the default output.
+	var ics string
 	if argBool(args, "as_ics", false) {
-		ics, icsErr := calendar.ScheduleICS(calendar.ScheduleICSInput{
+		if out, icsErr := calendar.ScheduleICS(calendar.ScheduleICSInput{
 			Date:          date,
 			AirportCode:   airport,
 			DepartureTime: depTime,
 			ReminderMin:   argInt(args, "reminder_minutes", 30),
 			Schedule:      schedule,
-		})
-		if icsErr == nil {
-			return content, journeyResponse{ScheduleTimeline: schedule, ICS: ics}, nil
+		}); icsErr == nil {
+			ics = out
 		}
+	}
+
+	if ics != "" || comparison != nil {
+		return content, journeyResponse{ScheduleTimeline: schedule, ICS: ics, GroundComparison: comparison}, nil
 	}
 	return content, schedule, nil
 }
 
-// journeyResponse wraps the schedule with an optional iCalendar export when the
-// caller requests the calendar handoff via as_ics.
+// pickScheduledOption chooses the default ground option to schedule from: the
+// best-value mode when labelled, else the first option. The full card is still
+// returned so the traveller can re-run with a specific mode.
+func pickScheduledOption(card models.TransferComparison) *models.TransferOption {
+	if len(card.Options) == 0 {
+		return nil
+	}
+	if card.BestValue != "" {
+		for i := range card.Options {
+			if card.Options[i].Mode == card.BestValue {
+				return &card.Options[i]
+			}
+		}
+	}
+	return &card.Options[0]
+}
+
+// journeyResponse wraps the schedule with an optional iCalendar export and the
+// optional auto-computed home->airport comparison card.
 type journeyResponse struct {
 	models.ScheduleTimeline
-	ICS string `json:"ics,omitempty"`
+	ICS              string                     `json:"ics,omitempty"`
+	GroundComparison *models.TransferComparison `json:"ground_comparison,omitempty"`
 }

--- a/mcp/tools_journey_test.go
+++ b/mcp/tools_journey_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/trip"
 )
 
 func TestHandleJourney_Success(t *testing.T) {
@@ -109,5 +112,58 @@ func TestPlanJourney_CallableViaIntent_NotAdvertised(t *testing.T) {
 	legacy := NewServer()
 	if toolRegistered(legacy.tools, "plan_journey") {
 		t.Error("plan_journey must NOT be advertised among the legacy compatibility aliases")
+	}
+}
+
+// TestHandleJourney_AutoStitchOrigin verifies B.1-phase2: when origin is given
+// and no explicit ground option, plan_journey searches the home->airport leg
+// (stubbed seam), schedules from the best-value option, and returns the card.
+func TestHandleJourney_AutoStitchOrigin(t *testing.T) {
+	orig := journeyTransferSearch
+	t.Cleanup(func() { journeyTransferSearch = orig })
+	journeyTransferSearch = func(ctx context.Context, in trip.AirportTransferInput) (*trip.AirportTransferResult, error) {
+		return &trip.AirportTransferResult{
+			Success: true,
+			Count:   2,
+			Routes: []models.GroundRoute{
+				{Provider: "train", Type: "train", Price: 4.10, Currency: "EUR", Duration: 33, Transfers: 0},
+				{Provider: "taxi", Type: "taxi", Price: 55, Currency: "EUR", Duration: 28, Transfers: 0},
+			},
+		}, nil
+	}
+
+	args := map[string]any{
+		"airport_code":   "HEL",
+		"date":           "2026-07-18",
+		"departure_time": "09:40",
+		"origin":         "Espoo",
+		// no ground_minutes/ground_mode — must be auto-computed
+	}
+	_, structured, err := handleJourney(context.Background(), args, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleJourney auto-stitch error: %v", err)
+	}
+	data, _ := json.Marshal(structured)
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["leave_home_by"] == nil || got["leave_home_by"] == "" {
+		t.Error("auto-stitched journey must produce a leave_home_by time")
+	}
+	if got["ground_comparison"] == nil {
+		t.Error("auto-stitch must attach the home-to-airport comparison card")
+	}
+}
+
+func TestHandleJourney_NoGroundNoOrigin_Errors(t *testing.T) {
+	args := map[string]any{
+		"airport_code":   "HEL",
+		"date":           "2026-07-18",
+		"departure_time": "09:40",
+		// no ground option AND no origin
+	}
+	if _, _, err := handleJourney(context.Background(), args, nil, nil, nil); err == nil {
+		t.Fatal("expected error when neither ground option nor origin is provided")
 	}
 }


### PR DESCRIPTION
## What

MIK-5734 B.1-phase2: plan_journey now auto-computes the home-to-airport leg. Pass origin (home city/address) and plan_journey searches the leg itself, builds the comparison card, schedules from the best-value option, and returns the card so the traveller can still choose another mode. No more manually passing ground_minutes/ground_mode.

## How

- New optional origin param. When set and no explicit ground option is given, plan_journey calls the home-to-airport ground search, runs BuildOptions, and picks the best-value option to schedule.
- The home-to-airport ground search goes through a test seam (journeyTransferSearch) so the default suite stays deterministic and offline; production points at trip.SearchAirportTransfers (which already resolves airport codes and merges providers).
- Response gains an optional ground_comparison field. Still additive; no new tool, no count change. Explicit ground_minutes/ground_mode path is unchanged.

## Tests

- auto-stitch via stubbed seam: origin yields a leave_home_by + an attached ground_comparison.
- error when neither a ground option nor origin is provided.

## Verification

go build, go vet, staticcheck clean. go test on mcp passes.

Tracking: MIK-5734 (epic), AC B.1-phase2.

Generated with Claude Code
