### PR TITLE
feat(transfer): expand airport KB to 16 major hubs (MIK-5734 C.4)

### DIFF
--- a/internal/transfer/airportkb/data/AMS.json
+++ b/internal/transfer/airportkb/data/AMS.json
@@ -1,0 +1,6 @@
+{
+  "code": "AMS",
+  "name": "Amsterdam Schiphol",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/ARN.json
+++ b/internal/transfer/airportkb/data/ARN.json
@@ -1,0 +1,6 @@
+{
+  "code": "ARN",
+  "name": "Stockholm Arlanda",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/CDG.json
+++ b/internal/transfer/airportkb/data/CDG.json
@@ -1,0 +1,6 @@
+{
+  "code": "CDG",
+  "name": "Paris Charles de Gaulle",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/CPH.json
+++ b/internal/transfer/airportkb/data/CPH.json
@@ -1,0 +1,6 @@
+{
+  "code": "CPH",
+  "name": "Copenhagen Kastrup",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/DUB.json
+++ b/internal/transfer/airportkb/data/DUB.json
@@ -1,0 +1,6 @@
+{
+  "code": "DUB",
+  "name": "Dublin",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/FCO.json
+++ b/internal/transfer/airportkb/data/FCO.json
@@ -1,0 +1,6 @@
+{
+  "code": "FCO",
+  "name": "Rome Fiumicino Leonardo da Vinci",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/FRA.json
+++ b/internal/transfer/airportkb/data/FRA.json
@@ -1,0 +1,6 @@
+{
+  "code": "FRA",
+  "name": "Frankfurt am Main",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/JFK.json
+++ b/internal/transfer/airportkb/data/JFK.json
@@ -1,0 +1,6 @@
+{
+  "code": "JFK",
+  "name": "New York John F. Kennedy",
+  "intl_buffer_min": 180,
+  "domestic_buffer_min": 120
+}

--- a/internal/transfer/airportkb/data/LHR.json
+++ b/internal/transfer/airportkb/data/LHR.json
@@ -1,0 +1,6 @@
+{
+  "code": "LHR",
+  "name": "London Heathrow",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/LIS.json
+++ b/internal/transfer/airportkb/data/LIS.json
@@ -1,0 +1,6 @@
+{
+  "code": "LIS",
+  "name": "Lisbon Humberto Delgado",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/MAD.json
+++ b/internal/transfer/airportkb/data/MAD.json
@@ -1,0 +1,6 @@
+{
+  "code": "MAD",
+  "name": "Madrid-Barajas Adolfo Suarez",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/MUC.json
+++ b/internal/transfer/airportkb/data/MUC.json
@@ -1,0 +1,6 @@
+{
+  "code": "MUC",
+  "name": "Munich Franz Josef Strauss",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/VIE.json
+++ b/internal/transfer/airportkb/data/VIE.json
@@ -1,0 +1,6 @@
+{
+  "code": "VIE",
+  "name": "Vienna International",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/ZRH.json
+++ b/internal/transfer/airportkb/data/ZRH.json
@@ -1,0 +1,6 @@
+{
+  "code": "ZRH",
+  "name": "Zurich",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/kb_test.go
+++ b/internal/transfer/airportkb/kb_test.go
@@ -32,8 +32,8 @@ func TestLookup_Missing(t *testing.T) {
 
 func TestCodes_NonEmpty(t *testing.T) {
 	codes := Codes()
-	if len(codes) < 2 {
-		t.Errorf("expected at least the seed profiles (BCN, HEL), got %v", codes)
+	if len(codes) < 12 {
+		t.Errorf("expected the expanded major-hub profile set (>=12), got %d: %v", len(codes), codes)
 	}
 	// Every listed code must load.
 	for _, c := range codes {


### PR DESCRIPTION
## What

MIK-5734 C.4: expand the curated airport knowledge base from 2 (BCN, HEL) to 16 major hubs (adds LHR, CDG, AMS, FRA, MAD, FCO, MUC, DUB, CPH, ARN, VIE, ZRH, LIS, JFK). This improves the Leave-By Scheduler accuracy: known airports get their grounded check-in/security buffer instead of the conservative unknown-airport default.

## Grounding discipline (important)

The new profiles carry only verifiable facts: airport name + the standard published check-in guidance (120-min international / 60-min domestic for the European hubs; JFK gets 180/120 for US security/peak). They deliberately OMIT exit_snippets and last_transit_depart, because asserting terminal-specific signage or last-departure times without per-airport verification would violate the grounding contract (the roadmap number-one trust failure is invented details). Where those are absent, step instructions fall back to route-data-grounded steps or are flagged estimated — never fabricated.

Buffers are conservative standard advice, not fabrication: "arrive 2 hours before an international flight" is universally published airline guidance.

## Tests

KB coverage test raised to assert the expanded set (>=12 profiles, all loadable). All JSON validated.

## Verification

go test on internal/transfer + airportkb passes.

Tracking: MIK-5734 (epic), AC C.4. Further expansion to 50 airports continues incrementally by adding data files (no code change); each addition stays buffer-first unless per-airport exit data is verified.

Generated with Claude Code
