### PR TITLE
feat(transfer): ride-hail deep-link options in the comparison card (MIK-5734 E.1)

### DIFF
--- a/LEGAL.md
+++ b/LEGAL.md
@@ -140,6 +140,7 @@ These providers are part of trvl's source code and are active by default. trvl's
 | Open-Meteo | Weather API | Free, CC-BY 4.0 |
 | Wikivoyage | MediaWiki API | CC-BY-SA 3.0 |
 | OpenStreetMap | Overpass API | ODbL licensed |
+| Uber / Bolt (ride-hail) | Deep-links only (no API call, no scraping) | trvl constructs a booking deep-link with pickup/dropoff; the user opens the app, where the real price/availability is shown. No data is fetched, no ToS engaged. |
 | Ticketmaster, Foursquare, etc. | Official APIs with keys | Optional, free tier available |
 | Deal feeds | RSS (Secret Flying, Fly4Free, Holiday Pirates, The Points Guy) | Public RSS syndication |
 

--- a/internal/transfer/option.go
+++ b/internal/transfer/option.go
@@ -16,7 +16,8 @@ import (
 // BuildOptions enriches raw ground routes into a TransferComparison for one
 // leg. airportCode is the IATA code of the airport endpoint (used to ground
 // step instructions from the curated KB); pass "" when neither endpoint is an
-// airport. from/to are display labels for the leg.
+// airport. from/to are display labels for the leg. Ride-hail deep-links (Uber,
+// Bolt) are appended as additional choosable options when from/to are known.
 func BuildOptions(routes []models.GroundRoute, airportCode, from, to string) models.TransferComparison {
 	profile, hasProfile := airportkb.Lookup(airportCode)
 	var profPtr *airportkb.Profile
@@ -41,6 +42,13 @@ func BuildOptions(routes []models.GroundRoute, airportCode, from, to string) mod
 		}
 		opt.Steps = AssembleSteps(r, opt.Mode, profPtr)
 		opts = append(opts, opt)
+	}
+
+	// Provider breadth (E.1): ride-hail deep-links as additional options, but
+	// only when there is at least one real route to compare against (avoid
+	// fabricating a card from nothing).
+	if len(opts) > 0 {
+		opts = append(opts, RideHailOptions(from, to)...)
 	}
 
 	// Pros/cons need the full set (price ratios, fastest, etc.).
@@ -98,43 +106,61 @@ func titleASCII(s string) string {
 
 // labelComparison fills the cheapest/fastest/best-value/luggage sort labels.
 // No option is removed and none is marked "the answer"; these are affordances.
+// Options with unknown price/duration (e.g. ride-hail deep-links) are skipped
+// for cheapest/fastest/best-value so they never falsely win on a zero value.
 func labelComparison(cmp *models.TransferComparison) {
 	if len(cmp.Options) == 0 {
 		return
 	}
-	cheapest := cmp.Options[0]
-	fastest := cmp.Options[0]
-	for _, o := range cmp.Options[1:] {
-		if o.TotalPrice < cheapest.TotalPrice {
+	var cheapest, fastest *models.TransferOption
+	for i := range cmp.Options {
+		o := &cmp.Options[i]
+		if o.TotalPrice > 0 && (cheapest == nil || o.TotalPrice < cheapest.TotalPrice) {
 			cheapest = o
 		}
-		if o.DoorToDoorMin < fastest.DoorToDoorMin {
+		if o.DoorToDoorMin > 0 && (fastest == nil || o.DoorToDoorMin < fastest.DoorToDoorMin) {
 			fastest = o
 		}
 	}
-	cmp.Cheapest = cheapest.Mode
-	cmp.Fastest = fastest.Mode
-	cmp.BestValue = bestValue(cmp.Options).Mode
+	if cheapest != nil {
+		cmp.Cheapest = cheapest.Mode
+	}
+	if fastest != nil {
+		cmp.Fastest = fastest.Mode
+	}
+	if bv := bestValue(cmp.Options); bv != nil {
+		cmp.BestValue = bv.Mode
+	}
 	cmp.LuggageBest = mostLuggageFriendly(cmp.Options).Mode
 }
 
-// bestValue ranks by a normalized price+time score (lower is better), so the
-// option that balances cost and speed surfaces — without hiding the others.
-func bestValue(opts []models.TransferOption) models.TransferOption {
-	minP, maxP := opts[0].TotalPrice, opts[0].TotalPrice
-	minT, maxT := opts[0].DoorToDoorMin, opts[0].DoorToDoorMin
-	for _, o := range opts[1:] {
+// bestValue ranks priced+timed options by a normalized price+time score
+// (lower is better). Options with unknown price or duration are excluded.
+// Returns nil when no option has both a price and a duration.
+func bestValue(opts []models.TransferOption) *models.TransferOption {
+	priced := make([]models.TransferOption, 0, len(opts))
+	for _, o := range opts {
+		if o.TotalPrice > 0 && o.DoorToDoorMin > 0 {
+			priced = append(priced, o)
+		}
+	}
+	if len(priced) == 0 {
+		return nil
+	}
+	minP, maxP := priced[0].TotalPrice, priced[0].TotalPrice
+	minT, maxT := priced[0].DoorToDoorMin, priced[0].DoorToDoorMin
+	for _, o := range priced[1:] {
 		minP, maxP = minf(minP, o.TotalPrice), maxf(maxP, o.TotalPrice)
 		minT, maxT = mini(minT, o.DoorToDoorMin), maxi(maxT, o.DoorToDoorMin)
 	}
-	best := opts[0]
-	bestScore := score(opts[0], minP, maxP, minT, maxT)
-	for _, o := range opts[1:] {
-		if s := score(o, minP, maxP, minT, maxT); s < bestScore {
-			best, bestScore = o, s
+	bestIdx := 0
+	bestScore := score(priced[0], minP, maxP, minT, maxT)
+	for i := 1; i < len(priced); i++ {
+		if s := score(priced[i], minP, maxP, minT, maxT); s < bestScore {
+			bestIdx, bestScore = i, s
 		}
 	}
-	return best
+	return &priced[bestIdx]
 }
 
 func score(o models.TransferOption, minP, maxP float64, minT, maxT int) float64 {

--- a/internal/transfer/option_test.go
+++ b/internal/transfer/option_test.go
@@ -35,8 +35,8 @@ func sampleRoutes() []models.GroundRoute {
 func TestBuildOptions_Success(t *testing.T) {
 	cmp := BuildOptions(sampleRoutes(), "BCN", "BCN airport", "Hotel Eixample")
 
-	if len(cmp.Options) != 3 {
-		t.Fatalf("want 3 options, got %d", len(cmp.Options))
+	if len(cmp.Options) != 5 { // 3 routes + 2 ride-hail deep-links (Uber, Bolt)
+		t.Fatalf("want 5 options (3 routes + 2 ride-hail), got %d", len(cmp.Options))
 	}
 	if cmp.Cheapest != "metro" { // metro provider, EUR 5.15
 		t.Errorf("cheapest mode = %q, want metro (EUR 5.15)", cmp.Cheapest)

--- a/internal/transfer/proscons.go
+++ b/internal/transfer/proscons.go
@@ -9,33 +9,40 @@ import (
 
 // annotateProsCons fills Pros/Cons for every option from STRUCTURED SIGNALS
 // only (price ratios, change count, mode, amenities) — never free-text opinion.
-// This keeps the comparison honest and reproducible.
+// This keeps the comparison honest and reproducible. Options with unknown
+// price AND duration (e.g. ride-hail deep-links) keep their pre-set pros/cons
+// and are excluded from the cheapest/fastest comparison.
 func annotateProsCons(opts []models.TransferOption) {
 	if len(opts) == 0 {
 		return
 	}
-	cheapest := opts[0].TotalPrice
-	fastest := opts[0].DoorToDoorMin
-	for _, o := range opts[1:] {
-		if o.TotalPrice < cheapest {
+	// Cheapest/fastest computed over priced+timed options only.
+	cheapest, fastest := 0.0, 0
+	for _, o := range opts {
+		if o.TotalPrice > 0 && (cheapest == 0 || o.TotalPrice < cheapest) {
 			cheapest = o.TotalPrice
 		}
-		if o.DoorToDoorMin < fastest {
+		if o.DoorToDoorMin > 0 && (fastest == 0 || o.DoorToDoorMin < fastest) {
 			fastest = o.DoorToDoorMin
 		}
 	}
 
 	for i := range opts {
 		o := &opts[i]
+		// Skip options with unknown price AND duration (ride-hail deep-links):
+		// they carry their own pre-set pros/cons; do not overwrite or rank them.
+		if o.TotalPrice <= 0 && o.DoorToDoorMin <= 0 {
+			continue
+		}
 		var pros, cons []string
 
-		if o.TotalPrice <= cheapest {
+		if o.TotalPrice > 0 && o.TotalPrice <= cheapest {
 			pros = append(pros, "cheapest option")
 		} else if cheapest > 0 && o.TotalPrice >= cheapest*2 {
 			cons = append(cons, fmt.Sprintf("%.1fx the cheapest option", o.TotalPrice/cheapest))
 		}
 
-		if o.DoorToDoorMin <= fastest {
+		if o.DoorToDoorMin > 0 && o.DoorToDoorMin <= fastest {
 			pros = append(pros, "fastest option")
 		}
 

--- a/internal/transfer/ridehail.go
+++ b/internal/transfer/ridehail.go
@@ -1,0 +1,42 @@
+package transfer
+
+import (
+	"net/url"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// RideHailOptions returns ride-hail deep-link options (Uber, Bolt) for a leg.
+// These are pure deep-links — trvl does not call any ride-hail API, so there is
+// no price, no duration, and no ToS exposure: the app shows the real price
+// before the user confirms. They are honest "tap to check availability and
+// price" options, not priced/timed routes, so they are excluded from the
+// cheapest/fastest/best-value labels (see labelComparison).
+//
+// from/to are human place labels (e.g. "BCN airport", "Hotel Eixample").
+func RideHailOptions(from, to string) []models.TransferOption {
+	if from == "" || to == "" {
+		return nil
+	}
+	uber := "https://m.uber.com/ul/?action=setPickup" +
+		"&pickup[formatted_address]=" + url.QueryEscape(from) +
+		"&dropoff[formatted_address]=" + url.QueryEscape(to)
+	bolt := "https://bolt.eu/?pickup=" + url.QueryEscape(from) + "&destination=" + url.QueryEscape(to)
+
+	mk := func(label, deeplink string) models.TransferOption {
+		return models.TransferOption{
+			Mode:            "ride_hail",
+			Label:           label,
+			PriceIsEstimate: true, // price unknown until the app quotes it
+			DoorToDoorMin:   0,    // unknown — depends on live traffic
+			BookURL:         deeplink,
+			Pros:            []string{"door-to-door, no luggage hassle", "price shown in-app before you confirm"},
+			Cons:            []string{"price and availability vary by city and demand"},
+			Steps: []models.Step{
+				{Order: 1, Text: "Open the " + label + " app or the link; set pickup to " + from + " and destination to " + to + ".", Grounded: true},
+				{Order: 2, Text: "Confirm the fare quote in the app before you ride.", Grounded: true},
+			},
+		}
+	}
+	return []models.TransferOption{mk("Uber", uber), mk("Bolt", bolt)}
+}

--- a/internal/transfer/ridehail_test.go
+++ b/internal/transfer/ridehail_test.go
@@ -1,0 +1,52 @@
+package transfer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func TestRideHailOptions_Success(t *testing.T) {
+	opts := RideHailOptions("BCN airport", "Hotel Eixample")
+	if len(opts) != 2 {
+		t.Fatalf("want Uber + Bolt, got %d", len(opts))
+	}
+	for _, o := range opts {
+		if o.Mode != "ride_hail" {
+			t.Errorf("mode = %q, want ride_hail", o.Mode)
+		}
+		if o.BookURL == "" || !strings.Contains(o.BookURL, "Eixample") {
+			t.Errorf("deep-link should encode the destination, got %q", o.BookURL)
+		}
+		if o.TotalPrice != 0 || o.DoorToDoorMin != 0 {
+			t.Errorf("ride-hail price/duration must be unknown (0), got %v/%v", o.TotalPrice, o.DoorToDoorMin)
+		}
+		if len(o.Steps) == 0 || !o.Steps[0].Grounded {
+			t.Errorf("ride-hail steps should be present and grounded (app instructions)")
+		}
+	}
+}
+
+func TestRideHailOptions_EmptyEndpoints(t *testing.T) {
+	if RideHailOptions("", "x") != nil || RideHailOptions("x", "") != nil {
+		t.Error("missing endpoints must yield no ride-hail options")
+	}
+}
+
+// TestBuildOptions_RideHailDoesNotStealLabels guards that ride-hail's unknown
+// price/duration never wins cheapest/fastest/best-value.
+func TestBuildOptions_RideHailDoesNotStealLabels(t *testing.T) {
+	routes := []models.GroundRoute{
+		{Provider: "metro", Type: "train", Price: 5.15, Currency: "EUR", Duration: 48, Transfers: 2},
+		{Provider: "taxi", Type: "taxi", Price: 35, Currency: "EUR", Duration: 25},
+	}
+	cmp := BuildOptions(routes, "BCN", "BCN airport", "Hotel Eixample")
+	if cmp.Cheapest == "ride_hail" || cmp.Fastest == "ride_hail" || cmp.BestValue == "ride_hail" {
+		t.Errorf("ride-hail (unknown price/time) must not win labels: cheapest=%q fastest=%q best=%q",
+			cmp.Cheapest, cmp.Fastest, cmp.BestValue)
+	}
+	if cmp.Cheapest != "metro" {
+		t.Errorf("cheapest should remain metro, got %q", cmp.Cheapest)
+	}
+}


### PR DESCRIPTION
## What

MIK-5734 E.1 (provider breadth): add ride-hail (Uber, Bolt) as choosable options in the door-to-door comparison card.

## Why deep-links, not an API

trvl constructs a booking deep-link with pickup/dropoff; the user opens the app where the real price and availability are shown. No API call, no scraping, no API key, no ToS engaged — so this adds provider breadth with zero ToS exposure (the safe slice of E.1). A full priced aggregator integration (Welcome Pickups / Mozio) remains separate, deliberately-gated work because it requires a ToS review and a live-probe per CONTRIBUTING.

## Honesty guarantees (tested)

- Ride-hail options carry no price and no duration (unknown until the app quotes them) and are flagged price-is-estimate.
- They are EXCLUDED from the cheapest / fastest / best-value labels so a zero value never falsely wins (TestBuildOptions_RideHailDoesNotStealLabels).
- Steps are grounded app instructions, not fabricated routes.
- Only appended when there is at least one real route to compare against.

## Changes

- internal/transfer/ridehail.go: pure deep-link builder (Uber + Bolt).
- internal/transfer/option.go: append ride-hail in BuildOptions; labelComparison + bestValue now skip unknown-price/duration options.
- internal/transfer/proscons.go: skip unpriced options (preserve their pre-set pros/cons), compute cheapest/fastest over priced options only.
- LEGAL.md: transparency row noting ride-hail is deep-links only, no data fetched.

## Verification

go build, go vet, staticcheck clean. go test on internal/transfer + mcp passes.

Tracking: MIK-5734 (epic), AC E.1 (deep-link slice).

Generated with Claude Code
