### PR TITLE
feat(transfer): expand airport KB to 31 global hubs (MIK-5734 C.4 follow-on)

### DIFF
--- a/internal/transfer/airportkb/data/ATH.json
+++ b/internal/transfer/airportkb/data/ATH.json
@@ -1,0 +1,6 @@
+{
+  "code": "ATH",
+  "name": "Athens Eleftherios Venizelos",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/BER.json
+++ b/internal/transfer/airportkb/data/BER.json
@@ -1,0 +1,6 @@
+{
+  "code": "BER",
+  "name": "Berlin Brandenburg",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/BRU.json
+++ b/internal/transfer/airportkb/data/BRU.json
@@ -1,0 +1,6 @@
+{
+  "code": "BRU",
+  "name": "Brussels",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/DXB.json
+++ b/internal/transfer/airportkb/data/DXB.json
@@ -1,0 +1,6 @@
+{
+  "code": "DXB",
+  "name": "Dubai International",
+  "intl_buffer_min": 180,
+  "domestic_buffer_min": 90
+}

--- a/internal/transfer/airportkb/data/HAM.json
+++ b/internal/transfer/airportkb/data/HAM.json
@@ -1,0 +1,6 @@
+{
+  "code": "HAM",
+  "name": "Hamburg",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/IST.json
+++ b/internal/transfer/airportkb/data/IST.json
@@ -1,0 +1,6 @@
+{
+  "code": "IST",
+  "name": "Istanbul",
+  "intl_buffer_min": 180,
+  "domestic_buffer_min": 90
+}

--- a/internal/transfer/airportkb/data/LAX.json
+++ b/internal/transfer/airportkb/data/LAX.json
@@ -1,0 +1,6 @@
+{
+  "code": "LAX",
+  "name": "Los Angeles International",
+  "intl_buffer_min": 180,
+  "domestic_buffer_min": 120
+}

--- a/internal/transfer/airportkb/data/LGW.json
+++ b/internal/transfer/airportkb/data/LGW.json
@@ -1,0 +1,6 @@
+{
+  "code": "LGW",
+  "name": "London Gatwick",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/MAN.json
+++ b/internal/transfer/airportkb/data/MAN.json
@@ -1,0 +1,6 @@
+{
+  "code": "MAN",
+  "name": "Manchester",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/ORD.json
+++ b/internal/transfer/airportkb/data/ORD.json
@@ -1,0 +1,6 @@
+{
+  "code": "ORD",
+  "name": "Chicago O'Hare International",
+  "intl_buffer_min": 180,
+  "domestic_buffer_min": 120
+}

--- a/internal/transfer/airportkb/data/OSL.json
+++ b/internal/transfer/airportkb/data/OSL.json
@@ -1,0 +1,6 @@
+{
+  "code": "OSL",
+  "name": "Oslo Gardermoen",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/PRG.json
+++ b/internal/transfer/airportkb/data/PRG.json
@@ -1,0 +1,6 @@
+{
+  "code": "PRG",
+  "name": "Prague Vaclav Havel",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/data/SFO.json
+++ b/internal/transfer/airportkb/data/SFO.json
@@ -1,0 +1,6 @@
+{
+  "code": "SFO",
+  "name": "San Francisco International",
+  "intl_buffer_min": 180,
+  "domestic_buffer_min": 120
+}

--- a/internal/transfer/airportkb/data/SIN.json
+++ b/internal/transfer/airportkb/data/SIN.json
@@ -1,0 +1,6 @@
+{
+  "code": "SIN",
+  "name": "Singapore Changi",
+  "intl_buffer_min": 180,
+  "domestic_buffer_min": 90
+}

--- a/internal/transfer/airportkb/data/WAW.json
+++ b/internal/transfer/airportkb/data/WAW.json
@@ -1,0 +1,6 @@
+{
+  "code": "WAW",
+  "name": "Warsaw Chopin",
+  "intl_buffer_min": 120,
+  "domestic_buffer_min": 60
+}

--- a/internal/transfer/airportkb/kb_test.go
+++ b/internal/transfer/airportkb/kb_test.go
@@ -32,8 +32,8 @@ func TestLookup_Missing(t *testing.T) {
 
 func TestCodes_NonEmpty(t *testing.T) {
 	codes := Codes()
-	if len(codes) < 12 {
-		t.Errorf("expected the expanded major-hub profile set (>=12), got %d: %v", len(codes), codes)
+	if len(codes) < 25 {
+		t.Errorf("expected the expanded global-hub profile set (>=25), got %d: %v", len(codes), codes)
 	}
 	// Every listed code must load.
 	for _, c := range codes {


### PR DESCRIPTION
## What

Follow-on to MIK-5734 C.4: expand the curated airport knowledge base from 16 to 31 global hubs. Adds LGW, MAN, BRU, OSL, HAM, BER, WAW, PRG, ATH (European, 120/60), LAX, ORD, SFO (US, 180/120 for longer security), and DXB, SIN, IST (mega-hubs, 180/90).

More known airports get their grounded check-in/security buffer in the Leave-By Scheduler instead of the conservative unknown-airport default.

## Grounding discipline (unchanged)

Buffer-only profiles: airport name + standard published check-in guidance. No exit_snippets or last_transit_depart, because asserting terminal-specific signage or last-departure times without per-airport verification would violate the grounding contract. Buffers are conservative standard advice (US/mega-hubs get longer buffers), not fabrication.

## Tests

KB coverage test threshold raised to >=25 profiles, all loadable. All JSON validated.

## Verification

go test on internal/transfer + airportkb passes; go vet clean.

Tracking: MIK-5734 (epic, already Done) — incremental data coverage, no code change.

Generated with Claude Code
