### PR TITLE
docs: release notes + tool docs for v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-06-04
+
+### Added
+- **Door-to-door transfer planning** — closes the first/last-mile gap (the part travellers Google every trip). New capabilities, all reachable via the `travel` smart router:
+  - **Transfer comparison card** — `search_airport_transfers` now returns every mode (public transit, airport express, metro, taxi, private transfer, ride-hail) as a choosable option with time, price, pros/cons, and **grounded step-by-step instructions**, plus cheapest / fastest / best-value / most-luggage-friendly labels. No single "best" is imposed; the traveller decides.
+  - **Leave-By Scheduler** (`plan_journey` intent) — answers "when do I leave home to reach the gate comfortably, not last-minute?" by backward induction from the flight: airport check-in/security buffer + ground time + mode variance + walk + safety margin, with surfaced assumptions, a confidence band, and a fallback. Conservative by design — never optimistic.
+  - **Home→airport auto-stitch** — pass `origin` to `plan_journey` and it computes the home→airport leg itself (comparison card + schedule) instead of requiring the ground option by hand.
+  - **Calendar handoff** — `plan_journey` with `as_ics` returns an iCalendar `.ics` carrying a "Leave home" event with a reminder alarm; drop it straight into Apple Calendar, Google Calendar, or Outlook.
+  - **Proactive surfacing** — after a flight search, trvl now offers the airport transfer and the leave-by schedule automatically.
+  - **Ride-hail options** — Uber and Bolt as deep-links in the card (no API, no scraping, no key); the app shows the real price before you confirm.
+  - **Curated airport knowledge base** — 31 major global hubs with conservative, grounded check-in/security buffers so the scheduler uses airport-specific guidance instead of a generic default.
+- **Time + location awareness by default** (CLI + MCP) — flight search resolves a missing origin from your saved home airport, then best-effort from your current location; results carry booking-time context. Includes an update-checker fix.
+
+### Changed
+- **Token efficiency front-and-centre** — the smart `travel` router advertises **1 tool (~378 tokens) instead of 64 (~33,500 tokens)** in `tools/list`, a measured **98.9% smaller context footprint**. README/npm now lead with this; corrected tool-count drift across all surfaces and added a registry-derived guard so the counts can't silently drift again.
+- **Go toolchain pinned to 1.26.4** (was 1.26.3) — picks up the upstream standard-library fixes for GO-2026-5037 (crypto/x509) and GO-2026-5039 (net/textproto).
+- Commercial-license sponsor rail added to the README.
+
+### CI / Release
+- npm package now published via **Trusted Publishing (OIDC)**, dropping the stored token; opt-in npm-publish job wired into the release workflow.
+
 ## [1.5.0] - 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ That's it. Your AI assistant now has 1 smart travel tool available. The old 63 t
 | **travel_guide** | Wikivoyage travel guide for a city | Neighbourhoods, getting around, safety |
 | **local_events** | Find events during your trip dates | Concerts, festivals, exhibitions |
 | **search_ground** | Search buses, trains and ferries (20 providers, API-first with optional browser fallbacks) | Prague -> Vienna, May 3rd, trains only |
-| **search_airport_transfers** | Search airport-to-hotel or airport-to-city ground transport, plus taxi estimates | CDG -> Hotel Lutetia Paris, after 14:30 |
+| **search_airport_transfers** | Door-to-door comparison card: every mode (transit, airport express, taxi, ride-hail) with time, price, pros/cons, grounded steps, and cheapest/fastest/best-value labels | CDG -> Hotel Lutetia Paris, after 14:30 |
+| **plan_journey** | Leave-By Scheduler: when to leave home to reach the gate comfortably (check-in + security buffer, conservative, never optimistic). Pass `origin` to auto-stitch the home→airport leg; `as_ics` returns a calendar event with a leave-home alarm | "when do I leave for my 09:40 HEL flight?" |
 | **search_restaurants** | Find restaurants near a location (Google Maps) | Barcelona, italian cuisine |
 | **search_deals** | Travel deals from 4 RSS feeds (error fares, flash sales) | Deals from HEL under EUR 400 |
 | **plan_trip** | Plan a complete trip — flights + hotel in one parallel search | AMS→PRG, Jun 15–18, EUR |


### PR DESCRIPTION
## What

Release prep for v1.6.0.

- **CHANGELOG.md**: complete 1.6.0 release notes covering everything merged since v1.5.0 — the door-to-door transfer planning epic (comparison card, Leave-By Scheduler, plan_journey, calendar handoff, proactive surfacing, ride-hail, 31-hub airport KB), the time + location awareness feature (#114), token-efficiency doc fix (#124), Go 1.26.4 toolchain bump (stdlib CVEs), sponsor rail, and the npm Trusted-Publishing CI change.
- **README.md**: tool table updated — search_airport_transfers now describes the comparison card; new plan_journey row for the Leave-By Scheduler + calendar handoff.

## Verification

Public-claims + plugin-bundle doc guards pass (counts unchanged; additive descriptive text only).

After merge, tag v1.6.0 to trigger goreleaser (cross-platform binaries + GitHub release + Homebrew) and the npm-publish job.

Generated with Claude Code
