### PR TITLE
ci(release): pin GOTOOLCHAIN=go1.26.4 for goreleaser (fixes v1.6.0 release)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,12 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # goreleaser-action defaults GOTOOLCHAIN=local, which blocks the Go
+          # toolchain auto-download in the before-hooks. go.mod requires
+          # >= 1.26.4 (stdlib CVE fixes GO-2026-5037/5039) but GitHub runners
+          # may still ship 1.26.3, so pin the toolchain so go fetches 1.26.4
+          # for the hooks and the release build.
+          GOTOOLCHAIN: "go1.26.4"
           # HOMEBREW_TAP_TOKEN: a GitHub personal access token (classic) with
           # `repo` scope, stored as a repository secret. Goreleaser uses it to
           # push the auto-generated Homebrew formula to


### PR DESCRIPTION
The v1.6.0 tag release failed: goreleaser-action defaults GOTOOLCHAIN=local, so its before-hooks could not auto-download Go 1.26.4 (go.mod requires it for the stdlib CVE fixes) on a runner shipping 1.26.3. Test jobs passed because they auto-download; only the release hook is pinned to local.

Fix: set GOTOOLCHAIN=go1.26.4 on the goreleaser step so go fetches the patched toolchain for the hooks and the release build.

No v1.6.0 artifacts shipped (release-not-found, npm skipped), so re-tagging after merge is clean.

Generated with Claude Code