### PR TITLE
ci(release): set GOTOOLCHAIN=go1.26.4 in goreleaser hooks + build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,9 +4,13 @@ project_name: trvl
 
 before:
   hooks:
-    - go mod tidy
-    - go vet ./...
-    - go test -short ./...
+    # goreleaser-action forces GOTOOLCHAIN=local; wrap each go hook in sh so we
+    # can set GOTOOLCHAIN=go1.26.4 (go.mod requires >= 1.26.4 for the stdlib CVE
+    # fixes) instead of failing on a runner that still ships 1.26.3. before.hooks
+    # must be strings in goreleaser v2, so the env cannot be a map here.
+    - sh -c "GOTOOLCHAIN=go1.26.4 go mod tidy"
+    - sh -c "GOTOOLCHAIN=go1.26.4 go vet ./..."
+    - sh -c "GOTOOLCHAIN=go1.26.4 go test -short ./..."
     # Sync npm/package.json version with the release tag before archives are
     # built. Previously lived under a top-level `after:` block which is not a
     # valid key in goreleaser v2 and made `goreleaser check` fail. Running it
@@ -22,6 +26,8 @@ builds:
     binary: trvl
     env:
       - CGO_ENABLED=0
+      # Build with the patched Go 1.26.4 stdlib (overrides the action's local).
+      - GOTOOLCHAIN=go1.26.4
     goos:
       - linux
       - darwin


### PR DESCRIPTION
Second fix for the v1.6.0 release. The goreleaser-action force-sets GOTOOLCHAIN=local (overrides step env), so the before-hooks (go mod tidy, go vet, go test) and the build ran on the runner's Go 1.26.3 and failed: go.mod requires >= 1.26.4.

Fix in .goreleaser.yaml (where it actually takes effect):
- before.hooks wrapped in sh -c "GOTOOLCHAIN=go1.26.4 go ..." — before.hooks must be strings in goreleaser v2, so the env-map form is invalid there.
- build env adds GOTOOLCHAIN=go1.26.4 so released binaries use the patched stdlib.

Validated: goreleaser check reports the config valid (only pre-existing deprecation warnings remain).

After merge, re-tag v1.6.0 to ship.

Generated with Claude Code
