### PR TITLE
ci(release): release.yml Go 1.26.4 + disable duplicate ci.yaml release jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,10 @@ jobs:
   release:
     needs: test
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Disabled: the canonical release pipeline lives in release.yml (macOS
+    # codesign + cosign + Homebrew + docker + npm + mcp-registry). Running
+    # goreleaser here too raced release.yml to create the same GitHub release.
+    if: false
     permissions:
       contents: write
       packages: write
@@ -140,7 +143,8 @@ jobs:
   npm-publish:
     needs: release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Disabled: npm is published by the canonical release.yml pipeline.
+    if: false
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          # Must satisfy go.mod (>= 1.26.4 for stdlib CVE fixes); goreleaser
+          # resolves the module path with GOTOOLCHAIN=local, so the runner's Go
+          # itself has to be 1.26.4, not just the build toolchain.
+          go-version: "1.26.4"
 
       # Install cosign for hybrid release signing — see signs: block in
       # .goreleaser.yaml. Keyless mode uses the workflow's OIDC token


### PR DESCRIPTION
Third and root fix for v1.6.0 shipping.

Two problems converged on the first release since v1.5.0:

1. release.yml (the canonical macOS codesign pipeline) pinned setup-go to 1.26.3. goreleaser resolves the module path with GOTOOLCHAIN=local BEFORE any hook or build env applies, so the runner's Go itself must be 1.26.4 (go.mod requires it). The earlier .goreleaser.yaml env fixes could not help that internal call. Fix: setup-go 1.26.3 to 1.26.4.

2. ci.yaml ALSO had release and npm-publish jobs firing on tags, racing release.yml to create the same GitHub release. These were added after v1.5.0 and never exercised until now. Fix: disabled with if false. release.yml owns goreleaser, docker, npm, mcp-registry, and Homebrew.

After merge, re-tag v1.6.0 to ship via the single canonical pipeline.

Generated with Claude Code
