### PR TITLE
ci(release): fix npm (setup-node) + docker (Go 1.26.4 base) channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,9 +170,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # OIDC trusted publishing needs npm >= 11.5.1; ubuntu-latest may ship older.
-      - name: Use recent npm
-        run: npm install -g npm@latest
+      # OIDC trusted publishing needs npm >= 11.5.1. Node 24 bundles a recent
+      # npm; using setup-node avoids the permission error from globally
+      # reinstalling npm on the runner.
+      - name: Set up Node 24
+        uses: actions/setup-node@49933ea5288caeca8642195f2ed94f3dd6952cd8 # v4.4.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Stamp version from tag and publish (OIDC, no token)
         working-directory: npm

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine AS build
+FROM golang:1.26.4-alpine AS build
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
v1.6.0 shipped binaries + Homebrew successfully; the npm and docker channels failed:

- npm: the new OIDC publish job ran npm install -g npm@latest without sudo and hit an EACCES permission error. Replaced with actions/setup-node node 24 (bundles npm >= 11.5.1), no global reinstall.
- docker: Dockerfile.release base was golang 1.26.3-alpine; go mod download failed go.mod requires 1.26.4. Bumped to golang 1.26.4-alpine.

After merge, re-cut v1.6.0 (delete release+tag, re-tag on fixed main) so all channels publish cleanly.

Generated with Claude Code