### PR TITLE
ci(release): correct setup-node SHA to real v4.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@49933ea5288caeca8642195f2ed94f3dd6952cd8 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
       # npm; using setup-node avoids the permission error from globally
       # reinstalling npm on the runner.
       - name: Set up Node 24
-        uses: actions/setup-node@49933ea5288caeca8642195f2ed94f3dd6952cd8 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
The npm release job failed at Set up job: Unable to resolve action actions/setup-node@49933ea5288caeca8642195f2ed94f3dd6952cd8 (that SHA does not exist). It was a stale pin in ci.yaml that I had copied; the disabled ci.yaml npm-publish job never ran so the bad SHA was never exposed.

Real actions/setup-node v4.4.0 commit SHA is 49933ea5288caeca8642d1e84afbd3f7d6820020 (verified via GitHub API). Fixed in both release.yml and ci.yaml.

Note: goreleaser binaries + Homebrew already shipped for v1.6.0; this unblocks the npm channel on the final re-cut.

Generated with Claude Code