### PR TITLE
ci(release): make MCP registry publish idempotent on duplicate version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,21 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
+        run: |
+          # Idempotent: the MCP registry rejects re-publishing the same version
+          # with a "duplicate version" 400. On a re-cut of an already-published
+          # tag that is success, not failure — don't fail the release run.
+          set +e
+          out="$(./mcp-publisher publish 2>&1)"
+          code=$?
+          echo "$out"
+          if [ "$code" -ne 0 ]; then
+            if echo "$out" | grep -qi "duplicate version"; then
+              echo "::notice::MCP registry already has this version — treating as published."
+              exit 0
+            fi
+            exit "$code"
+          fi
 
   # Publishes the trvl-mcp npm wrapper via npm Trusted Publishing (OIDC) — no
   # stored token. One-time npmjs.com setup required: package trvl-mcp ->


### PR DESCRIPTION
The mcp-registry job failed the v1.6.0 release run with a 400 cannot publish duplicate version, because an earlier re-cut had already published v1.6.0 to the registry. That is success, not failure, but it turned the whole run red.

Fix: capture the publish output and, when the only error is duplicate version, treat it as already-published and exit 0. Any other error still fails the job.

This is the last loose end from the v1.6.0 release — makes re-cuts and future releases stay green.

Generated with Claude Code