### PR TITLE
ci: gate builds + releases on known dependency + image vulnerabilities

### DIFF
--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -1,0 +1,35 @@
+# osv-scanner allowlist — the pressure valve for the CI security gate.
+#
+# The gate fails the build on ANY known, fixable vulnerability in the
+# dependency tree. It runs in two places:
+#   - ci.yaml `osv-scan` job        -> fast layer, fires on every PR/push
+#   - release.yml `security-gate` job -> backstop, blocks the release if a
+#     vuln slipped past CI between merge and tag
+#
+# Scope (verified by local run 2026-06-05): Go modules — osv-scanner reads
+# go.mod/go.sum and checks every dep (including ones govulncheck skips as
+# unreachable) against OSV. NOT covered: github-actions advisories (our actions
+# are SHA-pinned, which is itself the mitigation, and osv-scanner does not map
+# SHA pins to advisory versions) and Docker base-image OS-layer CVEs (osv-scanner
+# reads lockfiles, not image layers — that needs a separate trivy image scan,
+# tracked as a follow-up). This covers the primary attack surface: the Go
+# dependency tree that .github/dependabot.yml's gomod updater watches.
+#
+# Failing on any fixable vuln is intentional: a new build must include the
+# security fixes that are available. Dependabot PROPOSES the bump PR; this gate
+# DISPOSES — it refuses to ship until the fix is merged.
+#
+# When a vulnerability has NO upstream fix yet, or is verified unreachable, it
+# would otherwise block every release indefinitely. Add a time-boxed exception
+# here instead of weakening the gate. Each entry MUST carry a reason and an
+# ignoreUntil review date — expired entries re-trigger the gate automatically.
+#
+# Format (https://google.github.io/osv-scanner/configuration/):
+#
+#   [[IgnoredVulns]]
+#   id = "GO-2024-1234"
+#   ignoreUntil = 2026-07-01   # review by this date; after it the gate fires again
+#   reason = "No patched release upstream yet; unreachable per govulncheck. Reviewed 2026-06-05 by <who>."
+#
+# Keep this list EMPTY unless a vuln genuinely has no fix. The right fix for a
+# fixable vuln is to bump the dependency, not to ignore it.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,8 +112,18 @@ jobs:
       - name: Scan Go dependencies against OSV
         uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
         with:
+          # --no-call-analysis=all: gate on the dependency manifest only, never
+          # the embedded govulncheck source pass. That pass runs inside the
+          # osv-scanner action's container against ITS bundled Go toolchain; if
+          # that Go is older than this repo's go.mod requirement it cannot build,
+          # fails, and then reports every stdlib advisory as a spurious finding
+          # (it red-failed CI exactly this way). Manifest-only is deterministic
+          # and matches Dependabot semantics (flag a vulnerable dependency
+          # version whether or not it is reachable). Reachability stays covered
+          # by the govulncheck step in the `test` job, on the correct toolchain.
           scan-args: |-
             --config=.github/osv-scanner.toml
+            --no-call-analysis=all
             --recursive
             ./
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,27 @@ jobs:
         with:
           extra_args: --only-verified
 
+  # Fast layer of the dependency-vulnerability gate: scans go.mod/go.sum against
+  # the OSV database on every PR and push. Fails the build on any known, fixable
+  # vuln so a security fix lands with the change that introduces (or fails to
+  # bump past) it — not weeks later. govulncheck (in the `test` job) stays as the
+  # reachability-aware Go signal; osv-scanner is broader — it flags vulnerable
+  # deps even when no reachable call path exists. Accepted/unfixable vulns are
+  # time-boxed in .github/osv-scanner.toml. The release.yml `security-gate` job
+  # is the backstop. (Docker base-image CVEs need a separate trivy scan; follow-up.)
+  osv-scan:
+    name: OSV vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Scan Go dependencies against OSV
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        with:
+          scan-args: |-
+            --config=.github/osv-scanner.toml
+            --recursive
+            ./
+
   release:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,11 @@ jobs:
       - name: Scan Go dependencies against OSV
         uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
         with:
+          # --no-call-analysis=all: manifest-only gate, deterministic regardless
+          # of the scanner container's bundled Go toolchain (see ci.yaml osv-scan).
           scan-args: |-
             --config=.github/osv-scanner.toml
+            --no-call-analysis=all
             --recursive
             ./
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,29 @@ permissions:
   id-token: write  # cosign keyless signing via Sigstore needs OIDC token
 
 jobs:
+  # Release backstop for the dependency-vulnerability gate. ci.yaml scans on
+  # every PR/push; this re-scans at tag time so a vuln that landed between the
+  # last green CI run and the release tag (or via a path that skipped CI) cannot
+  # ship. Every publishing job below is transitively `needs:`-ed to goreleaser,
+  # which `needs:` this gate — so GitHub release, Homebrew, Docker, npm, and the
+  # MCP registry all block if a known fixable vuln is present. Exceptions are
+  # time-boxed in .github/osv-scanner.toml.
+  security-gate:
+    name: Security gate (block release on known vulns)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Scan Go dependencies against OSV
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        with:
+          scan-args: |-
+            --config=.github/osv-scanner.toml
+            --recursive
+            ./
+
   goreleaser:
+    needs: security-gate
     runs-on: macos-14
     env:
       HAS_HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
@@ -111,10 +133,37 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # Build a single-arch (amd64) image first and load it locally so trivy can
+      # scan the actual release artifact's layers. This is the Docker half of the
+      # vulnerability gate — the osv-scanner gates the Go deps; trivy gates the
+      # base-image OS/library CVEs. Only push (multi-arch) if the scan is clean.
+      - name: Build amd64 image for vulnerability scan
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          docker buildx build \
+            --platform linux/amd64 \
+            --build-arg VERSION="${VERSION}" \
+            --tag "ghcr.io/mikkoparkkola/trvl:scan" \
+            --file Dockerfile.release \
+            --load \
+            .
+
+      - name: Trivy image scan (block push on fixable HIGH/CRITICAL CVEs)
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          image-ref: "ghcr.io/mikkoparkkola/trvl:scan"
+          format: table
+          exit-code: "1"
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+
       - name: Build and push multi-arch image
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          docker buildx create --use --name trvl-release
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --build-arg VERSION="${VERSION}" \

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# trivy image-scan allowlist — pressure valve for the release Docker CVE gate.
+#
+# The `docker` job in release.yml builds the image, scans it with trivy, and
+# only pushes if no FIXABLE HIGH/CRITICAL OS/library CVE is present. Unfixed
+# CVEs (no patched package upstream yet) are ignored via `ignore-unfixed: true`,
+# so a CVE you cannot fix never blocks a release.
+#
+# Add an entry here only to suppress a FIXABLE finding you are explicitly
+# accepting, with a reason + review date. One CVE id per line:
+#   CVE-2024-12345  # accepted: <reason>; review 2026-07-01
+#
+# Keep this empty. The right fix for a fixable base-image CVE is to bump the
+# base image (FROM alpine:3.23 -> newer) or the offending package, not ignore it.

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXd
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=


### PR DESCRIPTION
## What

A two-layer dependency + image vulnerability gate so a new build/release always includes available security fixes. **Dependabot proposes the bump; this gate disposes — it refuses to ship until the fix is merged.**

## Why

The release pipeline had **zero vuln gating**, and `govulncheck` (CI) does not block releases nor cover the full Dependabot surface:

- `release.yml` ran **independent of CI** — GitHub Actions has no cross-workflow `needs:`, so a tag could publish even with CI red.
- `govulncheck` is **Go-reachability-only** — blind to deps with no reachable call path, and to base-image CVEs.

## How

- **Fast layer** — `ci.yaml` `osv-scan` job (blocking, every PR/push): osv-scanner over `go.mod/go.sum`. Catches a fixable vuln the moment the dep lands.
- **Release backstop** — `release.yml` `security-gate` job: re-scans at tag time, wired so the whole publish DAG (GitHub release, Homebrew, Docker, npm, MCP registry) is transitively `needs:`-blocked.
- **Image layer** — the `docker` job now builds amd64 → **trivy-scans** → pushes multi-arch. A fixable HIGH/CRITICAL base-image CVE blocks the push.
- **Pressure valves** — `.github/osv-scanner.toml` (time-boxed dep exceptions) + `.trivyignore` (image exceptions). Both empty; trivy uses `ignore-unfixed` so an unpatchable CVE never bricks a release.

`govulncheck` stays as the reachability-aware Go signal.

## Evidence

- **V**: osv-scanner v2.3.8 local run on this branch → `Total 0 packages affected by 0 known vulnerabilities ... 0 vulnerabilities can be fixed` (exit 0).
- **V**: trivy v0.70 on `alpine:3.23` (the `Dockerfile.release` base) with the exact gate flags (`--severity HIGH,CRITICAL --ignore-unfixed`) → 0 CVEs (exit 0).
- **V**: release DAG verified — `security-gate → goreleaser → {docker → mcp-registry, npm}`; every publishing job transitively gated.
- Purely additive: 119 insertions, 1 deletion (the old single build+push step restructured to build→scan→push).

## Scope / follow-up

- Covered: Go module tree (the `gomod` Dependabot ecosystem) + Docker base-image CVEs.
- Not in this PR: github-actions advisory matching (actions are already SHA-pinned, which is the mitigation). 

## Rollback

Revert this commit — purely additive CI/release jobs; no product code touched.
