### PR TITLE
ci(release): auto-credit external contributors in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+# GitHub native release-notes config (read by goreleaser's `changelog.use: github-native`
+# and by GitHub's "Generate release notes"). The "## New Contributors" section that
+# credits first-time external contributors by @handle is added automatically by GitHub
+# and cannot be disabled here — that is the point (see .goreleaser.yaml changelog note).
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - github-actions
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Bug Fixes
+      labels: ["bug", "fix"]
+    - title: Dependencies
+      labels: ["dependencies"]
+    # Catch-all MUST be last (GitHub assigns each PR to the first matching category).
+    - title: Changes
+      labels: ["*"]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -103,12 +103,14 @@ signs:
     output: true
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
-      - "^chore:"
+  # Use GitHub's native release-note generation so the auto "## New Contributors"
+  # section (crediting first-time external contributors by @handle) is included.
+  # goreleaser's default git-based changelog only lists raw commit subjects and
+  # silently omits contributor credit — which is how an external contributor's
+  # major feature shipped uncredited in v1.7.0 (#142, @marcello-russo). 2026-06-07.
+  # NOTE: github-native delegates grouping/filtering to .github/release.yml
+  # (sort/filters here are ignored by design).
+  use: github-native
 
 release:
   github:


### PR DESCRIPTION
## Why
@marcello-russo's major Booking.com + SerpAPI feature (#142) shipped **uncredited** in v1.7.0 because goreleaser's default git changelog lists only raw commit subjects. The repo explicitly tracks first-contributor momentum (CLAUDE.md) — this prevents the miss recurring.

## Change
- .goreleaser.yaml: changelog `use: github-native` → GitHub generates notes, including the automatic '## New Contributors' section (credits first-time external contributors by @handle).
- .github/release.yml: native config — categories + exclude dependabot/bot noise.

## Acceptance Criteria
- [ ] TRVL.REL.1 next release notes include a 'New Contributors' section when an external first-timer's PR ships
- [ ] TRVL.REL.2 goreleaser check passes (config valid; only pre-existing dockers/brews deprecations remain)

## Priority / ROI
P2 — goodwill + contributor retention; cheap, permanent.

## Rollback
Revert: restores the git-based changelog (no auto-credit).

## Note
v1.7.0 itself already hand-credited @marcello-russo (release notes edited 2026-06-07); this fixes the source so it's automatic going forward.