### PR TITLE
test: add hermetic tests for 10 untested MCP tool handlers

### DIFF
--- a/mcp/tools_baggage_test.go
+++ b/mcp/tools_baggage_test.go
@@ -1,0 +1,49 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetBaggageRulesTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := getBaggageRulesTool()
+	if tool.Name != "get_baggage_rules" {
+		t.Errorf("Name = %q, want get_baggage_rules", tool.Name)
+	}
+	if len(tool.InputSchema.Required) == 0 {
+		t.Error("expected required params")
+	}
+}
+
+func TestHandleGetBaggageRules_All(t *testing.T) {
+	t.Parallel()
+	content, structured, err := handleGetBaggageRules(context.Background(), map[string]any{
+		"airline_code": "ALL",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("expected content")
+	}
+	if structured == nil {
+		t.Fatal("expected structured result")
+	}
+}
+
+func TestHandleGetBaggageRules_ByAirlineCode(t *testing.T) {
+	t.Parallel()
+	content, structured, err := handleGetBaggageRules(context.Background(), map[string]any{
+		"airline_code": "FR",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("expected content")
+	}
+	if structured == nil {
+		t.Fatal("expected structured result")
+	}
+}

--- a/mcp/tools_deals_test.go
+++ b/mcp/tools_deals_test.go
@@ -1,0 +1,55 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/testutil"
+)
+
+func TestSearchDealsTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := searchDealsTool()
+	if tool.Name != "search_deals" {
+		t.Errorf("Name = %q, want search_deals", tool.Name)
+	}
+	if len(tool.InputSchema.Required) == 0 {
+		t.Error("expected required params")
+	}
+}
+
+func TestHandleSearchDeals_MissingParams(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{"empty", map[string]any{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := handleSearchDeals(context.Background(), tt.args, nil, nil, nil)
+			if err == nil {
+				t.Error("expected error for missing params")
+			}
+		})
+	}
+}
+
+func TestHandleSearchDeals_Success(t *testing.T) {
+	t.Parallel()
+	testutil.RequireLiveProbe(t)
+	content, structured, err := handleSearchDeals(context.Background(), map[string]any{
+		"origins": "HEL",
+		"type": "deal",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("expected content")
+	}
+	if structured == nil {
+		t.Fatal("expected structured result")
+	}
+}

--- a/mcp/tools_hacks_test.go
+++ b/mcp/tools_hacks_test.go
@@ -1,0 +1,27 @@
+package mcp
+
+import (
+	"testing"
+)
+
+func TestDetectTravelHacksTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := detectTravelHacksTool()
+	if tool.Name != "detect_travel_hacks" {
+		t.Errorf("Name = %q, want detect_travel_hacks", tool.Name)
+	}
+	if len(tool.InputSchema.Required) == 0 {
+		t.Error("expected required params")
+	}
+}
+
+func TestDetectAccommodationHacksTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := detectAccommodationHacksTool()
+	if tool.Name != "detect_accommodation_hacks" {
+		t.Errorf("Name = %q, want detect_accommodation_hacks", tool.Name)
+	}
+	if len(tool.InputSchema.Required) == 0 {
+		t.Error("expected required params")
+	}
+}

--- a/mcp/tools_lounges_test.go
+++ b/mcp/tools_lounges_test.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/testutil"
+)
+
+func TestSearchLoungesTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := searchLoungesTool()
+	if tool.Name != "search_lounges" {
+		t.Errorf("Name = %q, want search_lounges", tool.Name)
+	}
+	if len(tool.InputSchema.Required) == 0 {
+		t.Error("expected required params")
+	}
+}
+
+func TestHandleSearchLounges_MissingParams(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{"empty", map[string]any{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := handleSearchLounges(context.Background(), tt.args, nil, nil, nil)
+			if err == nil {
+				t.Error("expected error for missing params")
+			}
+		})
+	}
+}
+
+func TestHandleSearchLounges_InvalidIATA(t *testing.T) {
+	t.Parallel()
+	_, _, err := handleSearchLounges(context.Background(), map[string]any{
+		"airport": "INVALID",
+	}, nil, nil, nil)
+	if err == nil {
+		t.Error("expected error for invalid IATA code")
+	}
+}
+
+func TestHandleSearchLounges_Success(t *testing.T) {
+	t.Parallel()
+	testutil.RequireLiveProbe(t)
+	content, structured, err := handleSearchLounges(context.Background(), map[string]any{
+		"airport": "HEL",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("expected content")
+	}
+	if structured == nil {
+		t.Fatal("expected structured result")
+	}
+}

--- a/mcp/tools_opportunities_test.go
+++ b/mcp/tools_opportunities_test.go
@@ -1,0 +1,49 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWatchOpportunitiesTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := watchOpportunitiesTool()
+	if tool.Name != "watch_opportunities" {
+		t.Errorf("Name = %q, want watch_opportunities", tool.Name)
+	}
+}
+
+func TestListOpportunityWatchesTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := listOpportunityWatchesTool()
+	if tool.Name != "list_opportunity_watches" {
+		t.Errorf("Name = %q, want list_opportunity_watches", tool.Name)
+	}
+}
+
+func TestHandleWatchOpportunities_Defaults(t *testing.T) {
+	t.Parallel()
+	// All params are optional; should succeed with defaults.
+	content, structured, err := handleWatchOpportunities(context.Background(), map[string]any{}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("expected content")
+	}
+	if structured == nil {
+		t.Fatal("expected structured result")
+	}
+}
+
+func TestHandleListOpportunityWatches_Empty(t *testing.T) {
+	t.Parallel()
+	content, structured, err := handleListOpportunityWatches(context.Background(), map[string]any{}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if structured == nil {
+		t.Fatal("expected structured result")
+	}
+	_ = content
+}

--- a/mcp/tools_optimizer_test.go
+++ b/mcp/tools_optimizer_test.go
@@ -1,0 +1,102 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+func TestOptimizeBookingTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := optimizeBookingTool()
+	if tool.Name != "optimize_booking" {
+		t.Errorf("Name = %q, want optimize_booking", tool.Name)
+	}
+	if len(tool.InputSchema.Required) == 0 {
+		t.Error("expected required params")
+	}
+}
+
+func TestSuggestDatesTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := suggestDatesTool()
+	if tool.Name != "suggest_dates" {
+		t.Errorf("Name = %q, want suggest_dates", tool.Name)
+	}
+	if len(tool.InputSchema.Required) == 0 {
+		t.Error("expected required params")
+	}
+}
+
+func TestOptimizeMultiCityTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := optimizeMultiCityTool()
+	if tool.Name != "optimize_multi_city" {
+		t.Errorf("Name = %q, want optimize_multi_city", tool.Name)
+	}
+	if len(tool.InputSchema.Required) == 0 {
+		t.Error("expected required params")
+	}
+}
+
+func TestHandleOptimizeBooking_MissingParams(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{"empty", map[string]any{}},
+		{"missing_origin", map[string]any{"destination": "BCN", "departure_date": "2026-08-01"}},
+		{"missing_destination", map[string]any{"origin": "HEL", "departure_date": "2026-08-01"}},
+		{"missing_departure_date", map[string]any{"origin": "HEL", "destination": "BCN"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := handleOptimizeBooking(context.Background(), tt.args, nil, nil, nil)
+			if err == nil {
+				t.Error("expected error for missing params")
+			}
+		})
+	}
+}
+
+func TestHandleSuggestDates_MissingRequiredParams(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{"empty", map[string]any{}},
+		{"missing_origin", map[string]any{"destination": "BCN", "target_date": "2026-08-01"}},
+		{"missing_destination", map[string]any{"origin": "HEL", "target_date": "2026-08-01"}},
+		{"missing_target_date", map[string]any{"origin": "HEL", "destination": "BCN"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := handleSuggestDates(context.Background(), tt.args, nil, nil, nil)
+			if err == nil {
+				t.Error("expected error for missing params")
+			}
+		})
+	}
+}
+
+func TestHandleOptimizeMultiCity_MissingParams(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{"empty", map[string]any{}},
+		{"missing_home_airport", map[string]any{"cities": "BCN,ROM", "depart_date": "2026-08-01"}},
+		{"missing_cities", map[string]any{"home_airport": "HEL", "depart_date": "2026-08-01"}},
+		{"missing_depart_date", map[string]any{"home_airport": "HEL", "cities": "BCN,ROM"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := handleOptimizeMultiCity(context.Background(), tt.args, nil, nil, nil)
+			if err == nil {
+				t.Error("expected error for missing params")
+			}
+		})
+	}
+}

--- a/mcp/tools_optimizer_test.go
+++ b/mcp/tools_optimizer_test.go
@@ -38,26 +38,8 @@ func TestOptimizeMultiCityTool_Definition(t *testing.T) {
 	}
 }
 
-func TestHandleOptimizeBooking_MissingParams(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name string
-		args map[string]any
-	}{
-		{"empty", map[string]any{}},
-		{"missing_origin", map[string]any{"destination": "BCN", "departure_date": "2026-08-01"}},
-		{"missing_destination", map[string]any{"origin": "HEL", "departure_date": "2026-08-01"}},
-		{"missing_departure_date", map[string]any{"origin": "HEL", "destination": "BCN"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := handleOptimizeBooking(context.Background(), tt.args, nil, nil, nil)
-			if err == nil {
-				t.Error("expected error for missing params")
-			}
-		})
-	}
-}
+// handleOptimizeBooking does not validate missing params at the handler
+// level — it passes empty strings to the external API. We only test definition.
 
 func TestHandleSuggestDates_MissingRequiredParams(t *testing.T) {
 	t.Parallel()

--- a/mcp/tools_restaurants_test.go
+++ b/mcp/tools_restaurants_test.go
@@ -1,0 +1,56 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/testutil"
+)
+
+func TestSearchRestaurantsTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := searchRestaurantsTool()
+	if tool.Name != "search_restaurants" {
+		t.Errorf("Name = %q, want search_restaurants", tool.Name)
+	}
+	if len(tool.InputSchema.Required) == 0 {
+		t.Error("expected required params")
+	}
+}
+
+func TestHandleSearchRestaurants_MissingParams(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{"empty", map[string]any{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := handleSearchRestaurants(context.Background(), tt.args, nil, nil, nil)
+			if err == nil {
+				t.Error("expected error for missing params")
+			}
+		})
+	}
+}
+
+func TestHandleSearchRestaurants_Success(t *testing.T) {
+	t.Parallel()
+	testutil.RequireLiveProbe(t)
+	content, structured, err := handleSearchRestaurants(context.Background(), map[string]any{
+		"location": "Rome, Italy",
+		"query":    "pizza",
+		"limit":    3,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("expected content")
+	}
+	if structured == nil {
+		t.Fatal("expected structured result")
+	}
+}

--- a/mcp/tools_viability_test.go
+++ b/mcp/tools_viability_test.go
@@ -1,0 +1,39 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAssessTripTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := assessTripTool()
+	if tool.Name != "assess_trip" {
+		t.Errorf("Name = %q, want assess_trip", tool.Name)
+	}
+	if len(tool.InputSchema.Required) == 0 {
+		t.Error("expected required params")
+	}
+}
+
+func TestHandleAssessTrip_MissingParams(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{"empty", map[string]any{}},
+		{"missing_origin", map[string]any{"destination": "BCN", "depart_date": "2026-08-01", "return_date": "2026-08-10"}},
+		{"missing_destination", map[string]any{"origin": "HEL", "depart_date": "2026-08-01", "return_date": "2026-08-10"}},
+		{"missing_depart_date", map[string]any{"origin": "HEL", "destination": "BCN", "return_date": "2026-08-10"}},
+		{"missing_return_date", map[string]any{"origin": "HEL", "destination": "BCN", "depart_date": "2026-08-01"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := handleAssessTrip(context.Background(), tt.args, nil, nil, nil)
+			if err == nil {
+				t.Error("expected error for missing params")
+			}
+		})
+	}
+}

--- a/mcp/tools_viability_test.go
+++ b/mcp/tools_viability_test.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"context"
 	"testing"
 )
 
@@ -16,24 +15,5 @@ func TestAssessTripTool_Definition(t *testing.T) {
 	}
 }
 
-func TestHandleAssessTrip_MissingParams(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name string
-		args map[string]any
-	}{
-		{"empty", map[string]any{}},
-		{"missing_origin", map[string]any{"destination": "BCN", "depart_date": "2026-08-01", "return_date": "2026-08-10"}},
-		{"missing_destination", map[string]any{"origin": "HEL", "depart_date": "2026-08-01", "return_date": "2026-08-10"}},
-		{"missing_depart_date", map[string]any{"origin": "HEL", "destination": "BCN", "return_date": "2026-08-10"}},
-		{"missing_return_date", map[string]any{"origin": "HEL", "destination": "BCN", "depart_date": "2026-08-01"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := handleAssessTrip(context.Background(), tt.args, nil, nil, nil)
-			if err == nil {
-				t.Error("expected error for missing params")
-			}
-		})
-	}
-}
+// handleAssessTrip does not validate missing params at the handler level —
+// it passes empty strings to the external API. We only test definition.

--- a/mcp/tools_visa_test.go
+++ b/mcp/tools_visa_test.go
@@ -1,0 +1,34 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCheckVisaTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := checkVisaTool()
+	if tool.Name != "check_visa" {
+		t.Errorf("Name = %q, want check_visa", tool.Name)
+	}
+	if len(tool.InputSchema.Required) == 0 {
+		t.Error("expected required params")
+	}
+}
+
+func TestHandleCheckVisa_Success(t *testing.T) {
+	t.Parallel()
+	content, structured, err := handleCheckVisa(context.Background(), map[string]any{
+		"passport":    "IT",
+		"destination": "JP",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("expected content")
+	}
+	if structured == nil {
+		t.Fatal("expected structured result")
+	}
+}

--- a/mcp/tools_weather_test.go
+++ b/mcp/tools_weather_test.go
@@ -1,0 +1,36 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/testutil"
+)
+
+func TestGetWeatherTool_Definition(t *testing.T) {
+	t.Parallel()
+	tool := getWeatherTool()
+	if tool.Name != "get_weather" {
+		t.Errorf("Name = %q, want get_weather", tool.Name)
+	}
+	if len(tool.InputSchema.Required) == 0 {
+		t.Error("expected required params")
+	}
+}
+
+func TestHandleGetWeather_Success(t *testing.T) {
+	t.Parallel()
+	testutil.RequireLiveProbe(t)
+	content, structured, err := handleGetWeather(context.Background(), map[string]any{
+		"city": "Rome",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("expected content")
+	}
+	if structured == nil {
+		t.Fatal("expected structured result")
+	}
+}


### PR DESCRIPTION
## Summary

Adds test coverage for 10 tool handler files that previously had no tests. Follows the existing test patterns: white-box (`package mcp`), `t.Parallel()`, direct handler calls.

## New test files

| File | Handlers covered | Tests |
|------|------------------|-------|
| `tools_baggage_test.go` | `get_baggage_rules` | Definition, success (all + specific airline) |
| `tools_lounges_test.go` | `search_lounges` | Definition, missing params, invalid IATA, success (live probe) |
| `tools_visa_test.go` | `check_visa` | Definition, success |
| `tools_restaurants_test.go` | `search_restaurants` | Definition, missing params, success (live probe) |
| `tools_deals_test.go` | `search_deals` | Definition, missing params, success (live probe) |
| `tools_weather_test.go` | `get_weather` | Definition, success (live probe) |
| `tools_hacks_test.go` | `detect_travel_hacks`, `detect_accommodation_hacks` | Definition (2) |
| `tools_opportunities_test.go` | `watch_opportunities`, `list_opportunity_watches` | Definition (2), success (2) |
| `tools_optimizer_test.go` | `optimize_booking`, `suggest_dates`, `optimize_multi_city` | Definition (3), missing params for suggest_dates + multi_city |
| `tools_viability_test.go` | `assess_trip` | Definition |

## Testing

- All pass in `-short` mode (live API tests guarded by `RequireLiveProbe`)
- 473 lines, 10 files, 0 production code changes
- Missing-param tests only included where handlers validate inputs at the handler level (optimize_booking and assess_trip pass empty strings to external APIs and are tested at definition level only)