### PR TITLE
fix: make check_watches re-price against live prices + emit real JSON to assistant

### DIFF
--- a/.github/workflows/live-probes.yml
+++ b/.github/workflows/live-probes.yml
@@ -1,0 +1,31 @@
+name: Live Probes
+
+# Nightly (and on-demand) execution of the live provider probe tests. The default
+# CI suite is deterministic and offline, which means it cannot catch a tool that
+# is advertised as live but silently returns stub data (the class of bug that let
+# check_watches report a fake price of 0 for weeks). These probes hit the real
+# provider endpoints, so a re-stubbed checker or a rotated provider API (e.g. the
+# Wizz Air version path) fails here and surfaces as a tracked failure.
+
+on:
+  schedule:
+    # 05:17 UTC daily (off the hour to avoid Actions congestion).
+    - cron: "17 5 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  live-probes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26.4"
+      - name: Live provider probes
+        # -run Probe selects every *_probe_test.go test across the module; the
+        # env gate flips them from skipped to live.
+        run: TRVL_TEST_LIVE_PROBES=1 go test -count=1 -run Probe ./...

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-live-integrations:
 	TRVL_TEST_LIVE_INTEGRATIONS=1 $(GO_RUN) test -v -count=1 ./...
 
 test-live-probes:
-	TRVL_TEST_LIVE_PROBES=1 $(GO_RUN) test -v -count=1 ./internal/flights ./internal/hotels -run Probe
+	TRVL_TEST_LIVE_PROBES=1 $(GO_RUN) test -v -count=1 ./... -run Probe
 
 lint:
 	$(GO_RUN) vet ./...

--- a/cmd/trvl/watch.go
+++ b/cmd/trvl/watch.go
@@ -7,8 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MikkoParkkola/trvl/internal/flights"
-	"github.com/MikkoParkkola/trvl/internal/hotels"
+	"github.com/MikkoParkkola/trvl/internal/livecheck"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/watch"
 	"github.com/spf13/cobra"
@@ -460,101 +459,7 @@ func watchHistoryCmd() *cobra.Command {
 type liveChecker struct{}
 
 func (c *liveChecker) CheckPrice(ctx context.Context, w watch.Watch) (float64, string, string, error) {
-	switch w.Type {
-	case "flight":
-		return c.checkFlight(ctx, w)
-	case "hotel":
-		return c.checkHotel(ctx, w)
-	default:
-		return 0, "", "", fmt.Errorf("unknown watch type: %s", w.Type)
-	}
-}
-
-func (c *liveChecker) checkFlight(ctx context.Context, w watch.Watch) (float64, string, string, error) {
-	// Route watch or date range: use calendar/dates search.
-	if w.IsRouteWatch() || w.IsDateRange() {
-		return c.checkFlightRange(ctx, w)
-	}
-
-	// Specific date search.
-	opts := flights.SearchOptions{ReturnDate: w.ReturnDate}
-	result, err := flights.SearchFlights(ctx, w.Origin, w.Destination, w.DepartDate, opts)
-	if err != nil {
-		return 0, "", "", err
-	}
-	if !result.Success || len(result.Flights) == 0 {
-		return 0, "", "", nil
-	}
-
-	cheapest := result.Flights[0]
-	for _, f := range result.Flights[1:] {
-		if f.Price > 0 && (cheapest.Price == 0 || f.Price < cheapest.Price) {
-			cheapest = f
-		}
-	}
-	return cheapest.Price, cheapest.Currency, w.DepartDate, nil
-}
-
-func (c *liveChecker) checkFlightRange(ctx context.Context, w watch.Watch) (float64, string, string, error) {
-	from := w.DepartFrom
-	to := w.DepartTo
-	if w.IsRouteWatch() {
-		// No dates specified — scan next 60 days.
-		from = time.Now().AddDate(0, 0, 1).Format("2006-01-02")
-		to = time.Now().AddDate(0, 0, 60).Format("2006-01-02")
-	}
-
-	result, err := flights.SearchCalendar(ctx, w.Origin, w.Destination, flights.CalendarOptions{
-		FromDate: from,
-		ToDate:   to,
-	})
-	if err != nil {
-		return 0, "", "", err
-	}
-	if !result.Success || len(result.Dates) == 0 {
-		return 0, "", "", nil
-	}
-
-	cheapest := result.Dates[0]
-	for _, d := range result.Dates[1:] {
-		if d.Price > 0 && (cheapest.Price == 0 || d.Price < cheapest.Price) {
-			cheapest = d
-		}
-	}
-	return cheapest.Price, cheapest.Currency, cheapest.Date, nil
-}
-
-func (c *liveChecker) checkHotel(ctx context.Context, w watch.Watch) (float64, string, string, error) {
-	checkIn := w.DepartDate
-	checkOut := w.ReturnDate
-	if w.IsRouteWatch() {
-		// Default to next weekend.
-		now := time.Now()
-		fri := now.AddDate(0, 0, int((5-now.Weekday()+7)%7))
-		checkIn = fri.Format("2006-01-02")
-		checkOut = fri.AddDate(0, 0, 2).Format("2006-01-02")
-	}
-
-	opts := hotels.HotelSearchOptions{
-		CheckIn:  checkIn,
-		CheckOut: checkOut,
-		Currency: w.Currency,
-	}
-	result, err := hotels.SearchHotels(ctx, w.Destination, opts)
-	if err != nil {
-		return 0, "", "", err
-	}
-	if len(result.Hotels) == 0 {
-		return 0, "", "", nil
-	}
-
-	cheapest := result.Hotels[0]
-	for _, h := range result.Hotels[1:] {
-		if h.Price > 0 && (cheapest.Price == 0 || h.Price < cheapest.Price) {
-			cheapest = h
-		}
-	}
-	return cheapest.Price, cheapest.Currency, checkIn, nil
+	return livecheck.Checker{}.CheckPrice(ctx, w)
 }
 
 // liveRoomChecker implements watch.RoomChecker using the real hotel rooms API.

--- a/internal/livecheck/livecheck.go
+++ b/internal/livecheck/livecheck.go
@@ -1,0 +1,125 @@
+// Package livecheck provides the real flight/hotel price-checking logic used to
+// re-price active watches. It bridges the watch package to the live
+// flights/hotels search APIs without either of those packages depending on
+// watch, and is shared by the CLI watch daemon and the MCP check_watches tool so
+// the two cannot diverge (the original divergence — a live CLI checker and a
+// stubbed MCP checker — is what caused check_watches to silently return price 0).
+package livecheck
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/hotels"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// Checker implements watch.PriceChecker against the real flight/hotel search
+// APIs. The zero value is ready to use.
+type Checker struct{}
+
+// Compile-time assertion that Checker satisfies the watch.PriceChecker contract.
+var _ watch.PriceChecker = Checker{}
+
+// CheckPrice returns the cheapest live price for the watch. A zero price with a
+// nil error means "searched, found nothing" (an honest empty result); a non-nil
+// error means the search itself failed. It never fabricates a price.
+func (Checker) CheckPrice(ctx context.Context, w watch.Watch) (float64, string, string, error) {
+	switch w.Type {
+	case "flight":
+		return checkFlight(ctx, w)
+	case "hotel":
+		return checkHotel(ctx, w)
+	default:
+		return 0, "", "", fmt.Errorf("unknown watch type: %s", w.Type)
+	}
+}
+
+func checkFlight(ctx context.Context, w watch.Watch) (float64, string, string, error) {
+	// Route watch or date range: use calendar/dates search.
+	if w.IsRouteWatch() || w.IsDateRange() {
+		return checkFlightRange(ctx, w)
+	}
+
+	// Specific date search.
+	opts := flights.SearchOptions{ReturnDate: w.ReturnDate}
+	result, err := flights.SearchFlights(ctx, w.Origin, w.Destination, w.DepartDate, opts)
+	if err != nil {
+		return 0, "", "", err
+	}
+	if !result.Success || len(result.Flights) == 0 {
+		return 0, "", "", nil
+	}
+
+	cheapest := result.Flights[0]
+	for _, f := range result.Flights[1:] {
+		if f.Price > 0 && (cheapest.Price == 0 || f.Price < cheapest.Price) {
+			cheapest = f
+		}
+	}
+	return cheapest.Price, cheapest.Currency, w.DepartDate, nil
+}
+
+func checkFlightRange(ctx context.Context, w watch.Watch) (float64, string, string, error) {
+	from := w.DepartFrom
+	to := w.DepartTo
+	if w.IsRouteWatch() {
+		// No dates specified — scan next 60 days.
+		from = time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+		to = time.Now().AddDate(0, 0, 60).Format("2006-01-02")
+	}
+
+	result, err := flights.SearchCalendar(ctx, w.Origin, w.Destination, flights.CalendarOptions{
+		FromDate: from,
+		ToDate:   to,
+	})
+	if err != nil {
+		return 0, "", "", err
+	}
+	if !result.Success || len(result.Dates) == 0 {
+		return 0, "", "", nil
+	}
+
+	cheapest := result.Dates[0]
+	for _, d := range result.Dates[1:] {
+		if d.Price > 0 && (cheapest.Price == 0 || d.Price < cheapest.Price) {
+			cheapest = d
+		}
+	}
+	return cheapest.Price, cheapest.Currency, cheapest.Date, nil
+}
+
+func checkHotel(ctx context.Context, w watch.Watch) (float64, string, string, error) {
+	checkIn := w.DepartDate
+	checkOut := w.ReturnDate
+	if w.IsRouteWatch() {
+		// Default to next weekend.
+		now := time.Now()
+		fri := now.AddDate(0, 0, int((5-now.Weekday()+7)%7))
+		checkIn = fri.Format("2006-01-02")
+		checkOut = fri.AddDate(0, 0, 2).Format("2006-01-02")
+	}
+
+	opts := hotels.HotelSearchOptions{
+		CheckIn:  checkIn,
+		CheckOut: checkOut,
+		Currency: w.Currency,
+	}
+	result, err := hotels.SearchHotels(ctx, w.Destination, opts)
+	if err != nil {
+		return 0, "", "", err
+	}
+	if len(result.Hotels) == 0 {
+		return 0, "", "", nil
+	}
+
+	cheapest := result.Hotels[0]
+	for _, h := range result.Hotels[1:] {
+		if h.Price > 0 && (cheapest.Price == 0 || h.Price < cheapest.Price) {
+			cheapest = h
+		}
+	}
+	return cheapest.Price, cheapest.Currency, checkIn, nil
+}

--- a/internal/livecheck/livecheck_probe_test.go
+++ b/internal/livecheck/livecheck_probe_test.go
@@ -1,0 +1,36 @@
+package livecheck
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// TestChecker_LiveFlightProbe performs a real flight search end-to-end. It is the
+// automation that catches a re-stubbed checker: if CheckPrice ever stops calling
+// the live providers (the original bug), this returns 0 and fails. Probe-gated
+// via TRVL_TEST_LIVE_PROBES=1 so the default suite stays offline; run nightly in
+// CI (see .github/workflows/live-probes.yml).
+func TestChecker_LiveFlightProbe(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("hits live flight APIs; set TRVL_TEST_LIVE_PROBES=1 to run")
+	}
+	price, currency, _, err := Checker{}.CheckPrice(context.Background(), watch.Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "LHR",
+		DepartDate:  "2026-09-15",
+		Currency:    "EUR",
+	})
+	if err != nil {
+		t.Fatalf("live flight check failed: %v", err)
+	}
+	if price <= 0 {
+		t.Errorf("expected positive live price, got %f (a stubbed checker would return 0)", price)
+	}
+	if currency == "" {
+		t.Error("expected non-empty currency on a live result")
+	}
+}

--- a/internal/livecheck/livecheck_test.go
+++ b/internal/livecheck/livecheck_test.go
@@ -2,7 +2,6 @@ package livecheck
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/MikkoParkkola/trvl/internal/watch"
@@ -18,32 +17,5 @@ func TestChecker_UnsupportedType(t *testing.T) {
 	}
 	if price != 0 {
 		t.Errorf("price = %f, want 0 on error", price)
-	}
-}
-
-// TestChecker_LiveFlight is a probe-gated test that performs a real flight
-// search. It is skipped unless TRVL_TEST_LIVE_PROBES=1 so the default suite
-// stays deterministic and offline (per CLAUDE.md).
-func TestChecker_LiveFlight(t *testing.T) {
-	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
-		t.Skip("hits live flight APIs; set TRVL_TEST_LIVE_PROBES=1 to run")
-	}
-	price, currency, _, err := Checker{}.CheckPrice(context.Background(), watch.Watch{
-		Type:        "flight",
-		Origin:      "HEL",
-		Destination: "LHR",
-		DepartDate:  "2026-09-15",
-		Currency:    "EUR",
-	})
-	if err != nil {
-		t.Fatalf("live flight check failed: %v", err)
-	}
-	// A real result must carry a positive price and a currency. This is the
-	// assertion the original stub could never satisfy.
-	if price <= 0 {
-		t.Errorf("expected positive live price, got %f", price)
-	}
-	if currency == "" {
-		t.Error("expected non-empty currency on a live result")
 	}
 }

--- a/internal/livecheck/livecheck_test.go
+++ b/internal/livecheck/livecheck_test.go
@@ -1,0 +1,49 @@
+package livecheck
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// TestChecker_UnsupportedType is deterministic and hits no network: an
+// unsupported watch type must return an error rather than a fabricated price.
+func TestChecker_UnsupportedType(t *testing.T) {
+	t.Parallel()
+	price, _, _, err := Checker{}.CheckPrice(context.Background(), watch.Watch{Type: "bus"})
+	if err == nil {
+		t.Fatal("expected error for unsupported watch type")
+	}
+	if price != 0 {
+		t.Errorf("price = %f, want 0 on error", price)
+	}
+}
+
+// TestChecker_LiveFlight is a probe-gated test that performs a real flight
+// search. It is skipped unless TRVL_TEST_LIVE_PROBES=1 so the default suite
+// stays deterministic and offline (per CLAUDE.md).
+func TestChecker_LiveFlight(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("hits live flight APIs; set TRVL_TEST_LIVE_PROBES=1 to run")
+	}
+	price, currency, _, err := Checker{}.CheckPrice(context.Background(), watch.Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "LHR",
+		DepartDate:  "2026-09-15",
+		Currency:    "EUR",
+	})
+	if err != nil {
+		t.Fatalf("live flight check failed: %v", err)
+	}
+	// A real result must carry a positive price and a currency. This is the
+	// assertion the original stub could never satisfy.
+	if price <= 0 {
+		t.Errorf("expected positive live price, got %f", price)
+	}
+	if currency == "" {
+		t.Error("expected non-empty currency on a live result")
+	}
+}

--- a/internal/watch/check.go
+++ b/internal/watch/check.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/hotelarb"
@@ -115,6 +116,85 @@ func checkWatchesWithRoomsAndWebhookContext(checkCtx, webhookCtx context.Context
 			}
 		}
 	}
+	return results
+}
+
+// BoundedOptions tunes CheckAllBounded for synchronous callers (e.g. the MCP
+// check_watches tool) that must return within a request deadline rather than
+// running as an unbounded background daemon.
+type BoundedOptions struct {
+	// Concurrency caps how many watches are re-priced in parallel. Defaults to
+	// DefaultBoundedConcurrency when <= 0.
+	Concurrency int
+	// PerWatchTimeout bounds each individual live search. A watch that exceeds it
+	// is reported with an explicit timeout Error rather than a fabricated price.
+	// Defaults to DefaultBoundedPerWatchTimeout when <= 0.
+	PerWatchTimeout time.Duration
+}
+
+const (
+	// DefaultBoundedConcurrency is the default parallelism for CheckAllBounded.
+	DefaultBoundedConcurrency = 4
+	// DefaultBoundedPerWatchTimeout is the default per-watch deadline.
+	DefaultBoundedPerWatchTimeout = 15 * time.Second
+)
+
+// CheckAllBounded re-prices every watch concurrently with a per-watch timeout
+// and a concurrency cap, recording results in the store. Unlike CheckAll it does
+// not pause between checks, making it suitable for synchronous request/response
+// callers. Results are returned in the same order as store.List(). A watch whose
+// live search exceeds PerWatchTimeout (or whose parent context is canceled) is
+// returned with a non-nil Error so callers can render an honest "not checked"
+// status instead of a misleading price of 0.
+func CheckAllBounded(ctx context.Context, store *Store, checker PriceChecker, roomChecker RoomChecker, opts BoundedOptions) []CheckResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	concurrency := opts.Concurrency
+	if concurrency <= 0 {
+		concurrency = DefaultBoundedConcurrency
+	}
+	perWatch := opts.PerWatchTimeout
+	if perWatch <= 0 {
+		perWatch = DefaultBoundedPerWatchTimeout
+	}
+
+	watches := store.List()
+	results := make([]CheckResult, len(watches))
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	for i, w := range watches {
+		wg.Add(1)
+		go func(i int, w Watch) {
+			defer wg.Done()
+
+			// Respect parent cancellation before acquiring a slot.
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				results[i] = CheckResult{Watch: w, Error: ctx.Err()}
+				return
+			}
+
+			// The webhook context is the parent ctx so delivery is not killed by
+			// the per-watch search deadline; the check context is bounded.
+			checkCtx, cancel := context.WithTimeout(ctx, perWatch)
+			defer cancel()
+
+			switch {
+			case w.IsRoomWatch() && roomChecker != nil:
+				results[i] = checkRoomWithWebhookContext(checkCtx, ctx, store, roomChecker, w)
+			case w.IsRoomWatch():
+				results[i] = CheckResult{Watch: w, Error: fmt.Errorf("room checker not configured")}
+			default:
+				results[i] = checkOneWithWebhookContext(checkCtx, ctx, store, checker, w)
+			}
+		}(i, w)
+	}
+
+	wg.Wait()
 	return results
 }
 

--- a/internal/watch/check_bounded_test.go
+++ b/internal/watch/check_bounded_test.go
@@ -1,0 +1,153 @@
+package watch
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// boundedBlockChecker blocks until the per-watch context is cancelled, then returns
+// the context error. It is used to exercise the timeout path of CheckAllBounded.
+type boundedBlockChecker struct{}
+
+func (boundedBlockChecker) CheckPrice(ctx context.Context, _ Watch) (float64, string, string, error) {
+	<-ctx.Done()
+	return 0, "", "", ctx.Err()
+}
+
+// boundedCountChecker records the maximum number of concurrently in-flight checks so
+// a test can assert the concurrency cap is honoured.
+type boundedCountChecker struct {
+	mu       sync.Mutex
+	inFlight int
+	maxSeen  int
+	delay    time.Duration
+}
+
+func (c *boundedCountChecker) CheckPrice(ctx context.Context, _ Watch) (float64, string, string, error) {
+	c.mu.Lock()
+	c.inFlight++
+	if c.inFlight > c.maxSeen {
+		c.maxSeen = c.inFlight
+	}
+	c.mu.Unlock()
+
+	select {
+	case <-time.After(c.delay):
+	case <-ctx.Done():
+	}
+
+	c.mu.Lock()
+	c.inFlight--
+	c.mu.Unlock()
+	return 150, "EUR", "", nil
+}
+
+func addFlightWatch(t *testing.T, store *Store, origin, dest string) {
+	t.Helper()
+	if _, err := store.Add(Watch{
+		Type:        "flight",
+		Origin:      origin,
+		Destination: dest,
+		DepartDate:  "2026-09-01",
+		Currency:    "EUR",
+		BelowPrice:  200,
+	}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+}
+
+func TestCheckAllBounded_PricesAllWatchesInOrder(t *testing.T) {
+	t.Parallel()
+	store := NewStore(t.TempDir())
+	addFlightWatch(t, store, "HEL", "CDG")
+	addFlightWatch(t, store, "HEL", "BCN")
+	addFlightWatch(t, store, "HEL", "LIS")
+
+	checker := &stubPriceChecker{price: 150, currency: "EUR"}
+	results := CheckAllBounded(context.Background(), store, checker, nil, BoundedOptions{})
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	wantDest := []string{"CDG", "BCN", "LIS"} // store.List() order preserved
+	for i, r := range results {
+		if r.Error != nil {
+			t.Errorf("result[%d] unexpected error: %v", i, r.Error)
+		}
+		if r.NewPrice != 150 {
+			t.Errorf("result[%d] NewPrice = %f, want 150", i, r.NewPrice)
+		}
+		if r.Watch.Destination != wantDest[i] {
+			t.Errorf("result[%d] dest = %q, want %q (order not preserved)", i, r.Watch.Destination, wantDest[i])
+		}
+		if !r.BelowGoal {
+			t.Errorf("result[%d] expected BelowGoal (150 <= 200)", i)
+		}
+	}
+}
+
+// TestCheckAllBounded_TimeoutIsHonest verifies a watch whose search exceeds the
+// per-watch timeout is reported with an explicit Error and a zero price — never
+// a fabricated price. This is the regression guard for the original bug where
+// check_watches silently reported price 0 as if it were real data.
+func TestCheckAllBounded_TimeoutIsHonest(t *testing.T) {
+	t.Parallel()
+	store := NewStore(t.TempDir())
+	addFlightWatch(t, store, "HEL", "NRT")
+
+	start := time.Now()
+	results := CheckAllBounded(context.Background(), store, boundedBlockChecker{}, nil, BoundedOptions{
+		PerWatchTimeout: 40 * time.Millisecond,
+	})
+	elapsed := time.Since(start)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Error == nil {
+		t.Fatal("expected timeout error, got nil (a timed-out check must not look like a real result)")
+	}
+	if results[0].NewPrice != 0 {
+		t.Errorf("NewPrice = %f, want 0 on timeout", results[0].NewPrice)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("bounded check took %v; per-watch timeout was not enforced", elapsed)
+	}
+}
+
+func TestCheckAllBounded_RespectsConcurrencyCap(t *testing.T) {
+	t.Parallel()
+	store := NewStore(t.TempDir())
+	for i := 0; i < 8; i++ {
+		addFlightWatch(t, store, "HEL", "DST")
+	}
+
+	checker := &boundedCountChecker{delay: 30 * time.Millisecond}
+	_ = CheckAllBounded(context.Background(), store, checker, nil, BoundedOptions{Concurrency: 2})
+
+	if checker.maxSeen > 2 {
+		t.Errorf("max concurrent checks = %d, want <= 2", checker.maxSeen)
+	}
+	if checker.maxSeen == 0 {
+		t.Error("checker never ran")
+	}
+}
+
+func TestCheckAllBounded_ParentCancel(t *testing.T) {
+	t.Parallel()
+	store := NewStore(t.TempDir())
+	addFlightWatch(t, store, "HEL", "AMS")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before the call
+
+	results := CheckAllBounded(ctx, store, boundedBlockChecker{}, nil, BoundedOptions{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Error == nil {
+		t.Error("expected error when parent context already cancelled")
+	}
+}

--- a/mcp/coverage_boost4_test.go
+++ b/mcp/coverage_boost4_test.go
@@ -460,24 +460,23 @@ func TestWatchRoute_Default(t *testing.T) {
 // mcpPriceChecker.CheckPrice
 // ============================================================
 
-func TestMCPPriceChecker_ReturnsZero(t *testing.T) {
+// TestMCPPriceChecker_DelegatesUnsupportedType verifies the MCP price checker
+// delegates to the shared livecheck implementation: an unsupported watch type
+// yields an error (not a fabricated zero price). This is deterministic and hits
+// no network. Live re-pricing is covered by the probe-gated test in
+// tools_watch_price_live_test.go.
+func TestMCPPriceChecker_DelegatesUnsupportedType(t *testing.T) {
 	t.Parallel()
 	c := &mcpPriceChecker{}
-	price, currency, date, err := c.CheckPrice(context.Background(), watch.Watch{
-		Type:     "flight",
+	price, _, _, err := c.CheckPrice(context.Background(), watch.Watch{
+		Type:     "ferry", // not flight/hotel: livecheck rejects it
 		Currency: "EUR",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected error for unsupported watch type, got nil")
 	}
 	if price != 0 {
-		t.Errorf("price = %f, want 0", price)
-	}
-	if currency != "EUR" {
-		t.Errorf("currency = %q, want EUR", currency)
-	}
-	if date != "" {
-		t.Errorf("date = %q, want empty", date)
+		t.Errorf("price = %f, want 0 on error", price)
 	}
 }
 

--- a/mcp/no_placeholder_guard_test.go
+++ b/mcp/no_placeholder_guard_test.go
@@ -1,0 +1,55 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoPlaceholderAssistantBlocks is an enforcement gate (not just a one-off
+// fix). Several MCP tool handlers historically emitted a hand-rolled
+// assistant-audience content block with a placeholder string (e.g. "Structured
+// data attached.") instead of the actual JSON-serialized result. Clients that
+// read content blocks rather than structuredContent therefore got no data.
+//
+// This test fails the build if any non-test handler reintroduces a placeholder
+// assistant block, forcing the use of buildAnnotatedContentBlocks. It is the
+// "enforced, not documented" guard for that defect class.
+func TestNoPlaceholderAssistantBlocks(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+
+	// Forbidden placeholder fragments that indicate a hand-rolled assistant block
+	// stating data is "attached" without actually embedding it.
+	forbidden := []string{
+		"data attached.",
+	}
+
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		// This guard file itself names the forbidden strings; skip it.
+		if name == "no_placeholder_guard_test.go" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		src := string(data)
+		for _, frag := range forbidden {
+			if strings.Contains(src, frag) {
+				t.Errorf("%s contains placeholder assistant content %q; "+
+					"use buildAnnotatedContentBlocks(summary, structuredPayload) so the "+
+					"assistant receives real JSON, not a placeholder", name, frag)
+			}
+		}
+	}
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/hotels"
+	"github.com/MikkoParkkola/trvl/internal/livecheck"
 	"github.com/MikkoParkkola/trvl/internal/providers"
 	"github.com/MikkoParkkola/trvl/internal/telemetry"
 	"github.com/MikkoParkkola/trvl/internal/watch"
@@ -125,7 +126,10 @@ func NewServer() *Server {
 	// not here, so that tests calling NewServer() directly don't spawn goroutines).
 	if home, err := os.UserHomeDir(); err == nil {
 		watchDir := filepath.Join(home, ".trvl")
-		s.scheduler = watch.NewScheduler(watchDir, 30*time.Minute, watch.NoopChecker{})
+		// Use the real live checker so the in-process background scheduler
+		// actually re-prices watches; NoopChecker here meant the scheduler ran
+		// every 30 minutes but never updated any price.
+		s.scheduler = watch.NewScheduler(watchDir, 30*time.Minute, livecheck.Checker{})
 	}
 
 	// Initialize provider registry (best-effort; nil registry is handled gracefully).

--- a/mcp/tools_awards.go
+++ b/mcp/tools_awards.go
@@ -230,9 +230,9 @@ func handleSearchAwards(_ context.Context, args map[string]any, _ ElicitFunc, _ 
 	}
 
 	summary := buildAwardsSummary(filtered)
-	content := []ContentBlock{
-		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
-		{Type: "text", Text: "Structured award sweet-spot data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+	content, err := buildAnnotatedContentBlocks(summary, resp)
+	if err != nil {
+		return nil, nil, err
 	}
 	return content, resp, nil
 }

--- a/mcp/tools_baggage.go
+++ b/mcp/tools_baggage.go
@@ -67,9 +67,9 @@ func handleGetBaggageRules(_ context.Context, args map[string]any, _ ElicitFunc,
 			Found    bool                     `json:"found"`
 		}
 		resp := response{Airlines: airlines, Found: true}
-		content := []ContentBlock{
-			{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
-			{Type: "text", Text: "Structured baggage data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+		content, err := buildAnnotatedContentBlocks(summary, resp)
+		if err != nil {
+			return nil, nil, err
 		}
 		return content, resp, nil
 	}
@@ -88,9 +88,9 @@ func handleGetBaggageRules(_ context.Context, args map[string]any, _ ElicitFunc,
 		summary = fmt.Sprintf("Airline %q not found in baggage database. Use airline_code=\"all\" to see all available airlines.", code)
 	}
 
-	content := []ContentBlock{
-		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
-		{Type: "text", Text: "Structured baggage data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+	content, err := buildAnnotatedContentBlocks(summary, resp)
+	if err != nil {
+		return nil, nil, err
 	}
 	return content, resp, nil
 }

--- a/mcp/tools_deals.go
+++ b/mcp/tools_deals.go
@@ -122,9 +122,9 @@ func handleSearchDeals(ctx context.Context, args map[string]any, elicit ElicitFu
 		_, _ = fmt.Fprintf(&sb, "\n... and %d more deals", result.Count-10)
 	}
 
-	content := []ContentBlock{
-		{Type: "text", Text: sb.String(), Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
-		{Type: "text", Text: "Structured data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+	content, err := buildAnnotatedContentBlocks(sb.String(), result)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return content, result, nil

--- a/mcp/tools_ground.go
+++ b/mcp/tools_ground.go
@@ -168,9 +168,9 @@ func handleSearchGround(ctx context.Context, args map[string]any, elicit ElicitF
 		result.Routes,
 	)
 
-	content := []ContentBlock{
-		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
-		{Type: "text", Text: "Structured data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+	content, err := buildAnnotatedContentBlocks(summary, result)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return content, result, nil

--- a/mcp/tools_hacks.go
+++ b/mcp/tools_hacks.go
@@ -134,9 +134,9 @@ func handleDetectTravelHacks(ctx context.Context, args map[string]any, _ ElicitF
 	sendProgress(progress, 100, 100, fmt.Sprintf("Found %d hacks", len(detected)))
 
 	summary := buildHacksSummary(origin, destination, date, detected)
-	content := []ContentBlock{
-		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
-		{Type: "text", Text: "Structured hack data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+	content, err := buildAnnotatedContentBlocks(summary, resp)
+	if err != nil {
+		return nil, nil, err
 	}
 	return content, resp, nil
 }
@@ -255,9 +255,9 @@ func handleDetectAccommodationHacks(ctx context.Context, args map[string]any, _ 
 	}
 
 	summary := buildAccomHacksSummary(city, checkin, checkout, detected)
-	content := []ContentBlock{
-		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
-		{Type: "text", Text: "Structured accommodation hack data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+	content, err := buildAnnotatedContentBlocks(summary, resp)
+	if err != nil {
+		return nil, nil, err
 	}
 	return content, resp, nil
 }

--- a/mcp/tools_hidden_city.go
+++ b/mcp/tools_hidden_city.go
@@ -149,9 +149,9 @@ func handleSearchHiddenCity(_ context.Context, args map[string]any, _ ElicitFunc
 	}
 
 	summary := buildHiddenCitySummary(candidates, allowHiddenCity)
-	content := []ContentBlock{
-		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
-		{Type: "text", Text: "Structured hidden-city data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+	content, err := buildAnnotatedContentBlocks(summary, resp)
+	if err != nil {
+		return nil, nil, err
 	}
 	return content, resp, nil
 }

--- a/mcp/tools_journey.go
+++ b/mcp/tools_journey.go
@@ -101,10 +101,6 @@ func handleJourney(ctx context.Context, args map[string]any, elicit ElicitFunc, 
 		summary += "\n\nGround leg scheduled with the best-value option; the full comparison is attached so you can choose another."
 	}
 
-	content := []ContentBlock{
-		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
-	}
-
 	// Optional calendar handoff (F.1): when as_ics is set, attach an iCalendar
 	// "Leave home" event with a reminder alarm so the user can drop it straight
 	// into Apple/Google/Outlook. Additive — does not change the default output.
@@ -121,8 +117,20 @@ func handleJourney(ctx context.Context, args map[string]any, elicit ElicitFunc, 
 		}
 	}
 
+	// Emit the human summary plus an assistant-facing JSON block of the same
+	// structured payload returned as structuredContent, so content-block-only
+	// clients still receive the data (not just a placeholder string).
 	if ics != "" || comparison != nil {
-		return content, journeyResponse{ScheduleTimeline: schedule, ICS: ics, GroundComparison: comparison}, nil
+		resp := journeyResponse{ScheduleTimeline: schedule, ICS: ics, GroundComparison: comparison}
+		content, err := buildAnnotatedContentBlocks(summary, resp)
+		if err != nil {
+			return nil, nil, err
+		}
+		return content, resp, nil
+	}
+	content, err := buildAnnotatedContentBlocks(summary, schedule)
+	if err != nil {
+		return nil, nil, err
 	}
 	return content, schedule, nil
 }

--- a/mcp/tools_route.go
+++ b/mcp/tools_route.go
@@ -118,9 +118,9 @@ func handleSearchRoute(ctx context.Context, args map[string]any, elicit ElicitFu
 	sendProgress(progress, 100, 100, fmt.Sprintf("Found %d routes", result.Count))
 
 	summary := buildRouteSummary(result)
-	content := []ContentBlock{
-		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
-		{Type: "text", Text: "Structured data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+	content, err := buildAnnotatedContentBlocks(summary, result)
+	if err != nil {
+		return nil, nil, err
 	}
 	return content, result, nil
 }

--- a/mcp/tools_visa.go
+++ b/mcp/tools_visa.go
@@ -64,9 +64,9 @@ func handleCheckVisa(_ context.Context, args map[string]any, _ ElicitFunc, _ Sam
 	sendProgress(progress, 100, 100, "Done")
 
 	summary := buildVisaSummary(result)
-	content := []ContentBlock{
-		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
-		{Type: "text", Text: "Structured visa data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+	content, err := buildAnnotatedContentBlocks(summary, result)
+	if err != nil {
+		return nil, nil, err
 	}
 	return content, result, nil
 }

--- a/mcp/tools_watch_price.go
+++ b/mcp/tools_watch_price.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/livecheck"
 	"github.com/MikkoParkkola/trvl/internal/watch"
 )
 
@@ -388,9 +389,11 @@ func handleCheckWatches(ctx context.Context, _ map[string]any, _ ElicitFunc, _ S
 		return content, resp, nil
 	}
 
-	// Build a price checker that uses live flight/hotel search.
-	checker := &mcpPriceChecker{}
-	results := watch.CheckAll(ctx, store, checker)
+	// Re-price every watch against live sources, bounded so a synchronous MCP
+	// call cannot block indefinitely. checkWatchesChecker is a package var so
+	// tests can inject a deterministic checker. Room watches are reported with an
+	// honest "not checked" error until the room checker is wired (no fake price).
+	results := watch.CheckAllBounded(ctx, store, checkWatchesChecker, nil, watch.BoundedOptions{})
 
 	type resultItem struct {
 		ID           string  `json:"id"`
@@ -479,23 +482,20 @@ func handleCheckWatches(ctx context.Context, _ map[string]any, _ ElicitFunc, _ S
 	return content, resp, nil
 }
 
-// mcpPriceChecker implements watch.PriceChecker using live flight/hotel searches.
-// It is intentionally kept simple: it returns 0 price (no result) for hotel
-// watches since the hotel search requires a city resolver and external APIs that
-// are not easily callable without the full MCP handler context. Flight watches
-// are also non-trivial to re-invoke here; surfacing the mechanism without a
-// runtime import cycle is deferred to the daemon path. The check_watches tool
-// therefore records an informational result rather than a live price when no
-// price source is available.
+// checkWatchesChecker is the price checker used by handleCheckWatches. It is a
+// package var so tests can inject a deterministic fake; in production it performs
+// real live flight/hotel searches via the shared livecheck implementation.
+var checkWatchesChecker watch.PriceChecker = &mcpPriceChecker{}
+
+// mcpPriceChecker implements watch.PriceChecker by delegating to the shared
+// livecheck implementation that the CLI watch daemon also uses. Keeping a single
+// implementation behind both entry points is deliberate: the original bug was a
+// live CLI checker paired with a stubbed MCP checker that always returned 0,
+// which made check_watches silently report no price movement.
 type mcpPriceChecker struct{}
 
-func (m *mcpPriceChecker) CheckPrice(_ context.Context, w watch.Watch) (float64, string, string, error) {
-	// Live re-checking requires the full scraper stack (protobuf encoding,
-	// cookie jars, rate-limit backoff). The check_watches MCP tool surfaces
-	// the watch state and history; actual live re-checking is done by the
-	// background daemon (trvl watch --daemon). Return 0 to signal "no new
-	// data" so the store is not mutated and the existing last_price is shown.
-	return 0, w.Currency, "", nil
+func (m *mcpPriceChecker) CheckPrice(ctx context.Context, w watch.Watch) (float64, string, string, error) {
+	return livecheck.Checker{}.CheckPrice(ctx, w)
 }
 
 // --- helpers ---

--- a/mcp/tools_watch_price_live_test.go
+++ b/mcp/tools_watch_price_live_test.go
@@ -1,0 +1,101 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// fixedChecker is a deterministic watch.PriceChecker for handler tests.
+type fixedChecker struct {
+	price    float64
+	currency string
+}
+
+func (f fixedChecker) CheckPrice(_ context.Context, _ watch.Watch) (float64, string, string, error) {
+	return f.price, f.currency, "", nil
+}
+
+// TestHandleCheckWatches_ReturnsLivePrice proves the end-to-end wiring: a watch
+// is re-priced through the injected checker and the real price surfaces in the
+// tool response. Before the fix the response always carried current_price 0
+// regardless of the checker. Not parallel: it sets HOME and swaps a package var.
+func TestHandleCheckWatches_ReturnsLivePrice(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, err := watch.DefaultStore()
+	if err != nil {
+		t.Fatalf("DefaultStore: %v", err)
+	}
+	if _, err := store.Add(watch.Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "CDG",
+		DepartDate:  "2026-09-01",
+		Currency:    "EUR",
+		BelowPrice:  500,
+	}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	prev := checkWatchesChecker
+	checkWatchesChecker = fixedChecker{price: 123, currency: "EUR"}
+	defer func() { checkWatchesChecker = prev }()
+
+	_, structured, err := handleCheckWatches(context.Background(), nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleCheckWatches: %v", err)
+	}
+
+	raw, err := json.Marshal(structured)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(raw)
+	if !strings.Contains(got, `"checked":1`) {
+		t.Errorf("expected checked:1, got %s", got)
+	}
+	if !strings.Contains(got, `"current_price":123`) {
+		t.Errorf("expected current_price:123 (live price must flow through), got %s", got)
+	}
+	// 123 <= 500 target, so the watch should trigger.
+	if !strings.Contains(got, `"below_goal":true`) {
+		t.Errorf("expected below_goal:true, got %s", got)
+	}
+}
+
+// TestHandleCheckWatches_LiveProbe re-prices a real watch against live providers.
+// Probe-gated so the default suite stays offline (per CLAUDE.md).
+func TestHandleCheckWatches_LiveProbe(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("hits live flight APIs; set TRVL_TEST_LIVE_PROBES=1 to run")
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	store, err := watch.DefaultStore()
+	if err != nil {
+		t.Fatalf("DefaultStore: %v", err)
+	}
+	if _, err := store.Add(watch.Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "LHR",
+		DepartDate:  "2026-09-15",
+		Currency:    "EUR",
+	}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	_, structured, err := handleCheckWatches(context.Background(), nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleCheckWatches: %v", err)
+	}
+	raw, _ := json.Marshal(structured)
+	if strings.Contains(string(raw), `"current_price":0`) {
+		t.Errorf("live probe returned current_price 0 — re-check did not produce a real price: %s", string(raw))
+	}
+}

--- a/mcp/tools_watch_price_probe_test.go
+++ b/mcp/tools_watch_price_probe_test.go
@@ -1,0 +1,46 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// TestHandleCheckWatches_LiveProbe re-prices a real watch against live providers
+// end-to-end through the MCP handler. This is the regression guard that would
+// have caught the original bug (check_watches always returned current_price 0):
+// a stubbed checker fails this. Probe-gated; run nightly in CI
+// (.github/workflows/live-probes.yml).
+func TestHandleCheckWatches_LiveProbe(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("hits live flight APIs; set TRVL_TEST_LIVE_PROBES=1 to run")
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	store, err := watch.DefaultStore()
+	if err != nil {
+		t.Fatalf("DefaultStore: %v", err)
+	}
+	if _, err := store.Add(watch.Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "LHR",
+		DepartDate:  "2026-09-15",
+		Currency:    "EUR",
+	}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	_, structured, err := handleCheckWatches(context.Background(), nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleCheckWatches: %v", err)
+	}
+	raw, _ := json.Marshal(structured)
+	if strings.Contains(string(raw), `"current_price":0`) {
+		t.Errorf("live probe returned current_price 0 — re-check did not produce a real price: %s", string(raw))
+	}
+}

--- a/mcp/tools_watch_price_test.go
+++ b/mcp/tools_watch_price_test.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
@@ -62,40 +61,7 @@ func TestHandleCheckWatches_ReturnsLivePrice(t *testing.T) {
 	if !strings.Contains(got, `"current_price":123`) {
 		t.Errorf("expected current_price:123 (live price must flow through), got %s", got)
 	}
-	// 123 <= 500 target, so the watch should trigger.
 	if !strings.Contains(got, `"below_goal":true`) {
 		t.Errorf("expected below_goal:true, got %s", got)
-	}
-}
-
-// TestHandleCheckWatches_LiveProbe re-prices a real watch against live providers.
-// Probe-gated so the default suite stays offline (per CLAUDE.md).
-func TestHandleCheckWatches_LiveProbe(t *testing.T) {
-	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
-		t.Skip("hits live flight APIs; set TRVL_TEST_LIVE_PROBES=1 to run")
-	}
-	t.Setenv("HOME", t.TempDir())
-
-	store, err := watch.DefaultStore()
-	if err != nil {
-		t.Fatalf("DefaultStore: %v", err)
-	}
-	if _, err := store.Add(watch.Watch{
-		Type:        "flight",
-		Origin:      "HEL",
-		Destination: "LHR",
-		DepartDate:  "2026-09-15",
-		Currency:    "EUR",
-	}); err != nil {
-		t.Fatalf("Add: %v", err)
-	}
-
-	_, structured, err := handleCheckWatches(context.Background(), nil, nil, nil, nil)
-	if err != nil {
-		t.Fatalf("handleCheckWatches: %v", err)
-	}
-	raw, _ := json.Marshal(structured)
-	if strings.Contains(string(raw), `"current_price":0`) {
-		t.Errorf("live probe returned current_price 0 — re-check did not produce a real price: %s", string(raw))
 	}
 }

--- a/mcp/tools_weather.go
+++ b/mcp/tools_weather.go
@@ -81,9 +81,9 @@ func handleGetWeather(ctx context.Context, args map[string]any, _ ElicitFunc, _ 
 	sendProgress(progress, 100, 100, fmt.Sprintf("Got %d day forecast", len(result.Forecasts)))
 
 	summary := buildWeatherSummary(result)
-	content := []ContentBlock{
-		{Type: "text", Text: summary, Annotations: &ContentAnnotation{Audience: []string{"user"}, Priority: 1.0}},
-		{Type: "text", Text: "Structured forecast data attached.", Annotations: &ContentAnnotation{Audience: []string{"assistant"}, Priority: 0.5}},
+	content, err := buildAnnotatedContentBlocks(summary, result)
+	if err != nil {
+		return nil, nil, err
 	}
 	return content, result, nil
 }


### PR DESCRIPTION
## What & why

`check_watches` advertised *"re-check all active price watches against current live prices"* but never did. Its MCP price checker returned `(0, "", "", nil)` — a stub citing an import cycle that doesn't exist (`mcp` already imports `internal/flights` and `internal/hotels`). The in-process 30-minute background scheduler (`server.go`) was wired to `watch.NoopChecker`, so the background path was dead too. A real checker existed in `cmd/trvl` (`liveChecker`) but lived in a `main` package, so the MCP side carried a divergent stub. **Two implementations — one real, one fake.**

Verified live this session (`TRVL_TEST_LIVE_PROBES=1`): a real HEL to LHR search now flows end-to-end and returns a non-zero price.

## Changes

- **`internal/livecheck`** — the single real price `PriceChecker`, imported by both the CLI daemon and the MCP tool so they can't diverge again.
- **`watch.CheckAllBounded`** — concurrency-capped (default 4), per-watch timeout (default 15s), no 3s daemon pause; for synchronous callers. A watch that times out returns an explicit `Error`, **never a fabricated price of 0**.
- **`handleCheckWatches`** uses `CheckAllBounded` via an injectable checker var (testability).
- **`server.go`** background scheduler uses `livecheck.Checker` (was `NoopChecker`).
- **`cmd/trvl` `liveChecker`** delegates to `livecheck` (removes the duplication that caused the divergence).
- **Placeholder fix across 9 handlers** (`ground`, `route`, `hidden_city`, `journey`, `deals`, `awards`, `baggage`, `hacks`, `visa`, `weather`): they emitted `"...data attached."` instead of the JSON payload, so clients reading content blocks (not the newer `structuredContent`) received no data. Severity note: the data was still delivered via `structuredContent`, so this is a robustness fix for content-block-only clients, not total data loss.
- **`TestNoPlaceholderAssistantBlocks`** — build-failing enforcement gate against reintroducing the placeholder pattern.

## Tests

- `internal/livecheck` — unit (unsupported type) + live probe (passes, real price)
- `watch.CheckAllBounded` — order preservation, honest timeout, concurrency cap, parent-cancel
- `handleCheckWatches` — deterministic end-to-end (injected checker) + live probe (passes, non-zero price)
- Build, `go vet`, `staticcheck`, `-race` suite: all green.

## Deliberate decisions / caveats

- **Webhooks on synchronous checks:** `CheckAllBounded` uses the request context as the webhook context, so a price-drop webhook fired during a synchronous `check_watches` may be cancelled when the handler returns. Intentional — the daemon owns guaranteed webhook delivery; the synchronous tool returns the triggered watches directly in its response.
- **Worst-case latency:** per-watch 15s times ceil(N/4) is about 75s for ~20 watches if the request context has no deadline. Fine for typical 1-5 watch lists; a global budget is a reasonable follow-up.

## Enforcement scope (honest)

The new guard closes the placeholder class. The class that bit hardest — a tool advertising live behavior over a stub — is verified by the live probe but cannot be offline-enforced in CI (it needs network). The deterministic end-to-end test uses an injected stub, so it guards the wiring, not live behavior. Run `TRVL_TEST_LIVE_PROBES=1` before trusting the tool after future refactors.

## Credit & coordination

The `check_watches` no-op and the placeholder defect were diagnosed by **@marcello-russo** in #146/#147. This PR wires the live checker (rather than removing the tool as #147 proposed) and extends the structured-JSON fix to every affected handler. It supersedes #146 and #147 — suggest closing both with thanks once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
