### PR TITLE
test(providers): concurrency stress guard for breaker data-race (#144 class)

### DIFF
--- a/internal/providers/race_stress_test.go
+++ b/internal/providers/race_stress_test.go
@@ -1,0 +1,91 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestProviderBreaker_ConcurrentSearchAndMark stresses the circuit-breaker
+// read path in SearchHotels against concurrent MarkSuccess/MarkError writes on
+// the shared provider configs, under the race detector.
+//
+// This is a REGRESSION GUARD for the #144 class: an unsynchronized read of the
+// breaker fields (ErrorCount/LastError/LastErrorAt/LastSuccess) in the
+// SearchHotels breaker loop, racing the lock-protected writes in
+// MarkSuccess/MarkError, reached concurrently via singleflight in production.
+//
+// On the fixed code (SearchHotels reads via Registry.BreakerSnapshot under
+// RLock) this test passes clean under `go test -race`. On the pre-#144 code
+// (direct cfg.ErrorCount read in the loop) the race detector trips. The point
+// of the test is to make that class CI-catchable instead of escaping to
+// production: -race only sees races a test actually drives concurrently, and
+// no prior test drove Search x Mark on the same providers.
+func TestProviderBreaker_ConcurrentSearchAndMark(t *testing.T) {
+	var current, peak atomic.Int64
+	dir := t.TempDir()
+	reg, err := NewRegistryAt(dir)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+
+	const nprov = 8
+	ids := make([]string, nprov)
+	for i := 0; i < nprov; i++ {
+		srv := fakeHotelServer(t, time.Millisecond, &current, &peak)
+		id := fmt.Sprintf("fake-%02d", i)
+		ids[i] = id
+		registerFake(t, reg, srv, id)
+	}
+	rt := NewRuntime(reg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writers: hammer the lock-protected breaker mutations on shared configs.
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				for _, id := range ids {
+					reg.MarkError(id, "boom")
+					reg.MarkSuccess(id)
+				}
+			}
+		}()
+	}
+
+	// Readers: hammer SearchHotels, whose breaker loop reads the same fields.
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, _, _ = rt.SearchHotels(ctx, "Helsinki", 60.17, 24.94,
+					"2026-06-01", "2026-06-02", "EUR", 2, nil)
+			}
+		}()
+	}
+
+	// Hammer for long enough that any racy interleave is observed under -race.
+	time.Sleep(1500 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}


### PR DESCRIPTION
## What

Adds a concurrency stress test that guards the provider circuit-breaker against the data-race class fixed in #144.

The test drives N concurrent `SearchHotels` calls against M concurrent `MarkSuccess`/`MarkError` calls on the same provider configs, under the race detector.

## Why

#144 fixed a data race where `SearchHotels` read the breaker fields (`ErrorCount`/`LastErrorAt`/`LastSuccess`) directly off shared `*ProviderConfig` pointers at `runtime.go:322`, racing the lock-protected writes in `MarkSuccess`/`MarkError` at `registry.go:339`, reached concurrently via singleflight in production.

That race shipped to production even though CI runs `-race`. The reason: `-race` only detects races on paths a test actually drives concurrently, and no prior test drove `Search` against `Mark` on the same providers. The fix added a safe accessor but no regression test, so the class (previously #39, #40) had no guard against recurrence.

## Validation (this change)

- **Clean on current/fixed code** (reads via `Registry.BreakerSnapshot` under `RLock`): `go test -race` passes (`ok`, ~7.6s).
- **Trips on the pre-#144 code** (direct field read): `go test -race` reports `WARNING: DATA RACE` at `runtime.go:322` vs `registry.go:339` and fails — the exact locations named in #144.

So the test reproduces the escaped race and goes green once fixed, making the class CI-catchable rather than something that escapes to production.

## Note

The race detector is dynamic: this guard catches races on the concurrent surface it exercises. Extending the provider set or adding new concurrent interactions should extend this stress test in step. A structural follow-up (making the breaker fields private so an unlocked read cannot compile) would close the specific pattern at compile time; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
