### PR TITLE
feat: surface hotel cancellation, board, fees, room metadata in CLI + MCP (#90)

### DIFF
--- a/cmd/trvl/rooms.go
+++ b/cmd/trvl/rooms.go
@@ -153,7 +153,7 @@ func formatRoomsTable(result *hotels.RoomAvailability) error {
 	models.Banner(os.Stdout, "🛏️", "Rooms", fmt.Sprintf("%s · %s to %s", name, result.CheckIn, result.CheckOut))
 	fmt.Println()
 
-	headers := []string{"Room", "Price", "Guests", "Provider", "Amenities"}
+	headers := []string{"Room", "Price", "Guests", "Bed", "Board", "Cancellation", "Provider", "Amenities"}
 	rows := make([][]string, 0, len(result.Rooms))
 	var prices priceScale
 
@@ -181,6 +181,9 @@ func formatRoomsTable(result *hotels.RoomAvailability) error {
 			room.Name,
 			priceText,
 			guestsText,
+			room.BedType,
+			boardLabel(room),
+			cancellationLabel(room),
 			room.Provider,
 			amenitiesText,
 		})
@@ -195,8 +198,72 @@ func formatRoomsTable(result *hotels.RoomAvailability) error {
 		}
 	}
 	if cheapest.Price > 0 {
-		models.Summary(os.Stdout, fmt.Sprintf("Cheapest: %.0f %s (%s)", cheapest.Price, cheapest.Currency, cheapest.Name))
+		summary := fmt.Sprintf("Cheapest: %.0f %s (%s)", cheapest.Price, cheapest.Currency, cheapest.Name)
+		if extras := roomHighlight(cheapest); extras != "" {
+			summary += " — " + extras
+		}
+		models.Summary(os.Stdout, summary)
 	}
 
 	return nil
+}
+
+// boardLabel returns a short human-readable meal-plan label for a room, or an
+// empty string when the provider did not surface board data. It never
+// fabricates a value: an empty Board with no breakfast signal renders blank.
+func boardLabel(room hotels.RoomType) string {
+	if room.Board != "" {
+		return prettyLabel(room.Board)
+	}
+	if room.BreakfastIncluded != nil {
+		if *room.BreakfastIncluded {
+			return "Breakfast included"
+		}
+		return "No breakfast"
+	}
+	return ""
+}
+
+// cancellationLabel returns a short human-readable cancellation label for a
+// room, or an empty string when the provider did not surface cancellation
+// data. Absent-safe: nil pointers and empty policy render blank.
+func cancellationLabel(room hotels.RoomType) string {
+	if room.CancellationPolicy != "" {
+		return prettyLabel(room.CancellationPolicy)
+	}
+	if room.FreeCancellation != nil && *room.FreeCancellation {
+		return "Free cancellation"
+	}
+	if room.Refundable != nil {
+		if *room.Refundable {
+			return "Refundable"
+		}
+		return "Non refundable"
+	}
+	return ""
+}
+
+// roomHighlight builds a compact one-line decision summary (board +
+// cancellation) for the cheapest room, omitting absent fields entirely.
+func roomHighlight(room hotels.RoomType) string {
+	var parts []string
+	if b := boardLabel(room); b != "" {
+		parts = append(parts, b)
+	}
+	if c := cancellationLabel(room); c != "" {
+		parts = append(parts, c)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// prettyLabel converts a normalized snake_case enum value (e.g.
+// "free_cancellation", "breakfast_included") into a human-readable,
+// sentence-cased label ("Free cancellation", "Breakfast included").
+func prettyLabel(s string) string {
+	s = strings.ReplaceAll(s, "_", " ")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }

--- a/cmd/trvl/rooms_enrich_test.go
+++ b/cmd/trvl/rooms_enrich_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/hotels"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func bptr(v bool) *bool { return &v }
+
+func TestBoardLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		room hotels.RoomType
+		want string
+	}{
+		{"normalized board", hotels.RoomType{Board: "breakfast_included"}, "Breakfast included"},
+		{"half board", hotels.RoomType{Board: "half_board"}, "Half board"},
+		{"breakfast flag only", hotels.RoomType{BreakfastIncluded: bptr(true)}, "Breakfast included"},
+		{"no breakfast flag", hotels.RoomType{BreakfastIncluded: bptr(false)}, "No breakfast"},
+		{"absent renders blank", hotels.RoomType{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := boardLabel(tc.room); got != tc.want {
+				t.Fatalf("boardLabel = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCancellationLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		room hotels.RoomType
+		want string
+	}{
+		{"normalized policy", hotels.RoomType{CancellationPolicy: "free_cancellation"}, "Free cancellation"},
+		{"non refundable policy", hotels.RoomType{CancellationPolicy: "non_refundable"}, "Non refundable"},
+		{"free cancellation flag", hotels.RoomType{FreeCancellation: bptr(true)}, "Free cancellation"},
+		{"refundable flag", hotels.RoomType{Refundable: bptr(true)}, "Refundable"},
+		{"non refundable flag", hotels.RoomType{Refundable: bptr(false)}, "Non refundable"},
+		{"absent renders blank", hotels.RoomType{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cancellationLabel(tc.room); got != tc.want {
+				t.Fatalf("cancellationLabel = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatRoomsTable_RendersEnrichmentFields verifies that populated
+// cancellation/board/bed metadata is surfaced in the CLI table and summary.
+func TestFormatRoomsTable_RendersEnrichmentFields(t *testing.T) {
+	models.UseColor = false
+	defer func() { models.UseColor = false }()
+
+	result := &hotels.RoomAvailability{
+		Success:  true,
+		Name:     "Test Hotel",
+		CheckIn:  "2026-07-10",
+		CheckOut: "2026-07-12",
+		Rooms: []hotels.RoomType{
+			{
+				Name:               "Deluxe Room",
+				Price:              160,
+				Currency:           "EUR",
+				BedType:            "1 king bed",
+				Board:              "breakfast_included",
+				BreakfastIncluded:  bptr(true),
+				CancellationPolicy: "free_cancellation",
+				FreeCancellation:   bptr(true),
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := formatRoomsTable(result); err != nil {
+			t.Fatalf("formatRoomsTable: %v", err)
+		}
+	})
+
+	for _, want := range []string{"Board", "Cancellation", "1 king bed", "Breakfast included", "Free cancellation"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rooms table output missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+// TestFormatRoomsTable_AbsentSafe verifies that rooms without enrichment data
+// do not fabricate cancellation/board labels: the cells render blank and no
+// false claim text appears.
+func TestFormatRoomsTable_AbsentSafe(t *testing.T) {
+	models.UseColor = false
+	defer func() { models.UseColor = false }()
+
+	result := &hotels.RoomAvailability{
+		Success:  true,
+		Name:     "Plain Hotel",
+		CheckIn:  "2026-07-10",
+		CheckOut: "2026-07-12",
+		Rooms: []hotels.RoomType{
+			{Name: "Standard Room", Price: 100, Currency: "EUR"},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := formatRoomsTable(result); err != nil {
+			t.Fatalf("formatRoomsTable: %v", err)
+		}
+	})
+
+	for _, forbidden := range []string{"Free cancellation", "Breakfast included", "Refundable", "Non refundable", "No breakfast"} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("absent-safe violation: output contains fabricated %q\n--- output ---\n%s", forbidden, out)
+		}
+	}
+}
+
+func TestRoomHighlight(t *testing.T) {
+	got := roomHighlight(hotels.RoomType{Board: "breakfast_included", CancellationPolicy: "free_cancellation"})
+	if got != "Breakfast included, Free cancellation" {
+		t.Fatalf("roomHighlight = %q", got)
+	}
+	if got := roomHighlight(hotels.RoomType{}); got != "" {
+		t.Fatalf("roomHighlight(empty) = %q, want blank", got)
+	}
+}

--- a/mcp/tools_hotels_details.go
+++ b/mcp/tools_hotels_details.go
@@ -266,15 +266,42 @@ func hotelDetailsSummary(result hotelDetailsSearchResponse, location string) str
 	summary := fmt.Sprintf("Enriched %d of %d hotels in %s.", result.Count, result.TotalAvailable, location)
 	roomCount := 0
 	errorCount := 0
+	freeCancelCount := 0
+	breakfastCount := 0
 	for _, hotel := range result.Hotels {
 		roomCount += len(hotel.RoomTypes)
 		errorCount += len(hotel.DetailErrors)
+		for _, room := range hotel.RoomTypes {
+			if roomHasFreeCancellation(room) {
+				freeCancelCount++
+			}
+			if room.BreakfastIncluded != nil && *room.BreakfastIncluded {
+				breakfastCount++
+			}
+		}
 	}
 	if roomCount > 0 {
 		summary += fmt.Sprintf(" Found %d room type%s.", roomCount, pluralSuffix(roomCount))
+	}
+	if freeCancelCount > 0 {
+		summary += fmt.Sprintf(" %d with free cancellation.", freeCancelCount)
+	}
+	if breakfastCount > 0 {
+		summary += fmt.Sprintf(" %d with breakfast included.", breakfastCount)
 	}
 	if errorCount > 0 {
 		summary += fmt.Sprintf(" %d detail lookup%s had partial failures.", errorCount, pluralSuffix(errorCount))
 	}
 	return summary
+}
+
+// roomHasFreeCancellation reports whether a room's parsed metadata indicates
+// free cancellation. It only returns true when the provider surfaced an
+// affirmative signal (explicit flag or normalized policy); absent data
+// (nil pointer, empty policy) returns false rather than fabricating a claim.
+func roomHasFreeCancellation(room hotels.RoomType) bool {
+	if room.FreeCancellation != nil && *room.FreeCancellation {
+		return true
+	}
+	return room.CancellationPolicy == "free_cancellation"
 }

--- a/mcp/tools_hotels_details_test.go
+++ b/mcp/tools_hotels_details_test.go
@@ -103,7 +103,7 @@ func TestHandleSearchHotelsWithDetailsEnrichesTopResults(t *testing.T) {
 	if len(content) == 0 {
 		t.Fatal("expected summary content")
 	}
-	if got := content[0].Text; got != "Enriched 1 of 2 hotels in Paris. Found 1 room type." {
+	if got := content[0].Text; got != "Enriched 1 of 2 hotels in Paris. Found 1 room type. 1 with free cancellation. 1 with breakfast included." {
 		t.Fatalf("summary = %q, want sensible detail summary", got)
 	}
 	resp, ok := structured.(hotelDetailsSearchResponse)
@@ -217,6 +217,51 @@ func TestHandleSearchHotelsWithDetailsPartialFailuresUseTypedDetailErrors(t *tes
 	}
 	if len(resp.Hotels[1].DetailErrors) != 0 || len(resp.Hotels[1].RoomTypes) != 1 {
 		t.Fatalf("successful hotel = errors %#v rooms %#v, want no errors and one room", resp.Hotels[1].DetailErrors, resp.Hotels[1].RoomTypes)
+	}
+}
+
+func TestHotelDetailsSummaryAbsentSafe(t *testing.T) {
+	// Rooms that expose no cancellation/board metadata must not produce
+	// fabricated "free cancellation" / "breakfast included" summary clauses.
+	resp := hotelDetailsSearchResponse{
+		Success:        true,
+		Count:          1,
+		TotalAvailable: 1,
+		Hotels: []hotelWithDetails{
+			{
+				HotelResult: models.HotelResult{Name: "Plain Hotel"},
+				RoomTypes: []hotels.RoomType{
+					{Name: "Standard Room", Price: 100, Currency: "EUR"},
+				},
+			},
+		},
+	}
+	got := hotelDetailsSummary(resp, "Paris")
+	want := "Enriched 1 of 1 hotels in Paris. Found 1 room type."
+	if got != want {
+		t.Fatalf("summary = %q, want %q (no fabricated enrichment clauses)", got, want)
+	}
+}
+
+func TestHotelDetailsSummaryEnrichmentClauses(t *testing.T) {
+	resp := hotelDetailsSearchResponse{
+		Success:        true,
+		Count:          1,
+		TotalAvailable: 1,
+		Hotels: []hotelWithDetails{
+			{
+				HotelResult: models.HotelResult{Name: "Rich Hotel"},
+				RoomTypes: []hotels.RoomType{
+					{Name: "Flex Room", Price: 200, Currency: "EUR", FreeCancellation: boolPtr(true), BreakfastIncluded: boolPtr(true)},
+					{Name: "Saver Room", Price: 150, Currency: "EUR", CancellationPolicy: "non_refundable"},
+				},
+			},
+		},
+	}
+	got := hotelDetailsSummary(resp, "Paris")
+	want := "Enriched 1 of 1 hotels in Paris. Found 2 room types. 1 with free cancellation. 1 with breakfast included."
+	if got != want {
+		t.Fatalf("summary = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #90. The structured model (cancellation, board, fees, room metadata) already existed on main and is parsed from Booking.com. The gap was that none of it reached human-facing surfaces. Adds Bed, Board, and Cancellation columns to the rooms CLI table plus a free-cancellation and breakfast count in the MCP details summary. All additions are strictly absent-safe per the MIK-4950 no-lie principle (no field is synthesized when the provider did not return it). Agent self-verified DoD (build, vet, staticcheck, race suite green); CI re-verifies here.