### PR TITLE
fix: Wizz version-rotation degrades to a typed actionable status, not a silent failure (#115)

### DIFF
--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -291,12 +291,10 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 		wizzairFlights, wizzairErr = SearchWizzair(ctx, origin, destination, date, currency, opts)
 		if wizzairErr != nil {
 			slog.Warn("wizzair flight search failed", "origin", origin, "destination", destination, "date", date, "error", wizzairErr)
-			statuses = append(statuses, models.ProviderStatus{
-				ID:     "wizzair",
-				Name:   "Wizz Air",
-				Status: models.ClassifyProviderError(wizzairErr),
-				Error:  wizzairErr.Error(),
-			})
+			// wizzairFailureStatus renders a typed, actionable status; a 404
+			// version-rotation gets a WIZZ_VERSION_ROTATED fix hint. The search
+			// continues with the other providers either way.
+			statuses = append(statuses, wizzairFailureStatus(wizzairErr))
 		} else {
 			wizzairSucceeded = true
 			statuses = append(statuses, models.ProviderStatus{

--- a/internal/flights/wizzair.go
+++ b/internal/flights/wizzair.go
@@ -21,17 +21,23 @@ package flights
 //  1. WIZZAIR_API_VERSION env var (operator override, no code change / redeploy).
 //  2. wizzVersion package var (overridable in tests; seeded from the const).
 //
-// wizzDefaultVersion is the last-known-good value. A clean live-discovery path
-// (Wizz exposes its metadata via https://wizzair.com/.../metadata) is left as a
-// documented TODO below because it cannot be verified offline; the env override
-// gives operators a zero-deploy escape hatch in the meantime.
+// wizzDefaultVersion is the last-known-good value. There is deliberately NO
+// live-discovery path: Wizz's current API version is JS-gated and has no clean
+// server-side HTTP endpoint that reliably returns it, and a headless-browser
+// dependency is forbidden (single static binary, no frameworks). When the
+// segment rotates, the timetable endpoint 404s; SearchWizzair detects that and
+// returns ErrWizzVersionRotated, which the aggregate renders as a typed,
+// actionable ProviderStatus (FixHintCode "WIZZ_VERSION_ROTATED") telling the
+// operator to set WIZZAIR_API_VERSION. The env override is the authoritative,
+// zero-deploy manual fix.
 //
-// Tracking: low-cost-carrier provider breadth (flights domain).
+// Tracking: low-cost-carrier provider breadth (flights domain); GH #115.
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,12 +50,23 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// ErrWizzVersionRotated is the sentinel returned when the Wizz timetable endpoint
+// answers 404 — the signature of a rotated {version} path segment. Callers detect
+// it with errors.Is and render a typed, actionable ProviderStatus instead of a
+// silent failure. The wrapped message carries the version that was tried.
+//
+// Why no auto-discovery: Wizz's current API version is JS-gated and has no clean
+// server-side HTTP endpoint that reliably returns it. A guessed-but-unverified
+// discovery mechanism would be worse than none (it could pin the wrong version),
+// and a headless-browser dependency is forbidden by the single-binary principle.
+// The honest design is graceful degradation plus the WIZZAIR_API_VERSION env
+// override as the authoritative manual fix.
+var ErrWizzVersionRotated = errors.New("wizzair API version path rotated")
+
 // wizzDefaultVersion is the last-known-good API version path segment. See the
 // package comment: the segment rotates, so this is a fallback, not a contract.
-//
-// TODO(flights): add DiscoverWizzVersion(ctx) that fetches Wizz's published
-// metadata endpoint and refreshes wizzVersion at runtime. Cannot be implemented
-// + verified offline; WIZZAIR_API_VERSION env override covers operators today.
+// No runtime auto-discovery exists by design (JS-gated, undiscoverable
+// server-side); WIZZAIR_API_VERSION is the operator's authoritative override.
 const wizzDefaultVersion = "10.1.0"
 
 // wizzVersion is the active API version. Overridable in tests; the env var
@@ -159,9 +176,12 @@ func SearchWizzair(ctx context.Context, origin, destination, date, currency stri
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		// A 404 here most likely means the version path segment rotated.
+		// A 404 here is the version-rotation signature: the {version} path
+		// segment rotated and the one we tried no longer exists. Wrap the
+		// sentinel so the aggregate can render a typed, actionable status; the
+		// search continues and returns other providers' results regardless.
 		if resp.StatusCode == http.StatusNotFound {
-			return nil, fmt.Errorf("wizzair: unexpected status 404 (API version %q may have rotated; set WIZZAIR_API_VERSION)", wizzResolvedVersion())
+			return nil, fmt.Errorf("wizzair: tried API version %q: %w", wizzResolvedVersion(), ErrWizzVersionRotated)
 		}
 		return nil, fmt.Errorf("wizzair: unexpected status %d", resp.StatusCode)
 	}
@@ -245,6 +265,30 @@ func wizzDisplayTime(s string) string {
 		return t.Format(flightTimeLayout)
 	}
 	return s
+}
+
+// wizzairFailureStatus maps a SearchWizzair error to a typed ProviderStatus.
+// A version-rotation 404 (ErrWizzVersionRotated) renders an actionable status
+// carrying a typed FixHintCode and a hint naming the WIZZAIR_API_VERSION env
+// override plus the last-known-good version, so an operator or orchestrating LLM
+// can restore the provider without a code change. All other errors fall through
+// to the standard classification (timeout vs failed). This helper is pure so it
+// can be unit-tested offline, independent of the live aggregate search.
+func wizzairFailureStatus(err error) models.ProviderStatus {
+	st := models.ProviderStatus{
+		ID:     "wizzair",
+		Name:   "Wizz Air",
+		Status: models.ClassifyProviderError(err),
+		Error:  err.Error(),
+	}
+	if errors.Is(err, ErrWizzVersionRotated) {
+		st.FixHintCode = "WIZZ_VERSION_ROTATED"
+		st.FixHint = fmt.Sprintf(
+			"Wizz API version path rotated; set WIZZAIR_API_VERSION=<current> to restore (tried %q; last-known-good: %s)",
+			wizzResolvedVersion(), wizzDefaultVersion,
+		)
+	}
+	return st
 }
 
 func wizzBookingURL(origin, destination, departure string) string {

--- a/internal/flights/wizzair_probe_test.go
+++ b/internal/flights/wizzair_probe_test.go
@@ -1,0 +1,49 @@
+package flights
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/testutil"
+)
+
+// TestWizzairProbe hits Wizz Air's live timetable endpoint for a CEE route that
+// Wizz actually flies (BUD -> BCN). Opt-in via TRVL_TEST_LIVE_PROBES=1.
+//
+// The assertion is honest about the version-rotation failure mode documented in
+// GH #115: Wizz either returns results, or — if the {version} path segment has
+// rotated since the last-known-good — surfaces the typed ErrWizzVersionRotated
+// sentinel that the aggregate renders as an actionable status. Both are PASS;
+// the test only fails on an unexpected error class (which would mean a new,
+// undiagnosed failure mode worth investigating).
+func TestWizzairProbe(t *testing.T) {
+	testutil.RequireLiveProbe(t)
+
+	date := time.Now().AddDate(0, 0, 45).Format("2006-01-02")
+	t.Logf("searching BUD -> BCN on %s (one-way, economy) via Wizz Air", date)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	out, err := SearchWizzair(ctx, "BUD", "BCN", date, "EUR", SearchOptions{Adults: 1})
+	if err != nil {
+		if errors.Is(err, ErrWizzVersionRotated) {
+			st := wizzairFailureStatus(err)
+			t.Logf("Wizz API version rotated (expected, actionable): code=%s hint=%q",
+				st.FixHintCode, st.FixHint)
+			if st.FixHintCode != "WIZZ_VERSION_ROTATED" {
+				t.Fatalf("rotation should carry WIZZ_VERSION_ROTATED, got %q", st.FixHintCode)
+			}
+			return // actionable status is an acceptable live outcome
+		}
+		t.Fatalf("unexpected Wizz error class: %v", err)
+	}
+	t.Logf("Wizz returned %d result(s)", len(out))
+	for _, f := range out {
+		if f.Provider != "wizzair" {
+			t.Errorf("provider = %q, want wizzair", f.Provider)
+		}
+	}
+}

--- a/internal/flights/wizzair_test.go
+++ b/internal/flights/wizzair_test.go
@@ -2,9 +2,12 @@ package flights
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -109,5 +112,120 @@ func TestWizzairEligibleOptions(t *testing.T) {
 	}
 	if !wizzairEligibleOptions(SearchOptions{Airlines: []string{"W6"}}) {
 		t.Error("W6 airline filter should be eligible")
+	}
+}
+
+// TestSearchWizzair_404_VersionRotated proves the version-rotation 404 surfaces
+// the typed sentinel (errors.Is) rather than crashing or returning a generic
+// failure. The aggregate uses this to render an actionable status.
+func TestSearchWizzair_404_VersionRotated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	origHost, origVer := wizzHost, wizzVersion
+	wizzHost = srv.URL
+	wizzVersion = "10.1.0"
+	defer func() { wizzHost, wizzVersion = origHost, origVer }()
+	t.Setenv("WIZZAIR_API_VERSION", "")
+
+	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	if err == nil {
+		t.Fatal("want error on 404, got nil")
+	}
+	if !errors.Is(err, ErrWizzVersionRotated) {
+		t.Fatalf("error = %v, want errors.Is ErrWizzVersionRotated", err)
+	}
+	if out != nil {
+		t.Errorf("want nil results on failure, got %d", len(out))
+	}
+	// The tried version must appear in the message (honest, no fabricated current).
+	if !strings.Contains(err.Error(), "10.1.0") {
+		t.Errorf("error %q should name the tried version 10.1.0", err)
+	}
+}
+
+// TestWizzairFailureStatus_TypedActionable asserts the helper turns a rotation
+// error into an actionable ProviderStatus with the typed FixHintCode and a hint
+// naming the env override and last-known-good version. Pure / offline.
+func TestWizzairFailureStatus_TypedActionable(t *testing.T) {
+	orig := wizzVersion
+	wizzVersion = "10.1.0"
+	defer func() { wizzVersion = orig }()
+	t.Setenv("WIZZAIR_API_VERSION", "")
+
+	rotated := fmt.Errorf("wizzair: tried API version %q: %w", "10.1.0", ErrWizzVersionRotated)
+	st := wizzairFailureStatus(rotated)
+
+	if st.ID != "wizzair" || st.Name != "Wizz Air" {
+		t.Errorf("bad identity: %+v", st)
+	}
+	if st.Status == "ok" || st.Status == "" {
+		t.Errorf("status = %q, want a failure status", st.Status)
+	}
+	if st.FixHintCode != "WIZZ_VERSION_ROTATED" {
+		t.Errorf("fix_hint_code = %q, want WIZZ_VERSION_ROTATED", st.FixHintCode)
+	}
+	if !strings.Contains(st.FixHint, "WIZZAIR_API_VERSION") {
+		t.Errorf("fix_hint %q should name WIZZAIR_API_VERSION", st.FixHint)
+	}
+	if !strings.Contains(st.FixHint, "10.1.0") {
+		t.Errorf("fix_hint %q should name last-known-good 10.1.0", st.FixHint)
+	}
+	if st.Error == "" {
+		t.Error("error message should be populated")
+	}
+}
+
+// TestWizzairFailureStatus_GenericError checks a non-rotation error gets no
+// version-rotation fix hint (no false actionability).
+func TestWizzairFailureStatus_GenericError(t *testing.T) {
+	st := wizzairFailureStatus(errors.New("wizzair: decode: boom"))
+	if st.FixHintCode != "" {
+		t.Errorf("fix_hint_code = %q, want empty for generic error", st.FixHintCode)
+	}
+	if st.FixHint != "" {
+		t.Errorf("fix_hint = %q, want empty for generic error", st.FixHint)
+	}
+}
+
+// TestSearchWizzair_EnvOverrideRestores proves the WIZZAIR_API_VERSION override
+// is the working manual fix: the server 404s every path EXCEPT the override
+// version, and the search succeeds only because the override is honored on the
+// request path. This is the deterministic proof that the override restores the
+// provider after a rotation.
+func TestSearchWizzair_EnvOverrideRestores(t *testing.T) {
+	const goodVersion = "27.5.0"
+	fixture := loadFixture(t, "wizzair_timetable.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/"+goodVersion+"/") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer srv.Close()
+
+	origHost, origVer := wizzHost, wizzVersion
+	wizzHost = srv.URL
+	wizzVersion = "10.1.0" // stale default would 404
+	defer func() { wizzHost, wizzVersion = origHost, origVer }()
+
+	// Without the override: stale default 404s -> rotation sentinel.
+	t.Setenv("WIZZAIR_API_VERSION", "")
+	if _, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1}); !errors.Is(err, ErrWizzVersionRotated) {
+		t.Fatalf("stale default: err = %v, want ErrWizzVersionRotated", err)
+	}
+
+	// With the override: request path carries the good version -> results.
+	t.Setenv("WIZZAIR_API_VERSION", goodVersion)
+	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	if err != nil {
+		t.Fatalf("override should restore provider, got err: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 result after override, got %d", len(out))
 	}
 }


### PR DESCRIPTION
Closes #115. Wizz's API version path rotates periodically; the hard-coded version then 404s. Auto-discovery is not cleanly possible (the current version is JS-gated and a headless-browser dependency is out of scope for a single static binary), so this implements honest graceful degradation instead of a guessed discovery mechanism: a 404 now wraps a typed ErrWizzVersionRotated sentinel and produces a ProviderStatus with FixHintCode WIZZ_VERSION_ROTATED naming the WIZZAIR_API_VERSION override and last-known-good version. The aggregate flight search continues and returns other providers. WIZZAIR_API_VERSION remains the authoritative manual fix. Verified live: the probe confirms Wizz is currently rotated and trvl now returns the actionable status rather than failing. DoD green (build, vet, staticcheck, race suite); 5 tests incl a probe.