### PR TITLE
feat(flights): easyJet opt-in adapter; confirm Ryanair and Wizz already surface (MIK-4963)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ trvl is a travel MCP server + CLI that gives any AI assistant (Claude, Cursor, W
 
 - Go 1.26.4 · MCP 2025-11-25 · single binary · 22 transport providers (+ flight & hotel sources below)
 - Hotel providers working: Google Hotels, Booking.com (browser cookies), Airbnb (SSR/Niobe), Hostelworld (autocomplete), Trivago (Streamable HTTP MCP), HomeToGo (public SSR+JSON, vacation rentals)
-- Flight providers: Google Flights (hand-rolled protobuf), Kiwi, Skiplagged (hidden-city, opt-in), Ryanair (public API), Wizz Air (public unauthenticated), Air France–KLM Offers API v3 (opt-in), Transavia (official API, opt-in). Travelpayouts/Aviasales price signals are an opt-in source surfaced via `trvl pricetrends` (not in the bookable merge).
+- Flight providers: Google Flights (hand-rolled protobuf), Kiwi, Skiplagged (hidden-city, opt-in), Ryanair (public API), Wizz Air (public unauthenticated), Air France–KLM Offers API v3 (opt-in), Transavia (official API, opt-in), easyJet (opt-in, `EASYJET_API_BASE` — public availability API is Akamai bot-defended/403, so no default-on path; honest typed `AKAMAI_BLOCK` status when unconfigured). Travelpayouts/Aviasales price signals are an opt-in source surfaced via `trvl pricetrends` (not in the bookable merge).
 - Enrichment (free, unauthenticated): weather (Open-Meteo), air quality (`trvl air`), sun times (`trvl sun`, sunrise-sunset.org), bike-share (`trvl bikes`, CityBikes)
 - CI: build, vet, staticcheck, govulncheck, race tests, coverage ≥50% on ubuntu + windows
 - Latest release train: tag-triggered workflow + adhoc codesign identifier (PR #50)

--- a/internal/flights/easyjet.go
+++ b/internal/flights/easyjet.go
@@ -1,0 +1,255 @@
+package flights
+
+// easyJet flight provider (opt-in, endpoint-gated).
+//
+// easyJet (U2) is, like Ryanair and Wizz Air, an ultra-LCC that sells almost
+// exclusively through its own channel and is omitted from Google Flights / GDS
+// aggregation — so a meta-search misses its frequently-cheapest fares entirely.
+//
+// UNLIKE Ryanair (public Fare Finder JSON) and Wizz Air (public unauthenticated
+// timetable JSON), easyJet's availability endpoint
+//
+//	GET https://www.easyjet.com/ejavailability/api/v75/availability/query?...
+//
+// is fronted by Akamai bot defence and returns HTTP 403 (text/html challenge)
+// for any plain programmatic client — verified 2026-06-08 against AMS→BCN. There
+// is NO clean public unauthenticated JSON endpoint reachable from a static Go
+// binary without a headless/bot-evasion layer.
+//
+// Per the locked repo decisions (no browser/headless deps; honest typed status
+// over fabricated data; "API-first with optional opt-ins") we do NOT ship a
+// fragile scraper that races Akamai. Instead this provider mirrors the Transavia
+// / AFKLM opt-in pattern: it is a no-op skip unless the operator supplies a
+// reachable availability base URL via EASYJET_API_BASE (e.g. an authorised
+// partner endpoint or a self-hosted reverse proxy that handles the bot
+// challenge). When configured it maps an ASSUMED availability JSON shape to
+// canonical FlightResults tagged provider "easyjet" with carrier code "U2".
+//
+// SCHEMA NOT VERIFIED: the public endpoint is Akamai-blocked, so this parser is
+// written against a representative/assumed shape, NOT confirmed against a live
+// response. The field tags below may need adjustment once an operator supplies a
+// reachable endpoint; the parser is intentionally tolerant (two price encodings).
+//
+// When UNconfigured, searchFlightsCore surfaces an honest "skipped /
+// not_configured" ProviderStatus carrying the AKAMAI_BLOCK root cause and a fix
+// hint — never a crash, never a fabricated empty "no easyJet flights" result.
+//
+// Tracking: MIK-4963.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"golang.org/x/time/rate"
+)
+
+// easyjetDefaultHost is the canonical easyJet host used to build human booking
+// deep links. Its availability API is Akamai bot-defended (403 for plain
+// clients), so it is never queried for fares by default — the operator must
+// point EASYJET_API_BASE at a reachable endpoint for the fare-search path.
+const easyjetDefaultHost = "https" + "://" + "www.easyjet.com"
+
+var (
+	easyjetLimiter = rate.NewLimiter(rate.Every(500*time.Millisecond), 1)
+	easyjetClient  = &http.Client{Timeout: 25 * time.Second}
+)
+
+// easyjetAPIBase returns the operator-supplied easyJet availability base URL, or
+// "". When empty the provider is a no-op (honest skip), because the public
+// endpoint is Akamai-blocked for static clients.
+func easyjetAPIBase() string {
+	return strings.TrimSpace(os.Getenv("EASYJET_API_BASE"))
+}
+
+// easyjetConfigured reports whether an operator has opted in by supplying a
+// reachable availability base URL. Mirrors transaviaConfigured().
+func easyjetConfigured() bool {
+	return easyjetAPIBase() != ""
+}
+
+// easyjetFare is the lead-in price of an availability slice.
+type easyjetFare struct {
+	Amount   float64 `json:"amount"`
+	Currency string  `json:"currencyCode"`
+}
+
+// easyjetFlight is a single bookable flight in the availability response. The
+// shape is an ASSUMED/representative easyJet ejavailability payload — NOT
+// verified against the live API (the endpoint is Akamai-blocked). The parser is
+// intentionally tolerant of the two common price encodings.
+type easyjetFlight struct {
+	FlightNumber  string      `json:"flightNumber"`
+	DepartureIata string      `json:"departureAirport"`
+	ArrivalIata   string      `json:"arrivalAirport"`
+	Departure     string      `json:"departureDateTime"`
+	Arrival       string      `json:"arrivalDateTime"`
+	Fare          easyjetFare `json:"fare"`
+	LowestFare    float64     `json:"lowestFare"`
+	Currency      string      `json:"currencyCode"`
+}
+
+type easyjetAvailabilityResponse struct {
+	Flights []easyjetFlight `json:"flights"`
+}
+
+// SearchEasyjet queries an operator-configured easyJet availability endpoint for
+// one-way fares on the given route and date, returning canonical FlightResults
+// tagged provider "easyjet". It is a no-op (returns nil, nil) when no base URL is
+// configured, mirroring the Transavia opt-in pattern — the public easyJet
+// endpoint is Akamai bot-defended and unreachable from a static client.
+func SearchEasyjet(ctx context.Context, origin, destination, date, currency string, opts SearchOptions) ([]models.FlightResult, error) {
+	base := easyjetAPIBase()
+	if base == "" {
+		return nil, nil
+	}
+	if currency == "" {
+		currency = "EUR"
+	}
+	if err := easyjetLimiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("DepartureIata", strings.ToUpper(origin))
+	q.Set("ArrivalIata", strings.ToUpper(destination))
+	q.Set("DepartureDateFrom", date)
+	q.Set("DepartureDateTo", date)
+	q.Set("Currency", currency)
+	q.Set("NumberOfAdults", fmt.Sprintf("%d", max(opts.Adults, 1)))
+	reqURL := strings.TrimRight(base, "/") + "/ejavailability/api/v75/availability/query?" + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("easyjet: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "trvl/1.0")
+
+	resp, err := easyjetClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("easyjet: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+		// The default public host is Akamai-defended; a 403 here means the
+		// configured base is still serving a bot challenge, not real JSON.
+		return nil, fmt.Errorf("easyjet: blocked (status %d) — EASYJET_API_BASE must reach the JSON availability API, not the Akamai-defended public site", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("easyjet: unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, fmt.Errorf("easyjet: read body: %w", err)
+	}
+
+	var parsed easyjetAvailabilityResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("easyjet: decode: %w", err)
+	}
+
+	results := make([]models.FlightResult, 0, len(parsed.Flights))
+	for _, f := range parsed.Flights {
+		if mapped, ok := mapEasyjetFlight(f, date, currency); ok {
+			results = append(results, mapped)
+		}
+	}
+	return results, nil
+}
+
+// easyjetTimeLayout is the local datetime easyJet returns (no zone).
+const easyjetTimeLayout = "2006-01-02T15:04:05"
+
+// mapEasyjetFlight converts a single availability flight to a FlightResult,
+// keeping only flights whose local departure day matches wantDate. Returns
+// ok=false for off-date flights or zero-priced placeholders.
+func mapEasyjetFlight(f easyjetFlight, wantDate, fallbackCurrency string) (models.FlightResult, bool) {
+	if wantDate != "" && !strings.HasPrefix(f.Departure, wantDate) {
+		return models.FlightResult{}, false
+	}
+	price, cur := easyjetPrice(f, fallbackCurrency)
+	if price <= 0 {
+		return models.FlightResult{}, false
+	}
+	flightNo := strings.TrimSpace(f.FlightNumber)
+	if flightNo != "" && !strings.HasPrefix(strings.ToUpper(flightNo), "U2") {
+		flightNo = "U2" + flightNo
+	}
+	leg := models.FlightLeg{
+		DepartureAirport: models.AirportInfo{Code: strings.ToUpper(f.DepartureIata)},
+		ArrivalAirport:   models.AirportInfo{Code: strings.ToUpper(f.ArrivalIata)},
+		DepartureTime:    easyjetDisplayTime(f.Departure),
+		ArrivalTime:      easyjetDisplayTime(f.Arrival),
+		Duration:         easyjetDuration(f.Departure, f.Arrival),
+		Airline:          "easyJet",
+		AirlineCode:      "U2",
+		FlightNumber:     flightNo,
+	}
+	return models.FlightResult{
+		Price:      price,
+		Currency:   cur,
+		Duration:   leg.Duration,
+		Stops:      0,
+		Provider:   "easyjet",
+		Legs:       []models.FlightLeg{leg},
+		BookingURL: easyjetBookingURL(f.DepartureIata, f.ArrivalIata, f.Departure),
+	}, true
+}
+
+func easyjetPrice(f easyjetFlight, fallbackCurrency string) (float64, string) {
+	if f.Fare.Amount > 0 {
+		return f.Fare.Amount, firstNonEmpty(f.Fare.Currency, fallbackCurrency)
+	}
+	return f.LowestFare, firstNonEmpty(f.Currency, fallbackCurrency)
+}
+
+func easyjetDisplayTime(s string) string {
+	if t, err := time.Parse(easyjetTimeLayout, s); err == nil {
+		return t.Format(flightTimeLayout)
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.Format(flightTimeLayout)
+	}
+	return s
+}
+
+func easyjetDuration(dep, arr string) int {
+	dt, derr := easyjetParse(dep)
+	at, aerr := easyjetParse(arr)
+	if derr != nil || aerr != nil {
+		return 0
+	}
+	mins := int(at.Sub(dt).Minutes())
+	if mins < 0 {
+		return 0
+	}
+	return mins
+}
+
+func easyjetParse(s string) (time.Time, error) {
+	if t, err := time.Parse(easyjetTimeLayout, s); err == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC3339, s)
+}
+
+func easyjetBookingURL(origin, destination, departure string) string {
+	day := departure
+	if t, err := easyjetParse(departure); err == nil {
+		day = t.Format("2006-01-02")
+	}
+	q := url.Values{}
+	q.Set("origin", strings.ToUpper(origin))
+	q.Set("destination", strings.ToUpper(destination))
+	q.Set("dateofdeparture", day)
+	q.Set("adults", "1")
+	return easyjetDefaultHost + "/en/buy/flights?" + q.Encode()
+}

--- a/internal/flights/easyjet_probe_test.go
+++ b/internal/flights/easyjet_probe_test.go
@@ -1,0 +1,44 @@
+package flights
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestSearchEasyjet_LiveProbe documents the empirically-verified Akamai block on
+// easyJet's public availability endpoint. It is opt-in (TRVL_TEST_LIVE_PROBES=1)
+// and EASYJET_API_BASE-gated: it never runs in the default offline suite.
+//
+// Run it ONLY when an operator has configured a reachable endpoint
+// (EASYJET_API_BASE) — e.g. an authorised partner endpoint or a self-hosted
+// proxy that handles the bot challenge. Against the raw public host it returns
+// HTTP 403 (text/html), which the adapter surfaces as a typed error rather than
+// a fabricated empty result.
+func TestSearchEasyjet_LiveProbe(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("live probe: set TRVL_TEST_LIVE_PROBES=1 to run")
+	}
+	if os.Getenv("EASYJET_API_BASE") == "" {
+		t.Skip("easyJet is opt-in: set EASYJET_API_BASE to a reachable availability endpoint")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	date := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
+	out, err := SearchEasyjet(ctx, "AMS", "BCN", date, "EUR", SearchOptions{Adults: 1})
+	if err != nil {
+		// A typed error (e.g. Akamai 403 on a still-blocked base) is an
+		// acceptable, honest outcome — log it rather than fail the probe.
+		t.Logf("easyJet live probe returned a typed error (expected when base is bot-defended): %v", err)
+		return
+	}
+	t.Logf("easyJet live probe returned %d flights", len(out))
+	for _, f := range out {
+		if len(f.Legs) == 0 || f.Legs[0].AirlineCode != "U2" {
+			t.Errorf("unexpected non-U2 result from easyJet: %+v", f)
+		}
+	}
+}

--- a/internal/flights/easyjet_test.go
+++ b/internal/flights/easyjet_test.go
@@ -1,0 +1,185 @@
+package flights
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/batchexec"
+)
+
+// TestSearchEasyjet_MapsFlight proves the opt-in adapter parses the documented
+// availability JSON shape into canonical FlightResults when an operator points
+// EASYJET_API_BASE at a reachable endpoint. Date-scoping drops the off-date
+// flight; both price encodings (fare.amount and lowestFare) are handled.
+func TestSearchEasyjet_MapsFlight(t *testing.T) {
+	fixture := loadFixture(t, "easyjet_availability.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if got := r.URL.Query().Get("DepartureIata"); got != "AMS" {
+			t.Errorf("DepartureIata = %q, want AMS", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer srv.Close()
+
+	t.Setenv("EASYJET_API_BASE", srv.URL)
+
+	out, err := SearchEasyjet(context.Background(), "AMS", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	if err != nil {
+		t.Fatalf("SearchEasyjet error: %v", err)
+	}
+	// Two 2026-07-07 flights match; the 07-08 flight is date-scoped out.
+	if len(out) != 2 {
+		t.Fatalf("want 2 date-scoped results, got %d", len(out))
+	}
+
+	first := out[0]
+	if first.Provider != "easyjet" || first.Currency != "EUR" || first.Stops != 0 {
+		t.Errorf("bad first result: %+v", first)
+	}
+	if first.Price != 38.99 {
+		t.Errorf("first price = %v, want 38.99", first.Price)
+	}
+	if len(first.Legs) != 1 {
+		t.Fatalf("want 1 leg, got %d", len(first.Legs))
+	}
+	leg := first.Legs[0]
+	if leg.AirlineCode != "U2" || leg.Airline != "easyJet" {
+		t.Errorf("bad leg airline: %+v", leg)
+	}
+	// Bare numeric flight number is prefixed with the U2 carrier code.
+	if leg.FlightNumber != "U28431" {
+		t.Errorf("flight number = %q, want U28431", leg.FlightNumber)
+	}
+	if leg.DepartureAirport.Code != "AMS" || leg.ArrivalAirport.Code != "BCN" {
+		t.Errorf("bad leg airports: %+v", leg)
+	}
+	if leg.DepartureTime != "2026-07-07T06:40" {
+		t.Errorf("departure time = %q, want 2026-07-07T06:40", leg.DepartureTime)
+	}
+	if leg.Duration != 135 {
+		t.Errorf("duration = %d, want 135", leg.Duration)
+	}
+	if first.BookingURL == "" {
+		t.Error("booking URL not set")
+	}
+
+	// Second flight uses the lowestFare encoding and an already-prefixed number.
+	second := out[1]
+	if second.Price != 52.49 {
+		t.Errorf("second price = %v, want 52.49 (lowestFare encoding)", second.Price)
+	}
+	if second.Legs[0].FlightNumber != "U28433" {
+		t.Errorf("second flight number = %q, want U28433 (already-prefixed, not doubled)", second.Legs[0].FlightNumber)
+	}
+}
+
+// TestSearchEasyjet_NoopWhenUnconfigured proves the adapter is a silent no-op
+// (nil, nil) when no opt-in endpoint is configured — never a crash, never a
+// fabricated empty result. This is the honest default given the Akamai block.
+func TestSearchEasyjet_NoopWhenUnconfigured(t *testing.T) {
+	t.Setenv("EASYJET_API_BASE", "")
+	out, err := SearchEasyjet(context.Background(), "AMS", "BCN", "2026-07-07", "EUR", SearchOptions{})
+	if err != nil {
+		t.Fatalf("unconfigured easyJet should be a no-op, got error: %v", err)
+	}
+	if out != nil {
+		t.Errorf("unconfigured easyJet should return nil results, got %d", len(out))
+	}
+}
+
+// TestSearchEasyjet_ForbiddenIsTypedError proves a 403 (Akamai challenge served
+// to a configured-but-still-blocked base) yields an honest typed error, not a
+// silent empty — the AKAMAI_BLOCK reality surfaced as a failure, never a lie.
+func TestSearchEasyjet_ForbiddenIsTypedError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("<html>Access Denied</html>"))
+	}))
+	defer srv.Close()
+	t.Setenv("EASYJET_API_BASE", srv.URL)
+
+	_, err := SearchEasyjet(context.Background(), "AMS", "BCN", "2026-07-07", "EUR", SearchOptions{})
+	if err == nil {
+		t.Fatal("403 from easyJet should surface a typed error, got nil")
+	}
+}
+
+func TestEasyjetEligibleOptions(t *testing.T) {
+	if !easyjetEligibleOptions(SearchOptions{}) {
+		t.Error("plain one-way economy should be eligible")
+	}
+	if easyjetEligibleOptions(SearchOptions{ReturnDate: "2026-07-10"}) {
+		t.Error("round-trip should be ineligible")
+	}
+	if easyjetEligibleOptions(SearchOptions{Alliances: []string{"STAR_ALLIANCE"}}) {
+		t.Error("alliance filter should be ineligible (easyJet non-aligned)")
+	}
+	if easyjetEligibleOptions(SearchOptions{Airlines: []string{"BA"}}) {
+		t.Error("non-U2 airline filter should be ineligible")
+	}
+	if !easyjetEligibleOptions(SearchOptions{Airlines: []string{"U2"}}) {
+		t.Error("U2 airline filter should be eligible")
+	}
+}
+
+func TestEasyjetSearchEligible_RequiresSharedClientAndConfig(t *testing.T) {
+	// Injected (non-shared) client: never eligible, regardless of config.
+	injected := batchexec.NewTestClient("http" + "://" + "127.0.0.1:0")
+	t.Setenv("EASYJET_API_BASE", "http"+"://"+"example.invalid")
+	if easyjetSearchEligible(injected, SearchOptions{}) {
+		t.Error("injected client must never be eligible (shared-client guard)")
+	}
+
+	// Shared client but unconfigured: opt-in gate keeps it skipped.
+	t.Setenv("EASYJET_API_BASE", "")
+	if easyjetSearchEligible(batchexec.SharedClient(), SearchOptions{}) {
+		t.Error("unconfigured easyJet must be ineligible even on the shared client")
+	}
+}
+
+// TestSearchFlightsCore_EasyjetHonestStatusWhenUnconfigured is the surfacing
+// proof: a default-merge search (injected Google client, so the LCC providers
+// auto-skip) still emits an HONEST typed easyJet ProviderStatus carrying the
+// AKAMAI_BLOCK root cause and a fix hint — never a fabricated empty result and
+// never a crash. This is the Case-C deliverable: the opt-in path is wired and
+// reports its unavailability truthfully.
+func TestSearchFlightsCore_EasyjetHonestStatusWhenUnconfigured(t *testing.T) {
+	t.Setenv("EASYJET_API_BASE", "")
+	body := makeFlightResponseBody(t)
+	ts := flightsTestServer(t, 200, body)
+	defer ts.Close()
+
+	client := batchexec.NewTestClient(ts.URL)
+	result, err := SearchFlightsWithClient(t.Context(), client, "AMS", "BCN", "2026-07-07", SearchOptions{})
+	if err != nil {
+		t.Fatalf("search error: %v", err)
+	}
+
+	var ej *struct {
+		status, code, fixHint string
+	}
+	for _, s := range result.ProviderStatuses {
+		if s.ID == "easyjet" {
+			ej = &struct{ status, code, fixHint string }{s.Status, s.FixHintCode, s.FixHint}
+			break
+		}
+	}
+	if ej == nil {
+		t.Fatal("easyJet provider status not present in default merge — opt-in path not wired")
+	}
+	if ej.status != "skipped" {
+		t.Errorf("easyJet status = %q, want skipped (honest opt-in skip)", ej.status)
+	}
+	if ej.code != "AKAMAI_BLOCK" {
+		t.Errorf("easyJet fix_hint_code = %q, want AKAMAI_BLOCK", ej.code)
+	}
+	if ej.fixHint == "" {
+		t.Error("easyJet skip must carry an actionable fix hint (set EASYJET_API_BASE)")
+	}
+}

--- a/internal/flights/results.go
+++ b/internal/flights/results.go
@@ -450,6 +450,49 @@ func transaviaEligibleOptions(opts SearchOptions) bool {
 	return true
 }
 
+// easyjetSearchEligible gates the easyJet provider. Like Transavia it is opt-in:
+// the public availability API is Akamai bot-defended (HTTP 403), so it only
+// fires when the operator supplies a reachable endpoint via EASYJET_API_BASE.
+// The shared-client guard keeps it out of injected-client unit tests.
+func easyjetSearchEligible(client *batchexec.Client, opts SearchOptions) bool {
+	if client == nil || client != batchexec.SharedClient() {
+		return false
+	}
+	if !easyjetConfigured() {
+		return false
+	}
+	return easyjetEligibleOptions(opts)
+}
+
+// easyjetEligibleOptions reports whether a search can be served by easyJet's
+// availability endpoint. easyJet is non-aligned and the availability search here
+// is one-way nonstop economy; round-trip / non-economy / alliance filters skip
+// it. An airline filter, if present, must include easyJet (U2).
+func easyjetEligibleOptions(opts SearchOptions) bool {
+	if opts.ReturnDate != "" {
+		return false
+	}
+	if len(opts.Alliances) > 0 {
+		return false
+	}
+	if opts.CabinClass != 0 && opts.CabinClass != models.Economy {
+		return false
+	}
+	if len(opts.Airlines) > 0 {
+		ok := false
+		for _, a := range opts.Airlines {
+			if strings.EqualFold(strings.TrimSpace(a), "U2") {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // okOrNoHit returns StatusCheckedNoHit when a provider succeeded but returned
 // zero results (a definitive "checked, found nothing"), else StatusOK.
 // Distinguishing this from a failure/timeout is the evidence-envelope contract.

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -354,6 +354,51 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 		})
 	}
 
+	// easyJet direct (availability API) is opt-in: the public endpoint is Akamai
+	// bot-defended (HTTP 403), so it only fires when the operator supplies a
+	// reachable base URL via EASYJET_API_BASE. Mirrors the Transavia opt-in
+	// pattern; honest typed status when unavailable (never a fabricated empty).
+	var easyjetFlights []models.FlightResult
+	var easyjetErr error
+	easyjetSucceeded := false
+	if easyjetSearchEligible(client, opts) {
+		easyjetFlights, easyjetErr = SearchEasyjet(ctx, origin, destination, date, currency, opts)
+		if easyjetErr != nil {
+			slog.Warn("easyjet flight search failed", "origin", origin, "destination", destination, "date", date, "error", easyjetErr)
+			statuses = append(statuses, models.ProviderStatus{
+				ID:     "easyjet",
+				Name:   "easyJet",
+				Status: models.ClassifyProviderError(easyjetErr),
+				Error:  easyjetErr.Error(),
+			})
+		} else {
+			easyjetSucceeded = true
+			statuses = append(statuses, models.ProviderStatus{
+				ID:      "easyjet",
+				Name:    "easyJet",
+				Status:  okOrNoHit(len(easyjetFlights)),
+				Results: len(easyjetFlights),
+			})
+		}
+	} else {
+		fixHint := "search one-way economy; drop the alliance/airline filter"
+		reason := "options not supported by easyJet direct (round-trip / non-economy cabin / alliance filter / non-U2 airline filter)"
+		fixHintCode := ""
+		if !easyjetConfigured() {
+			reason = "easyJet's public availability API is Akamai bot-defended (HTTP 403); it is opt-in and requires a reachable endpoint"
+			fixHint = "set EASYJET_API_BASE to an authorised partner endpoint or a self-hosted proxy that returns the JSON availability API"
+			fixHintCode = "AKAMAI_BLOCK"
+		}
+		statuses = append(statuses, models.ProviderStatus{
+			ID:          "easyjet",
+			Name:        "easyJet",
+			Status:      "skipped",
+			Error:       reason,
+			FixHint:     fixHint,
+			FixHintCode: fixHintCode,
+		})
+	}
+
 	// Normalize all provider prices to the session currency so resolution and
 	// ranking compare like with like (Skiplagged returns USD, Kiwi its own).
 	// Best-effort and offline-safe: same-currency conversions never hit the net.
@@ -367,9 +412,10 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	normalizeFlightCurrencies(ctx, ryanairFlights, target, destinations.ConvertCurrency)
 	normalizeFlightCurrencies(ctx, wizzairFlights, target, destinations.ConvertCurrency)
 	normalizeFlightCurrencies(ctx, transaviaFlights, target, destinations.ConvertCurrency)
+	normalizeFlightCurrencies(ctx, easyjetFlights, target, destinations.ConvertCurrency)
 
-	mergedFlights := mergeFlightResults(googleFlights, kiwiFlights, skiplaggedFlights, opts, ryanairFlights, wizzairFlights, transaviaFlights)
-	if googleSucceeded || kiwiSucceeded || skiplaggedSucceeded || ryanairSucceeded || wizzairSucceeded || transaviaSucceeded {
+	mergedFlights := mergeFlightResults(googleFlights, kiwiFlights, skiplaggedFlights, opts, ryanairFlights, wizzairFlights, transaviaFlights, easyjetFlights)
+	if googleSucceeded || kiwiSucceeded || skiplaggedSucceeded || ryanairSucceeded || wizzairSucceeded || transaviaSucceeded || easyjetSucceeded {
 		return &models.FlightSearchResult{
 			Success:          true,
 			Count:            len(mergedFlights),
@@ -398,6 +444,9 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	}
 	if transaviaErr != nil {
 		errs = append(errs, transaviaErr)
+	}
+	if easyjetErr != nil {
+		errs = append(errs, easyjetErr)
 	}
 	if len(errs) > 0 {
 		err := errors.Join(errs...)

--- a/internal/flights/testdata/easyjet_availability.json
+++ b/internal/flights/testdata/easyjet_availability.json
@@ -1,0 +1,29 @@
+{
+  "flights": [
+    {
+      "flightNumber": "8431",
+      "departureAirport": "AMS",
+      "arrivalAirport": "BCN",
+      "departureDateTime": "2026-07-07T06:40:00",
+      "arrivalDateTime": "2026-07-07T08:55:00",
+      "fare": { "amount": 38.99, "currencyCode": "EUR" }
+    },
+    {
+      "flightNumber": "U28433",
+      "departureAirport": "AMS",
+      "arrivalAirport": "BCN",
+      "departureDateTime": "2026-07-07T19:10:00",
+      "arrivalDateTime": "2026-07-07T21:25:00",
+      "lowestFare": 52.49,
+      "currencyCode": "EUR"
+    },
+    {
+      "flightNumber": "8435",
+      "departureAirport": "AMS",
+      "arrivalAirport": "BCN",
+      "departureDateTime": "2026-07-08T06:40:00",
+      "arrivalDateTime": "2026-07-08T08:55:00",
+      "fare": { "amount": 41.99, "currencyCode": "EUR" }
+    }
+  ]
+}


### PR DESCRIPTION
MIK-4963. Investigation finding: Ryanair (FR) and Wizz (W6) are ALREADY in the default flight merge (searchFlightsCore fans out to both; MIK-4962 all-in bag pricing applies). The reported zero-results was a route fact (Ryanair flies EIN and CRL, not AMS), not a wiring bug. The genuine gap was easyJet (U2), which had no adapter. easyJet's public availability API is Akamai bot-defended (403), so per the no-scraper single-binary principle this adds an OPT-IN adapter (activates only when EASYJET_API_BASE is set) that returns an honest typed AKAMAI_BLOCK ProviderStatus when unconfigured, never a fabricated result, never a crash. The parser is labeled unverified-against-live (no overclaim). U2 bag fees already flow through the MIK-4962 baggage table. Rebased onto current main (keeps the #115 Wizz fix); DoD green (build, vet, staticcheck, race suite).