### PR TITLE
feat(mcp): OAuth 2.1 resource-server remote-bind safety + scope audit (#89) [SECURITY REVIEW]

### DIFF
--- a/cmd/trvl/mcp.go
+++ b/cmd/trvl/mcp.go
@@ -33,7 +33,11 @@ requires bearer-token authentication, using --token, TRVL_MCP_TOKEN, or a
 random token generated at startup. Remote deployments can use scoped
 read/write bearer tokens or OAuth 2.1 access-token introspection; trvl acts as
 the MCP resource server and expects the OAuth provider or gateway to handle
-Authorization Code + PKCE.`,
+Authorization Code + PKCE.
+
+For safety, binding to a non-loopback host (e.g. --host 0.0.0.0) without any
+token or OAuth introspection configured is refused: remote exposure requires
+explicit authentication. See docs/REMOTE-MCP-OAUTH.md.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if httpMode {
 				return mcp.RunHTTPWithOptions(mcp.HTTPServerOptions{

--- a/docs/REMOTE-MCP-OAUTH.md
+++ b/docs/REMOTE-MCP-OAUTH.md
@@ -94,8 +94,11 @@ Environment variables: `TRVL_MCP_OAUTH_INTROSPECTION_URL`,
 `TRVL_MCP_OAUTH_CLIENT_ID`, `TRVL_MCP_OAUTH_CLIENT_SECRET`,
 `TRVL_MCP_OAUTH_AUDIENCE`.
 
-Set `--oauth-audience` to the resource identifier you registered for trvl so a
-token minted for a different service is rejected.
+**Required for production.** Set `--oauth-audience` to the resource identifier
+you registered for trvl so a token minted for a different service at the same
+IdP is rejected (confused-deputy protection, RFC 7662 §2.2). Without it, trvl
+accepts any active token from the introspection endpoint and logs a startup
+warning.
 
 ### Client-side flow: Authorization Code + PKCE
 
@@ -153,7 +156,7 @@ for per-decision detail.
 
 - Keep the default loopback bind unless you genuinely need remote access.
 - Never expose a remote host without auth; trvl refuses this by design.
-- Prefer OAuth introspection with a pinned `--oauth-audience` over static tokens
+- Use OAuth introspection with a pinned `--oauth-audience` (required for production) over static tokens
   for multi-user deployments.
 - Hand out `trvl:read` by default; grant `trvl:write` only to clients that must
   mutate `~/.trvl` state.

--- a/docs/REMOTE-MCP-OAUTH.md
+++ b/docs/REMOTE-MCP-OAUTH.md
@@ -1,0 +1,160 @@
+# Remote MCP mode with OAuth 2.1 (resource-server)
+
+trvl ships as a local stdio MCP server by default, which keeps your travel
+profile, price watches, and trip state on your own machine. This document
+explains the optional **remote HTTP mode** and how to put it behind an OAuth
+2.1 gateway so a hosted client can reach it safely.
+
+trvl is an OAuth **resource server** only. It validates access tokens issued by
+an external identity provider (IdP)/gateway. trvl does not run a login page, a
+consent screen, user management, nor a token endpoint. Pair it with an IdP you
+already trust (Auth0, Okta, Keycloak, Google, an API gateway, a reverse proxy
+that injects tokens).
+
+## Localhost-safe defaults
+
+Running `trvl mcp --http` binds to `127.0.0.1:8080` and requires a bearer
+token. If you do not supply one, trvl generates a random token at startup and
+prints it to the log. Nothing is reachable from another machine because the
+listener is loopback-only.
+
+```bash
+trvl mcp --http                   # 127.0.0.1:8080, random token printed at startup
+trvl mcp --http --token hunter2   # 127.0.0.1:8080, fixed token
+```
+
+## Remote exposure requires explicit auth (GH-89.AUTH.4)
+
+Binding to a non-loopback host (for example `--host 0.0.0.0`, a public IP, a
+DNS name) **without** any token/OAuth introspection configured is refused. trvl
+will not start:
+
+```
+$ trvl mcp --http --host 0.0.0.0
+refusing to start: --host "0.0.0.0" exposes the MCP server beyond localhost but
+no authentication is configured; set --token/--read-token/--write-token (or
+TRVL_MCP_TOKEN), or --oauth-introspection-url, before binding to a non-loopback host
+```
+
+This is deliberate. A remote listener with an auto-generated token printed to a
+log is weak, so trvl forces you to make the auth decision explicitly before it
+will accept connections from the network.
+
+## Scope model: read vs write
+
+trvl enforces two scopes:
+
+| Scope        | Grants                                                              |
+|--------------|--------------------------------------------------------------------|
+| `trvl:read`  | Read-only tools: search flights/hotels/ground, weather, baggage, lounges, view preferences and trips. |
+| `trvl:write` | Everything `trvl:read` grants, plus state-mutating tools that write `~/.trvl`: `update_preferences`, `watch_price`, trip-workspace mutations. |
+
+Every MCP tool is annotated read-only/read-write. A request that carries only
+`trvl:read` and calls a write tool is denied with a JSON-RPC error (`-32001`,
+"permission denied: tool X requires trvl:write scope") before the tool runs. A
+request with no valid token is rejected with HTTP `401` before any JSON-RPC
+handling.
+
+When trvl introspects an OAuth token, it accepts these scope spellings and maps
+them onto its two scopes: `trvl:read`/`trvl:write`, `read`/`write`,
+`mcp:read`/`mcp:write`, `travel:read`/`travel:write`.
+
+## Option A: static scoped bearer tokens
+
+The simplest pluggable verifier. Issue two long random secrets and hand the
+read one to read-only clients, the write one to trusted clients.
+
+```bash
+trvl mcp --http \
+  --host 0.0.0.0 --port 8080 \
+  --read-token  "$(openssl rand -base64 32)" \
+  --write-token "$(openssl rand -base64 32)"
+```
+
+Equivalent environment variables: `TRVL_MCP_READ_TOKEN`, `TRVL_MCP_WRITE_TOKEN`,
+`TRVL_MCP_TOKEN` (full access). Use this for a small deployment, also while
+wiring up a gateway.
+
+## Option B: OAuth 2.1 token introspection
+
+Point trvl at your IdP's RFC 7662 introspection endpoint. trvl validates each
+incoming access token against it, checks the `active`, `exp`, plus (optionally)
+`aud` claims, and reads scopes from the `scope`/`scp` claim.
+
+```bash
+trvl mcp --http \
+  --host 0.0.0.0 --port 8080 \
+  --oauth-introspection-url "https://idp.example.org/oauth/introspect" \
+  --oauth-client-id "trvl-mcp" \
+  --oauth-client-secret "$INTROSPECTION_SECRET" \
+  --oauth-audience "trvl-mcp"
+```
+
+Environment variables: `TRVL_MCP_OAUTH_INTROSPECTION_URL`,
+`TRVL_MCP_OAUTH_CLIENT_ID`, `TRVL_MCP_OAUTH_CLIENT_SECRET`,
+`TRVL_MCP_OAUTH_AUDIENCE`.
+
+Set `--oauth-audience` to the resource identifier you registered for trvl so a
+token minted for a different service is rejected.
+
+### Client-side flow: Authorization Code + PKCE
+
+trvl never sees the user's credentials. The client and IdP run the standard
+OAuth 2.1 Authorization-Code flow with PKCE, then the client presents the
+resulting access token to trvl:
+
+1. The MCP client generates a PKCE `code_verifier` plus its `code_challenge`
+   (`S256`).
+2. The client opens the IdP authorize URL with `response_type=code`,
+   `code_challenge`, `code_challenge_method=S256`, the redirect URI, the scopes
+   it needs (`trvl:read`, `trvl:write`).
+3. The user authenticates and consents at the IdP. The IdP redirects back with
+   an authorization `code`.
+4. The client exchanges the `code` plus the `code_verifier` at the IdP token
+   endpoint for an access token (optionally a refresh token).
+5. The client calls trvl: `POST /mcp` with `Authorization: Bearer <access_token>`.
+6. trvl introspects the token, enforces scope, then serves the MCP request.
+
+trvl owns only step 6. Steps 1 through 5 belong to the IdP plus the client.
+
+## Reverse-proxy / gateway pattern
+
+If you front trvl with an API gateway that already authenticates users, let the
+gateway terminate OAuth and forward an `Authorization: Bearer` header that trvl
+can introspect (Option B). Alternatively, have the gateway inject one of the
+static scoped tokens (Option A) on the internal hop. Keep trvl bound to loopback
+or a private interface that only the gateway can reach.
+
+## Auditing auth decisions
+
+trvl logs every auth decision (allow/deny, tool, scope, plus a server-side-only
+detail) as a structured log line, and exposes aggregate counts on the
+unauthenticated `/health` endpoint:
+
+```json
+{
+  "status": "ok",
+  "server": "trvl",
+  "version": "...",
+  "tools": 66,
+  "auth": {
+    "enforced": true,
+    "decisions_allowed": 128,
+    "decisions_denied": 3
+  }
+}
+```
+
+`/health` exposes counts only. It never returns subjects, tokens, scopes, nor
+denial reasons, because it is unauthenticated. Use the structured server logs
+for per-decision detail.
+
+## Security checklist
+
+- Keep the default loopback bind unless you genuinely need remote access.
+- Never expose a remote host without auth; trvl refuses this by design.
+- Prefer OAuth introspection with a pinned `--oauth-audience` over static tokens
+  for multi-user deployments.
+- Hand out `trvl:read` by default; grant `trvl:write` only to clients that must
+  mutate `~/.trvl` state.
+- Terminate TLS at a reverse proxy/load balancer in front of trvl.

--- a/mcp/http.go
+++ b/mcp/http.go
@@ -13,10 +13,21 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
 const defaultHTTPHost = "127.0.0.1"
+
+// authAudit holds aggregate counters for auth decisions surfaced on /health.
+//
+// Only aggregate counts are exposed (never subjects, tokens, or denial
+// reasons) because /health is unauthenticated. Counters are atomic so the
+// shared HTTPServer is safe under concurrent requests.
+type authAudit struct {
+	allowed atomic.Uint64
+	denied  atomic.Uint64
+}
 
 // HTTPServer wraps an MCP Server with an HTTP transport.
 type HTTPServer struct {
@@ -24,6 +35,7 @@ type HTTPServer struct {
 	host   string
 	port   int
 	auth   *HTTPAuth
+	audit  authAudit
 }
 
 // HTTPServerOptions configures the HTTP MCP transport.
@@ -96,6 +108,8 @@ func (h *HTTPServer) handleMCP(w http.ResponseWriter, r *http.Request) {
 
 	access, ok := h.authorize(r)
 	if !ok {
+		h.audit.denied.Add(1)
+		slogHTTPAuthDecision("deny", "", "", "missing or invalid bearer token")
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
@@ -127,7 +141,8 @@ func (h *HTTPServer) handleMCP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if errResp := h.authorizeJSONRPC(&req, access); errResp != nil {
-		slogHTTPAuthDenied(req.Method, errResp.Message)
+		h.audit.denied.Add(1)
+		slogHTTPAuthDecision("deny", req.Method, scopeSummary(access), errResp.Message)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(Response{
@@ -137,6 +152,9 @@ func (h *HTTPServer) handleMCP(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+
+	h.audit.allowed.Add(1)
+	slogHTTPAuthDecision("allow", req.Method, scopeSummary(access), access.Subject)
 
 	resp := h.server.HandleRequest(&req)
 	if resp == nil {
@@ -180,11 +198,18 @@ func (h *HTTPServer) authorizeJSONRPC(req *Request, access RequestAccess) *Error
 
 func (h *HTTPServer) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	// /health is unauthenticated: expose only aggregate auth-decision counts,
+	// never subjects, tokens, scopes, or denial reasons.
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"status":  "ok",
 		"server":  serverName,
 		"version": serverVersion,
 		"tools":   len(h.server.tools),
+		"auth": map[string]interface{}{
+			"enforced":          h.auth != nil && h.auth.Configured(),
+			"decisions_allowed": h.audit.allowed.Load(),
+			"decisions_denied":  h.audit.denied.Load(),
+		},
 	})
 }
 
@@ -203,6 +228,53 @@ func isLocalhostOrigin(origin string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+// isRemoteBindHost reports whether binding to host exposes the server beyond
+// the loopback interface. Empty/loopback hosts are local; "0.0.0.0", "::", any
+// public IP, or a non-localhost hostname are treated as remote.
+func isRemoteBindHost(host string) bool {
+	h := strings.TrimSpace(host)
+	if h == "" {
+		// Empty defaults to the loopback host (see NewHTTPServerWithOptions).
+		return false
+	}
+	if strings.EqualFold(h, "localhost") {
+		return false
+	}
+	if ip := net.ParseIP(h); ip != nil {
+		// Unspecified (0.0.0.0, ::) binds all interfaces — that is remote.
+		return !ip.IsLoopback()
+	}
+	// A non-loopback hostname (e.g. a public DNS name) is remote.
+	return true
+}
+
+// requireRemoteAuth enforces GH-89.AUTH.4: a remote (non-loopback) bind must
+// have authentication explicitly configured. authConfigured reports whether a
+// token or OAuth introspection URL was supplied. It returns a clear error when
+// a remote bind would otherwise run unauthenticated.
+func requireRemoteAuth(host string, authConfigured bool) error {
+	if authConfigured || !isRemoteBindHost(host) {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to start: --host %q exposes the MCP server beyond localhost but no authentication is configured; "+
+			"set --token/--read-token/--write-token (or TRVL_MCP_TOKEN), or --oauth-introspection-url, before binding to a non-loopback host",
+		strings.TrimSpace(host),
+	)
+}
+
+// scopeSummary renders an access scope set for audit logging (never the token).
+func scopeSummary(access RequestAccess) string {
+	switch {
+	case access.CanWrite():
+		return "read+write"
+	case access.CanRead():
+		return "read"
+	default:
+		return "none"
+	}
 }
 
 // RunHTTP starts the MCP server in HTTP mode on the given host and port.
@@ -237,6 +309,13 @@ func RunHTTPWithOptions(opts HTTPServerOptions) error {
 		opts.OAuthAudience = strings.TrimSpace(os.Getenv("TRVL_MCP_OAUTH_AUDIENCE"))
 	}
 	if !NewHTTPAuth(opts).Configured() {
+		// GH-89.AUTH.4: remote exposure requires explicit auth. A non-loopback
+		// bind with no configured token/OAuth is refused rather than silently
+		// protected by an auto-generated token printed to logs. Localhost keeps
+		// the convenient auto-generated token.
+		if err := requireRemoteAuth(opts.Host, false); err != nil {
+			return err
+		}
 		generated, err := generateMCPToken()
 		if err != nil {
 			return fmt.Errorf("generate MCP HTTP token: %w", err)

--- a/mcp/http_auth.go
+++ b/mcp/http_auth.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -41,7 +42,7 @@ func NewHTTPAuth(opts HTTPServerOptions) *HTTPAuth {
 	if client == nil {
 		client = &http.Client{Timeout: 5 * time.Second}
 	}
-	return &HTTPAuth{
+	a := &HTTPAuth{
 		token:                 strings.TrimSpace(opts.Token),
 		readToken:             strings.TrimSpace(opts.ReadToken),
 		writeToken:            strings.TrimSpace(opts.WriteToken),
@@ -51,6 +52,13 @@ func NewHTTPAuth(opts HTTPServerOptions) *HTTPAuth {
 		oauthAudience:         strings.TrimSpace(opts.OAuthAudience),
 		client:                client,
 	}
+	if a.oauthIntrospectionURL != "" && a.oauthAudience == "" {
+		// Confused-deputy guard (RFC 7662 §2.2): without a pinned audience, any
+		// valid token at this IdP — including tokens minted for other services —
+		// is accepted. Warn loudly; do not hard-fail (single-tenant dev setups).
+		slog.Warn("mcp oauth: no --oauth-audience configured; tokens issued for any client at this introspection endpoint will be accepted (set --oauth-audience for production)")
+	}
+	return a
 }
 
 // Configured reports whether HTTP auth should be enforced.
@@ -69,19 +77,25 @@ func (a *HTTPAuth) Authenticate(ctx context.Context, token string) (RequestAcces
 	if token == "" {
 		return RequestAccess{}, false
 	}
-	if a.token != "" && token == a.token {
+	if a.token != "" && safeTokenCompare(token, a.token) {
 		return FullAccess("local-token", "static"), true
 	}
-	if a.writeToken != "" && token == a.writeToken {
+	if a.writeToken != "" && safeTokenCompare(token, a.writeToken) {
 		return FullAccess("write-token", "static"), true
 	}
-	if a.readToken != "" && token == a.readToken {
+	if a.readToken != "" && safeTokenCompare(token, a.readToken) {
 		return ReadAccess("read-token", "static"), true
 	}
 	if a.oauthIntrospectionURL != "" {
 		return a.authenticateOAuth(ctx, token)
 	}
 	return RequestAccess{}, false
+}
+
+// safeTokenCompare reports whether two tokens are equal in constant time,
+// preventing a byte-by-byte timing oracle on static bearer tokens.
+func safeTokenCompare(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
 // FullAccess returns an access context with read and write scopes.

--- a/mcp/http_auth.go
+++ b/mcp/http_auth.go
@@ -244,8 +244,22 @@ func claimString(claims map[string]any, key string) string {
 	return ""
 }
 
-func slogHTTPAuthDenied(method, message string) {
-	slog.Warn("mcp http request denied", "method", method, "reason", message)
+// slogHTTPAuthDecision emits a structured audit record of an auth decision.
+// detail carries the denial reason for "deny" or the subject for "allow"; it
+// is logged server-side only and never surfaced on the unauthenticated
+// /health endpoint. Denials log at Warn (security-relevant), allows at Info.
+func slogHTTPAuthDecision(decision, method, scope, detail string) {
+	attrs := []any{
+		"decision", decision,
+		"tool", method,
+		"scope", scope,
+		"detail", detail,
+	}
+	if decision == "deny" {
+		slog.Warn("mcp http auth decision", attrs...)
+		return
+	}
+	slog.Info("mcp http auth decision", attrs...)
 }
 
 func (s *Server) toolWriteRequirement(req *Request) (string, bool, bool) {

--- a/mcp/http_auth_remote_test.go
+++ b/mcp/http_auth_remote_test.go
@@ -1,0 +1,298 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- GH-89.AUTH.4: remote bind requires explicit auth ---
+
+func TestRequireRemoteAuth_GateMatrix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		host           string
+		authConfigured bool
+		wantErr        bool
+	}{
+		{"loopback default empty no auth", "", false, false},
+		{"loopback ipv4 no auth", "127.0.0.1", false, false},
+		{"loopback ipv6 no auth", "::1", false, false},
+		{"localhost name no auth", "localhost", false, false},
+		{"remote all-interfaces no auth refused", "0.0.0.0", false, true},
+		{"remote ipv6 unspecified no auth refused", "::", false, true},
+		{"remote public ip no auth refused", "203.0.113.5", false, true},
+		{"remote hostname no auth refused", "mcp.example.com", false, true},
+		{"remote all-interfaces with auth allowed", "0.0.0.0", true, false},
+		{"remote public ip with auth allowed", "203.0.113.5", true, false},
+		{"remote hostname with auth allowed", "mcp.example.com", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireRemoteAuth(tt.host, tt.authConfigured)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("requireRemoteAuth(%q, %v) err=%v, wantErr=%v", tt.host, tt.authConfigured, err, tt.wantErr)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), "refusing to start") {
+				t.Fatalf("error message = %q, want refusal text", err.Error())
+			}
+		})
+	}
+}
+
+func TestIsRemoteBindHost(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"", false},
+		{"127.0.0.1", false},
+		{"::1", false},
+		{"localhost", false},
+		{"LOCALHOST", false},
+		{"0.0.0.0", true},
+		{"::", true},
+		{"203.0.113.5", true},
+		{"example.org", true},
+	}
+	for _, tt := range tests {
+		if got := isRemoteBindHost(tt.host); got != tt.want {
+			t.Errorf("isRemoteBindHost(%q) = %v, want %v", tt.host, got, tt.want)
+		}
+	}
+}
+
+// RunHTTPWithOptions must refuse to start when a remote host has no auth.
+// This exercises the gate without binding a socket because the gate runs
+// before ListenAndServe.
+func TestRunHTTPWithOptions_RemoteHostWithoutAuthRefused(t *testing.T) {
+	// Ensure env-derived auth does not accidentally configure the server.
+	t.Setenv("TRVL_MCP_TOKEN", "")
+	t.Setenv("TRVL_MCP_READ_TOKEN", "")
+	t.Setenv("TRVL_MCP_WRITE_TOKEN", "")
+	t.Setenv("TRVL_MCP_OAUTH_INTROSPECTION_URL", "")
+
+	err := RunHTTPWithOptions(HTTPServerOptions{Host: "0.0.0.0", Port: 0})
+	if err == nil {
+		t.Fatal("expected refusal error for remote host without auth, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to start") {
+		t.Fatalf("error = %q, want refusal", err.Error())
+	}
+}
+
+// --- Audit counters surfaced on /health ---
+
+func TestHealth_AuthAuditCounters(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{
+		Port:       0,
+		ReadToken:  "read-token",
+		WriteToken: "write-token",
+	})
+
+	// Baseline health: enforced, zero decisions.
+	health := getHealth(t, hs)
+	auth, ok := health["auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("health missing auth object: %#v", health)
+	}
+	if auth["enforced"] != true {
+		t.Fatalf("auth.enforced = %v, want true", auth["enforced"])
+	}
+	if auth["decisions_allowed"].(float64) != 0 || auth["decisions_denied"].(float64) != 0 {
+		t.Fatalf("baseline counters non-zero: %#v", auth)
+	}
+
+	// One allowed call (read token, read-only tool).
+	postHTTPToolCall(t, hs, "read-token", "get_preferences", map[string]any{})
+	// One denied call (read token, write tool).
+	postHTTPToolCall(t, hs, "read-token", "update_preferences", map[string]any{"display_currency": "EUR"})
+	// One denied call (no/invalid token → 401).
+	{
+		body, _ := json.Marshal(Request{JSONRPC: "2.0", ID: float64(9), Method: "initialize"})
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/mcp", bytes.NewReader(body))
+		hs.handleMCP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("missing-token status = %d, want 401", rr.Code)
+		}
+	}
+
+	health = getHealth(t, hs)
+	auth = health["auth"].(map[string]any)
+	if got := auth["decisions_allowed"].(float64); got < 1 {
+		t.Fatalf("decisions_allowed = %v, want >=1", got)
+	}
+	if got := auth["decisions_denied"].(float64); got < 2 {
+		t.Fatalf("decisions_denied = %v, want >=2", got)
+	}
+}
+
+// /health must never leak subjects, tokens, scopes, or denial reasons.
+func TestHealth_DoesNotLeakSensitiveAuthDetail(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{
+		Port:       0,
+		ReadToken:  "super-secret-read-token",
+		WriteToken: "super-secret-write-token",
+	})
+	postHTTPToolCall(t, hs, "super-secret-read-token", "update_preferences", map[string]any{"display_currency": "EUR"})
+
+	rr := httptest.NewRecorder()
+	hs.handleHealth(rr, httptest.NewRequest("GET", "/health", nil))
+	raw := rr.Body.String()
+	for _, leak := range []string{"super-secret-read-token", "super-secret-write-token", "trvl:write", "requires trvl"} {
+		if strings.Contains(raw, leak) {
+			t.Fatalf("/health leaked sensitive value %q: %s", leak, raw)
+		}
+	}
+}
+
+func getHealth(t *testing.T, hs *HTTPServer) map[string]any {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	hs.handleHealth(rr, httptest.NewRequest("GET", "/health", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("health status = %d, want 200", rr.Code)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("health unmarshal: %v", err)
+	}
+	return out
+}
+
+// --- OAuth introspection path (deterministic via httptest fake IdP) ---
+
+func TestOAuthIntrospection_ScopeEnforcement(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Fake external IdP introspection endpoint. Token "rw" → read+write,
+	// "ro" → read only, anything else → inactive.
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		tok := r.Form.Get("token")
+		w.Header().Set("Content-Type", "application/json")
+		switch tok {
+		case "rw":
+			_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "scope": "trvl:read trvl:write", "sub": "alice", "aud": "trvl-mcp"})
+		case "ro":
+			_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "scope": "trvl:read", "sub": "bob", "aud": "trvl-mcp"})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{"active": false})
+		}
+	}))
+	defer idp.Close()
+
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{
+		Port:                  0,
+		OAuthIntrospectionURL: idp.URL,
+		OAuthAudience:         "trvl-mcp",
+	})
+
+	// Inactive token → 401 before JSON-RPC.
+	{
+		body, _ := json.Marshal(Request{JSONRPC: "2.0", ID: float64(1), Method: "initialize"})
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/mcp", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer nonsense")
+		hs.handleMCP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("inactive token status = %d, want 401", rr.Code)
+		}
+	}
+
+	// Read-only OAuth token denied on a write tool.
+	resp, status := postHTTPToolCall(t, hs, "ro", "update_preferences", map[string]any{"display_currency": "EUR"})
+	if status != http.StatusOK {
+		t.Fatalf("ro write-tool status = %d, want 200 JSON-RPC error", status)
+	}
+	if resp.Error == nil || resp.Error.Code != -32001 {
+		t.Fatalf("ro write-tool expected -32001 scope error, got %#v", resp.Error)
+	}
+
+	// Read/write OAuth token allowed on the same write tool.
+	resp, status = postHTTPToolCall(t, hs, "rw", "update_preferences", map[string]any{"display_currency": "EUR"})
+	if status != http.StatusOK {
+		t.Fatalf("rw write-tool status = %d, want 200", status)
+	}
+	if resp.Error != nil {
+		t.Fatalf("rw write-tool unexpected error: %#v", resp.Error)
+	}
+}
+
+func TestOAuthIntrospection_AudienceMismatchRejected(t *testing.T) {
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "scope": "trvl:read", "sub": "carol", "aud": "some-other-rs"})
+	}))
+	defer idp.Close()
+
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{
+		Port:                  0,
+		OAuthIntrospectionURL: idp.URL,
+		OAuthAudience:         "trvl-mcp",
+	})
+
+	body, _ := json.Marshal(Request{JSONRPC: "2.0", ID: float64(1), Method: "initialize"})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/mcp", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer mismatched")
+	hs.handleMCP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("audience mismatch status = %d, want 401", rr.Code)
+	}
+}
+
+// --- Tool-to-scope matrix (read vs write) ---
+
+// GH-89.AUTH.3: state-mutating tools must require trvl:write; read-only tools
+// must not. This table is the authoritative read/write scope matrix and pins
+// the annotation-driven classification used by authorizeJSONRPC.
+func TestToolScopeMatrix_ReadVsWrite(t *testing.T) {
+	t.Setenv(smartToolModeEnv, "legacy")
+	s := NewServer()
+
+	tests := []struct {
+		tool          string
+		args          map[string]any
+		requiresWrite bool
+	}{
+		// Read-only tools must not require write scope.
+		{"get_preferences", map[string]any{}, false},
+		{"search_flights", map[string]any{"origin": "HEL", "destination": "LHR"}, false},
+		{"get_weather", map[string]any{"location": "Paris"}, false},
+		{"get_baggage_rules", map[string]any{"airline": "AY"}, false},
+		// State-mutating tools (write to ~/.trvl) must require write scope.
+		{"update_preferences", map[string]any{"display_currency": "EUR"}, true},
+		{"watch_price", map[string]any{"origin": "HEL", "destination": "LHR"}, true},
+		{"trip_workspace", map[string]any{"action": "add", "name": "Summer"}, true},
+		// trip_workspace read action must not require write scope.
+		{"trip_workspace", map[string]any{"action": "get"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tool+"_"+writeLabel(tt.requiresWrite), func(t *testing.T) {
+			if _, ok := s.toolDefs[tt.tool]; !ok {
+				t.Skipf("tool %q not registered in this build", tt.tool)
+			}
+			_, gotWrite := s.toolRequiresWrite(tt.tool, tt.args)
+			if gotWrite != tt.requiresWrite {
+				t.Fatalf("toolRequiresWrite(%q, %v) = %v, want %v", tt.tool, tt.args, gotWrite, tt.requiresWrite)
+			}
+		})
+	}
+}
+
+func writeLabel(w bool) string {
+	if w {
+		return "write"
+	}
+	return "read"
+}

--- a/mcp/http_auth_remote_test.go
+++ b/mcp/http_auth_remote_test.go
@@ -296,3 +296,34 @@ func writeLabel(w bool) string {
 	}
 	return "read"
 }
+
+// TestSafeTokenCompare_ConstantTime verifies the constant-time token comparison
+// accepts only exact matches (timing-attack hardening, security review fix 1).
+func TestSafeTokenCompare_ConstantTime(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"secret-token-abc", "secret-token-abc", true},
+		{"secret-token-abc", "secret-token-abd", false},
+		{"secret-token-abc", "secret-token-ab", false}, // length mismatch
+		{"", "", true},
+		{"x", "", false},
+	}
+	for _, c := range cases {
+		if got := safeTokenCompare(c.a, c.b); got != c.want {
+			t.Errorf("safeTokenCompare(%q,%q)=%v want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// TestNewHTTPAuth_OAuthWithoutAudienceStillConstructs verifies the confused-deputy
+// warning path (security review fix 2) does not break construction or auth.
+func TestNewHTTPAuth_OAuthWithoutAudienceStillConstructs(t *testing.T) {
+	t.Parallel()
+	a := NewHTTPAuth(HTTPServerOptions{OAuthIntrospectionURL: "https://idp.example/introspect"})
+	if a == nil || !a.Configured() {
+		t.Fatal("expected configured auth with OAuth introspection URL")
+	}
+}


### PR DESCRIPTION
Closes #89. **Auth change — requires human security review before merge (not auto-merged).**

Scope: resource-server only (trvl validates externally-issued tokens; no authorization server, no token issuance). Found AUTH.1/2/3 already shipped on main; this adds the four real gaps:

1. **AUTH.4 remote-bind safety**: RunHTTPWithOptions REFUSES to start when binding a non-loopback host with no token or OAuth configured (deny-by-default), instead of silently auto-generating a token. Localhost path byte-identical. Pure helpers requireRemoteAuth + isRemoteBindHost, offline-tested.
2. **Audit log**: structured slog per auth decision (deny at Warn), plus atomic allowed and denied counters surfaced on /health as counts only; a test asserts /health leaks no tokens, scopes, subjects, or reasons.
3. **docs/REMOTE-MCP-OAUTH.md**: deployment doc (localhost-safe defaults, the AUTH.4 refusal, read vs write scope model, static-token and OAuth-introspection options, client-side PKCE flow, reverse-proxy pattern, security checklist).
4. **Tests**: auth-required, invalid token, valid token, scope-denial, tool-scope matrix, default-localhost-safe, fake-IdP introspection, audience-mismatch, no-leak — all deterministic and offline under -race.

My review: deny-by-default verified, no existing auth weakened, conservative gate, leak-guarded health. DoD green (build, vet, staticcheck, race suite). Rebased onto current main (keeps #115). Your decision to ship remote-auth.