### PR TITLE
feat(flights): MIK-4956 Phase C cross-shop re-pricing of Kiwi itineraries (gated, off by default)

### DIFF
--- a/internal/flights/crossshop.go
+++ b/internal/flights/crossshop.go
@@ -1,0 +1,313 @@
+// crossshop.go — MIK-4956 Phase C: cross-shop re-pricing of Kiwi itineraries.
+//
+// Kiwi's routing intelligence finds self-connect / multi-stop itineraries that
+// no single GDS sells as one fare. Those same physical segments are often
+// cheaper booked direct (separate tickets) on a per-leg basis via Google
+// Flights. This file decomposes a Kiwi itinerary into ordered segments, re-
+// prices each on Google Flights, and — only when EVERY segment prices — emits
+// a synthetic "book-direct" alternative carrying per-segment PriceSources and a
+// summed price, so the cheaper of (Kiwi-bundled, book-direct) is visible.
+//
+// No-fabrication guard (MIK-4956 XSHOP.4): a book-direct alternative appears
+// ONLY when all segments priced. If any segment cannot be priced, NO fake total
+// is emitted and the enricher reports a non-definitive ProviderStatus so the
+// MIK-4950 completeness envelope marks the search partial.
+//
+// The enricher never touches existing booking flows: it is gated behind
+// crossShopEnabled() and only ever APPENDS book-direct alternatives. Rollback =
+// revert the wiring commit in search.go.
+package flights
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+const (
+	crossShopProviderID   = "book_direct"
+	crossShopProviderName = "Book-Direct (cross-shop)"
+	// crossShopSelfConnectWarning is carried on every book-direct alternative:
+	// separate tickets mean the traveller owns missed-connection risk.
+	crossShopSelfConnectWarning = "Book-direct: separately ticketed segments — a missed connection is not protected, bags may need re-checking, and a delay on one leg will not rebook the next."
+	// crossShopDefaultWindow is the half-width of the departure-time match
+	// window. A re-priced segment must depart within +/- this of the Kiwi
+	// segment's scheduled departure, else it is a different flight and the
+	// segment is treated as unpriceable (no off-time substitution).
+	crossShopDefaultWindow = 3 * time.Hour
+	// crossShopMinSegments is the routing threshold: only multi-stop / self-
+	// connect itineraries (>=2 segments) are cross-shopped. A single-segment
+	// itinerary has nothing to re-price separately.
+	crossShopMinSegments = 2
+)
+
+// segmentPricer re-prices one segment (origin->dest on date) and returns the
+// candidate flights for that route. It is the injectable seam that keeps the
+// enricher offline-testable: production wires it to Google Flights, tests pass
+// a synthetic map-backed fake. Returning (nil, nil) means "queried, no hit".
+type segmentPricer func(ctx context.Context, origin, dest, date string, opts SearchOptions) ([]models.FlightResult, error)
+
+// flightSegment is one ordered leg of a decomposed itinerary: a bookable
+// origin->dest hop on a specific date with a scheduled departure time used to
+// match a re-priced direct flight.
+type flightSegment struct {
+	Origin   string
+	Dest     string
+	Date     string    // "YYYY-MM-DD", the segment's local departure date
+	DepartAt time.Time // scheduled departure (zero if unparseable)
+	HasTime  bool      // DepartAt is meaningful
+}
+
+// crossShopEnabled gates the enricher. Off by default so it never alters
+// existing flows; opt in with TRVL_CROSSSHOP_ENRICH=1.
+func crossShopEnabled() bool {
+	switch os.Getenv("TRVL_CROSSSHOP_ENRICH") {
+	case "1", "true", "TRUE", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// decomposeSegments turns a (mapped) Kiwi itinerary into ordered bookable
+// segments derived from its Legs — i.e. flyFrom -> layover0 -> ... -> flyTo —
+// using each leg's departure date + time. It relies ONLY on route + time data
+// (no carrier/flight-number, which Kiwi does not expose). Returns nil when the
+// itinerary is not a self-connect candidate (fewer than crossShopMinSegments).
+func decomposeSegments(f models.FlightResult) []flightSegment {
+	if len(f.Legs) < crossShopMinSegments {
+		return nil
+	}
+	segs := make([]flightSegment, 0, len(f.Legs))
+	for _, leg := range f.Legs {
+		origin := leg.DepartureAirport.Code
+		dest := leg.ArrivalAirport.Code
+		if origin == "" || dest == "" {
+			// A leg with no resolvable endpoints cannot be re-priced; surface
+			// the gap as an empty-date segment so the enricher fails closed.
+			segs = append(segs, flightSegment{Origin: origin, Dest: dest})
+			continue
+		}
+		seg := flightSegment{Origin: origin, Dest: dest}
+		if t, err := time.Parse(flightTimeLayout, leg.DepartureTime); err == nil {
+			seg.Date = t.Format("2006-01-02")
+			seg.DepartAt = t
+			seg.HasTime = true
+		}
+		segs = append(segs, seg)
+	}
+	return segs
+}
+
+// priceSegment re-prices a single segment and returns the cheapest priced
+// candidate that departs within +/- window of the segment's scheduled time and
+// shares the requested currency. ok=false means the segment is UNPRICEABLE —
+// the pricer failed, returned nothing, or returned only off-window / wrong-
+// currency / zero-price candidates. We never substitute an off-time flight: an
+// itinerary's value is its specific routing, and re-timing it would misrepresent
+// what the traveller is being quoted.
+func priceSegment(ctx context.Context, price segmentPricer, seg flightSegment, currency string, window time.Duration, opts SearchOptions) (models.PriceSource, bool) {
+	if seg.Origin == "" || seg.Dest == "" || seg.Date == "" {
+		return models.PriceSource{}, false
+	}
+	candidates, err := price(ctx, seg.Origin, seg.Dest, seg.Date, opts)
+	if err != nil || len(candidates) == 0 {
+		return models.PriceSource{}, false
+	}
+	best := -1
+	for i, c := range candidates {
+		if c.Price <= 0 {
+			continue
+		}
+		if currency != "" && c.Currency != "" && c.Currency != currency {
+			continue // cross-currency sum would be a fabricated total
+		}
+		if seg.HasTime && !departsWithinWindow(c, seg.DepartAt, window) {
+			continue // different flight than the routed segment
+		}
+		if best == -1 || c.Price < candidates[best].Price {
+			best = i
+		}
+	}
+	if best == -1 {
+		return models.PriceSource{}, false
+	}
+	c := candidates[best]
+	now := time.Now()
+	return models.PriceSource{
+		Provider:    c.Provider,
+		Price:       c.Price,
+		Currency:    c.Currency,
+		BookingURL:  c.BookingURL,
+		RetrievedAt: now,
+		Freshness:   models.ClassifyFreshness(c.Provider, now, now),
+	}, true
+}
+
+// departsWithinWindow reports whether candidate c departs within +/- window of
+// target. A candidate with no parseable departure cannot be matched and is
+// rejected (fail closed).
+func departsWithinWindow(c models.FlightResult, target time.Time, window time.Duration) bool {
+	dep := flightDeparture(c)
+	if dep.IsZero() {
+		return false
+	}
+	d := dep.Sub(target)
+	if d < 0 {
+		d = -d
+	}
+	return d <= window
+}
+
+// buildBookDirectAlternative assembles a synthetic separate-tickets alternative
+// from a fully-priced set of per-segment sources. Caller MUST guarantee
+// len(sources) == len(base.Legs) and every source priced (XSHOP.4); this
+// function does not re-validate the count — see enrichCrossShop.
+func buildBookDirectAlternative(base models.FlightResult, sources []models.PriceSource) models.FlightResult {
+	var total float64
+	currency := ""
+	for _, s := range sources {
+		total += s.Price
+		if currency == "" {
+			currency = s.Currency
+		}
+	}
+
+	alt := models.FlightResult{
+		Price:          total,
+		Currency:       currency,
+		Duration:       base.Duration,
+		Stops:          base.Stops,
+		Provider:       crossShopProviderID,
+		SelfConnect:    true,
+		BookDirect:     true,
+		Legs:           append([]models.FlightLeg(nil), base.Legs...),
+		SegmentSources: append([]models.PriceSource(nil), sources...),
+		Warnings:       []string{crossShopSelfConnectWarning},
+	}
+
+	// Cheapest-source comparison (XSHOP.5): expose Kiwi-bundled vs book-direct
+	// summed price so the cheaper option is visible. Savings is positive when
+	// book-direct beats the bundled fare. We never suppress the more-expensive
+	// case — surfacing the comparison is the point.
+	if base.Price > 0 {
+		alt.Savings = base.Price - total
+		if alt.Savings > 0 {
+			alt.CheapestSource = crossShopProviderID
+		} else {
+			alt.CheapestSource = base.Provider
+		}
+	}
+	return alt
+}
+
+// enrichCrossShop re-prices the eligible itineraries in flights and returns the
+// book-direct alternatives plus a ProviderStatus describing the outcome for the
+// completeness envelope. Contract:
+//   - Not gated / no eligible itineraries -> (nil, StatusSkipped): does not
+//     touch completeness.
+//   - At least one eligible itinerary, every one of its segments priced ->
+//     (alts, StatusCheckedHit/StatusCheckedNoHit): definitive.
+//   - An eligible itinerary had a segment that could not be priced ->
+//     (alts-so-far, StatusFailed): completeness goes partial, and NO book-
+//     direct total is fabricated for that itinerary (XSHOP.4).
+func enrichCrossShop(ctx context.Context, flights []models.FlightResult, price segmentPricer, window time.Duration, opts SearchOptions) ([]models.FlightResult, models.ProviderStatus) {
+	if window <= 0 {
+		window = crossShopDefaultWindow
+	}
+
+	var (
+		alts        []models.FlightResult
+		eligible    int
+		unpriceable int
+	)
+
+	for _, f := range flights {
+		// Only cross-shop genuine self-connect itineraries (Kiwi's moat).
+		// Single-ticket through-fares from Google/Ryanair/etc. carry through-
+		// fare protection that re-pricing as separate tickets would discard —
+		// they are not the cross-shop target. Kiwi marks its self-connects with
+		// SelfConnect=true (see mapKiwiItinerary); single-ticket carriers don't.
+		if !f.SelfConnect {
+			continue
+		}
+		segs := decomposeSegments(f)
+		if len(segs) < crossShopMinSegments {
+			continue
+		}
+		eligible++
+
+		currency := f.Currency
+		sources := make([]models.PriceSource, 0, len(segs))
+		allPriced := true
+		for _, seg := range segs {
+			src, ok := priceSegment(ctx, price, seg, currency, window, opts)
+			if !ok {
+				allPriced = false
+				break
+			}
+			sources = append(sources, src)
+		}
+		if !allPriced {
+			// No-fabrication guard: do NOT emit a partial total.
+			unpriceable++
+			continue
+		}
+		alts = append(alts, buildBookDirectAlternative(f, sources))
+	}
+
+	if eligible == 0 {
+		return nil, models.ProviderStatus{
+			ID:     crossShopProviderID,
+			Name:   crossShopProviderName,
+			Status: models.StatusSkipped,
+			Error:  "no self-connect / multi-stop itineraries eligible for cross-shop re-pricing",
+		}
+	}
+	if unpriceable > 0 {
+		// Some itinerary could not be fully priced. Report a non-definitive
+		// status so ComputeCompleteness marks the search partial (XSHOP.4).
+		return alts, models.ProviderStatus{
+			ID:      crossShopProviderID,
+			Name:    crossShopProviderName,
+			Status:  models.StatusFailed,
+			Results: len(alts),
+			Error:   "one or more itineraries had a segment that could not be re-priced; book-direct total withheld to avoid a fabricated price",
+			FixHint: "retry later or widen the departure-time match window",
+		}
+	}
+	status := models.StatusCheckedHit
+	if len(alts) == 0 {
+		status = models.StatusCheckedNoHit
+	}
+	return alts, models.ProviderStatus{
+		ID:      crossShopProviderID,
+		Name:    crossShopProviderName,
+		Status:  status,
+		Results: len(alts),
+	}
+}
+
+// googleSegmentPricer is the production segmentPricer: it re-prices a segment
+// via Google Flights only (a single bookable direct fare per leg), forcing the
+// session currency so per-segment prices sum cleanly. It deliberately does NOT
+// recurse into Kiwi (which would re-introduce bundling).
+func googleSegmentPricer(currency string) segmentPricer {
+	return func(ctx context.Context, origin, dest, date string, opts SearchOptions) ([]models.FlightResult, error) {
+		segOpts := SearchOptions{
+			Adults:     opts.Adults,
+			CabinClass: opts.CabinClass,
+			Currency:   currency,
+			SortBy:     models.SortCheapest,
+		}
+		res, err := searchGoogleFlightsWithClient(ctx, DefaultClient(), origin, dest, date, segOpts)
+		if err != nil {
+			return nil, err
+		}
+		if res == nil {
+			return nil, nil
+		}
+		return res.Flights, nil
+	}
+}

--- a/internal/flights/crossshop_test.go
+++ b/internal/flights/crossshop_test.go
@@ -1,0 +1,369 @@
+package flights
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// fakePricer returns a synthetic segmentPricer backed by a route->results map,
+// keyed by "ORIGIN-DEST". A missing key yields zero candidates (unpriceable).
+func fakePricer(by map[string][]models.FlightResult) segmentPricer {
+	return func(_ context.Context, origin, dest, _ string, _ SearchOptions) ([]models.FlightResult, error) {
+		return by[origin+"-"+dest], nil
+	}
+}
+
+// gflight builds a synthetic Google Flights single-segment candidate departing
+// at the given "2006-01-02T15:04" local time.
+func gflight(origin, dest, depart string, price float64, currency string) models.FlightResult {
+	return models.FlightResult{
+		Price:    price,
+		Currency: currency,
+		Provider: "google_flights",
+		Legs: []models.FlightLeg{{
+			DepartureAirport: models.AirportInfo{Code: origin},
+			ArrivalAirport:   models.AirportInfo{Code: dest},
+			DepartureTime:    depart,
+		}},
+	}
+}
+
+// helInBcnItinerary builds a Kiwi-shaped self-connect HEL->IST->BCN itinerary
+// directly from the mapped-itinerary path so the test exercises the real
+// layover->segment decomposition (XSHOP.1).
+func helIstBcnKiwi(bundledPrice float64) models.FlightResult {
+	itin := kiwiItinerary{
+		FlyFrom:   "HEL",
+		FlyTo:     "BCN",
+		CityFrom:  "Helsinki",
+		CityTo:    "Barcelona",
+		Departure: kiwiDateTime{Local: "2026-07-01T08:00:00", UTC: "2026-07-01T05:00:00Z"},
+		Arrival:   kiwiDateTime{Local: "2026-07-01T18:00:00", UTC: "2026-07-01T16:00:00Z"},
+		Price:     bundledPrice,
+		Currency:  "EUR",
+		Layovers: []kiwiLayover{{
+			At:        "IST",
+			City:      "Istanbul",
+			CityCode:  "IST",
+			Arrival:   kiwiDateTime{Local: "2026-07-01T11:00:00", UTC: "2026-07-01T08:00:00Z"},
+			Departure: kiwiDateTime{Local: "2026-07-01T13:00:00", UTC: "2026-07-01T10:00:00Z"},
+		}},
+	}
+	return mapKiwiItinerary(itin, "EUR")
+}
+
+// TestDecomposeSegments_FromLayovers proves segment decomposition derives the
+// ordered route + per-segment date/time from flyFrom + layovers + flyTo, with
+// NO reliance on carrier data (MIK-4956 XSHOP.1, test (a)).
+func TestDecomposeSegments_FromLayovers(t *testing.T) {
+	f := helIstBcnKiwi(300)
+	segs := decomposeSegments(f)
+
+	if len(segs) != 2 {
+		t.Fatalf("want 2 segments (HEL->IST, IST->BCN), got %d", len(segs))
+	}
+	if segs[0].Origin != "HEL" || segs[0].Dest != "IST" {
+		t.Errorf("segment 0 = %s->%s, want HEL->IST", segs[0].Origin, segs[0].Dest)
+	}
+	if segs[1].Origin != "IST" || segs[1].Dest != "BCN" {
+		t.Errorf("segment 1 = %s->%s, want IST->BCN", segs[1].Origin, segs[1].Dest)
+	}
+	if segs[0].Date != "2026-07-01" || segs[1].Date != "2026-07-01" {
+		t.Errorf("segment dates = %q, %q, want both 2026-07-01", segs[0].Date, segs[1].Date)
+	}
+	// Segment 0 departs at the itinerary departure (08:00); segment 1 departs
+	// at the layover departure (13:00) — proving times come from the layover.
+	if !segs[0].HasTime || segs[0].DepartAt.Hour() != 8 {
+		t.Errorf("segment 0 depart hour = %d, want 8", segs[0].DepartAt.Hour())
+	}
+	if !segs[1].HasTime || segs[1].DepartAt.Hour() != 13 {
+		t.Errorf("segment 1 depart hour = %d, want 13 (from layover departure)", segs[1].DepartAt.Hour())
+	}
+}
+
+// TestDecomposeSegments_SingleSegmentSkipped proves a non-stop itinerary is not
+// eligible for cross-shop decomposition (nothing to re-price separately).
+func TestDecomposeSegments_SingleSegmentSkipped(t *testing.T) {
+	direct := models.FlightResult{
+		Currency: "EUR",
+		Legs: []models.FlightLeg{{
+			DepartureAirport: models.AirportInfo{Code: "HEL"},
+			ArrivalAirport:   models.AirportInfo{Code: "BCN"},
+			DepartureTime:    "2026-07-01T08:00",
+		}},
+	}
+	if segs := decomposeSegments(direct); segs != nil {
+		t.Fatalf("single-segment itinerary should not decompose, got %d segments", len(segs))
+	}
+}
+
+// TestEnrichCrossShop_BookDirectWhenAllPricedAndCheaper proves the book-direct
+// alternative is assembled with per-segment PriceSources, a SUMMED price, and a
+// positive Savings vs the Kiwi-bundled fare when it is cheaper
+// (MIK-4956 XSHOP.4 happy path + XSHOP.5 comparison, test (b)).
+func TestEnrichCrossShop_BookDirectWhenAllPricedAndCheaper(t *testing.T) {
+	bundled := 300.0
+	f := helIstBcnKiwi(bundled)
+
+	pricer := fakePricer(map[string][]models.FlightResult{
+		"HEL-IST": {gflight("HEL", "IST", "2026-07-01T08:30", 90, "EUR")},  // within window of 08:00
+		"IST-BCN": {gflight("IST", "BCN", "2026-07-01T13:15", 110, "EUR")}, // within window of 13:00
+	})
+
+	alts, status := enrichCrossShop(context.Background(), []models.FlightResult{f}, pricer, crossShopDefaultWindow, SearchOptions{})
+
+	if status.Status != models.StatusCheckedHit {
+		t.Fatalf("status = %q, want checked_hit", status.Status)
+	}
+	if len(alts) != 1 {
+		t.Fatalf("want 1 book-direct alternative, got %d", len(alts))
+	}
+	alt := alts[0]
+	if !alt.BookDirect {
+		t.Error("alternative not flagged BookDirect")
+	}
+	if want := 90.0 + 110.0; alt.Price != want {
+		t.Errorf("summed price = %.2f, want %.2f", alt.Price, want)
+	}
+	if len(alt.SegmentSources) != 2 {
+		t.Fatalf("want 2 segment sources, got %d", len(alt.SegmentSources))
+	}
+	if alt.SegmentSources[0].Price != 90 || alt.SegmentSources[1].Price != 110 {
+		t.Errorf("segment prices = %.0f, %.0f; want 90, 110", alt.SegmentSources[0].Price, alt.SegmentSources[1].Price)
+	}
+	// XSHOP.5: comparison surfaced — Kiwi 300 vs book-direct 200 => savings 100.
+	if want := bundled - 200.0; alt.Savings != want {
+		t.Errorf("savings = %.2f, want %.2f", alt.Savings, want)
+	}
+	if alt.CheapestSource != crossShopProviderID {
+		t.Errorf("cheapest source = %q, want %q", alt.CheapestSource, crossShopProviderID)
+	}
+}
+
+// TestEnrichCrossShop_SelfConnectWarning proves the missed-connection risk
+// warning is carried on every book-direct alternative (test (d)).
+func TestEnrichCrossShop_SelfConnectWarning(t *testing.T) {
+	f := helIstBcnKiwi(300)
+	pricer := fakePricer(map[string][]models.FlightResult{
+		"HEL-IST": {gflight("HEL", "IST", "2026-07-01T08:30", 90, "EUR")},
+		"IST-BCN": {gflight("IST", "BCN", "2026-07-01T13:15", 110, "EUR")},
+	})
+
+	alts, _ := enrichCrossShop(context.Background(), []models.FlightResult{f}, pricer, crossShopDefaultWindow, SearchOptions{})
+	if len(alts) != 1 {
+		t.Fatalf("want 1 alternative, got %d", len(alts))
+	}
+	if !alts[0].SelfConnect {
+		t.Error("book-direct alternative must be flagged SelfConnect")
+	}
+	found := false
+	for _, w := range alts[0].Warnings {
+		if w == crossShopSelfConnectWarning {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("self-connect warning missing; warnings = %v", alts[0].Warnings)
+	}
+}
+
+// TestEnrichCrossShop_NoFabricationWhenSegmentUnpriceable proves the
+// no-fabrication guard: when a segment cannot be priced, NO book-direct total is
+// emitted and the status is non-definitive so completeness goes partial
+// (MIK-4956 XSHOP.4, test (c)).
+func TestEnrichCrossShop_NoFabricationWhenSegmentUnpriceable(t *testing.T) {
+	f := helIstBcnKiwi(300)
+	// Only the first segment prices; IST-BCN is missing from the map.
+	pricer := fakePricer(map[string][]models.FlightResult{
+		"HEL-IST": {gflight("HEL", "IST", "2026-07-01T08:30", 90, "EUR")},
+	})
+
+	alts, status := enrichCrossShop(context.Background(), []models.FlightResult{f}, pricer, crossShopDefaultWindow, SearchOptions{})
+
+	if len(alts) != 0 {
+		t.Fatalf("no book-direct should be emitted when a segment is unpriceable, got %d", len(alts))
+	}
+	if status.Status != models.StatusFailed {
+		t.Fatalf("status = %q, want failed (drives partial completeness)", status.Status)
+	}
+
+	// Drive the completeness envelope as the search would: Google + Kiwi
+	// definitive, the cross-shop enricher failed => overall partial.
+	statuses := []models.ProviderStatus{
+		{ID: "google_flights", Name: "Google Flights", Status: models.StatusCheckedHit, Results: 5},
+		{ID: "kiwi", Name: "Kiwi", Status: models.StatusCheckedHit, Results: 3},
+		status,
+	}
+	c := models.ComputeCompleteness(statuses)
+	if c.State != models.CompletenessPartial {
+		t.Errorf("completeness = %q, want partial", c.State)
+	}
+	if c.MayClaimExhaustive() {
+		t.Error("partial search must not claim exhaustive")
+	}
+}
+
+// TestEnrichCrossShop_OffWindowSegmentUnpriceable proves a candidate outside the
+// departure-time window is NOT substituted (it is a different flight than the
+// routed segment), so the segment is unpriceable and no total is fabricated.
+func TestEnrichCrossShop_OffWindowSegmentUnpriceable(t *testing.T) {
+	f := helIstBcnKiwi(300)
+	pricer := fakePricer(map[string][]models.FlightResult{
+		"HEL-IST": {gflight("HEL", "IST", "2026-07-01T08:30", 90, "EUR")},
+		// IST-BCN candidate departs 22:00 — far outside the 13:00 +/- 3h window.
+		"IST-BCN": {gflight("IST", "BCN", "2026-07-01T22:00", 110, "EUR")},
+	})
+
+	alts, status := enrichCrossShop(context.Background(), []models.FlightResult{f}, pricer, crossShopDefaultWindow, SearchOptions{})
+	if len(alts) != 0 {
+		t.Fatalf("off-window candidate must not be matched, got %d alternatives", len(alts))
+	}
+	if status.Status != models.StatusFailed {
+		t.Errorf("status = %q, want failed", status.Status)
+	}
+}
+
+// TestEnrichCrossShop_CrossCurrencyUnpriceable proves a segment priced in a
+// different currency is not summed (a cross-currency total would be fabricated).
+func TestEnrichCrossShop_CrossCurrencyUnpriceable(t *testing.T) {
+	f := helIstBcnKiwi(300)
+	pricer := fakePricer(map[string][]models.FlightResult{
+		"HEL-IST": {gflight("HEL", "IST", "2026-07-01T08:30", 90, "EUR")},
+		"IST-BCN": {gflight("IST", "BCN", "2026-07-01T13:15", 110, "USD")}, // wrong currency
+	})
+
+	alts, status := enrichCrossShop(context.Background(), []models.FlightResult{f}, pricer, crossShopDefaultWindow, SearchOptions{})
+	if len(alts) != 0 {
+		t.Fatalf("cross-currency segment must not be summed, got %d alternatives", len(alts))
+	}
+	if status.Status != models.StatusFailed {
+		t.Errorf("status = %q, want failed", status.Status)
+	}
+}
+
+// TestEnrichCrossShop_NoEligibleItinerariesSkipped proves that when no itinerary
+// is multi-stop, the enricher reports skipped (does not touch completeness).
+func TestEnrichCrossShop_NoEligibleItinerariesSkipped(t *testing.T) {
+	direct := models.FlightResult{
+		Currency: "EUR",
+		Legs: []models.FlightLeg{{
+			DepartureAirport: models.AirportInfo{Code: "HEL"},
+			ArrivalAirport:   models.AirportInfo{Code: "BCN"},
+			DepartureTime:    "2026-07-01T08:00",
+		}},
+	}
+	alts, status := enrichCrossShop(context.Background(), []models.FlightResult{direct}, fakePricer(nil), crossShopDefaultWindow, SearchOptions{})
+	if len(alts) != 0 {
+		t.Fatalf("want no alternatives, got %d", len(alts))
+	}
+	if status.Status != models.StatusSkipped {
+		t.Errorf("status = %q, want skipped", status.Status)
+	}
+	// Skipped must not degrade completeness.
+	c := models.ComputeCompleteness([]models.ProviderStatus{
+		{ID: "google_flights", Status: models.StatusCheckedHit, Results: 1},
+		status,
+	})
+	if c.State != models.CompletenessComplete {
+		t.Errorf("completeness = %q, want complete (skipped does not gate)", c.State)
+	}
+}
+
+// TestEnrichCrossShop_MoreExpensiveStillSurfaced proves XSHOP.5 surfaces the
+// comparison even when book-direct is dearer (negative savings, Kiwi cheapest);
+// the alternative is not suppressed.
+func TestEnrichCrossShop_MoreExpensiveStillSurfaced(t *testing.T) {
+	bundled := 150.0
+	f := helIstBcnKiwi(bundled)
+	pricer := fakePricer(map[string][]models.FlightResult{
+		"HEL-IST": {gflight("HEL", "IST", "2026-07-01T08:30", 120, "EUR")},
+		"IST-BCN": {gflight("IST", "BCN", "2026-07-01T13:15", 130, "EUR")},
+	})
+
+	alts, _ := enrichCrossShop(context.Background(), []models.FlightResult{f}, pricer, crossShopDefaultWindow, SearchOptions{})
+	if len(alts) != 1 {
+		t.Fatalf("want 1 alternative even when dearer, got %d", len(alts))
+	}
+	if alts[0].Price != 250 {
+		t.Errorf("summed price = %.2f, want 250", alts[0].Price)
+	}
+	if want := bundled - 250.0; alts[0].Savings != want {
+		t.Errorf("savings = %.2f, want %.2f (negative)", alts[0].Savings, want)
+	}
+	if alts[0].CheapestSource != "kiwi" {
+		t.Errorf("cheapest source = %q, want kiwi (the dearer book-direct must not claim cheapest)", alts[0].CheapestSource)
+	}
+}
+
+// TestEnrichCrossShop_SingleTicketConnectionSkipped proves a multi-leg
+// single-ticket through-fare (SelfConnect=false, e.g. a Google/Ryanair
+// connection with through-fare protection) is NOT cross-shopped — only Kiwi's
+// self-connect itineraries are the target. Otherwise we would discard through-
+// fare protection for no reason.
+func TestEnrichCrossShop_SingleTicketConnectionSkipped(t *testing.T) {
+	through := models.FlightResult{
+		Currency:    "EUR",
+		Provider:    "google_flights",
+		SelfConnect: false, // single ticket — protected connection
+		Legs: []models.FlightLeg{
+			{
+				DepartureAirport: models.AirportInfo{Code: "HEL"},
+				ArrivalAirport:   models.AirportInfo{Code: "IST"},
+				DepartureTime:    "2026-07-01T08:00",
+			},
+			{
+				DepartureAirport: models.AirportInfo{Code: "IST"},
+				ArrivalAirport:   models.AirportInfo{Code: "BCN"},
+				DepartureTime:    "2026-07-01T13:00",
+			},
+		},
+	}
+	pricer := fakePricer(map[string][]models.FlightResult{
+		"HEL-IST": {gflight("HEL", "IST", "2026-07-01T08:30", 90, "EUR")},
+		"IST-BCN": {gflight("IST", "BCN", "2026-07-01T13:15", 110, "EUR")},
+	})
+
+	alts, status := enrichCrossShop(context.Background(), []models.FlightResult{through}, pricer, crossShopDefaultWindow, SearchOptions{})
+	if len(alts) != 0 {
+		t.Fatalf("single-ticket through-fare must not be cross-shopped, got %d alternatives", len(alts))
+	}
+	if status.Status != models.StatusSkipped {
+		t.Errorf("status = %q, want skipped (no eligible self-connect itinerary)", status.Status)
+	}
+}
+
+// TestCrossShopEnabled_DefaultOff proves the enricher is gated off by default so
+// it never alters existing booking flows without explicit opt-in.
+func TestCrossShopEnabled_DefaultOff(t *testing.T) {
+	t.Setenv("TRVL_CROSSSHOP_ENRICH", "")
+	if crossShopEnabled() {
+		t.Error("cross-shop must be off by default")
+	}
+	t.Setenv("TRVL_CROSSSHOP_ENRICH", "1")
+	if !crossShopEnabled() {
+		t.Error("cross-shop must enable with TRVL_CROSSSHOP_ENRICH=1")
+	}
+}
+
+// TestPriceSegment_RejectsZeroPrice proves a zero-price candidate is not treated
+// as a valid re-price (it would corrupt the sum).
+func TestPriceSegment_RejectsZeroPrice(t *testing.T) {
+	seg := flightSegment{Origin: "HEL", Dest: "IST", Date: "2026-07-01", DepartAt: mustTime("2026-07-01T08:00"), HasTime: true}
+	pricer := fakePricer(map[string][]models.FlightResult{
+		"HEL-IST": {gflight("HEL", "IST", "2026-07-01T08:10", 0, "EUR")},
+	})
+	if _, ok := priceSegment(context.Background(), pricer, seg, "EUR", crossShopDefaultWindow, SearchOptions{}); ok {
+		t.Error("zero-price candidate must not price a segment")
+	}
+}
+
+func mustTime(s string) time.Time {
+	t, err := time.Parse(flightTimeLayout, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -415,6 +415,21 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	normalizeFlightCurrencies(ctx, easyjetFlights, target, destinations.ConvertCurrency)
 
 	mergedFlights := mergeFlightResults(googleFlights, kiwiFlights, skiplaggedFlights, opts, ryanairFlights, wizzairFlights, transaviaFlights, easyjetFlights)
+
+	// Cross-shop re-pricing (MIK-4956 Phase C): re-price each segment of a
+	// Kiwi-discovered self-connect itinerary on Google Flights and append a
+	// "book-direct" separate-tickets alternative. Gated + append-only, so it
+	// never alters the existing merge/booking flow. A segment that cannot be
+	// priced yields a non-definitive status -> completeness goes partial below
+	// (no fabricated total). Only runs when Google succeeded (it is the pricer).
+	if crossShopEnabled() && googleSucceeded {
+		alts, xshopStatus := enrichCrossShop(ctx, mergedFlights, googleSegmentPricer(target), crossShopDefaultWindow, opts)
+		statuses = append(statuses, xshopStatus)
+		if len(alts) > 0 {
+			mergedFlights = append(mergedFlights, alts...)
+		}
+	}
+
 	if googleSucceeded || kiwiSucceeded || skiplaggedSucceeded || ryanairSucceeded || wizzairSucceeded || transaviaSucceeded || easyjetSucceeded {
 		return &models.FlightSearchResult{
 			Success:          true,
@@ -481,6 +496,12 @@ func cloneFlightSearchResult(shared *models.FlightSearchResult) *models.FlightSe
 			}
 			if flight.Legs != nil {
 				flightCopy.Legs = append([]models.FlightLeg(nil), flight.Legs...)
+			}
+			if flight.Sources != nil {
+				flightCopy.Sources = append([]models.PriceSource(nil), flight.Sources...)
+			}
+			if flight.SegmentSources != nil {
+				flightCopy.SegmentSources = append([]models.PriceSource(nil), flight.SegmentSources...)
 			}
 			if flight.CarryOnIncluded != nil {
 				carryOn := *flight.CarryOnIncluded

--- a/internal/models/flight.go
+++ b/internal/models/flight.go
@@ -51,6 +51,22 @@ type FlightResult struct {
 	// favoured over fares that already include a bag. 0 = not computed (use Price).
 	ComparablePrice     float64 `json:"comparable_price,omitempty"`
 	ComparableBreakdown string  `json:"comparable_breakdown,omitempty"`
+
+	// SegmentSources carries the cross-shop "book-direct" re-pricing of a
+	// multi-stop / self-connect itinerary (MIK-4956 Phase C, XSHOP.4): one
+	// PriceSource per leg, aligned to Legs by index, each re-priced on a
+	// direct provider (Google Flights) for that segment's route + date. It is
+	// DISTINCT from Sources: Sources collapses the same physical itinerary
+	// returned by several providers (cheapest headline), whereas
+	// SegmentSources decomposes ONE itinerary into separately-bookable legs
+	// whose prices are SUMMED into the headline Price. The no-fabrication
+	// guard (XSHOP.4) requires SegmentSources to be either empty or fully
+	// populated (one entry per leg); a partially-priced itinerary never
+	// carries a summed total.
+	SegmentSources []PriceSource `json:"segment_sources,omitempty"`
+	// BookDirect marks this FlightResult as a synthetic separate-tickets
+	// alternative assembled from SegmentSources, not a single bookable fare.
+	BookDirect bool `json:"book_direct,omitempty"`
 }
 
 // PriceForRanking returns ComparablePrice when computed, else the base Price.


### PR DESCRIPTION
MIK-4956 Phase C. Decomposes a Kiwi self-connect itinerary into ordered segments using route plus layover-time data (Kiwi exposes no carrier data, per the verified Phase B finding), re-prices each segment on Google Flights within a time window, and appends a book-direct (separate-tickets) alternative with summed price, per-segment PriceSources, savings vs Kiwi-bundled, and a self-connect risk warning. No-fabrication guard: the alternative appears only when ALL segments price; otherwise completeness goes partial (MIK-4950 envelope), never a fake total. Behind TRVL_CROSSSHOP_ENRICH (off by default; append-only, rollback equals revert). 12 deterministic offline tests. Rebased onto current main (resolved the searchFlightsCore conflict to keep both the #115 Wizz fix and the #161 easyJet adapter); DoD green (build, vet, staticcheck, race suite).