### PR TITLE
docs: #167 surface find_trip_window + one-binary pipeline; add ROADMAP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,18 @@ Optional parameters:
 ```
 Optional: `trip_duration` (days), `is_round_trip` (true/false)
 
+### find_trip_window — Cheapest flexible-date window for a stay of N–M nights
+```json
+{"origin": "BGY", "destination": "NAP", "earliest_depart": "2026-07-22", "latest_return": "2026-08-06", "min_nights": 5, "max_nights": 7}
+```
+Use this when the trip length is a *range*, not a fixed date: it returns the cheapest
+round-trip date combinations whose stay falls between `min_nights` (default 3) and
+`max_nights` (default 7), ranked by price. This is the flexible-date duration-window
+search — one tool call instead of scanning every date pair by hand. `Adults` is
+honoured, so prices are for the real party size (not single-adult-only). For a
+multi-airport city, call it once per airport code (e.g. BGY, MXP, LIN) and merge —
+`fli`-style metro codes are not used; each airport is a separate round-trip.
+
 ### search_accommodations — Criteria-first room/apartment search
 ```json
 {"location": "Tokyo", "check_in": "2026-06-15", "check_out": "2026-06-18", "adults": 2, "children_ages": [7], "accommodation_type": "entire_apartment", "must_have_kitchen": true, "refundable_required": true}
@@ -541,6 +553,25 @@ Runs 37 detectors in parallel: hidden-city, throwaway, positioning, back-to-back
 - `plan-trip` — Full trip planning: flights + hotels + budget analysis
 - `find-cheapest-dates` — Month-wide price calendar for a route
 - `compare-hotels` — Side-by-side hotel comparison by user priorities
+
+## Budget travel pipeline (one binary)
+
+trvl covers the whole flight + accommodation budget search on its own — no separate
+flight tool, no separate price-verification server. The reliable pattern (sequential,
+not joint — LLMs lose track over hundreds of speculative calls):
+
+1. **Flights window** — `find_trip_window` per departure airport (`min_nights`/`max_nights`,
+   real `adults` count). Merge the per-airport results and keep the top 8–10 cheapest dates.
+2. **Accommodation, verified** — for each kept flight date, call `search_accommodations`
+   (check-in = outbound, check-out = return, the real `adults`). It verifies room-level
+   rates for the shortlist and returns only criteria-matched offers in `offers`; raw
+   `candidates` lead-in prices are Google Hotels teasers and must not be ranked on.
+3. **Rank by total trip cost** — flight (×party) + the verified accommodation total.
+   Hotel nightly rates are far more stable than flight prices across small date shifts,
+   so let flights be the variable part and rank on the combined total.
+
+This is the same flights-then-accommodation flow people build with three separate tools,
+done with trvl alone.
 
 ## Response Tips
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,38 @@
+# trvl Roadmap
+
+Living roadmap. Sequenced by ROI and dependency, not by wishlist size. Each item links a tracking issue.
+
+## Shipped
+
+- **v1.9.2** (2026-06-14): wrong-hotel SerpAPI guard. A name-based lookup with no Google place ID no longer returns a different property's prices labelled `verified` (reported by @RobertoReale). main healed to the released line; LCC integration (Ryanair/Wizz/easyJet) confirmed shipped.
+
+## v1.10 — Trust & Discoverability
+
+The batch surfaced by @RobertoReale's "Budget Travel Pipeline" blog (parts 1 & 2). Most of what the blog asked for already exists in trvl (`find_trip_window`, multi-passenger `adults`, `search_accommodations` verification, `price_basis` tax basis, anomaly `missing_criteria`), so the work is exposing and hardening it, not building net-new subsystems. Four of five touch the accommodation trust surface, so they ship as one release.
+
+| Issue | Pri | What | Why |
+|---|---|---|---|
+| #167 | P1 | Docs: surface `find_trip_window`, multi-pax, verified accommodation | A power user forked `fli` and built `hotel-rates-mcp` to get what trvl already does, because the docs hid it. Highest leverage, docs-only, zero code risk. **Do first.** |
+| #168 | P1 | Link-durability triage: drop dead `aclk`/`travel/clk` redirects, always emit a durable Booking.com fallback | Fulfils the "link that works" promise; an expired link sends the user to a 404. |
+| #169 | P2 | Tourist/city tax as a separate cash note (never estimated, never ranked) | Completes the honesty story; one field. |
+| #171 | P3 | Flag tax-added-at-checkout when shown total == pre-tax | Sharpens the existing `price_basis` signal. |
+| #170 | P2 | Expose `--min-duration`/`--max-duration` on `trvl dates` CLI (engine already supports it) | Closes the exact CLI gap behind the `fli` fork. Flight-side, parallelizable. |
+
+**Exit:** cut v1.10, then reply to @RobertoReale: the gaps he worked around are now native.
+
+## v1.11 — Reach
+
+| Issue | Pri | What |
+|---|---|---|
+| #19 / MIK-6076 | P3 | Directory submissions (mcp.so, Glama, Smithery, PulseMCP). trvl is discoverable via GitHub/pkg.go.dev but not yet broadly registry-listed; submission has real value. |
+| MIK-3288 | P3 | Stealth-mode opt-in for nab + trvl: hardens the scrapers the no-key promise depends on. |
+
+## vNext — Platform
+
+| Issue | What |
+|---|---|
+| MIK-4633 | trvl-plugin epic — price-watch automation. Monitors + CronCreate + PushNotification = "tell me when this trip drops below €X". The leap from search tool to standing agent. Needs its own design spike before it is DoR-ready. |
+
+## Meta
+
+- **Release process**: v1.9.1 was tagged off a feature branch and never merged back to `main`, orphaning `main` 5 commits behind the released code. Fix the tag-triggered flow to merge back (or release only from `main`) before the next release repeats it.


### PR DESCRIPTION
Implements #167 (discoverability) and adds a public roadmap.

## #167 — discoverability
`find_trip_window` (min/max-nights flexible-window flight search) was **absent from the AGENTS.md tool list**, so power users reinvented it — @RobertoReale forked `fli` to build the same `--min-duration`/`--max-duration` feature trvl already ships. This adds:
- a `find_trip_window` tool section (min/max nights, multi-airport, real `adults`)
- a one-binary budget-pipeline recipe (flights window -> top-N -> verified accommodation -> rank by total)

## ROADMAP.md
v1.10 Trust & Discoverability batch (#167-#171), v1.11 Reach (#19, MIK-3288), vNext platform epic (MIK-4633), and the release-process meta-fix (v1.9.1 orphaned main).

Docs-only. anti-ai-tell lint clean on ROADMAP.md.

Refs #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)