### PR TITLE
feat(cli): --min-duration/--max-duration on 'trvl dates' (#170)

### DIFF
--- a/cmd/trvl/dates.go
+++ b/cmd/trvl/dates.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/MikkoParkkola/trvl/internal/destinations"
@@ -18,6 +19,8 @@ func datesCmd() *cobra.Command {
 		fromDate       string
 		toDate         string
 		duration       int
+		minDuration    int
+		maxDuration    int
 		roundTrip      bool
 		adults         int
 		format         string
@@ -59,52 +62,47 @@ Examples:
 				return err
 			}
 
-			if legacy {
-				// Legacy: per-date N-call approach.
-				opts := flights.DateSearchOptions{
-					FromDate:  fromDate,
-					ToDate:    toDate,
-					Duration:  duration,
-					RoundTrip: roundTrip,
-					Adults:    adults,
-				}
-
-				result, err := flights.SearchDates(cmd.Context(), origin, destination, opts)
-				if err != nil {
-					return err
-				}
-
-				if format == "json" {
-					return models.FormatJSON(os.Stdout, result)
-				}
-				return printDatesTable(cmd.Context(), targetCurrency, result)
-			}
-
-			// Default: CalendarGraph (single request, fast).
-			opts := flights.CalendarOptions{
-				FromDate:   fromDate,
-				ToDate:     toDate,
-				TripLength: duration,
-				RoundTrip:  roundTrip,
-				Adults:     adults,
-			}
-
-			result, err := flights.SearchCalendar(cmd.Context(), origin, destination, opts)
+			// Resolve the stay-duration range. --duration is the single-length
+			// shorthand; --min-duration/--max-duration request a window of stay
+			// lengths (the feature @RobertoReale forked fli to add). A range
+			// only makes sense for a round trip, so it implies --round-trip.
+			durations, err := durationRange(duration, minDuration, maxDuration)
 			if err != nil {
 				return err
 			}
-
-			if format == "json" {
-				return models.FormatJSON(os.Stdout, result)
+			if len(durations) > 1 {
+				roundTrip = true
 			}
 
-			return printDatesTable(cmd.Context(), targetCurrency, result)
+			merged := &models.DateSearchResult{Success: true, TripType: tripTypeLabel(roundTrip)}
+			for _, d := range durations {
+				result, err := runDateSearch(cmd.Context(), origin, destination, dateSearchParams{
+					fromDate:  fromDate,
+					toDate:    toDate,
+					duration:  d,
+					roundTrip: roundTrip,
+					adults:    adults,
+					legacy:    legacy,
+				})
+				if err != nil {
+					return err
+				}
+				mergeDateResults(merged, result)
+			}
+			finalizeMergedDates(merged)
+
+			if format == "json" {
+				return models.FormatJSON(os.Stdout, merged)
+			}
+			return printDatesTable(cmd.Context(), targetCurrency, merged)
 		},
 	}
 
 	cmd.Flags().StringVar(&fromDate, "from", "", "Start of date range (YYYY-MM-DD); default: tomorrow")
 	cmd.Flags().StringVar(&toDate, "to", "", "End of date range (YYYY-MM-DD); default: from + 30 days")
-	cmd.Flags().IntVar(&duration, "duration", 7, "Trip duration in days (for round-trip)")
+	cmd.Flags().IntVar(&duration, "duration", 7, "Trip duration in days (for round-trip). Shorthand for --min-duration N --max-duration N")
+	cmd.Flags().IntVar(&minDuration, "min-duration", 0, "Minimum stay length in nights for a flexible-duration window (round-trip)")
+	cmd.Flags().IntVar(&maxDuration, "max-duration", 0, "Maximum stay length in nights for a flexible-duration window (round-trip)")
 	cmd.Flags().BoolVar(&roundTrip, "round-trip", false, "Search round-trip prices")
 	cmd.Flags().IntVar(&adults, "adults", 1, "Number of adult passengers")
 	cmd.Flags().StringVar(&format, "format", "table", "Output format: table, json")
@@ -115,6 +113,108 @@ Examples:
 	cmd.ValidArgsFunction = airportCompletion
 
 	return cmd
+}
+
+// dateSearchParams bundles the inputs for a single-duration date search.
+type dateSearchParams struct {
+	fromDate  string
+	toDate    string
+	duration  int
+	roundTrip bool
+	adults    int
+	legacy    bool
+}
+
+// durationRange resolves the requested stay-length range into the explicit list
+// of night counts to search. --duration is the single-length default;
+// --min-duration/--max-duration request a window. Either bound alone fills in
+// the other. Returns an error for an invalid (min > max or non-positive) range.
+func durationRange(duration, minDuration, maxDuration int) ([]int, error) {
+	if minDuration == 0 && maxDuration == 0 {
+		if duration <= 0 {
+			return []int{1}, nil
+		}
+		return []int{duration}, nil
+	}
+	lo, hi := minDuration, maxDuration
+	if lo == 0 {
+		lo = hi
+	}
+	if hi == 0 {
+		hi = lo
+	}
+	if lo <= 0 {
+		return nil, fmt.Errorf("--min-duration must be at least 1")
+	}
+	if lo > hi {
+		return nil, fmt.Errorf("--min-duration (%d) cannot exceed --max-duration (%d)", lo, hi)
+	}
+	out := make([]int, 0, hi-lo+1)
+	for d := lo; d <= hi; d++ {
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+// runDateSearch runs one date search for a single stay length via the default
+// CalendarGraph path or the legacy per-date path.
+func runDateSearch(ctx context.Context, origin, destination string, p dateSearchParams) (*models.DateSearchResult, error) {
+	if p.legacy {
+		return flights.SearchDates(ctx, origin, destination, flights.DateSearchOptions{
+			FromDate:  p.fromDate,
+			ToDate:    p.toDate,
+			Duration:  p.duration,
+			RoundTrip: p.roundTrip,
+			Adults:    p.adults,
+		})
+	}
+	return flights.SearchCalendar(ctx, origin, destination, flights.CalendarOptions{
+		FromDate:   p.fromDate,
+		ToDate:     p.toDate,
+		TripLength: p.duration,
+		RoundTrip:  p.roundTrip,
+		Adults:     p.adults,
+	})
+}
+
+// mergeDateResults appends one search's dated prices into the accumulator.
+// Failed sub-searches (Success=false) contribute nothing.
+func mergeDateResults(into, from *models.DateSearchResult) {
+	if from == nil || !from.Success {
+		return
+	}
+	into.Dates = append(into.Dates, from.Dates...)
+	if into.DateRange == "" {
+		into.DateRange = from.DateRange
+	}
+}
+
+// finalizeMergedDates dedupes (by depart+return date), sorts by price ascending,
+// and sets the count on a merged multi-duration result.
+func finalizeMergedDates(r *models.DateSearchResult) {
+	seen := make(map[string]bool, len(r.Dates))
+	deduped := r.Dates[:0]
+	for _, d := range r.Dates {
+		key := d.Date + "|" + d.ReturnDate
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		deduped = append(deduped, d)
+	}
+	r.Dates = deduped
+	sort.SliceStable(r.Dates, func(i, j int) bool {
+		return r.Dates[i].Price < r.Dates[j].Price
+	})
+	r.Count = len(r.Dates)
+}
+
+// tripTypeLabel maps the round-trip flag to the result's trip_type string.
+func tripTypeLabel(roundTrip bool) string {
+	if roundTrip {
+		return "round_trip"
+	}
+	return "one_way"
 }
 
 // printDatesTable renders date price results as an ASCII table.

--- a/cmd/trvl/dates_minmax_test.go
+++ b/cmd/trvl/dates_minmax_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// #170: --min-duration/--max-duration request a window of stay lengths (the
+// feature @RobertoReale forked fli to add). --duration stays the single-length
+// shorthand.
+func TestDurationRange(t *testing.T) {
+	cases := []struct {
+		name                     string
+		duration, minDur, maxDur int
+		want                     []int
+		wantErr                  bool
+	}{
+		{"single default duration", 7, 0, 0, []int{7}, false},
+		{"explicit range", 7, 5, 7, []int{5, 6, 7}, false},
+		{"min only fills max", 7, 5, 0, []int{5}, false},
+		{"max only fills min", 7, 0, 6, []int{6}, false},
+		{"same min max", 7, 5, 5, []int{5}, false},
+		{"min exceeds max", 7, 8, 5, nil, true},
+		{"non-positive min", 7, -1, 5, nil, true},
+		{"zero duration falls back to 1", 0, 0, 0, []int{1}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := durationRange(c.duration, c.minDur, c.maxDur)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("durationRange(%d,%d,%d) want error, got %v", c.duration, c.minDur, c.maxDur, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("durationRange(%d,%d,%d) unexpected error: %v", c.duration, c.minDur, c.maxDur, err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("durationRange(%d,%d,%d) = %v, want %v", c.duration, c.minDur, c.maxDur, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMergeAndFinalizeDates(t *testing.T) {
+	merged := &models.DateSearchResult{Success: true, TripType: "round_trip"}
+	mergeDateResults(merged, &models.DateSearchResult{Success: true, DateRange: "Jul", Dates: []models.DatePriceResult{
+		{Date: "2026-07-30", ReturnDate: "2026-08-04", Price: 779},
+		{Date: "2026-07-25", ReturnDate: "2026-07-30", Price: 46},
+	}})
+	// A failed sub-search contributes nothing.
+	mergeDateResults(merged, &models.DateSearchResult{Success: false, Dates: []models.DatePriceResult{
+		{Date: "2026-09-01", ReturnDate: "2026-09-06", Price: 1},
+	}})
+	// A duplicate depart+return is deduped.
+	mergeDateResults(merged, &models.DateSearchResult{Success: true, Dates: []models.DatePriceResult{
+		{Date: "2026-07-30", ReturnDate: "2026-08-04", Price: 779},
+		{Date: "2026-08-01", ReturnDate: "2026-08-07", Price: 49},
+	}})
+	finalizeMergedDates(merged)
+
+	if merged.Count != 3 {
+		t.Fatalf("count = %d, want 3 (deduped, failed search excluded)", merged.Count)
+	}
+	if merged.Dates[0].Price != 46 {
+		t.Errorf("cheapest first: got %.0f, want 46", merged.Dates[0].Price)
+	}
+	for i := 1; i < len(merged.Dates); i++ {
+		if merged.Dates[i].Price < merged.Dates[i-1].Price {
+			t.Errorf("dates not sorted ascending by price at %d", i)
+		}
+	}
+}


### PR DESCRIPTION
Closes #170 (v1.10 Trust & Discoverability batch).

The `find_trip_window` MCP tool already supports a stay-length range (`min_nights`/`max_nights`), but `trvl dates` only had a single `--duration`. @RobertoReale forked `fli` specifically to add `--min-duration`/`--max-duration` — trvl's engine already does it, the CLI just didn't expose it. This closes that gap.

- `--min-duration`/`--max-duration`: searches each night-count in the range, merges + dedupes the dated prices, ranks by price
- `--duration N` stays the single-length shorthand (back-compat)
- a range implies `--round-trip`; invalid ranges (min>max, non-positive) error clearly

Tests: `durationRange` resolution + merge/dedup/sort. build + vet + `-short` green.

Credit @RobertoReale — this closes the exact CLI gap behind his fli fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)