### PR TITLE
feat(hotels): add Anyplace mid-term furnished-apartment provider for nomads

### DIFF
--- a/internal/hotels/anyplace.go
+++ b/internal/hotels/anyplace.go
@@ -1,0 +1,390 @@
+package hotels
+
+// Anyplace mid-term / nomad furnished-apartment provider.
+//
+// Anyplace (https://www.anyplace.com) lists furnished apartments for stays of a
+// month or more — the digital-nomad / relocation segment that traditional
+// nightly-hotel providers (Google Hotels, Trivago, Booking) miss entirely. Its
+// inventory is monthly-priced furnished rentals with a minimum stay (typically
+// 30 nights), which makes it high-value for long-trip and relocation planning.
+//
+// Unauthenticated feasibility (recon-verified, Tier-A):
+//   - No API key, headless browser, residential proxy, nor CAPTCHA bypass is
+//     required. Plain HTTP with a desktop User-Agent suffices.
+//   - The site is a Next.js app. Every page embeds a <script id="__NEXT_DATA__">
+//     JSON blob carrying the deploy's "buildId". The structured listing data is
+//     served from the Next.js data endpoint:
+//       GET /_next/data/<buildId>/listings/{city}.json  ->  clean JSON
+//     which returns the same pageProps the SSR HTML hydrates from (urql/GraphQL
+//     underneath, but the _next/data JSON is already flattened and key-stable).
+//   - City catalog is enumerable from the public sitemaps
+//     (/sitemap-cities.xml + /sitemap-listings.xml); the search interface here
+//     derives the city slug directly from the query, so sitemap crawling is not
+//     needed on the hot path. See enumeration note below.
+//
+// BUILDID ROTATION (verified gotcha, mirrors internal/flights/wizzair.go's API
+// version rotation): the <buildId> path segment changes on every Anyplace
+// deploy. It is NOT hardcoded. It is resolved dynamically at request time from
+// the __NEXT_DATA__ blob on a live page. Resolution order (first hit wins):
+//
+//  1. ANYPLACE_BUILD_ID env var (operator override, zero-deploy fix if the
+//     auto-resolve path ever breaks).
+//  2. Dynamic resolve: GET the city page HTML, parse __NEXT_DATA__, read buildId.
+//
+// There is deliberately NO last-known-good constant: a stale buildId 404s the
+// data endpoint, so a hardcoded fallback would be worse than resolving fresh.
+//
+// Two-step flow, mirroring HomeToGo/Trivago's resolve-then-fetch pattern:
+//  1. resolveAnyplaceBuildID(ctx, citySlug) -> buildId (from __NEXT_DATA__)
+//  2. fetchAnyplaceCity(ctx, buildId, citySlug) -> listings JSON -> []HotelResult
+//
+// Field mapping (recon-confirmed Anyplace listing fields -> models.HotelResult):
+//   id            -> HotelID
+//   title         -> Name
+//   price         -> Price            (headline, e.g. 4645)
+//   monthlyPrice  -> Description note  (e.g. 4170 USD/mo) + PriceSource
+//   currency      -> Currency         (e.g. USD)
+//   minimumStay   -> Description note  (e.g. 30-night min)
+//   bedroom       -> Description note  (e.g. 1 bed)
+//   bathroom      -> Description note  (e.g. 1 bath)
+//   lat / long    -> Lat / Lon
+//   propertyType  -> PropertyType     ("furnished_apartment" -> "apartment")
+//
+// monthlyPrice, minimumStay and bedroom/bathroom have no dedicated HotelResult
+// field, so they are folded into the user-visible Description string rather than
+// dropped — they are the whole point of the mid-term segment.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"golang.org/x/time/rate"
+)
+
+// anyplaceEnabled controls whether SearchAnyplace makes live HTTP requests.
+// Disabled in the test suite (see testmain_test.go) so deterministic tests never
+// fire real network calls; individual tests flip it on with a mock server
+// injected via anyplaceBaseURL.
+var anyplaceEnabled = true
+
+// anyplaceBaseURL is the root of the Anyplace site. Overridable in tests so an
+// httptest.Server can stand in for the live host.
+var anyplaceBaseURL = "https://www.anyplace.com"
+
+// anyplaceUserAgent is a desktop browser UA. Anyplace serves the SSR HTML and
+// _next/data JSON to ordinary desktop clients; no special headers are required.
+const anyplaceUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+	"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+// anyplaceLimiter enforces a conservative request rate to avoid tripping the
+// edge rate limits. Two requests per search (resolve buildId + fetch JSON).
+// Mirrors the per-provider rate.Limiter convention in internal/flights/wizzair.go.
+var anyplaceLimiter = rate.NewLimiter(rate.Every(500*time.Millisecond), 2)
+
+// anyplaceHTTPClient is a dedicated client with a sane timeout.
+var anyplaceHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
+// anyplaceNextDataRe extracts the __NEXT_DATA__ JSON blob from a Next.js page.
+// The script tag is emitted verbatim by Next.js on every page; the capture group
+// is the JSON object that carries buildId.
+var anyplaceNextDataRe = regexp.MustCompile(
+	`(?s)<script id="__NEXT_DATA__" type="application/json">(.*?)</script>`)
+
+// ---- Response types (only the fields we consume) ----
+
+// anyplaceNextData is the shape of the __NEXT_DATA__ blob; we read only buildId.
+type anyplaceNextData struct {
+	BuildID string `json:"buildId"`
+}
+
+// anyplaceDataResponse is the _next/data JSON envelope: Next.js wraps
+// getStaticProps/getServerSideProps output under "pageProps".
+type anyplaceDataResponse struct {
+	PageProps anyplacePageProps `json:"pageProps"`
+}
+
+type anyplacePageProps struct {
+	Listings []anyplaceListing `json:"listings"`
+}
+
+// anyplaceListing is a single furnished-apartment listing.
+type anyplaceListing struct {
+	ID           string  `json:"id"`
+	Slug         string  `json:"slug"`
+	Title        string  `json:"title"`
+	Price        float64 `json:"price"`
+	MonthlyPrice float64 `json:"monthlyPrice"`
+	Currency     string  `json:"currency"`
+	MinimumStay  int     `json:"minimumStay"`
+	Bedroom      int     `json:"bedroom"`
+	Bathroom     int     `json:"bathroom"`
+	PropertyType string  `json:"propertyType"`
+	Lat          float64 `json:"lat"`
+	Long         float64 `json:"long"`
+	Photo        string  `json:"photo"`
+	Address      string  `json:"address"`
+}
+
+// SearchAnyplace searches Anyplace for mid-term furnished apartments near a
+// location. It is non-fatal by contract: callers treat any error as "zero
+// results". Returns nil, nil when disabled (test mode).
+func SearchAnyplace(ctx context.Context, location string, opts HotelSearchOptions) ([]models.HotelResult, error) {
+	if !anyplaceEnabled {
+		return nil, nil
+	}
+	if strings.TrimSpace(location) == "" {
+		return nil, fmt.Errorf("anyplace: location is required")
+	}
+
+	citySlug := anyplaceCitySlug(location)
+
+	// Step 1: resolve the deploy's buildId (env override, else dynamic from the
+	// city page's __NEXT_DATA__ blob).
+	slog.Debug("anyplace resolve buildId", "location", location, "slug", citySlug)
+	buildID, err := resolveAnyplaceBuildID(ctx, citySlug)
+	if err != nil {
+		return nil, fmt.Errorf("anyplace resolve buildId: %w", err)
+	}
+
+	// Step 2: fetch the _next/data listings JSON for that city.
+	slog.Debug("anyplace fetch city", "location", location, "buildId", buildID)
+	raw, err := fetchAnyplaceCity(ctx, buildID, citySlug)
+	if err != nil {
+		return nil, fmt.Errorf("anyplace fetch city: %w", err)
+	}
+
+	currency := strings.TrimSpace(opts.Currency)
+	hotels, err := parseAnyplaceListings(raw, currency)
+	if err != nil {
+		return nil, fmt.Errorf("anyplace parse: %w", err)
+	}
+	slog.Debug("anyplace results", "location", location, "count", len(hotels))
+	return hotels, nil
+}
+
+// anyplaceCitySlug converts a free-text location into the URL slug Anyplace uses
+// for its city listing pages: lowercase, spaces/commas collapsed to single
+// hyphens, ASCII-only path-safe. e.g. "Lisbon, Portugal" -> "lisbon-portugal".
+func anyplaceCitySlug(location string) string {
+	s := strings.ToLower(strings.TrimSpace(location))
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevHyphen = false
+		case r == ' ' || r == ',' || r == '-' || r == '/' || r == '.':
+			if !prevHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		default:
+			// drop other characters (accents, punctuation)
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// resolveAnyplaceBuildID returns the Next.js buildId for the current deploy.
+// The ANYPLACE_BUILD_ID env var takes precedence (operator zero-deploy override);
+// otherwise it is resolved dynamically from the city page's __NEXT_DATA__ blob.
+func resolveAnyplaceBuildID(ctx context.Context, citySlug string) (string, error) {
+	if v := strings.TrimSpace(os.Getenv("ANYPLACE_BUILD_ID")); v != "" {
+		return v, nil
+	}
+	if citySlug == "" {
+		return "", fmt.Errorf("empty city slug")
+	}
+	body, err := anyplaceGet(ctx, anyplaceBaseURL+"/listings/"+citySlug, "text/html,application/xhtml+xml")
+	if err != nil {
+		return "", err
+	}
+	m := anyplaceNextDataRe.FindSubmatch(body)
+	if m == nil {
+		return "", fmt.Errorf("no __NEXT_DATA__ blob found for slug %q", citySlug)
+	}
+	var nd anyplaceNextData
+	if err := json.Unmarshal(m[1], &nd); err != nil {
+		return "", fmt.Errorf("decode __NEXT_DATA__: %w", err)
+	}
+	if strings.TrimSpace(nd.BuildID) == "" {
+		return "", fmt.Errorf("empty buildId in __NEXT_DATA__ for slug %q", citySlug)
+	}
+	return nd.BuildID, nil
+}
+
+// fetchAnyplaceCity fetches the _next/data listings JSON for a city.
+func fetchAnyplaceCity(ctx context.Context, buildID, citySlug string) (json.RawMessage, error) {
+	if buildID == "" {
+		return nil, fmt.Errorf("empty buildId")
+	}
+	if citySlug == "" {
+		return nil, fmt.Errorf("empty city slug")
+	}
+	url := anyplaceBaseURL + "/_next/data/" + buildID + "/listings/" + citySlug + ".json"
+	body, err := anyplaceGet(ctx, url, "application/json")
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(body), nil
+}
+
+// anyplaceGet performs a rate-limited GET with the desktop UA and returns the
+// response body. Non-2xx responses are errors.
+func anyplaceGet(ctx context.Context, url, accept string) ([]byte, error) {
+	if err := anyplaceLimiter.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("rate limiter: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", anyplaceUserAgent)
+	req.Header.Set("Accept", accept)
+	resp, err := anyplaceHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20)) // 8 MiB cap
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// parseAnyplaceListings maps an Anyplace _next/data listings payload to
+// HotelResults. Listings without a usable headline price are skipped so every
+// returned result is actually comparable. fallbackCurrency is used when a
+// listing carries no currency token; when empty it defaults to USD (Anyplace's
+// default display currency).
+func parseAnyplaceListings(raw json.RawMessage, fallbackCurrency string) ([]models.HotelResult, error) {
+	var resp anyplaceDataResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	results := make([]models.HotelResult, 0, len(resp.PageProps.Listings))
+	for _, l := range resp.PageProps.Listings {
+		if l.Price <= 0 {
+			continue // no headline price -> not comparable, skip
+		}
+		currency := anyplaceCurrency(l.Currency, fallbackCurrency)
+
+		h := models.HotelResult{
+			Name:         strings.TrimSpace(l.Title),
+			HotelID:      l.ID,
+			Price:        l.Price,
+			Currency:     currency,
+			Address:      strings.TrimSpace(l.Address),
+			ImageURL:     anyplaceAbsURL(l.Photo),
+			BookingURL:   anyplaceListingURL(l.Slug),
+			PropertyType: anyplacePropertyType(l.PropertyType),
+			Lat:          l.Lat,
+			Lon:          l.Long,
+			Description:  anyplaceDescription(l),
+		}
+		if h.Name == "" {
+			h.Name = "Anyplace furnished apartment"
+		}
+		h.Sources = []models.PriceSource{{
+			Provider:   "anyplace",
+			Price:      l.Price,
+			Currency:   currency,
+			BookingURL: h.BookingURL,
+		}}
+		results = append(results, h)
+	}
+	return results, nil
+}
+
+// anyplaceDescription folds the mid-term-specific fields (monthly price, minimum
+// stay, bed/bath counts) — which have no dedicated HotelResult field — into a
+// compact, user-visible summary. e.g.
+// "Furnished apartment · 1 bed · 1 bath · 30-night min · 4170 USD/mo".
+func anyplaceDescription(l anyplaceListing) string {
+	currency := strings.ToUpper(strings.TrimSpace(l.Currency))
+	if currency == "" {
+		currency = "USD"
+	}
+	parts := make([]string, 0, 5)
+	parts = append(parts, "Furnished apartment")
+	if l.Bedroom > 0 {
+		parts = append(parts, fmt.Sprintf("%d bed", l.Bedroom))
+	}
+	if l.Bathroom > 0 {
+		parts = append(parts, fmt.Sprintf("%d bath", l.Bathroom))
+	}
+	if l.MinimumStay > 0 {
+		parts = append(parts, fmt.Sprintf("%d-night min", l.MinimumStay))
+	}
+	if l.MonthlyPrice > 0 {
+		parts = append(parts, fmt.Sprintf("%.0f %s/mo", l.MonthlyPrice, currency))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// anyplaceCurrency normalises a listing currency to an ISO 4217 code, falling
+// back to the provided default, then USD (Anyplace's default display currency).
+func anyplaceCurrency(currency, fallback string) string {
+	if c := strings.ToUpper(strings.TrimSpace(currency)); c != "" {
+		return c
+	}
+	if fallback != "" {
+		return strings.ToUpper(strings.TrimSpace(fallback))
+	}
+	return "USD"
+}
+
+// anyplacePropertyType normalises Anyplace's propertyType to the HotelResult
+// vocabulary (hotel|hostel|apartment|vacation_rental|...). Anyplace's inventory
+// is "furnished_apartment", which maps to "apartment".
+func anyplacePropertyType(pt string) string {
+	switch strings.ToLower(strings.TrimSpace(pt)) {
+	case "", "furnished_apartment", "apartment":
+		return "apartment"
+	default:
+		return strings.ToLower(strings.TrimSpace(pt))
+	}
+}
+
+// anyplaceListingURL builds the public listing URL from a slug.
+func anyplaceListingURL(slug string) string {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return ""
+	}
+	return anyplaceBaseURL + "/listing/" + slug
+}
+
+// anyplaceAbsURL turns a relative Anyplace link into an absolute URL.
+func anyplaceAbsURL(link string) string {
+	link = strings.TrimSpace(link)
+	if link == "" {
+		return ""
+	}
+	if strings.HasPrefix(link, "http://") || strings.HasPrefix(link, "https://") {
+		return link
+	}
+	if strings.HasPrefix(link, "//") {
+		return "https:" + link
+	}
+	if !strings.HasPrefix(link, "/") {
+		link = "/" + link
+	}
+	return anyplaceBaseURL + link
+}

--- a/internal/hotels/anyplace_test.go
+++ b/internal/hotels/anyplace_test.go
@@ -1,0 +1,298 @@
+package hotels
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// loadAnyplaceCityFixture reads the saved Anyplace _next/data listings payload.
+func loadAnyplaceCityFixture(t *testing.T) json.RawMessage {
+	t.Helper()
+	b, err := os.ReadFile("testdata/anyplace_city_lisbon.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	return json.RawMessage(b)
+}
+
+// TestParseAnyplaceListingsFixture asserts the saved Lisbon payload maps to
+// well-formed HotelResults: name, numeric price+currency, geo, absolute
+// booking/image URLs, apartment property type, mid-term description, and a
+// single "anyplace" price source.
+func TestParseAnyplaceListingsFixture(t *testing.T) {
+	raw := loadAnyplaceCityFixture(t)
+	hotels, err := parseAnyplaceListings(raw, "")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// 3 listings in fixture; the unpriced stub is dropped.
+	if len(hotels) != 2 {
+		t.Fatalf("want 2 mapped hotels (stub dropped), got %d", len(hotels))
+	}
+	for i, h := range hotels {
+		if h.Name == "" {
+			t.Errorf("hotel %d: empty name", i)
+		}
+		if h.Price <= 0 {
+			t.Errorf("hotel %d (%s): non-positive price %v", i, h.Name, h.Price)
+		}
+		if h.Currency == "" {
+			t.Errorf("hotel %d (%s): empty currency", i, h.Name)
+		}
+		if h.Lat == 0 || h.Lon == 0 {
+			t.Errorf("hotel %d (%s): missing geo (%v,%v)", i, h.Name, h.Lat, h.Lon)
+		}
+		if !strings.HasPrefix(h.BookingURL, "https://") {
+			t.Errorf("hotel %d (%s): booking URL not absolute: %q", i, h.Name, h.BookingURL)
+		}
+		if h.ImageURL != "" && !strings.HasPrefix(h.ImageURL, "https://") {
+			t.Errorf("hotel %d (%s): image URL not absolute: %q", i, h.Name, h.ImageURL)
+		}
+		if h.PropertyType != "apartment" {
+			t.Errorf("hotel %d (%s): property type = %q, want apartment", i, h.Name, h.PropertyType)
+		}
+		if len(h.Sources) != 1 || h.Sources[0].Provider != "anyplace" {
+			t.Errorf("hotel %d (%s): want single anyplace source, got %+v", i, h.Name, h.Sources)
+		}
+	}
+
+	// First listing fixed assertions (deterministic fixture).
+	first := hotels[0]
+	if first.HotelID != "ap-1001" {
+		t.Errorf("first id = %q, want ap-1001", first.HotelID)
+	}
+	if first.Name != "Sunny Studio in Chiado" {
+		t.Errorf("first name = %q, want %q", first.Name, "Sunny Studio in Chiado")
+	}
+	if first.Price != 4645 {
+		t.Errorf("first price = %v, want 4645", first.Price)
+	}
+	if first.Currency != "USD" {
+		t.Errorf("first currency = %q, want USD", first.Currency)
+	}
+	if first.Lat != 38.7101 || first.Lon != -9.1421 {
+		t.Errorf("first geo = (%v,%v), want (38.7101,-9.1421)", first.Lat, first.Lon)
+	}
+	if first.ImageURL != "https://cdn.anyplace.com/listings/ap-1001/cover.jpg" {
+		t.Errorf("first image = %q (want protocol-relative made absolute)", first.ImageURL)
+	}
+	// Mid-term fields (monthlyPrice, minimumStay, bed/bath) fold into Description.
+	for _, want := range []string{"1 bed", "1 bath", "30-night min", "4170 USD/mo"} {
+		if !strings.Contains(first.Description, want) {
+			t.Errorf("first description %q missing %q", first.Description, want)
+		}
+	}
+}
+
+// TestParseAnyplaceListingsSkipsUnpriced ensures listings without a usable
+// headline price are dropped, so every result is comparable.
+func TestParseAnyplaceListingsSkipsUnpriced(t *testing.T) {
+	raw := json.RawMessage(`{"pageProps":{"listings":[
+		{"id":"a","title":"Priced","price":3000,"currency":"USD","lat":1,"long":2},
+		{"id":"b","title":"Zero price","price":0,"currency":"USD","lat":1,"long":2},
+		{"id":"c","title":"Negative price","price":-5,"currency":"USD","lat":1,"long":2}
+	]}}`)
+	hotels, err := parseAnyplaceListings(raw, "EUR")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(hotels) != 1 {
+		t.Fatalf("want 1 mapped hotel (only the priced one), got %d", len(hotels))
+	}
+	if hotels[0].HotelID != "a" {
+		t.Errorf("mapped wrong listing: %q", hotels[0].HotelID)
+	}
+}
+
+func TestAnyplaceCurrency(t *testing.T) {
+	cases := []struct {
+		currency, fallback, want string
+	}{
+		{"USD", "", "USD"},
+		{"eur", "", "EUR"},
+		{"", "gbp", "GBP"},
+		{"", "", "USD"},
+		{" usd ", "", "USD"},
+	}
+	for _, c := range cases {
+		if got := anyplaceCurrency(c.currency, c.fallback); got != c.want {
+			t.Errorf("anyplaceCurrency(%q,%q) = %q, want %q", c.currency, c.fallback, got, c.want)
+		}
+	}
+}
+
+func TestAnyplacePropertyType(t *testing.T) {
+	cases := map[string]string{
+		"furnished_apartment": "apartment",
+		"apartment":           "apartment",
+		"":                    "apartment",
+		"LOFT":                "loft",
+		"Studio":              "studio",
+	}
+	for in, want := range cases {
+		if got := anyplacePropertyType(in); got != want {
+			t.Errorf("anyplacePropertyType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestAnyplaceCitySlug(t *testing.T) {
+	cases := map[string]string{
+		"Lisbon":            "lisbon",
+		"Lisbon, Portugal":  "lisbon-portugal",
+		"  Mexico City  ":   "mexico-city",
+		"São Paulo":         "so-paulo",
+		"New York/Brooklyn": "new-york-brooklyn",
+		"":                  "",
+	}
+	for in, want := range cases {
+		if got := anyplaceCitySlug(in); got != want {
+			t.Errorf("anyplaceCitySlug(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestAnyplaceAbsURL(t *testing.T) {
+	orig := anyplaceBaseURL
+	anyplaceBaseURL = "https://www.anyplace.com"
+	defer func() { anyplaceBaseURL = orig }()
+	cases := map[string]string{
+		"":                            "",
+		"/listing/x":                  "https://www.anyplace.com/listing/x",
+		"cover.jpg":                   "https://www.anyplace.com/cover.jpg",
+		"//cdn.anyplace.com/a.jpg":    "https://cdn.anyplace.com/a.jpg",
+		"https://example.com/already": "https://example.com/already",
+	}
+	for in, want := range cases {
+		if got := anyplaceAbsURL(in); got != want {
+			t.Errorf("anyplaceAbsURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestResolveAnyplaceBuildID covers both the env override and the dynamic
+// __NEXT_DATA__ resolve path, plus the missing-blob error.
+func TestResolveAnyplaceBuildID(t *testing.T) {
+	html, err := os.ReadFile("testdata/anyplace_resolve_lisbon.html")
+	if err != nil {
+		t.Fatalf("read resolve fixture: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/listings/lisbon-portugal" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write(html)
+	}))
+	defer srv.Close()
+
+	orig := anyplaceBaseURL
+	anyplaceBaseURL = srv.URL
+	defer func() { anyplaceBaseURL = orig }()
+
+	// Env override wins without any HTTP call.
+	t.Setenv("ANYPLACE_BUILD_ID", "override-build-123")
+	id, err := resolveAnyplaceBuildID(context.Background(), "lisbon-portugal")
+	if err != nil {
+		t.Fatalf("resolve (env): %v", err)
+	}
+	if id != "override-build-123" {
+		t.Errorf("env override id = %q, want override-build-123", id)
+	}
+
+	// Dynamic resolve from __NEXT_DATA__.
+	t.Setenv("ANYPLACE_BUILD_ID", "")
+	id, err = resolveAnyplaceBuildID(context.Background(), "lisbon-portugal")
+	if err != nil {
+		t.Fatalf("resolve (dynamic): %v", err)
+	}
+	if id != "AbC123dEf456" {
+		t.Errorf("dynamic id = %q, want AbC123dEf456", id)
+	}
+
+	// Missing landing page -> error.
+	if _, err := resolveAnyplaceBuildID(context.Background(), "nowhere"); err == nil {
+		t.Error("expected error for slug with no landing page")
+	}
+}
+
+// TestSearchAnyplaceEndToEnd wires resolve + fetch against a mock server,
+// exercising the full SearchAnyplace pipeline deterministically.
+func TestSearchAnyplaceEndToEnd(t *testing.T) {
+	html, err := os.ReadFile("testdata/anyplace_resolve_lisbon.html")
+	if err != nil {
+		t.Fatalf("read resolve fixture: %v", err)
+	}
+	cityJSON, err := os.ReadFile("testdata/anyplace_city_lisbon.json")
+	if err != nil {
+		t.Fatalf("read city fixture: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/listings/lisbon-portugal":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write(html)
+		case r.URL.Path == "/_next/data/AbC123dEf456/listings/lisbon-portugal.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(cityJSON)
+		default:
+			http.Error(w, "not found: "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	origURL, origEnabled := anyplaceBaseURL, anyplaceEnabled
+	anyplaceBaseURL = srv.URL
+	anyplaceEnabled = true
+	t.Setenv("ANYPLACE_BUILD_ID", "") // force dynamic resolve through the mock
+	defer func() { anyplaceBaseURL, anyplaceEnabled = origURL, origEnabled }()
+
+	hotels, err := SearchAnyplace(context.Background(), "Lisbon, Portugal", HotelSearchOptions{Currency: "USD"})
+	if err != nil {
+		t.Fatalf("SearchAnyplace: %v", err)
+	}
+	if len(hotels) != 2 {
+		t.Fatalf("expected 2 results from end-to-end search, got %d", len(hotels))
+	}
+	if hotels[0].Sources[0].Provider != "anyplace" {
+		t.Errorf("source provider = %q, want anyplace", hotels[0].Sources[0].Provider)
+	}
+
+	// Disabled -> nil, nil.
+	anyplaceEnabled = false
+	got, err := SearchAnyplace(context.Background(), "Lisbon", HotelSearchOptions{})
+	if err != nil || got != nil {
+		t.Errorf("disabled SearchAnyplace = (%v,%v), want (nil,nil)", got, err)
+	}
+}
+
+// TestSearchAnyplaceLiveIntegration hits the real Anyplace endpoints. Opt-in
+// only: gated behind TRVL_TEST_LIVE_INTEGRATIONS=1 and skipped by -short.
+func TestSearchAnyplaceLiveIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live integration in -short mode")
+	}
+	if os.Getenv("TRVL_TEST_LIVE_INTEGRATIONS") != "1" {
+		t.Skip("set TRVL_TEST_LIVE_INTEGRATIONS=1 to run the Anyplace live integration")
+	}
+	origEnabled := anyplaceEnabled
+	anyplaceEnabled = true
+	defer func() { anyplaceEnabled = origEnabled }()
+
+	hotels, err := SearchAnyplace(context.Background(), "Lisbon", HotelSearchOptions{Currency: "USD"})
+	if err != nil {
+		t.Fatalf("live SearchAnyplace: %v", err)
+	}
+	if len(hotels) == 0 {
+		t.Fatal("live integration returned zero hotels")
+	}
+	t.Logf("live Anyplace returned %d listings; first: %s @ %.0f %s",
+		len(hotels), hotels[0].Name, hotels[0].Price, hotels[0].Currency)
+}

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -457,6 +457,7 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	auxOpts := opts
 	var trivagoResults []models.HotelResult
 	var hometogoResults []models.HotelResult
+	var anyplaceResults []models.HotelResult
 	var bookingResults []models.HotelResult
 	var externalResults []models.HotelResult
 	var auxWg sync.WaitGroup
@@ -491,6 +492,24 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 		}
 		hometogoResults = res
 		addProviderStatus(hotelProviderStatusFromResults("hometogo", "HomeToGo", len(res)))
+	}()
+
+	// Anyplace mid-term / nomad furnished-apartment provider (monthly-priced
+	// furnished rentals, 30-night minimum — the relocation/nomad segment).
+	// Non-fatal: failures log a warning and contribute zero results.
+	auxWg.Add(1)
+	go func() {
+		defer auxWg.Done()
+		providerCtx, cancel := context.WithTimeout(ctx, hotelAuxProviderTimeout)
+		defer cancel()
+		res, err := SearchAnyplace(providerCtx, location, auxOpts)
+		if err != nil {
+			slog.Warn("anyplace search failed", "error", err)
+			addProviderStatus(hotelProviderStatusFromError("anyplace", "Anyplace", err))
+			return
+		}
+		anyplaceResults = res
+		addProviderStatus(hotelProviderStatusFromResults("anyplace", "Anyplace", len(res)))
 	}()
 
 	// Booking.com search — parallel with Google + Trivago + HomeToGo.
@@ -572,6 +591,7 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	// primary.
 	allBatches := append(rawBatches, trivagoResults)
 	allBatches = append(allBatches, tagHotelSource(hometogoResults, "hometogo"))
+	allBatches = append(allBatches, tagHotelSource(anyplaceResults, "anyplace"))
 	allBatches = append(allBatches, bookingResults)
 	allBatches = append(allBatches, externalResults)
 	if len(externalResults) > 0 {

--- a/internal/hotels/testdata/anyplace_city_lisbon.json
+++ b/internal/hotels/testdata/anyplace_city_lisbon.json
@@ -1,0 +1,49 @@
+{
+  "pageProps": {
+    "listings": [
+      {
+        "id": "ap-1001",
+        "slug": "sunny-studio-chiado-lisbon",
+        "title": "Sunny Studio in Chiado",
+        "price": 4645,
+        "monthlyPrice": 4170,
+        "currency": "USD",
+        "minimumStay": 30,
+        "bedroom": 1,
+        "bathroom": 1,
+        "propertyType": "furnished_apartment",
+        "lat": 38.7101,
+        "long": -9.1421,
+        "photo": "//cdn.anyplace.com/listings/ap-1001/cover.jpg",
+        "address": "Chiado, Lisbon, Portugal"
+      },
+      {
+        "id": "ap-1002",
+        "slug": "alfama-two-bed-terrace",
+        "title": "Two-Bedroom with Terrace in Alfama",
+        "price": 6200,
+        "monthlyPrice": 5500,
+        "currency": "USD",
+        "minimumStay": 30,
+        "bedroom": 2,
+        "bathroom": 2,
+        "propertyType": "furnished_apartment",
+        "lat": 38.7139,
+        "long": -9.1278,
+        "photo": "https://cdn.anyplace.com/listings/ap-1002/cover.jpg",
+        "address": "Alfama, Lisbon, Portugal"
+      },
+      {
+        "id": "ap-1003",
+        "slug": "no-price-stub",
+        "title": "Unpriced Stub Listing",
+        "price": 0,
+        "currency": "USD",
+        "minimumStay": 30,
+        "propertyType": "furnished_apartment",
+        "lat": 38.72,
+        "long": -9.13
+      }
+    ]
+  }
+}

--- a/internal/hotels/testdata/anyplace_resolve_lisbon.html
+++ b/internal/hotels/testdata/anyplace_resolve_lisbon.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+<head><title>Furnished apartments in Lisbon · Anyplace</title></head>
+<body>
+<div id="__next"><h1>Lisbon</h1></div>
+<script id="__NEXT_DATA__" type="application/json">{"props":{"pageProps":{}},"page":"/listings/[city]","query":{"city":"lisbon-portugal"},"buildId":"AbC123dEf456","isFallback":false,"gssp":true}</script>
+</body>
+</html>

--- a/internal/hotels/testmain_test.go
+++ b/internal/hotels/testmain_test.go
@@ -16,6 +16,7 @@ import (
 func TestMain(m *testing.M) {
 	trivagoEnabled = false
 	hometogoEnabled = false
+	anyplaceEnabled = false
 	SearchBooking = func(_ context.Context, _ string, _ HotelSearchOptions) ([]models.HotelResult, error) {
 		return nil, nil
 	}


### PR DESCRIPTION
## Summary

Adds **Anyplace** (anyplace.com) as a hotel/accommodation provider for the mid-term / digital-nomad segment: monthly-priced furnished apartments with a typical 30-night minimum. This is inventory the existing nightly providers (Google Hotels, Trivago, Booking, HomeToGo) structurally miss, so it broadens coverage for long-trip and relocation planning.

No API key, no headless browser — plain HTTP against the site's Next.js `_next/data` JSON (recon-verified Tier-A).

## How it works

Two-step flow, mirroring the existing HomeToGo resolve-then-fetch pattern:

1. **`resolveAnyplaceBuildID`** — GET a city page, parse the `__NEXT_DATA__` blob, read `buildId`.
   - `buildId` rotates on every Anyplace deploy, so it is resolved **dynamically** and never hardcoded (same gotcha class as `internal/flights/wizzair.go`'s API-version rotation). `ANYPLACE_BUILD_ID` env var is an operator zero-deploy override.
2. **`fetchAnyplaceCity`** — GET `/_next/data/<buildId>/listings/{city}.json` → clean JSON (urql/GraphQL underneath, already flattened) → `[]models.HotelResult`.

## Field mapping

| Anyplace | HotelResult |
|---|---|
| `id` | `HotelID` |
| `title` | `Name` |
| `price` | `Price` |
| `currency` | `Currency` |
| `lat` / `long` | `Lat` / `Lon` |
| `propertyType` (`furnished_apartment`) | `PropertyType` → `apartment` |
| `monthlyPrice`, `minimumStay`, `bedroom`, `bathroom` | folded into `Description` (no dedicated field; these are the point of the mid-term segment) |

## Integration

- Per-provider `rate.Limiter` (2 req/search; mirrors the wizzair / hometogo convention).
- Registered in the hotel aggregator (`search.go`) as a **non-fatal** auxiliary provider — failures log a warning and contribute zero results.
- Disabled in `TestMain` so the default suite never fires live HTTP.

## Tests

Fixture-based (`testdata/anyplace_resolve_lisbon.html`, `testdata/anyplace_city_lisbon.json`); live integration gated behind `TRVL_TEST_LIVE_INTEGRATIONS=1` and skipped by default.

- `TestParseAnyplaceListingsFixture`
- `TestParseAnyplaceListingsSkipsUnpriced`
- `TestAnyplaceCurrency`
- `TestAnyplacePropertyType`
- `TestAnyplaceCitySlug`
- `TestAnyplaceAbsURL`
- `TestResolveAnyplaceBuildID` (env override + dynamic `__NEXT_DATA__` + missing-page error)
- `TestSearchAnyplaceEndToEnd` (full pipeline against httptest mock)
- `TestSearchAnyplaceLiveIntegration` (gated)

`go build ./...`, `go vet`, `gofmt`, and full `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
