### PR TITLE
feat(hotels): add Uniplaces mid-term student-housing provider

### DIFF
--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -457,6 +457,7 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	auxOpts := opts
 	var trivagoResults []models.HotelResult
 	var hometogoResults []models.HotelResult
+	var uniplacesResults []models.HotelResult
 	var bookingResults []models.HotelResult
 	var externalResults []models.HotelResult
 	var auxWg sync.WaitGroup
@@ -491,6 +492,24 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 		}
 		hometogoResults = res
 		addProviderStatus(hotelProviderStatusFromResults("hometogo", "HomeToGo", len(res)))
+	}()
+
+	// Uniplaces mid-term / student-housing provider (rooms, studios, apartments
+	// for weeks-to-months stays that nightly-rate providers miss). Non-fatal:
+	// failures log a warning and contribute zero results.
+	auxWg.Add(1)
+	go func() {
+		defer auxWg.Done()
+		providerCtx, cancel := context.WithTimeout(ctx, hotelAuxProviderTimeout)
+		defer cancel()
+		res, err := SearchUniplaces(providerCtx, location, auxOpts)
+		if err != nil {
+			slog.Warn("uniplaces search failed", "error", err)
+			addProviderStatus(hotelProviderStatusFromError("uniplaces", "Uniplaces", err))
+			return
+		}
+		uniplacesResults = res
+		addProviderStatus(hotelProviderStatusFromResults("uniplaces", "Uniplaces", len(res)))
 	}()
 
 	// Booking.com search — parallel with Google + Trivago + HomeToGo.
@@ -572,6 +591,7 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	// primary.
 	allBatches := append(rawBatches, trivagoResults)
 	allBatches = append(allBatches, tagHotelSource(hometogoResults, "hometogo"))
+	allBatches = append(allBatches, tagHotelSource(uniplacesResults, "uniplaces"))
 	allBatches = append(allBatches, bookingResults)
 	allBatches = append(allBatches, externalResults)
 	if len(externalResults) > 0 {

--- a/internal/hotels/testdata/uniplaces_listing_lisbon.html
+++ b/internal/hotels/testdata/uniplaces_listing_lisbon.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><title>Lisbon</title></head><body><script id="__NEXT_DATA__" type="application/json">{"props":{},"page":"/accommodation/[city]","buildId":"search-06e8c5954f295939db05be8c4e59664a7fc91851","isFallback":false}</script></body></html>

--- a/internal/hotels/testdata/uniplaces_search_lisbon.json
+++ b/internal/hotels/testdata/uniplaces_search_lisbon.json
@@ -1,0 +1,333 @@
+{
+ "pageProps": {
+  "offers": {
+   "data": [
+    {
+     "type": "offers",
+     "id": "846117",
+     "attributes": {
+      "accommodation_offer": {
+       "title": "Cozy Double Bedroom close to Carnide Metro",
+       "description": "",
+       "reviews_average": 0,
+       "price": {
+        "amount": 47000,
+        "currency_code": "EUR"
+       },
+       "old_price": null,
+       "available_from": "2026-06-17T00:00:00+00:00",
+       "all_bills_included": true,
+       "exclusive": false,
+       "is_instant_booking": false,
+       "reviews_count": 0,
+       "has_variable_price": false,
+       "max_guests": 2,
+       "contract_type": "fortnight",
+       "created_at": "2026-02-17T17:55:25+00:00",
+       "is_sponsored": false,
+       "is_insured": false,
+       "number_of_units_available": null,
+       "is_sold_out": false,
+       "has_rent_collection": false
+      },
+      "accommodation_provider": {
+       "id": "4741e462-0f34-441c-a64b-402607bd6616",
+       "verifications": {
+        "email": true,
+        "phone": true,
+        "offline_id": true,
+        "trusted": true
+       },
+       "stats": {
+        "response_rate_percentage": 100,
+        "response_time_hours": 9.011816
+       }
+      },
+      "photos": [
+       {
+        "hash": "0d814029fa49074353def54fc8891f2e532e9f60f76cc2d4a681294aec32ccbc",
+        "placeholder": false
+       },
+       {
+        "hash": "68cb2840658cd3f9deabad536883ef6485910f1db4080b36e2ed6b66b94e0a28",
+        "placeholder": false
+       }
+      ],
+      "property": {
+       "id": 500623,
+       "rent_by": "unit",
+       "has_video": false,
+       "neighbourhood": {
+        "name": "Carnide"
+       },
+       "verified": false,
+       "number_of_rooms": 5,
+       "number_of_bathrooms": 2,
+       "coordinates": [
+        38.7573393,
+        -9.1914737
+       ],
+       "has_resident_landlord": false,
+       "type": "apartment",
+       "accommodation_type": "private",
+       "building": {
+        "features": [],
+        "units": []
+       },
+       "photos": [
+        {
+         "hash": "5319ca16687baef177709162e4cf7b1c74cf53b2c30214ad555882a6836d63d9",
+         "placeholder": true
+        },
+        {
+         "hash": "0d814029fa49074353def54fc8891f2e532e9f60f76cc2d4a681294aec32ccbc",
+         "placeholder": false
+        }
+       ],
+       "university_places": []
+      },
+      "quality": 0.88410085,
+      "query_quality": 0.88410085
+     }
+    },
+    {
+     "type": "offers",
+     "id": "871815",
+     "attributes": {
+      "accommodation_offer": {
+       "title": "Comfy Double Bedroom with a private Bathroom close to Sao Pedro do Estoril Train Station",
+       "description": "",
+       "reviews_average": 0,
+       "price": {
+        "amount": 65000,
+        "currency_code": "EUR"
+       },
+       "old_price": null,
+       "available_from": "2026-06-17T00:00:00+00:00",
+       "all_bills_included": true,
+       "exclusive": false,
+       "is_instant_booking": false,
+       "reviews_count": 0,
+       "has_variable_price": false,
+       "max_guests": 2,
+       "contract_type": "fortnight",
+       "created_at": "2026-05-25T14:22:30+00:00",
+       "is_sponsored": false,
+       "is_insured": false,
+       "number_of_units_available": null,
+       "is_sold_out": false,
+       "has_rent_collection": false
+      },
+      "accommodation_provider": {
+       "id": "d5615923-c5ac-429f-9856-18af64f39aef",
+       "verifications": {
+        "email": true,
+        "phone": true,
+        "offline_id": false,
+        "trusted": false
+       },
+       "stats": {
+        "response_rate_percentage": 100,
+        "response_time_hours": 0
+       }
+      },
+      "photos": [
+       {
+        "hash": "1c148e537e083465f22b27e4dbc8df96118be67f0af09df605ba0bc3ed613f41",
+        "placeholder": false
+       },
+       {
+        "hash": "1494527fc422d099c9f6bd7595ed43c072825fbb6d36e8250fa8feeda94bc269",
+        "placeholder": false
+       }
+      ],
+      "property": {
+       "id": 512883,
+       "rent_by": "unit",
+       "has_video": false,
+       "neighbourhood": {
+        "name": "Estoril"
+       },
+       "verified": false,
+       "number_of_rooms": 3,
+       "number_of_bathrooms": 3,
+       "coordinates": [
+        38.7000293,
+        -9.3768026
+       ],
+       "has_resident_landlord": false,
+       "type": "apartment",
+       "accommodation_type": "private",
+       "building": {
+        "features": [],
+        "units": []
+       },
+       "photos": [
+        {
+         "hash": "7d9241806046dae8d230b4374a7a879b7885c6817511608d7fe51c8773e6b711",
+         "placeholder": false
+        },
+        {
+         "hash": "1494527fc422d099c9f6bd7595ed43c072825fbb6d36e8250fa8feeda94bc269",
+         "placeholder": false
+        }
+       ],
+       "university_places": []
+      },
+      "quality": 0.8728865,
+      "query_quality": 0.8728865
+     }
+    },
+    {
+     "type": "offers",
+     "id": "130713",
+     "attributes": {
+      "accommodation_offer": {
+       "title": "Cosy and modern apartment in Santa Apolónia",
+       "description": "",
+       "reviews_average": 0,
+       "price": {
+        "amount": 95000,
+        "currency_code": "EUR"
+       },
+       "old_price": null,
+       "available_from": "2026-07-01T00:00:00+00:00",
+       "all_bills_included": false,
+       "exclusive": true,
+       "is_instant_booking": false,
+       "reviews_count": 0,
+       "has_variable_price": false,
+       "max_guests": 2,
+       "contract_type": "fortnight",
+       "created_at": "2018-04-02T08:53:44+00:00",
+       "is_sponsored": false,
+       "is_insured": false,
+       "number_of_units_available": null,
+       "is_sold_out": false,
+       "has_rent_collection": false
+      },
+      "accommodation_provider": {
+       "id": "96fca12f-9048-4831-b9e3-f11756f4ed8a",
+       "verifications": {
+        "email": true,
+        "phone": true,
+        "offline_id": false,
+        "trusted": true
+       },
+       "stats": {
+        "response_rate_percentage": 97,
+        "response_time_hours": 7.5817347
+       }
+      },
+      "photos": [
+       {
+        "hash": "752c4326bdd93a9c709b4ec6da01b340311e22c1ec02358854e4e5b5c194e8b1",
+        "placeholder": false
+       },
+       {
+        "hash": "7b967dcec25c988b87936a82a481ed0f6bf6fac71c5402b3c9cf928ccdcd4b10",
+        "placeholder": false
+       }
+      ],
+      "property": {
+       "id": 76787,
+       "rent_by": "property",
+       "has_video": false,
+       "neighbourhood": {
+        "name": "Santa Apolónia"
+       },
+       "verified": true,
+       "number_of_rooms": 1,
+       "number_of_bathrooms": 1,
+       "coordinates": [
+        38.716983,
+        -9.1250977
+       ],
+       "has_resident_landlord": false,
+       "type": "apartment",
+       "accommodation_type": "private",
+       "building": {
+        "features": [],
+        "units": []
+       },
+       "photos": [
+        {
+         "hash": "ecf302bf14d3feec295c56bccdd9ff8c48a49b6c62869069d53c7eeda179f9f6",
+         "placeholder": false
+        },
+        {
+         "hash": "cfa98ab7f43bc156b5ef982cee61cb6fada0077de4990b1f7fd999aefb1e57be",
+         "placeholder": false
+        }
+       ],
+       "university_places": []
+      },
+      "quality": 0.8583209,
+      "query_quality": 0.8583209
+     }
+    }
+   ],
+   "meta": {
+    "experiment_id": "default-0",
+    "max_price": 900000,
+    "max_query_quality": 3.5256145,
+    "min_price": 20000,
+    "price_histogram": {
+     "0": 0,
+     "18000": 321,
+     "36000": 1358,
+     "54000": 1258,
+     "72000": 378,
+     "90000": 145,
+     "108000": 138,
+     "126000": 128,
+     "144000": 153,
+     "162000": 92,
+     "180000": 126,
+     "198000": 99,
+     "216000": 85,
+     "234000": 61,
+     "252000": 29,
+     "270000": 38,
+     "288000": 38,
+     "306000": 7,
+     "324000": 9,
+     "342000": 18,
+     "360000": 2,
+     "378000": 11,
+     "396000": 11,
+     "414000": 0,
+     "432000": 9,
+     "450000": 7,
+     "468000": 2,
+     "486000": 7,
+     "504000": 0,
+     "522000": 0,
+     "540000": 3,
+     "558000": 0,
+     "576000": 0,
+     "594000": 5,
+     "612000": 0,
+     "630000": 0,
+     "648000": 0,
+     "666000": 1,
+     "684000": 0,
+     "702000": 0,
+     "720000": 0,
+     "738000": 1,
+     "756000": 0,
+     "774000": 0,
+     "792000": 0,
+     "810000": 0,
+     "828000": 0,
+     "846000": 0,
+     "864000": 0,
+     "882000": 0,
+     "900000": 1
+    },
+    "total_found": 4541,
+    "total_page_number": 95
+   }
+  }
+ }
+}

--- a/internal/hotels/testmain_test.go
+++ b/internal/hotels/testmain_test.go
@@ -16,6 +16,7 @@ import (
 func TestMain(m *testing.M) {
 	trivagoEnabled = false
 	hometogoEnabled = false
+	uniplacesEnabled = false
 	SearchBooking = func(_ context.Context, _ string, _ HotelSearchOptions) ([]models.HotelResult, error) {
 		return nil, nil
 	}

--- a/internal/hotels/uniplaces.go
+++ b/internal/hotels/uniplaces.go
@@ -1,0 +1,320 @@
+package hotels
+
+// Uniplaces mid-term / student-housing provider.
+//
+// Uniplaces (https://www.uniplaces.com) lists rooms, studios and apartments for
+// medium-term stays (weeks to months) — a segment traditional nightly-rate hotel
+// providers (Google Hotels, Trivago, Booking) miss entirely. High value for
+// relocation, student housing and extended remote-work stays.
+//
+// Unauthenticated feasibility (verified 2026-06-18):
+//   - No API key, headless browser, residential proxy nor CAPTCHA bypass is
+//     required. Plain HTTP with a desktop User-Agent suffices.
+//   - The listing page is a Next.js app whose search data is exposed as static
+//     SSR JSON at:
+//       GET /_next/data/{buildId}/en/accommodation/{city}.json -> 200 JSON
+//   - {buildId} rotates per deploy (mirrors the Wizz Air version-rotation
+//     gotcha). It is NOT hardcoded: it is read at request time from the
+//     "buildId" field of the __NEXT_DATA__ <script> blob on the listing page
+//     (GET /accommodation/{city}), then substituted into the _next/data URL.
+//
+// Two-step flow, mirroring HomeToGo's resolve-then-fetch pattern:
+//  1. resolveUniplacesBuildID(city) -> buildId   (from listing page __NEXT_DATA__)
+//  2. fetchUniplacesOffers(buildId, city) -> offer JSON -> []models.HotelResult
+//
+// Response shape (verified, NOT the originally-assumed `units[]`):
+//   pageProps.offers.data[] (48 per page), each:
+//     id                                      -> offer id (HotelID + listing URL)
+//     attributes.accommodation_offer.title    -> Name
+//     attributes.accommodation_offer.price.amount        (CENTS -> /100)
+//     attributes.accommodation_offer.price.currency_code -> Currency
+//     attributes.property.coordinates          -> [lat, lon]  (VERIFIED order:
+//        Lisbon = [38.75, -9.19]; index 0 is latitude, index 1 longitude)
+//     attributes.property.type                 -> PropertyType ("apartment", ...)
+//     attributes.property.neighbourhood.name   -> Neighborhood
+//
+// Listing URL is built from the offer id: /accommodation/{city}/{id} (verified
+// 200). Photos carry only opaque hashes with no publicly-derivable CDN URL
+// template (cdn.uniplaces.com/property-photos/<hash> returns 403, unverified),
+// so ImageURL is deliberately left empty rather than shipping a guessed URL.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"golang.org/x/time/rate"
+)
+
+// uniplacesEnabled controls whether SearchUniplaces makes live HTTP requests.
+// Disabled in the test suite (see testmain_test.go) so deterministic tests
+// never fire real network calls; individual tests flip it on with a mock
+// server injected via uniplacesBaseURL.
+var uniplacesEnabled = true
+
+// uniplacesBaseURL is the root of the Uniplaces site. Overridable in tests so
+// an httptest.Server can stand in for the live host.
+var uniplacesBaseURL = "https://www.uniplaces.com"
+
+// uniplacesUserAgent is a desktop browser UA. Uniplaces serves the SSR JSON/HTML
+// to ordinary desktop clients; no special headers are required.
+const uniplacesUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+	"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+// uniplacesLimiter enforces a conservative request rate to avoid tripping the
+// edge rate limits. Two requests per search (resolve buildId + fetch offers).
+// Mirrors the per-provider rate.Limiter used by flights/wizzair.go.
+var uniplacesLimiter = rate.NewLimiter(rate.Every(500*time.Millisecond), 2)
+
+// uniplacesHTTPClient is a dedicated client with a sane timeout.
+var uniplacesHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
+// uniplacesBuildIDRe extracts the Next.js build id from the listing page's
+// __NEXT_DATA__ blob, e.g. `"buildId":"search-06e8c595..."`. The id rotates per
+// deploy, so it is read dynamically rather than hardcoded.
+var uniplacesBuildIDRe = regexp.MustCompile(`"buildId"\s*:\s*"([^"]+)"`)
+
+// ---- Response types (only the fields we consume) ----
+
+type uniplacesResponse struct {
+	PageProps struct {
+		Offers struct {
+			Data []uniplacesOffer `json:"data"`
+		} `json:"offers"`
+	} `json:"pageProps"`
+}
+
+type uniplacesOffer struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		AccommodationOffer struct {
+			Title          string  `json:"title"`
+			Description    string  `json:"description"`
+			ReviewsAverage float64 `json:"reviews_average"`
+			ReviewsCount   int     `json:"reviews_count"`
+			MaxGuests      int     `json:"max_guests"`
+			ContractType   string  `json:"contract_type"`
+			IsSoldOut      bool    `json:"is_sold_out"`
+			Price          struct {
+				Amount       int64  `json:"amount"` // CENTS
+				CurrencyCode string `json:"currency_code"`
+			} `json:"price"`
+		} `json:"accommodation_offer"`
+		Property struct {
+			Type          string    `json:"type"`
+			Coordinates   []float64 `json:"coordinates"` // [lat, lon]
+			Neighbourhood struct {
+				Name string `json:"name"`
+			} `json:"neighbourhood"`
+		} `json:"property"`
+	} `json:"attributes"`
+}
+
+// SearchUniplaces searches Uniplaces for mid-term rooms/apartments in a city.
+// It is non-fatal by contract: callers treat any error as "zero results".
+// Returns nil, nil when disabled (test mode).
+func SearchUniplaces(ctx context.Context, location string, opts HotelSearchOptions) ([]models.HotelResult, error) {
+	if !uniplacesEnabled {
+		return nil, nil
+	}
+	if strings.TrimSpace(location) == "" {
+		return nil, fmt.Errorf("uniplaces: location is required")
+	}
+
+	city := uniplacesCitySlug(location)
+	if city == "" {
+		return nil, fmt.Errorf("uniplaces: could not derive city slug from %q", location)
+	}
+
+	// Step 1: read the rotating Next.js buildId from the listing page.
+	slog.Debug("uniplaces resolve", "location", location, "city", city)
+	buildID, err := resolveUniplacesBuildID(ctx, city)
+	if err != nil {
+		return nil, fmt.Errorf("uniplaces resolve: %w", err)
+	}
+
+	// Step 2: fetch the SSR JSON offers for that city.
+	slog.Debug("uniplaces search", "location", location, "city", city, "buildId", buildID)
+	raw, err := fetchUniplacesOffers(ctx, buildID, city)
+	if err != nil {
+		return nil, fmt.Errorf("uniplaces offers: %w", err)
+	}
+
+	currency := strings.TrimSpace(opts.Currency)
+	hotels, err := parseUniplacesOffers(raw, city, currency)
+	if err != nil {
+		return nil, fmt.Errorf("uniplaces parse: %w", err)
+	}
+	slog.Debug("uniplaces results", "location", location, "count", len(hotels))
+	return hotels, nil
+}
+
+// uniplacesCitySlug reduces a free-text location to the single-token city slug
+// Uniplaces uses in its accommodation URLs: lowercase, first path segment only
+// (Uniplaces routes are /accommodation/{city}, not multi-word). e.g.
+// "Lisbon, Portugal" -> "lisbon", "New York" -> "new-york".
+func uniplacesCitySlug(location string) string {
+	s := strings.ToLower(strings.TrimSpace(location))
+	// Take the part before the first comma (drop ", Portugal" etc).
+	if i := strings.IndexByte(s, ','); i >= 0 {
+		s = s[:i]
+	}
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevHyphen = false
+		case r == ' ' || r == '-' || r == '/' || r == '.':
+			if !prevHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		default:
+			// drop other characters (accents, punctuation)
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// resolveUniplacesBuildID fetches the city listing page and extracts the
+// rotating Next.js buildId from its __NEXT_DATA__ blob.
+func resolveUniplacesBuildID(ctx context.Context, city string) (string, error) {
+	if city == "" {
+		return "", fmt.Errorf("empty city")
+	}
+	body, err := uniplacesGet(ctx, uniplacesBaseURL+"/accommodation/"+city, "text/html,application/xhtml+xml")
+	if err != nil {
+		return "", err
+	}
+	m := uniplacesBuildIDRe.FindSubmatch(body)
+	if m == nil {
+		return "", fmt.Errorf("no buildId found on listing page for city %q", city)
+	}
+	return string(m[1]), nil
+}
+
+// fetchUniplacesOffers fetches the SSR JSON search payload for a city using the
+// resolved buildId.
+func fetchUniplacesOffers(ctx context.Context, buildID, city string) (json.RawMessage, error) {
+	if buildID == "" {
+		return nil, fmt.Errorf("empty buildId")
+	}
+	url := uniplacesBaseURL + "/_next/data/" + buildID + "/en/accommodation/" + city + ".json"
+	body, err := uniplacesGet(ctx, url, "application/json")
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(body), nil
+}
+
+// uniplacesGet performs a rate-limited GET with the desktop UA and returns the
+// response body. Non-2xx responses are errors.
+func uniplacesGet(ctx context.Context, url, accept string) ([]byte, error) {
+	if err := uniplacesLimiter.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("rate limiter: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", uniplacesUserAgent)
+	req.Header.Set("Accept", accept)
+	resp, err := uniplacesHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20)) // 8 MiB cap
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// parseUniplacesOffers maps a Uniplaces search JSON payload to HotelResults.
+// Offers without a positive price or that are sold out are skipped so every
+// returned result is actually comparable and bookable. fallbackCurrency is used
+// when an offer's price carries no currency code; when empty it defaults to EUR
+// (Uniplaces' default for the public endpoint).
+func parseUniplacesOffers(raw json.RawMessage, city, fallbackCurrency string) ([]models.HotelResult, error) {
+	var resp uniplacesResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	offers := resp.PageProps.Offers.Data
+	results := make([]models.HotelResult, 0, len(offers))
+	for _, o := range offers {
+		ao := o.Attributes.AccommodationOffer
+		if ao.IsSoldOut {
+			continue
+		}
+		// Price is in cents; convert to a major-unit amount.
+		price := float64(ao.Price.Amount) / 100.0
+		if price <= 0 {
+			continue
+		}
+		currency := strings.ToUpper(strings.TrimSpace(ao.Price.CurrencyCode))
+		if currency == "" {
+			if fallbackCurrency != "" {
+				currency = strings.ToUpper(fallbackCurrency)
+			} else {
+				currency = "EUR"
+			}
+		}
+
+		h := models.HotelResult{
+			Name:         strings.TrimSpace(ao.Title),
+			HotelID:      o.ID,
+			Price:        price,
+			Currency:     currency,
+			Description:  strings.TrimSpace(ao.Description),
+			Rating:       ao.ReviewsAverage,
+			ReviewCount:  ao.ReviewsCount,
+			PropertyType: strings.TrimSpace(o.Attributes.Property.Type),
+			Neighborhood: strings.TrimSpace(o.Attributes.Property.Neighbourhood.Name),
+			BookingURL:   uniplacesListingURL(city, o.ID),
+		}
+		// coordinates are [lat, lon] (verified order).
+		if coords := o.Attributes.Property.Coordinates; len(coords) == 2 {
+			h.Lat = coords[0]
+			h.Lon = coords[1]
+		}
+		if h.Name == "" {
+			h.Name = "Uniplaces accommodation"
+		}
+		h.Sources = []models.PriceSource{{
+			Provider:   "uniplaces",
+			Price:      price,
+			Currency:   currency,
+			BookingURL: h.BookingURL,
+		}}
+		results = append(results, h)
+	}
+	return results, nil
+}
+
+// uniplacesListingURL builds the canonical listing URL for an offer from its id.
+// Verified: /accommodation/{city}/{id} returns 200.
+func uniplacesListingURL(city, id string) string {
+	if id == "" {
+		return ""
+	}
+	if city == "" {
+		return uniplacesBaseURL + "/accommodation/" + id
+	}
+	return uniplacesBaseURL + "/accommodation/" + city + "/" + id
+}

--- a/internal/hotels/uniplaces_test.go
+++ b/internal/hotels/uniplaces_test.go
@@ -1,0 +1,221 @@
+package hotels
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// loadUniplacesFixture reads the saved Uniplaces search payload from testdata.
+func loadUniplacesFixture(t *testing.T) json.RawMessage {
+	t.Helper()
+	b, err := os.ReadFile("testdata/uniplaces_search_lisbon.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	return json.RawMessage(b)
+}
+
+// TestParseUniplacesOffersFixture asserts the saved Lisbon search payload maps
+// to well-formed HotelResults: name, numeric price (converted from cents),
+// currency, geo, absolute booking URL, property type, and a "uniplaces" price
+// source.
+func TestParseUniplacesOffersFixture(t *testing.T) {
+	raw := loadUniplacesFixture(t)
+	hotels, err := parseUniplacesOffers(raw, "lisbon", "")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(hotels) == 0 {
+		t.Fatal("expected at least one mapped hotel, got 0")
+	}
+	for i, h := range hotels {
+		if h.Name == "" {
+			t.Errorf("hotel %d: empty name", i)
+		}
+		if h.Price <= 0 {
+			t.Errorf("hotel %d (%s): non-positive price %v", i, h.Name, h.Price)
+		}
+		if h.Currency == "" {
+			t.Errorf("hotel %d (%s): empty currency", i, h.Name)
+		}
+		if h.Lat == 0 || h.Lon == 0 {
+			t.Errorf("hotel %d (%s): missing geo (%v,%v)", i, h.Name, h.Lat, h.Lon)
+		}
+		if !strings.HasPrefix(h.BookingURL, "https://") {
+			t.Errorf("hotel %d (%s): booking URL not absolute: %q", i, h.Name, h.BookingURL)
+		}
+		if len(h.Sources) != 1 || h.Sources[0].Provider != "uniplaces" {
+			t.Errorf("hotel %d (%s): want single uniplaces source, got %+v", i, h.Name, h.Sources)
+		}
+	}
+
+	// First Lisbon offer fixed assertions (deterministic fixture).
+	first := hotels[0]
+	if first.Name != "Cozy Double Bedroom close to Carnide Metro" {
+		t.Errorf("first name = %q", first.Name)
+	}
+	if first.HotelID != "846117" {
+		t.Errorf("first id = %q, want 846117", first.HotelID)
+	}
+	// 47000 cents -> 470.00.
+	if first.Price != 470 {
+		t.Errorf("first price = %v, want 470 (47000 cents / 100)", first.Price)
+	}
+	if first.Currency != "EUR" {
+		t.Errorf("first currency = %q, want EUR", first.Currency)
+	}
+	// Coordinates are [lat, lon]: Lisbon ~ (38.75, -9.19).
+	if first.Lat < 38 || first.Lat > 39 {
+		t.Errorf("first lat = %v, want ~38.75 (coordinate order [lat,lon])", first.Lat)
+	}
+	if first.Lon > -9 || first.Lon < -10 {
+		t.Errorf("first lon = %v, want ~-9.19 (coordinate order [lat,lon])", first.Lon)
+	}
+	if first.PropertyType != "apartment" {
+		t.Errorf("first property type = %q, want apartment", first.PropertyType)
+	}
+	if !strings.Contains(first.BookingURL, "/accommodation/lisbon/846117") {
+		t.Errorf("first booking URL = %q", first.BookingURL)
+	}
+}
+
+// TestParseUniplacesOffersSkips ensures sold-out and zero-price offers are
+// dropped so every result is comparable.
+func TestParseUniplacesOffersSkips(t *testing.T) {
+	raw := json.RawMessage(`{"pageProps":{"offers":{"data":[
+		{"id":"a","attributes":{"accommodation_offer":{"title":"Priced","price":{"amount":50000,"currency_code":"EUR"}},"property":{"type":"apartment","coordinates":[38.7,-9.1]}}},
+		{"id":"b","attributes":{"accommodation_offer":{"title":"Sold out","is_sold_out":true,"price":{"amount":60000,"currency_code":"EUR"}},"property":{"coordinates":[38.7,-9.1]}}},
+		{"id":"c","attributes":{"accommodation_offer":{"title":"Zero price","price":{"amount":0,"currency_code":"EUR"}},"property":{"coordinates":[38.7,-9.1]}}}
+	]}}}`)
+	hotels, err := parseUniplacesOffers(raw, "lisbon", "USD")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(hotels) != 1 {
+		t.Fatalf("want 1 mapped hotel (sold-out + zero-price dropped), got %d", len(hotels))
+	}
+	if hotels[0].Name != "Priced" {
+		t.Errorf("mapped wrong offer: %q", hotels[0].Name)
+	}
+	if hotels[0].Price != 500 {
+		t.Errorf("price = %v, want 500", hotels[0].Price)
+	}
+}
+
+// TestParseUniplacesOffersCurrencyFallback verifies the fallback currency is
+// used when an offer omits a currency code.
+func TestParseUniplacesOffersCurrencyFallback(t *testing.T) {
+	raw := json.RawMessage(`{"pageProps":{"offers":{"data":[
+		{"id":"a","attributes":{"accommodation_offer":{"title":"No currency","price":{"amount":30000}},"property":{"coordinates":[1,2]}}}
+	]}}}`)
+	hotels, err := parseUniplacesOffers(raw, "lisbon", "gbp")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(hotels) != 1 || hotels[0].Currency != "GBP" {
+		t.Fatalf("want GBP fallback currency, got %+v", hotels)
+	}
+}
+
+// TestUniplacesCitySlug verifies free-text -> single-token city slug reduction.
+func TestUniplacesCitySlug(t *testing.T) {
+	cases := map[string]string{
+		"Lisbon":            "lisbon",
+		"Lisbon, Portugal":  "lisbon",
+		"New York":          "new-york",
+		"  Berlin  ":        "berlin",
+		"São Paulo, Brazil": "so-paulo",
+	}
+	for in, want := range cases {
+		if got := uniplacesCitySlug(in); got != want {
+			t.Errorf("uniplacesCitySlug(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestSearchUniplacesMockServer exercises the full two-step flow against an
+// httptest server: resolve the rotating buildId from the listing page's
+// __NEXT_DATA__ blob, then fetch the _next/data JSON for that buildId.
+func TestSearchUniplacesMockServer(t *testing.T) {
+	listingHTML, err := os.ReadFile("testdata/uniplaces_listing_lisbon.html")
+	if err != nil {
+		t.Fatalf("read listing fixture: %v", err)
+	}
+	offersJSON, err := os.ReadFile("testdata/uniplaces_search_lisbon.json")
+	if err != nil {
+		t.Fatalf("read offers fixture: %v", err)
+	}
+	const wantBuildID = "search-06e8c5954f295939db05be8c4e59664a7fc91851"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/accommodation/lisbon":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write(listingHTML)
+		case r.URL.Path == "/_next/data/"+wantBuildID+"/en/accommodation/lisbon.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(offersJSON)
+		default:
+			http.Error(w, "not found: "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Enable live path against the mock server.
+	savedEnabled, savedBase := uniplacesEnabled, uniplacesBaseURL
+	uniplacesEnabled, uniplacesBaseURL = true, srv.URL
+	defer func() { uniplacesEnabled, uniplacesBaseURL = savedEnabled, savedBase }()
+
+	hotels, err := SearchUniplaces(context.Background(), "Lisbon, Portugal", HotelSearchOptions{Currency: "EUR"})
+	if err != nil {
+		t.Fatalf("SearchUniplaces: %v", err)
+	}
+	if len(hotels) != 3 {
+		t.Fatalf("want 3 hotels from fixture, got %d", len(hotels))
+	}
+	if hotels[0].HotelID != "846117" {
+		t.Errorf("first hotel id = %q, want 846117", hotels[0].HotelID)
+	}
+}
+
+// TestSearchUniplacesDisabledReturnsNil verifies the test-mode short circuit.
+func TestSearchUniplacesDisabledReturnsNil(t *testing.T) {
+	saved := uniplacesEnabled
+	uniplacesEnabled = false
+	defer func() { uniplacesEnabled = saved }()
+	hotels, err := SearchUniplaces(context.Background(), "Lisbon", HotelSearchOptions{})
+	if err != nil || hotels != nil {
+		t.Fatalf("want nil,nil when disabled; got %v, %v", hotels, err)
+	}
+}
+
+// TestSearchUniplacesLive is an opt-in live integration probe. It is skipped by
+// default (offline-default-suite rule) and only runs when
+// TRVL_TEST_LIVE_INTEGRATIONS is set. It exercises the real rotating-buildId
+// resolution and _next/data fetch against the live site.
+func TestSearchUniplacesLive(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_INTEGRATIONS") == "" {
+		t.Skip("set TRVL_TEST_LIVE_INTEGRATIONS=1 to run live Uniplaces probe")
+	}
+	saved := uniplacesEnabled
+	uniplacesEnabled = true
+	defer func() { uniplacesEnabled = saved }()
+
+	hotels, err := SearchUniplaces(context.Background(), "Lisbon", HotelSearchOptions{Currency: "EUR"})
+	if err != nil {
+		t.Fatalf("live SearchUniplaces: %v", err)
+	}
+	if len(hotels) == 0 {
+		t.Fatal("live: expected at least one hotel")
+	}
+	for i, h := range hotels {
+		if h.Price <= 0 || h.Currency == "" || h.Name == "" {
+			t.Errorf("live hotel %d malformed: %+v", i, h)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **Uniplaces** hotel/mid-term-stay provider to `internal/hotels`, mirroring the existing HomeToGo external-provider pattern (HTTP -> SSR JSON -> `models.HotelResult`). No API key, no browser — plain HTTP with a desktop User-Agent against Uniplaces' public Next.js data endpoint.

Uniplaces lists rooms, studios and apartments for **medium-term stays** (weeks to months) — a segment nightly-rate providers (Google Hotels, Trivago, Booking, HomeToGo) don't cover. Useful for relocation, student housing and extended remote-work stays.

## How it works

Two-step flow (mirrors HomeToGo's resolve-then-fetch):

1. **Resolve buildId** — `GET /accommodation/{city}`, extract the rotating Next.js `buildId` from the `__NEXT_DATA__` blob.
2. **Fetch offers** — `GET /_next/data/{buildId}/en/accommodation/{city}.json` -> JSON.

The `buildId` rotates per deploy (same class of gotcha as the Wizz Air API-version rotation), so it is read **dynamically at request time**, never hardcoded.

## Contract notes (recon-verified 2026-06-18)

The originally-assumed contract differed from the live shape — verified against `www.uniplaces.com/accommodation/lisbon`:

| Assumed | Actual (verified) |
|---|---|
| `units[]` | `pageProps.offers.data[]` (48 per page, confirmed) |
| `amount` in cents | confirmed — `attributes.accommodation_offer.price.amount` is **cents** (47000 -> EUR 470) |
| `coordinates` order unverified | **`[lat, lon]`** — Lisbon = `[38.75, -9.19]` |
| `slug` -> URL | no slug field; listing URL built from **offer id**: `/accommodation/{city}/{id}` (verified 200) |
| `type` | `attributes.property.type` (`"apartment"`, ...) |

Photos carry only opaque hashes with no publicly-derivable CDN URL template (`cdn.uniplaces.com/property-photos/<hash>` returns 403, unverified), so `ImageURL` is left empty rather than shipping a guessed URL.

## Implementation

- Per-provider `rate.Limiter` (2 req / 500ms), mirroring `internal/flights/wizzair.go`.
- Sold-out and zero-price offers dropped so every result is comparable.
- Registered as a **non-fatal** aux provider in `SearchHotels` alongside Trivago / HomeToGo / Booking (failure -> warn + zero results).
- `uniplacesEnabled = false` in `TestMain` so the default suite never fires live calls.

## Tests

Fixture-based per the offline-default-suite rule (`testdata/uniplaces_search_lisbon.json` + listing HTML); live probe env-gated behind `TRVL_TEST_LIVE_INTEGRATIONS`.

- `TestParseUniplacesOffersFixture` — full mapping + cents/coordinate assertions
- `TestParseUniplacesOffersSkips` — sold-out / zero-price dropped
- `TestParseUniplacesOffersCurrencyFallback`
- `TestUniplacesCitySlug`
- `TestSearchUniplacesMockServer` — full two-step flow (buildId resolve + `_next/data` fetch) via `httptest`
- `TestSearchUniplacesDisabledReturnsNil`
- `TestSearchUniplacesLive` — skipped unless `TRVL_TEST_LIVE_INTEGRATIONS=1`

`go build ./...`, `go vet ./...`, `gofmt -l` all clean. Full suite: `go test ./...` -> exit 0, 72 packages ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
