### PR TITLE
test(probes): fix Live Probes nightly drift (Wizz version, transient throttling, eco-cert)

### DIFF
--- a/internal/flights/flights_probe_test.go
+++ b/internal/flights/flights_probe_test.go
@@ -21,10 +21,18 @@ func TestFlightsProbe(t *testing.T) {
 	defer cancel()
 
 	result, err := SearchFlights(ctx, "HEL", "BCN", date, SearchOptions{})
+	// Google throttles no-key batchexecute calls from datacenter IPs (HTTP 429,
+	// retried with backoff until the context deadline). That is transient noise,
+	// not a regression: skip rather than red the nightly. A real format/shape
+	// change ("unexpected flight data format") is non-transient and still fails.
+	testutil.SkipIfTransient(t, err)
 	if err != nil {
 		t.Fatalf("SearchFlights: %v", err)
 	}
 	if !result.Success {
+		if testutil.IsTransientMsg(result.Error) {
+			t.Skipf("skipping: transient provider noise (not a regression): %s", result.Error)
+		}
 		t.Fatalf("search unsuccessful: %s", result.Error)
 	}
 	if result.Count == 0 || len(result.Flights) == 0 {

--- a/internal/flights/wizzair.go
+++ b/internal/flights/wizzair.go
@@ -67,7 +67,12 @@ var ErrWizzVersionRotated = errors.New("wizzair API version path rotated")
 // package comment: the segment rotates, so this is a fallback, not a contract.
 // No runtime auto-discovery exists by design (JS-gated, undiscoverable
 // server-side); WIZZAIR_API_VERSION is the operator's authoritative override.
-const wizzDefaultVersion = "10.1.0"
+//
+// 2026-06-19: rotated "10.1.0" -> "29.3.0". Verified against the web app's own
+// config (wizzair.com/en-gb embeds apiUrl:"https://be.wizzair.com/29.3.0/Api")
+// and confirmed live: POST be.wizzair.com/29.3.0/Api/search/timetable -> 200,
+// while the prior 10.1.0 path -> 404 (the rotation signature). (GH #115)
+const wizzDefaultVersion = "29.3.0"
 
 // wizzVersion is the active API version. Overridable in tests; the env var
 // WIZZAIR_API_VERSION takes precedence at request time via wizzResolvedVersion.

--- a/internal/hotels/eco_probe_test.go
+++ b/internal/hotels/eco_probe_test.go
@@ -168,9 +168,16 @@ func TestProbeEcoCertification(t *testing.T) {
 	ecoPR := parseHotelsFromPageFull(string(ecoBody), "USD")
 	t.Logf("Eco results: %d hotels (total=%d)", len(ecoPR.Hotels), ecoPR.TotalAvailable)
 
-	// The eco-filtered set should be smaller than the unfiltered set.
-	if ecoPR.TotalAvailable >= basePR.TotalAvailable && basePR.TotalAvailable > 0 {
-		t.Errorf("eco total (%d) should be less than base total (%d)",
+	// 2026-06-19 provider drift: TotalAvailable now reports the destination's
+	// city-wide inventory (e.g. 3629 for Copenhagen) and is IDENTICAL with and
+	// without ecof=1, so it can no longer be used to prove server-side eco
+	// filtering. The filter is still applied — the returned hotel SET differs
+	// (observed 25 eco vs 23 base on the same page) — so we assert the eco
+	// request still succeeds and returns hotels, and log the (now non-
+	// differentiating) totals for monitoring instead of failing on them.
+	if basePR.TotalAvailable > 0 && ecoPR.TotalAvailable >= basePR.TotalAvailable {
+		t.Logf("NOTE: eco total (%d) not below base total (%d) — TotalAvailable "+
+			"reflects city inventory, not the eco-filtered count (see comment)",
 			ecoPR.TotalAvailable, basePR.TotalAvailable)
 	}
 

--- a/internal/livecheck/livecheck_probe_test.go
+++ b/internal/livecheck/livecheck_probe_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/MikkoParkkola/trvl/internal/testutil"
 	"github.com/MikkoParkkola/trvl/internal/watch"
 )
 
@@ -24,6 +25,11 @@ func TestChecker_LiveFlightProbe(t *testing.T) {
 		DepartDate:  "2026-09-15",
 		Currency:    "EUR",
 	})
+	// A throttled night (Google 429 from the CI datacenter IP) is transient
+	// noise, not the re-stubbed-checker regression this guard exists for: skip
+	// rather than red the nightly. A stubbed checker returns price 0 with no
+	// error and still fails the assertion below.
+	testutil.SkipIfTransient(t, err)
 	if err != nil {
 		t.Fatalf("live flight check failed: %v", err)
 	}

--- a/internal/testutil/transient.go
+++ b/internal/testutil/transient.go
@@ -1,0 +1,71 @@
+package testutil
+
+import (
+	"strings"
+	"testing"
+)
+
+// transientMarkers are substrings that identify an error as transient network
+// noise rather than a genuine provider regression. These come up nightly when
+// the CI runner's datacenter IP gets throttled by no-key providers (Google
+// Flights/Hotels return HTTP 429; Skiplagged's origin returns 429/502). A
+// rate-limited night is noise: it must not red the Live Probes workflow,
+// otherwise the signal we actually care about (a rotated API, a re-stubbed
+// checker, a real format change) drowns in flapping.
+//
+// The classification is deliberately conservative: only well-known throttle and
+// transient-gateway markers are matched, plus the context-deadline that follows
+// the batchexec client's internal 429 retry/backoff loop. A 200 response with an
+// unexpected body shape ("unexpected flight data format") is NOT transient and
+// still fails — that is real drift worth surfacing.
+var transientMarkers = []string{
+	"429",
+	"rate limited",
+	"too many requests",
+	"unexpected status 429",
+	"bad gateway",
+	"502",
+	"context deadline exceeded",
+	"timeout",
+	"connection reset",
+}
+
+// IsTransientProbeErr reports whether err looks like transient network noise
+// (provider throttling or a transient gateway/timeout) rather than a real
+// provider regression.
+func IsTransientProbeErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return IsTransientMsg(err.Error())
+}
+
+// IsTransientMsg is the string form of IsTransientProbeErr, for callers that
+// carry a failure reason as a plain string (e.g. a result.Error field) rather
+// than an error value.
+func IsTransientMsg(msg string) bool {
+	msg = strings.ToLower(msg)
+	for _, m := range transientMarkers {
+		if strings.Contains(msg, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// SkipIfTransient skips the test when err is transient network noise, and is a
+// no-op when err is nil. Live probes call this on a provider error so a throttled
+// nightly run skips (yellow) instead of failing (red). Real regressions — which
+// surface as non-transient errors — fall through to the caller's own assertions.
+//
+// Usage:
+//
+//	out, err := SearchFlights(ctx, ...)
+//	testutil.SkipIfTransient(t, err)        // skips on 429/timeout noise
+//	if err != nil { t.Fatalf("...", err) }  // real failure still fails
+func SkipIfTransient(t *testing.T, err error) {
+	t.Helper()
+	if IsTransientProbeErr(err) {
+		t.Skipf("skipping: transient provider noise (not a regression): %v", err)
+	}
+}

--- a/internal/testutil/transient_test.go
+++ b/internal/testutil/transient_test.go
@@ -1,0 +1,52 @@
+package testutil
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsTransientMsg(t *testing.T) {
+	transient := []string{
+		"HTTP 429 Too Many Requests",
+		"rate limited by provider",
+		"upstream returned 502 bad gateway",
+		"context deadline exceeded",
+		"i/o timeout",
+		"connection reset by peer",
+	}
+	for _, m := range transient {
+		if !IsTransientMsg(m) {
+			t.Errorf("IsTransientMsg(%q) = false, want true", m)
+		}
+	}
+	// The whole point of the gate: a real provider-format drift must NOT be
+	// swallowed as transient, or the nightly would silently green on breakage.
+	nonTransient := []string{
+		"extract flights: unexpected flight data format",
+		"apollo store not found in page",
+		"",
+		"invalid IATA code",
+	}
+	for _, m := range nonTransient {
+		if IsTransientMsg(m) {
+			t.Errorf("IsTransientMsg(%q) = true, want false (real failure must surface)", m)
+		}
+	}
+}
+
+func TestIsTransientProbeErr(t *testing.T) {
+	if !IsTransientProbeErr(errors.New("got status 429")) {
+		t.Error("429 error should be transient")
+	}
+	if IsTransientProbeErr(errors.New("unexpected flight data format")) {
+		t.Error("format-drift error must NOT be transient")
+	}
+	if IsTransientProbeErr(nil) {
+		t.Error("nil error is not transient")
+	}
+}
+
+func TestSkipIfTransient_NilIsNoop(t *testing.T) {
+	// Must not skip (or panic) when there is no error.
+	SkipIfTransient(t, nil)
+}

--- a/mcp/tools_watch_price_probe_test.go
+++ b/mcp/tools_watch_price_probe_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/MikkoParkkola/trvl/internal/testutil"
 	"github.com/MikkoParkkola/trvl/internal/watch"
 )
 
@@ -40,6 +41,13 @@ func TestHandleCheckWatches_LiveProbe(t *testing.T) {
 		t.Fatalf("handleCheckWatches: %v", err)
 	}
 	raw, _ := json.Marshal(structured)
+	// A throttled night (Google 429 from the CI datacenter IP) re-prices to 0
+	// the same way a stubbed checker would, but for a transient reason. If the
+	// structured output carries a rate-limit/transient marker, treat the 0 as
+	// noise and skip rather than red the nightly.
+	if testutil.IsTransientMsg(string(raw)) {
+		t.Skipf("skipping: transient provider noise (not a regression): %s", string(raw))
+	}
 	if strings.Contains(string(raw), `"current_price":0`) {
 		t.Errorf("live probe returned current_price 0 — re-check did not produce a real price: %s", string(raw))
 	}


### PR DESCRIPTION
## Summary

Fixes nightly **Live Probes** workflow drift (MIK-6167). Four targets triaged; the tractable ones are fixed, the environmentally-blocked one is documented honestly — no fabricated versions or guessed protobuf shapes.

| Target | Outcome |
|---|---|
| **Wizz Air version path** | Fixed — `10.1.0` to `29.3.0` (prior commit on this branch). Verified live: POST to the carrier API `search/timetable` endpoint returns 200 on the new version; the old version returns 404. Version sourced from the carrier site embedded `apiUrl`, env-overridable via `WIZZAIR_API_VERSION`. |
| **Google Flights "unexpected flight data format"** | Deferred — cannot reproduce. The error fires only on a 200 with a bad body shape; this single datacenter IP gets 429-throttled instead, so the 200 path is unreachable here. No format change confirmed, so none guessed. Now tolerated as transient (see below) so it stops red-flapping; a real 200+bad-shape still fails. |
| **Hotel probes (EcoCert + HomeToGo)** | HomeToGo: transient-only, passes (no fix). EcoCert: fixed — see below. |
| **Skiplagged transient 429** | No dedicated probe exists; the aggregate flight probe already tolerates per-provider failure. 429 markers now classified transient by the shared helper. |

## Changes

**1. Transient-throttling tolerance (`internal/testutil/transient.go`)**
New `IsTransientProbeErr`, `IsTransientMsg`, `SkipIfTransient`. Conservative marker set (429, 502, throttle, timeout, connection-reset). Wired into the three Google-dependent aggregate probes — `TestFlightsProbe`, `livecheck.TestChecker_LiveFlightProbe`, `mcp.TestHandleCheckWatches_LiveProbe` — so a throttled night SKIPs (yellow) instead of failing (red). A 200 with `"unexpected flight data format"` is not transient and still fails, preserving real-drift signal.

**2. Eco-certification assertion (`internal/hotels/eco_probe_test.go`)**
`TestProbeEcoCertification` asserted the eco-filtered total was below the base total, but the provider `TotalAvailable` now reports city-wide inventory (3629 for Copenhagen) — identical with and without the filter. The filter still works (returned set differs: 25 eco vs 23 base on the same page), so the total comparison can no longer prove server-side filtering. Downgraded to a logged observation; kept the hard "eco request returns hotels" assertion.

## Verification

- Live (`TRVL_TEST_LIVE_PROBES=1`): `TestFlightsProbe` SKIP on 429 (was FAIL); `TestProbeEcoCertification` PASS (was FAIL); `TestWizzairProbe` PASS; `TestSearchHomeToGoLiveProbe` PASS.
- Offline test suite green across changed packages.
- `gofmt` clean; `go vet` clean.

**Do not merge** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0195S4SLMFqfBd8gCQLqbAcr
