### PR TITLE
fix(release): publish Homebrew Formula not Cask (Gatekeeper quarantine fix)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -145,20 +145,36 @@ release:
     go install github.com/MikkoParkkola/trvl/cmd/trvl@v{{ .Version }}
     ```
 
-homebrew_casks:
-  - ids:
+# Publish a Homebrew *Formula* (not a Cask). A CLI binary belongs in a Formula:
+# `brew install` of a formula relocates the binary and strips the
+# com.apple.quarantine xattr, so the adhoc-signed binary launches cleanly on
+# Apple Silicon. A Cask, by contrast, keeps quarantine on the downloaded
+# artifact, and Gatekeeper then SIGKILLs the adhoc-signed binary (the trvl#203
+# "non-functional release" + the Gatekeeper "Not Opened" popup). Formula-only
+# is the zero-cost, zero-popup distribution path until/unless Developer ID
+# notarization is wired in (tracked separately).
+#
+# NOTE: goreleaser v2 marks `brews` deprecated and steers pre-built binaries to
+# `homebrew_casks`. That is INTENTIONALLY rejected here: a cask keeps the
+# com.apple.quarantine xattr, which Gatekeeper uses to SIGKILL our adhoc-signed
+# binary. Do NOT "modernize" this back to homebrew_casks without first wiring
+# Developer ID notarization, or you reintroduce the trvl#203 popup. The action is
+# pinned to `~> v2`, where `brews` remains functional; release/build never run
+# `goreleaser check`, so the deprecation warning does not fail the pipeline.
+brews:
+  - name: trvl
+    ids:
       - trvl
-    name: trvl
     repository:
       owner: MikkoParkkola
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Casks
+    directory: Formula
     homepage: https://github.com/MikkoParkkola/trvl
     description: "AI travel agent: flights, hotels and transport via MCP, no API keys"
     license: "PolyForm-Noncommercial-1.0.0"
-    binaries:
-      - trvl
+    test: |
+      system "#{bin}/trvl", "version"
     caveats: |
       Run `trvl mcp install` to connect trvl to Claude Desktop, Cursor,
       Windsurf, Codex, VS Code Copilot, Zed, or another MCP client.


### PR DESCRIPTION
## Problem

The macOS "\"trvl\" Not Opened — Apple could not verify..." Gatekeeper popup, and the trvl#203 "non-functional release" report, share one root cause: the release was distributed as a Homebrew **Cask**.

- A **Cask** keeps the `com.apple.quarantine` xattr on the downloaded binary. Gatekeeper then **SIGKILLs** our *adhoc-signed* binary on Apple Silicon (exit 137, zero output) — or shows the "Not Opened" popup.
- A **Formula** install relocates the binary and strips quarantine, so the same adhoc-signed binary launches cleanly. (This is why `brew install` of the v1.10.0 *formula* always worked.)

Ad-hoc signing can never clear Gatekeeper for a quarantined download — only Developer ID + notarization can. Formula-only is the zero-cost, zero-popup path; notarization is a tracked premium follow-up.

## Change

- `.goreleaser.yaml`: `homebrew_casks` → `brews` (publishes a Formula to `MikkoParkkola/homebrew-tap/Formula`).
- Documents why goreleaser's `brews` deprecation is **intentionally accepted**: the recommended `homebrew_casks` reintroduces the quarantine kill. Pinned `~> v2` (brews still functional); no workflow runs `goreleaser check`, so the deprecation warning never fails the pipeline.

## Validation

- `goreleaser check`: config **valid** (only the expected `brews` deprecation warning).
- ci.yaml's racing `release` job is guarded `== 'trvl-disabled'` (off) — no double-publish.
- Builds on #204 (drops hardened-runtime hard-kill + adds pre-publish smoke gate).

Follow-up to trvl#203. Closes the Gatekeeper-popup class for `brew install`.