### PR TITLE
fix(release): restore working tree after smoke-test build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,8 +140,21 @@ jobs:
       # Re-clean dist/ so the snapshot artifacts above don't collide with the
       # real release build below (goreleaser release also runs --clean, but be
       # explicit so a stale snapshot binary can never be archived/published).
-      - name: Reset dist before release build
-        run: rm -rf dist
+      #
+      # The smoke-test `goreleaser build` above runs .goreleaser.yaml before.hooks
+      # (go mod tidy + a sed that bumps npm/package.json to the tag version). That
+      # leaves the working tree dirty, and `goreleaser release` validates git state
+      # at startup and aborts with "git is in a dirty state" (it tolerates its OWN
+      # before-hooks dirtying the tree, but not a pre-existing dirty tree). So
+      # restore all tracked files to HEAD before the real release runs. dist/ is
+      # gitignored and removed separately; no local commits exist to lose (HEAD is
+      # the tag), so `git checkout -- .` is safe and surgical.
+      - name: Reset working tree before release build
+        run: |
+          rm -rf dist
+          git checkout -- .
+          echo "git status after reset:"
+          git status --porcelain
 
       - name: Run GoReleaser with Homebrew tap
         if: env.HAS_HOMEBREW_TAP_TOKEN == 'true'


### PR DESCRIPTION
## Problem

v1.11.1 release **failed**: `goreleaser release` aborted with `git is in a dirty state: M npm/package.json` before producing any artifact. The smoke gate passed and nothing shipped — the gate worked.

**Root cause:** the smoke-test `goreleaser build` step (#204) runs `.goreleaser.yaml` `before.hooks`, which sed-bump `npm/package.json` to the tag version, leaving the tree dirty. `goreleaser release` validates git state at startup and aborts (it tolerates its *own* before-hooks dirtying the tree, not a pre-existing dirty tree). v1.11.0 never hit this — no pre-release goreleaser invocation existed. #204 added one; the "Reset dist" step only cleaned `dist/`, not the hook's file mutation.

## Fix

`git checkout -- .` between smoke test and release to restore tracked files to HEAD. `dist/` is gitignored; HEAD is the tag (no local commits to lose), so it is safe and surgical. Logs `git status --porcelain` for evidence.

## Validation

PR unit-CI does not exercise `release.yml` (tag-triggered only); the real test is re-cutting v1.11.1 and watching the release go green end-to-end, done on merge. YAML validated locally (`yaml.safe_load`).