### PR TITLE
fix(hotels): Trivago tool-rename, Booking.com WAF retry coverage, hotel_rooms honors hotel_id

### DIFF
--- a/internal/hotels/booking_search.go
+++ b/internal/hotels/booking_search.go
@@ -97,15 +97,31 @@ func buildBookingSearchURL(location, checkIn, checkOut, currency string, adults,
 	return bookingBaseURL + "/searchresults.html?" + q.Encode()
 }
 
+// bookingAcquireTokenFn and bookingGetFn are indirection seams for tests so the
+// 202/403/503 re-harvest-and-retry logic can be exercised deterministically
+// without a live WAF token or HTTP round-trip. Production wiring is the real
+// acquireBookingWAFToken / bookingGet.
+var (
+	bookingAcquireTokenFn = acquireBookingWAFToken
+	bookingGetFn          = bookingGet
+)
+
+// bookingWAFChallenged reports whether an HTTP status indicates the Booking.com
+// WAF rejected the request (challenge / stale token) and a token re-harvest is
+// warranted.
+func bookingWAFChallenged(status int) bool {
+	return status == 202 || status == 403 || status == 503
+}
+
 // fetchBookingSearch performs the token-seeded GET against Booking.com. On a
 // 202 (WAF challenge / stale token) it re-harvests the token once and retries.
 func fetchBookingSearch(ctx context.Context, searchURL string) (string, error) {
-	token, err := acquireBookingWAFToken(ctx, searchURL, false)
+	token, err := bookingAcquireTokenFn(ctx, searchURL, false)
 	if err != nil {
 		return "", fmt.Errorf("acquire aws-waf-token: %w", err)
 	}
 
-	status, body, err := bookingGet(ctx, searchURL, token)
+	status, body, err := bookingGetFn(ctx, searchURL, token)
 	if err != nil {
 		return "", err
 	}
@@ -114,13 +130,13 @@ func fetchBookingSearch(ctx context.Context, searchURL string) (string, error) {
 	}
 
 	// 202 (and 403/503) mean the WAF rejected the token. Re-harvest once.
-	if status == 202 || status == 403 || status == 503 {
+	if bookingWAFChallenged(status) {
 		slog.Debug("booking search: WAF challenge, re-harvesting token", "status", status)
-		token, err = acquireBookingWAFToken(ctx, searchURL, true)
+		token, err = bookingAcquireTokenFn(ctx, searchURL, true)
 		if err != nil {
 			return "", fmt.Errorf("re-harvest aws-waf-token after status %d: %w", status, err)
 		}
-		status, body, err = bookingGet(ctx, searchURL, token)
+		status, body, err = bookingGetFn(ctx, searchURL, token)
 		if err != nil {
 			return "", err
 		}

--- a/internal/hotels/booking_waf_retry_test.go
+++ b/internal/hotels/booking_waf_retry_test.go
@@ -1,0 +1,91 @@
+package hotels
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Regression tests for GH #187 / #188 Bug 2: a Booking.com WAF challenge (HTTP
+// 202, also 403/503) must trigger exactly one token re-harvest (forceRefresh)
+// and a retry, rather than returning an empty result. Verified deterministically
+// via the bookingAcquireTokenFn / bookingGetFn seams.
+
+func TestFetchBookingSearch_202ReharvestsAndRetries(t *testing.T) {
+	origAcquire := bookingAcquireTokenFn
+	origGet := bookingGetFn
+	defer func() { bookingAcquireTokenFn = origAcquire; bookingGetFn = origGet }()
+
+	var forceFlags []bool
+	bookingAcquireTokenFn = func(_ context.Context, _ string, force bool) (string, error) {
+		forceFlags = append(forceFlags, force)
+		if force {
+			return "fresh-token", nil
+		}
+		return "stale-token", nil
+	}
+
+	var gets []string
+	bookingGetFn = func(_ context.Context, _ string, token string) (int, []byte, error) {
+		gets = append(gets, token)
+		if token == "stale-token" {
+			return 202, nil, nil // WAF challenge
+		}
+		return 200, []byte("<html>listings</html>"), nil
+	}
+
+	body, err := fetchBookingSearch(context.Background(), "https://booking.com/searchresults.html")
+	if err != nil {
+		t.Fatalf("fetchBookingSearch: %v", err)
+	}
+	if !strings.Contains(body, "listings") {
+		t.Errorf("expected listings body after retry, got %q", body)
+	}
+	// First acquire (force=false), then re-harvest (force=true).
+	if len(forceFlags) != 2 || forceFlags[0] != false || forceFlags[1] != true {
+		t.Errorf("expected [false true] acquire flags, got %v", forceFlags)
+	}
+	if len(gets) != 2 || gets[0] != "stale-token" || gets[1] != "fresh-token" {
+		t.Errorf("expected stale then fresh token GETs, got %v", gets)
+	}
+}
+
+func TestFetchBookingSearch_WAFChallengeStatuses(t *testing.T) {
+	for _, status := range []int{202, 403, 503} {
+		if !bookingWAFChallenged(status) {
+			t.Errorf("status %d should be treated as a WAF challenge", status)
+		}
+	}
+	for _, status := range []int{200, 404, 500} {
+		if bookingWAFChallenged(status) {
+			t.Errorf("status %d should NOT be treated as a WAF challenge", status)
+		}
+	}
+}
+
+func TestFetchBookingSearch_PersistentChallengeErrors(t *testing.T) {
+	origAcquire := bookingAcquireTokenFn
+	origGet := bookingGetFn
+	defer func() { bookingAcquireTokenFn = origAcquire; bookingGetFn = origGet }()
+
+	bookingAcquireTokenFn = func(_ context.Context, _ string, _ bool) (string, error) {
+		return "tok", nil
+	}
+	calls := 0
+	bookingGetFn = func(_ context.Context, _ string, _ string) (int, []byte, error) {
+		calls++
+		return 202, nil, nil // never recovers
+	}
+
+	_, err := fetchBookingSearch(context.Background(), "https://booking.com/searchresults.html")
+	if err == nil {
+		t.Fatal("expected error when WAF challenge persists after re-harvest")
+	}
+	if !strings.Contains(err.Error(), "after token re-harvest") {
+		t.Errorf("expected re-harvest error, got: %v", err)
+	}
+	// Exactly two GETs: initial + one retry (no infinite loop).
+	if calls != 2 {
+		t.Errorf("expected 2 GET attempts, got %d", calls)
+	}
+}

--- a/internal/hotels/hotels_coverage_boost_test.go
+++ b/internal/hotels/hotels_coverage_boost_test.go
@@ -189,19 +189,15 @@ func TestSearchTrivago_FullRoundTrip(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{}}}`)
 
+		case "tools/list":
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"trivago-accommodation-radius-search"},{"name":"trivago-accommodation-search"}]}}`)
+
 		case "tools/call":
-			// First tools/call is suggestions, second is accommodation search.
-			if callCount == 2 {
-				// Suggestions response.
-				payload := `{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{}"}],"structuredContent":{"suggestions":[{"ns":200,"id":22235,"location":"Paris"}]}}}`
-				w.WriteHeader(http.StatusOK)
-				_, _ = fmt.Fprint(w, payload)
-			} else {
-				// Accommodation search response.
-				payload := `{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{}"}],"structuredContent":{"accommodations":[{"accommodation_name":"Mock Paris Hotel","currency":"EUR","price_per_night":"€150","hotel_rating":4,"review_rating":"8.8","review_count":300,"latitude":48.8566,"longitude":2.3522,"accommodation_url":"https://trivago.com/book/mock1"}]}}}`
-				w.WriteHeader(http.StatusOK)
-				_, _ = fmt.Fprint(w, payload)
-			}
+			// Single accommodation-search call (no suggestions step anymore).
+			payload := `{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{}"}],"structuredContent":{"accommodations":[{"accommodation_name":"Mock Paris Hotel","currency":"EUR","price_per_night":"€150","hotel_rating":4,"review_rating":"8.8","review_count":"300","latitude":48.8566,"longitude":2.3522,"accommodation_url":"https://trivago.com/book/mock1"}]}}}`
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, payload)
 
 		default:
 			http.Error(w, fmt.Sprintf("unexpected method: %s", req.Method), http.StatusBadRequest)
@@ -313,14 +309,16 @@ func TestSearchTrivago_InitSessionFails_MockHTTP500(t *testing.T) {
 	}
 }
 
+// TestSearchTrivago_SuggestionsFail verifies a tool-call rejection surfaces as
+// an error. The suggestions step was removed (GH #187/#188); when tools/list
+// and the accommodation-search call both return 429, the error reports the
+// accommodation search failure.
 func TestSearchTrivago_SuggestionsFail(t *testing.T) {
 	origEnabled := trivagoEnabled
 	trivagoEnabled = true
 	defer func() { trivagoEnabled = origEnabled }()
 
-	callCount := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
 		var req trivagoRPCRequest
 		_ = json.NewDecoder(r.Body).Decode(&req)
 
@@ -331,7 +329,7 @@ func TestSearchTrivago_SuggestionsFail(t *testing.T) {
 			_, _ = fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{}}`)
 			return
 		}
-		// Return 429 for the tool call to simulate suggestions failure.
+		// Return 429 for tools/list and the tool call.
 		w.WriteHeader(http.StatusTooManyRequests)
 	}))
 	defer srv.Close()
@@ -347,10 +345,10 @@ func TestSearchTrivago_SuggestionsFail(t *testing.T) {
 		CheckOut: "2026-07-05",
 	})
 	if err == nil {
-		t.Fatal("expected error for suggestions failure")
+		t.Fatal("expected error for tool-call failure")
 	}
-	if !strings.Contains(err.Error(), "trivago suggestions") {
-		t.Errorf("expected 'trivago suggestions' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "trivago accommodation search") {
+		t.Errorf("expected 'trivago accommodation search' in error, got: %v", err)
 	}
 }
 

--- a/internal/hotels/testdata/trivago_accommodation_search.json
+++ b/internal/hotels/testdata/trivago_accommodation_search.json
@@ -1,0 +1,56 @@
+{
+ "jsonrpc": "2.0",
+ "id": 3,
+ "result": {
+  "content": [
+   {
+    "type": "text",
+    "text": "{\"accommodations\": [{\"accommodation_id\": \"100-8007\", \"arrival\": \"2026-09-05\", \"departure\": \"2026-09-09\", \"accommodation_name\": \"Hotel Riu Plaza Fishermans Wharf\", \"currency\": \"USD\", \"price_per_night\": \"$223\", \"price_per_stay\": \"$891\", \"advertisers\": \"Riu.com\", \"hotel_rating\": 4, \"country_city\": \"San Francisco, USA\", \"review_rating\": \"8.5\", \"review_count\": \"25,711\", \"top_amenities\": \"WiFi in lobby, WiFi in rooms, Pool, Parking, A/C, Restaurant, Hotel bar, Gym\", \"accommodation_url\": \"https://www.trivago.com/en-US/lm/hotel-riu-plaza-fishermans-wharf-san-francisco?search=100-8007;dr-20260905-20260909;drs-40;rc-1-2&cip=234716015\", \"latitude\": 37.807411193847656, \"longitude\": -122.41348266601562, \"distance\": \"0.2 miles to Fisherman's Wharf\", \"main_image\": \"https://imgcy.trivago.com/c_fill,d_dummy.jpeg,e_sharpen:60,f_auto,h_534,q_40,w_800/partner-images/ac/a7/dac684a0a4869ce18da6e77b6b63c6c417ed68e774f5b1aa55f303735d5e\"}, {\"accommodation_id\": \"100-61755\", \"arrival\": \"2026-09-05\", \"departure\": \"2026-09-09\", \"accommodation_name\": \"Holiday Inn San Francisco-golden Gateway By Ihg\", \"currency\": \"USD\", \"price_per_night\": \"$168\", \"price_per_stay\": \"$673\", \"advertisers\": \"Hotels.com\", \"hotel_rating\": 3, \"country_city\": \"San Francisco, USA\", \"review_rating\": \"8.4\", \"review_count\": \"20,318\", \"top_amenities\": \"WiFi in lobby, WiFi in rooms, Pool, Parking, A/C, Restaurant, Hotel bar, Gym\", \"accommodation_url\": \"https://www.trivago.com/en-US/lm/hotel-holiday-inn-san-francisco-golden-gateway-by-ihg?search=100-61755;dr-20260905-20260909;drs-40;rc-1-2&cip=234716015\", \"latitude\": 37.78981018066406, \"longitude\": -122.42195129394531, \"distance\": \"0.8 miles to Union Square\", \"main_image\": \"https://imgcy.trivago.com/c_fill,d_dummy.jpeg,e_sharpen:60,f_auto,h_534,q_40,w_800/partner-images/dc/88/0c18b16182f0e89ceac661bf3db163bbc4d62b8b6bdba0e00e16fdf81a19\"}]}"
+   }
+  ],
+  "structuredContent": {
+   "accommodations": [
+    {
+     "accommodation_id": "100-8007",
+     "arrival": "2026-09-05",
+     "departure": "2026-09-09",
+     "accommodation_name": "Hotel Riu Plaza Fishermans Wharf",
+     "currency": "USD",
+     "price_per_night": "$223",
+     "price_per_stay": "$891",
+     "advertisers": "Riu.com",
+     "hotel_rating": 4,
+     "country_city": "San Francisco, USA",
+     "review_rating": "8.5",
+     "review_count": "25,711",
+     "top_amenities": "WiFi in lobby, WiFi in rooms, Pool, Parking, A/C, Restaurant, Hotel bar, Gym",
+     "accommodation_url": "https://www.trivago.com/en-US/lm/hotel-riu-plaza-fishermans-wharf-san-francisco?search=100-8007;dr-20260905-20260909;drs-40;rc-1-2&cip=234716015",
+     "latitude": 37.807411193847656,
+     "longitude": -122.41348266601562,
+     "distance": "0.2 miles to Fisherman's Wharf",
+     "main_image": "https://imgcy.trivago.com/c_fill,d_dummy.jpeg,e_sharpen:60,f_auto,h_534,q_40,w_800/partner-images/ac/a7/dac684a0a4869ce18da6e77b6b63c6c417ed68e774f5b1aa55f303735d5e"
+    },
+    {
+     "accommodation_id": "100-61755",
+     "arrival": "2026-09-05",
+     "departure": "2026-09-09",
+     "accommodation_name": "Holiday Inn San Francisco-golden Gateway By Ihg",
+     "currency": "USD",
+     "price_per_night": "$168",
+     "price_per_stay": "$673",
+     "advertisers": "Hotels.com",
+     "hotel_rating": 3,
+     "country_city": "San Francisco, USA",
+     "review_rating": "8.4",
+     "review_count": "20,318",
+     "top_amenities": "WiFi in lobby, WiFi in rooms, Pool, Parking, A/C, Restaurant, Hotel bar, Gym",
+     "accommodation_url": "https://www.trivago.com/en-US/lm/hotel-holiday-inn-san-francisco-golden-gateway-by-ihg?search=100-61755;dr-20260905-20260909;drs-40;rc-1-2&cip=234716015",
+     "latitude": 37.78981018066406,
+     "longitude": -122.42195129394531,
+     "distance": "0.8 miles to Union Square",
+     "main_image": "https://imgcy.trivago.com/c_fill,d_dummy.jpeg,e_sharpen:60,f_auto,h_534,q_40,w_800/partner-images/dc/88/0c18b16182f0e89ceac661bf3db163bbc4d62b8b6bdba0e00e16fdf81a19"
+    }
+   ]
+  }
+ }
+}

--- a/internal/hotels/testdata/trivago_tools_list.json
+++ b/internal/hotels/testdata/trivago_tools_list.json
@@ -1,0 +1,1 @@
+{"jsonrpc": "2.0", "id": 2, "result": {"tools": [{"name": "trivago-accommodation-radius-search"}, {"name": "trivago-accommodation-search"}]}}

--- a/internal/hotels/trivago.go
+++ b/internal/hotels/trivago.go
@@ -129,7 +129,7 @@ type trivagoAccommodation struct {
 	CountryCity       string                   `json:"country_city"`
 	HotelRating       int                      `json:"hotel_rating"`
 	ReviewRating      string                   `json:"review_rating"`
-	ReviewCount       int                      `json:"review_count"`
+	ReviewCount       trivagoFlexInt           `json:"review_count"`
 	Currency          string                   `json:"currency"`
 	PricePerNight     string                   `json:"price_per_night"`
 	PricePerStay      string                   `json:"price_per_stay"`
@@ -154,6 +154,48 @@ type trivagoAccommodation struct {
 type trivagoDistanceToCenter struct {
 	Value float64 `json:"value"`
 	Unit  string  `json:"unit"`
+}
+
+// trivagoFlexInt unmarshals an integer that the Trivago API may encode either
+// as a JSON number (legacy) or as a thousands-separated string such as
+// "25,711" (current API). A failed parse yields 0 rather than an error, so a
+// single malformed count never aborts the whole accommodation list decode.
+type trivagoFlexInt int
+
+func (c *trivagoFlexInt) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || string(b) == "null" {
+		*c = 0
+		return nil
+	}
+	// Numeric form: 25711
+	if b[0] != '"' {
+		var n float64
+		if err := json.Unmarshal(b, &n); err != nil {
+			*c = 0
+			return nil
+		}
+		*c = trivagoFlexInt(int(n))
+		return nil
+	}
+	// String form: "25,711" or "25711".
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		*c = 0
+		return nil
+	}
+	s = strings.NewReplacer(",", "", " ", "", " ", "").Replace(strings.TrimSpace(s))
+	if s == "" {
+		*c = 0
+		return nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		*c = 0
+		return nil
+	}
+	*c = trivagoFlexInt(n)
+	return nil
 }
 
 type trivagoPrice struct {
@@ -337,10 +379,13 @@ func extractTrivagoContent(rpc trivagoRPCResponse) (json.RawMessage, error) {
 
 // SearchTrivago searches for hotels using the Trivago MCP API.
 //
-// It performs three sequential HTTP calls:
+// Trivago's MCP server dropped the old two-step (suggestions → ns/id → search)
+// flow. The current `trivago-accommodation-search` tool resolves the location
+// itself from a free-text `query`, so trvl now performs:
 //  1. initialize — handshake to obtain a session ID.
-//  2. trivago-search-suggestions(query) — resolve location to ns + id.
-//  3. trivago-accommodation-search(ns, id, arrival, departure, …) — hotel list.
+//  2. tools/list — discover the live accommodation-search tool name (resilient
+//     to further upstream renames; falls back to the documented default).
+//  3. <accommodation-search>(query, arrival, departure, adults, …) — hotel list.
 //
 // Each returned HotelResult is tagged with a PriceSource for "trivago".
 func SearchTrivago(ctx context.Context, location string, opts HotelSearchOptions) ([]models.HotelResult, error) {
@@ -365,32 +410,43 @@ func SearchTrivago(ctx context.Context, location string, opts HotelSearchOptions
 		return nil, fmt.Errorf("trivago init: %w", err)
 	}
 
-	// Step 1: Resolve location to a Trivago ns + id.
-	slog.Debug("trivago search suggestions", "location", location)
-	suggRaw, err := trivagoMCPCall(ctx, sessionID, "trivago-search-suggestions", map[string]any{
-		"query": location,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("trivago suggestions: %w", err)
+	// Step 1: Discover the accommodation-search tool from tools/list rather
+	// than hard-coding it. If discovery fails (network/parse), fall back to
+	// the documented default so a transient list error doesn't take Trivago
+	// down. If the server genuinely no longer exposes any query-based search
+	// tool, return a clear, actionable error.
+	toolName := trivagoDefaultSearchTool
+	if names, lerr := trivagoListToolNames(ctx, sessionID); lerr == nil {
+		selected, serr := selectTrivagoSearchTool(names)
+		if serr != nil {
+			return nil, fmt.Errorf("trivago: %w", serr)
+		}
+		toolName = selected
+	} else {
+		slog.Debug("trivago tools/list failed, using default tool", "tool", toolName, "error", lerr)
 	}
 
-	locRef, err := parseTrivagoSuggestions(suggRaw)
-	if err != nil {
-		return nil, fmt.Errorf("trivago suggestions parse: %w", err)
-	}
-
-	// Step 2: Search accommodations.
-	slog.Debug("trivago accommodation search", "location", location, "ns", locRef.NS, "id", locRef.ID,
+	// Step 2: Search accommodations. The current tool resolves the location
+	// from a free-text query, so no separate suggestions lookup is required.
+	slog.Debug("trivago accommodation search", "location", location, "tool", toolName,
 		"arrival", opts.CheckIn, "departure", opts.CheckOut, "guests", opts.Guests)
 	accomArgs := map[string]any{
-		"ns":        locRef.NS,
-		"id":        locRef.ID,
+		"query":     location,
 		"arrival":   opts.CheckIn,
 		"departure": opts.CheckOut,
 		"adults":    opts.Guests,
 		"rooms":     1,
+		"currency":  strings.ToUpper(currency),
 	}
-	accomRaw, err := trivagoMCPCall(ctx, sessionID, "trivago-accommodation-search", accomArgs)
+	if len(opts.ChildrenAges) > 0 {
+		accomArgs["children"] = len(opts.ChildrenAges)
+		ages := make([]string, 0, len(opts.ChildrenAges))
+		for _, a := range opts.ChildrenAges {
+			ages = append(ages, strconv.Itoa(a))
+		}
+		accomArgs["children_ages"] = strings.Join(ages, "-")
+	}
+	accomRaw, err := trivagoMCPCall(ctx, sessionID, toolName, accomArgs)
 	if err != nil {
 		return nil, fmt.Errorf("trivago accommodation search: %w", err)
 	}
@@ -402,6 +458,111 @@ func SearchTrivago(ctx context.Context, location string, opts HotelSearchOptions
 
 	slog.Debug("trivago results", "location", location, "count", len(hotels))
 	return hotels, nil
+}
+
+// trivagoDefaultSearchTool is the documented query-based accommodation search
+// tool. Used as a fallback when tools/list discovery is unavailable.
+const trivagoDefaultSearchTool = "trivago-accommodation-search"
+
+// trivagoToolsListResult is the minimal shape of a tools/list response.
+type trivagoToolsListResult struct {
+	Tools []struct {
+		Name string `json:"name"`
+	} `json:"tools"`
+}
+
+// trivagoListToolNames calls tools/list on the Trivago MCP endpoint and returns
+// the advertised tool names.
+func trivagoListToolNames(ctx context.Context, sessionID string) ([]string, error) {
+	if err := trivagoLimiter.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("trivago: rate limiter: %w", err)
+	}
+
+	reqBody := trivagoRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/list",
+		Params:  map[string]any{},
+	}
+	reqBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("trivago: marshal tools/list: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, trivagoMCPEndpoint, bytes.NewReader(reqBytes))
+	if err != nil {
+		return nil, fmt.Errorf("trivago: build tools/list request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+
+	resp, err := trivagoHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("trivago: tools/list HTTP request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("trivago: tools/list HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("trivago: read tools/list body: %w", err)
+	}
+	return parseTrivagoToolNames(body)
+}
+
+// parseTrivagoToolNames extracts tool names from a tools/list JSON-RPC body.
+func parseTrivagoToolNames(body []byte) ([]string, error) {
+	var rpcResp trivagoRPCResponse
+	if err := json.Unmarshal(body, &rpcResp); err != nil {
+		return nil, fmt.Errorf("trivago: unmarshal tools/list: %w", err)
+	}
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("trivago: tools/list RPC error %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+	}
+	var result trivagoToolsListResult
+	if err := json.Unmarshal(rpcResp.Result, &result); err != nil {
+		return nil, fmt.Errorf("trivago: decode tools/list result: %w", err)
+	}
+	names := make([]string, 0, len(result.Tools))
+	for _, t := range result.Tools {
+		if t.Name != "" {
+			names = append(names, t.Name)
+		}
+	}
+	return names, nil
+}
+
+// selectTrivagoSearchTool picks the best query-based accommodation-search tool
+// from the advertised tool names. It prefers the exact documented name, then
+// any accommodation-search tool that is not the coordinate/radius variant.
+// Returns an error if no suitable tool is present so the caller can surface an
+// actionable message instead of calling a non-existent tool.
+func selectTrivagoSearchTool(names []string) (string, error) {
+	for _, n := range names {
+		if n == trivagoDefaultSearchTool {
+			return n, nil
+		}
+	}
+	for _, n := range names {
+		lower := strings.ToLower(n)
+		if strings.Contains(lower, "accommodation-search") && !strings.Contains(lower, "radius") {
+			return n, nil
+		}
+	}
+	// Fall back to any accommodation search tool (including radius) as a last
+	// resort before failing outright.
+	for _, n := range names {
+		if strings.Contains(strings.ToLower(n), "accommodation") && strings.Contains(strings.ToLower(n), "search") {
+			return n, nil
+		}
+	}
+	return "", fmt.Errorf("no accommodation-search tool found in Trivago tools/list (advertised: %s)", strings.Join(names, ", "))
 }
 
 // parseTrivagoSuggestions extracts the first location's ns and id from a
@@ -610,7 +771,7 @@ func mapTrivagoAccommodations(accoms []trivagoAccommodation, defaultCurrency str
 		}
 
 		// Determine review count.
-		reviewCount := a.ReviewCount
+		reviewCount := int(a.ReviewCount)
 
 		// Determine booking URL.
 		bookingURL := sanitizeBookingURL(a.BookingURL)

--- a/internal/hotels/trivago_toolrename_test.go
+++ b/internal/hotels/trivago_toolrename_test.go
@@ -1,0 +1,211 @@
+package hotels
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression tests for GH #187 / #188 Bug 1: Trivago dropped the
+// trivago-search-suggestions tool and trivago-accommodation-search now takes a
+// free-text `query` (no ns/id). Its review_count is also a thousands-separated
+// string (e.g. "25,711") which previously broke the typed decode.
+
+func readTrivagoFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return b
+}
+
+func TestParseTrivagoToolNamesLiveFixture(t *testing.T) {
+	body := readTrivagoFixture(t, "trivago_tools_list.json")
+	names, err := parseTrivagoToolNames(body)
+	if err != nil {
+		t.Fatalf("parseTrivagoToolNames: %v", err)
+	}
+	// The live server no longer advertises trivago-search-suggestions.
+	for _, n := range names {
+		if n == "trivago-search-suggestions" {
+			t.Fatalf("did not expect trivago-search-suggestions in tools list: %v", names)
+		}
+	}
+	if len(names) == 0 {
+		t.Fatal("expected at least one tool name")
+	}
+}
+
+func TestSelectTrivagoSearchTool(t *testing.T) {
+	tests := []struct {
+		name  string
+		names []string
+		want  string
+		err   bool
+	}{
+		{"exact", []string{"trivago-accommodation-radius-search", "trivago-accommodation-search"}, "trivago-accommodation-search", false},
+		{"renamed_non_radius", []string{"trivago-accommodation-radius-search", "trivago-v2-accommodation-search"}, "trivago-v2-accommodation-search", false},
+		{"radius_only_fallback", []string{"trivago-accommodation-radius-search"}, "trivago-accommodation-radius-search", false},
+		{"none", []string{"trivago-something-else"}, "", true},
+		{"empty", nil, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectTrivagoSearchTool(tt.names)
+			if tt.err {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTrivagoAccommodationsLiveFixture(t *testing.T) {
+	body := readTrivagoFixture(t, "trivago_accommodation_search.json")
+	raw, err := parseTrivagoResponse(body)
+	if err != nil {
+		t.Fatalf("parseTrivagoResponse: %v", err)
+	}
+	hotels, err := parseTrivagoAccommodations(raw, "USD")
+	if err != nil {
+		t.Fatalf("parseTrivagoAccommodations: %v", err)
+	}
+	if len(hotels) != 2 {
+		t.Fatalf("expected 2 hotels, got %d", len(hotels))
+	}
+	h := hotels[0]
+	if h.Name != "Hotel Riu Plaza Fishermans Wharf" {
+		t.Errorf("name: got %q", h.Name)
+	}
+	if h.Price != 223 {
+		t.Errorf("price: got %v, want 223", h.Price)
+	}
+	// review_count "25,711" must parse to 25711 (comma-string tolerance).
+	if h.ReviewCount != 25711 {
+		t.Errorf("review count: got %d, want 25711", h.ReviewCount)
+	}
+	if len(h.Sources) == 0 || h.Sources[0].Provider != "trivago" {
+		t.Errorf("expected trivago price source, got %+v", h.Sources)
+	}
+}
+
+func TestTrivagoFlexIntFormats(t *testing.T) {
+	cases := map[string]int{
+		`"25,711"`: 25711,
+		`"512"`:    512,
+		`512`:      512,
+		`"1 234"`:  1234,
+		`null`:     0,
+		`""`:       0,
+		`"abc"`:    0,
+	}
+	for in, want := range cases {
+		var c trivagoFlexInt
+		if err := json.Unmarshal([]byte(in), &c); err != nil {
+			t.Fatalf("unmarshal %s: %v", in, err)
+		}
+		if int(c) != want {
+			t.Errorf("flexint(%s) = %d, want %d", in, int(c), want)
+		}
+	}
+}
+
+// TestSearchTrivagoNoSuggestionsCall is the end-to-end guard: SearchTrivago must
+// NOT call trivago-search-suggestions, must discover the tool via tools/list,
+// and must pass a free-text `query` to the accommodation-search tool.
+func TestSearchTrivagoNoSuggestionsCall(t *testing.T) {
+	origEnabled := trivagoEnabled
+	trivagoEnabled = true
+	defer func() { trivagoEnabled = origEnabled }()
+
+	toolsList := readTrivagoFixture(t, "trivago_tools_list.json")
+	accom := readTrivagoFixture(t, "trivago_accommodation_search.json")
+
+	var calledTools []string
+	var lastArgs map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req trivagoRPCRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		switch req.Method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "sess-1")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+		case "tools/list":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(toolsList)
+		case "tools/call":
+			// Capture which tool + args were requested.
+			b, _ := json.Marshal(req.Params)
+			var p trivagoToolCallParams
+			_ = json.Unmarshal(b, &p)
+			calledTools = append(calledTools, p.Name)
+			lastArgs = p.Arguments
+			if p.Name == "trivago-search-suggestions" {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"tool 'trivago-search-suggestions' not found: tool not found"}}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(accom)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+		}
+	}))
+	defer srv.Close()
+
+	origClient := trivagoHTTPClient
+	trivagoHTTPClient = &http.Client{Transport: &rewriteTransport{target: srv.URL}}
+	defer func() { trivagoHTTPClient = origClient }()
+
+	hotels, err := SearchTrivago(context.Background(), "San Francisco", HotelSearchOptions{
+		CheckIn:      "2026-09-05",
+		CheckOut:     "2026-09-09",
+		Guests:       2,
+		ChildrenAges: []int{5, 7},
+		Currency:     "USD",
+	})
+	if err != nil {
+		t.Fatalf("SearchTrivago: %v", err)
+	}
+	if len(hotels) != 2 {
+		t.Fatalf("expected 2 hotels, got %d", len(hotels))
+	}
+	for _, tool := range calledTools {
+		if tool == "trivago-search-suggestions" {
+			t.Fatalf("SearchTrivago must not call trivago-search-suggestions; called: %v", calledTools)
+		}
+	}
+	if len(calledTools) != 1 || calledTools[0] != "trivago-accommodation-search" {
+		t.Fatalf("expected single trivago-accommodation-search call, got %v", calledTools)
+	}
+	if q, _ := lastArgs["query"].(string); q != "San Francisco" {
+		t.Errorf("expected query=San Francisco, got %v", lastArgs["query"])
+	}
+	if _, hasNS := lastArgs["ns"]; hasNS {
+		t.Errorf("must not pass ns/id to accommodation-search: %v", lastArgs)
+	}
+	if ages, _ := lastArgs["children_ages"].(string); !strings.Contains(ages, "5") {
+		t.Errorf("expected children_ages to include child ages, got %v", lastArgs["children_ages"])
+	}
+}

--- a/mcp/tools_hotels.go
+++ b/mcp/tools_hotels.go
@@ -613,13 +613,14 @@ func hotelRoomsTool() ToolDef {
 		InputSchema: InputSchema{
 			Type: "object",
 			Properties: map[string]Property{
-				"hotel_name":  {Type: "string", Description: "Hotel name and optional city, e.g. 'Beverly Hills Heights, Tenerife'"},
+				"hotel_id":    {Type: "string", Description: "Google Hotels property ID from search_hotels results. When provided, used directly — skips the hotel-name lookup and avoids resolving to the wrong property."},
+				"hotel_name":  {Type: "string", Description: "Hotel name and optional city, e.g. 'Beverly Hills Heights, Tenerife'. Required only when hotel_id is absent; also used as a location hint."},
 				"check_in":    {Type: "string", Description: "Check-in date in YYYY-MM-DD format"},
 				"check_out":   {Type: "string", Description: "Check-out date in YYYY-MM-DD format"},
 				"currency":    {Type: "string", Description: "Currency code (e.g. USD, EUR). Default: USD"},
 				"booking_url": {Type: "string", Description: "Booking.com hotel URL from search_hotels results (enables rich room data: descriptions, bed types, sizes, amenities, cancellation, board, and price metadata)"},
 			},
-			Required: []string{"hotel_name", "check_in", "check_out"},
+			Required: []string{"check_in", "check_out"},
 		},
 		OutputSchema: hotelRoomsOutputSchema(),
 		Annotations: &ToolAnnotations{
@@ -648,6 +649,7 @@ func hotelRoomsOutputSchema() interface{} {
 }
 
 func handleHotelRooms(ctx context.Context, args map[string]any, elicit ElicitFunc, sampling SamplingFunc, progress ProgressFunc) ([]ContentBlock, interface{}, error) {
+	hotelID := argString(args, "hotel_id")
 	hotelName := argString(args, "hotel_name")
 	checkIn := argString(args, "check_in")
 	checkOut := argString(args, "check_out")
@@ -657,34 +659,40 @@ func handleHotelRooms(ctx context.Context, args map[string]any, elicit ElicitFun
 		currency = "USD"
 	}
 
-	if hotelName == "" || checkIn == "" || checkOut == "" {
-		return nil, nil, fmt.Errorf("hotel_name, check_in, and check_out are required")
+	if (hotelID == "" && hotelName == "") || checkIn == "" || checkOut == "" {
+		return nil, nil, fmt.Errorf("hotel_id or hotel_name, plus check_in and check_out, are required")
 	}
 
 	if err := models.ValidateDateRange(checkIn, checkOut); err != nil {
 		return nil, nil, err
 	}
 
-	// Resolve hotel name to a Google ID.
-	hotel, err := hotels.SearchHotelByName(ctx, hotelName, checkIn, checkOut, currency)
-	if err != nil {
-		return nil, nil, fmt.Errorf("hotel lookup for %q: %w", hotelName, err)
-	}
-
-	if hotel.HotelID == "" {
-		return nil, nil, fmt.Errorf("hotel %q found (%s) but has no Google ID", hotelName, hotel.Name)
-	}
-
-	// Use the booking URL from the search result if the caller didn't provide one.
-	if bookingURL == "" && hotel.BookingURL != "" {
-		bookingURL = hotel.BookingURL
+	// Resolved property identity. When the caller supplies a hotel_id (from
+	// search_hotels), use it directly — re-running the fuzzy name search can
+	// resolve to a different property and fetch room data for the wrong hotel.
+	resolvedID := hotelID
+	resolvedName := hotelName
+	if resolvedID == "" {
+		hotel, err := searchHotelByNameFunc(ctx, hotelName, checkIn, checkOut, currency)
+		if err != nil {
+			return nil, nil, fmt.Errorf("hotel lookup for %q: %w", hotelName, err)
+		}
+		if hotel.HotelID == "" {
+			return nil, nil, fmt.Errorf("hotel %q found (%s) but has no Google ID", hotelName, hotel.Name)
+		}
+		resolvedID = hotel.HotelID
+		resolvedName = hotel.Name
+		// Use the booking URL from the search result if the caller didn't provide one.
+		if bookingURL == "" && hotel.BookingURL != "" {
+			bookingURL = hotel.BookingURL
+		}
 	}
 
 	// Fetch room availability with optional Booking.com enrichment.
 	// Pass the hotel name as a location hint for the search-page fallback
 	// (entity pages now use deferred data loading).
-	availability, err := hotels.GetRoomAvailabilityWithOpts(ctx, hotels.RoomSearchOptions{
-		HotelID:    hotel.HotelID,
+	availability, err := getRoomAvailabilityWithOptsFunc(ctx, hotels.RoomSearchOptions{
+		HotelID:    resolvedID,
 		CheckIn:    checkIn,
 		CheckOut:   checkOut,
 		Currency:   currency,
@@ -692,11 +700,11 @@ func handleHotelRooms(ctx context.Context, args map[string]any, elicit ElicitFun
 		Location:   hotelName,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("room availability for %s: %w", hotel.Name, err)
+		return nil, nil, fmt.Errorf("room availability for %s: %w", resolvedName, err)
 	}
 
 	if availability.Name == "" {
-		availability.Name = hotel.Name
+		availability.Name = resolvedName
 	}
 
 	summary := fmt.Sprintf("Found %d room types at %s (%s to %s).",

--- a/mcp/tools_hotels_details.go
+++ b/mcp/tools_hotels_details.go
@@ -12,6 +12,7 @@ import (
 
 var fetchHotelAmenitiesFunc = hotels.FetchHotelAmenities
 var getRoomAvailabilityWithOptsFunc = hotels.GetRoomAvailabilityWithOpts
+var searchHotelByNameFunc = hotels.SearchHotelByName
 
 type hotelWithDetails struct {
 	models.HotelResult

--- a/mcp/tools_hotels_rooms_id_test.go
+++ b/mcp/tools_hotels_rooms_id_test.go
@@ -1,0 +1,95 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/hotels"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// Regression tests for GH #187 / #188 Bug 3(a): hotel_rooms must honor a
+// supplied hotel_id directly and NOT re-run the fuzzy hotel-name search, which
+// can resolve to a different property and fetch room data for the wrong hotel.
+
+func TestHandleHotelRooms_HonorsSuppliedHotelID(t *testing.T) {
+	origSearch := searchHotelByNameFunc
+	origRooms := getRoomAvailabilityWithOptsFunc
+	defer func() { searchHotelByNameFunc = origSearch; getRoomAvailabilityWithOptsFunc = origRooms }()
+
+	searchCalled := false
+	searchHotelByNameFunc = func(_ context.Context, _, _, _, _ string) (*models.HotelResult, error) {
+		searchCalled = true
+		return &models.HotelResult{Name: "WRONG Hotel", HotelID: "wrong-id"}, nil
+	}
+	var gotID string
+	getRoomAvailabilityWithOptsFunc = func(_ context.Context, opts hotels.RoomSearchOptions) (*hotels.RoomAvailability, error) {
+		gotID = opts.HotelID
+		return &hotels.RoomAvailability{Success: true, HotelID: opts.HotelID, Name: "Right Hotel"}, nil
+	}
+
+	_, _, err := handleHotelRooms(context.Background(), map[string]any{
+		"hotel_id":  "/g/right-id",
+		"check_in":  "2099-06-18",
+		"check_out": "2099-06-20",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleHotelRooms: %v", err)
+	}
+	if searchCalled {
+		t.Error("must NOT call SearchHotelByName when hotel_id is supplied")
+	}
+	if gotID != "/g/right-id" {
+		t.Errorf("room fetch HotelID = %q, want /g/right-id", gotID)
+	}
+}
+
+func TestHandleHotelRooms_FallsBackToNameSearch(t *testing.T) {
+	origSearch := searchHotelByNameFunc
+	origRooms := getRoomAvailabilityWithOptsFunc
+	defer func() { searchHotelByNameFunc = origSearch; getRoomAvailabilityWithOptsFunc = origRooms }()
+
+	searchCalled := false
+	searchHotelByNameFunc = func(_ context.Context, name, _, _, _ string) (*models.HotelResult, error) {
+		searchCalled = true
+		if name != "Hotel Lutetia, Paris" {
+			t.Errorf("name search query = %q", name)
+		}
+		return &models.HotelResult{Name: "Hotel Lutetia", HotelID: "/g/lutetia", BookingURL: "https://booking.example/lutetia"}, nil
+	}
+	var gotID, gotBookingURL string
+	getRoomAvailabilityWithOptsFunc = func(_ context.Context, opts hotels.RoomSearchOptions) (*hotels.RoomAvailability, error) {
+		gotID = opts.HotelID
+		gotBookingURL = opts.BookingURL
+		return &hotels.RoomAvailability{Success: true, HotelID: opts.HotelID, Name: "Hotel Lutetia"}, nil
+	}
+
+	_, _, err := handleHotelRooms(context.Background(), map[string]any{
+		"hotel_name": "Hotel Lutetia, Paris",
+		"check_in":   "2099-06-18",
+		"check_out":  "2099-06-20",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleHotelRooms: %v", err)
+	}
+	if !searchCalled {
+		t.Error("expected SearchHotelByName to run when only hotel_name is supplied")
+	}
+	if gotID != "/g/lutetia" {
+		t.Errorf("room fetch HotelID = %q, want /g/lutetia", gotID)
+	}
+	// Booking URL from the search result should propagate when caller omits it.
+	if gotBookingURL != "https://booking.example/lutetia" {
+		t.Errorf("BookingURL = %q, want propagated search-result URL", gotBookingURL)
+	}
+}
+
+func TestHandleHotelRooms_RequiresIDOrName(t *testing.T) {
+	_, _, err := handleHotelRooms(context.Background(), map[string]any{
+		"check_in":  "2099-06-18",
+		"check_out": "2099-06-20",
+	}, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error when neither hotel_id nor hotel_name is supplied")
+	}
+}


### PR DESCRIPTION
## Summary

Addresses the hotel-provider degradation reported in #187 / #188. Three of the four failure modes are fixed and regression-tested here; the last is scoped out with analysis below.

### Bug 1 — Trivago returned zero hotels (fixed)
Trivago's MCP server dropped `trivago-search-suggestions`, and `trivago-accommodation-search` now resolves the location itself from a free-text `query` (no `ns`/`id` step). The old two-step flow always failed. Separately, `review_count` is now a thousands-separated string (e.g. `"25,711"`) which broke the typed decode and zeroed out every result.

- `SearchTrivago` discovers the live accommodation-search tool via the MCP list endpoint (resilient to further renames; falls back to the documented default and surfaces a clear error if no search tool is advertised), then calls it with a free-text query plus dates/guests/children.
- Added a tolerant `trivagoFlexInt` accepting `null` / numeric / comma- or space-separated string forms.
- Regression tests cover tool discovery/selection, comma-string parsing, and an end-to-end guard asserting no suggestions call and a free-text query.

### Bug 2 — Booking.com 202 escape-hatch (confirmed + locked in)
PR #200 already rebuilt Booking.com search on an `aws-waf-token` with a `202/403/503 -> force-refresh -> retry` escape hatch, but the retry path had no coverage. Added unexported test seams (`bookingAcquireTokenFn` / `bookingGetFn`) and a `bookingWAFChallenged` helper, then asserted: a 202 triggers exactly one re-harvest + retry recovering a 200; 202/403/503 are challenges and 200/404/500 are not; a persistent challenge errors after exactly one retry (no loop). No behavioral change to the production path.

### Bug 3(a) — `hotel_rooms` fetched the wrong property (fixed)
`hotel_rooms` only accepted `hotel_name` and always re-ran `SearchHotelByName`, even when the caller already had the exact Google property ID from `search_hotels`. The fuzzy name re-search can resolve to a *different* property, so room/price data came back for the wrong hotel.

- Accept an optional `hotel_id`; when present, use it directly and skip the name lookup. `hotel_name` becomes a location hint, required only when `hotel_id` is absent. Schema `Required` relaxed to `[check_in, check_out]` with in-handler validation that at least one identifier is present.
- Routed the handler through the existing `getRoomAvailabilityWithOptsFunc` seam plus a new `searchHotelByNameFunc` seam for deterministic testing.
- Tests: `hotel_id` supplied → name search NOT called, ID flows through; name-only → search runs and its `booking_url` propagates; neither → error.

### Bug 3(b) — room-level / OTA price *content* still empty (not in this PR)
The Google price/search payload shape changed and `parseHotelsFromPayload` / `findPriceArrays` no longer locate the price arrays. Fixing this correctly requires a captured fixture of the *new* live payload — there are none in `testdata/`, and capture requires `TRVL_TEST_LIVE_PROBES=1`. A speculative parser change with no real fixture would be unverifiable, so this is intentionally left for a follow-up that lands a captured fixture first. (The lead-in-only fallback in `tryPriceFallback` is intentional, documented graceful degradation when the OTA matrix is unavailable without the optional SerpAPI key.)

## Verification
```
GOTOOLCHAIN=go1.26.4 go vet ./mcp/ ./internal/hotels/        # clean
staticcheck ./mcp/ ./internal/hotels/                        # clean
GOTOOLCHAIN=go1.26.4 go test -short ./internal/hotels/       # ok
GOTOOLCHAIN=go1.26.4 go test -short ./mcp/                   # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
