### PR TITLE
feat(flights): round-trip search via two-one-way composition (#198)

### DIFF
--- a/internal/flights/roundtrip.go
+++ b/internal/flights/roundtrip.go
@@ -1,0 +1,229 @@
+package flights
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// Round-trip support is delivered by COMPOSITION: trvl runs two independent
+// one-way searches (outbound origin->destination on the departure date, inbound
+// destination->origin on the return date) and pairs the cheapest priced options
+// into combined itineraries. This sidesteps the native Google Flights round-trip
+// request encoding (tripType=1 + two segments), which Google rejects with a
+// travel.frontend.flights.ErrorResponse — the true root cause of issue #198,
+// where the misleading "unexpected flight data format" surfaced on every
+// --return_date search. Composition reuses the full one-way provider fan-out
+// (Google, Kiwi, Ryanair, Wizz, …) for each direction, so a round-trip benefits
+// from every working provider instead of a single broken code path.
+//
+// Composed itineraries are explicitly two separate one-way tickets: each carries
+// a warning so callers never mistake the summed price for a single bookable fare.
+
+const (
+	// roundTripLegCandidates bounds how many of the cheapest priced one-way
+	// options from each direction are considered when pairing, capping the
+	// N(outbound) x N(inbound) combinatorial blow-up.
+	roundTripLegCandidates = 8
+	// roundTripMaxResults bounds the number of composed itineraries returned,
+	// sorted cheapest-total first. When more pairings exist than this, the
+	// composer reports the truncation in its provider status (never silently).
+	roundTripMaxResults = 12
+)
+
+// searchRoundTripComposed answers a round-trip query (opts.ReturnDate set) by
+// running two one-way searches and composing the results. It reuses
+// SearchFlightsWithClient for each leg so every working one-way provider
+// contributes; the two sub-searches have distinct singleflight keys (their
+// ReturnDate differs from this call's), so there is no self-deadlock.
+func searchRoundTripComposed(ctx context.Context, client *batchexec.Client, origin, destination, date string, opts SearchOptions) (*models.FlightSearchResult, error) {
+	returnDate := opts.ReturnDate
+
+	// Per-leg options are one-way (clear ReturnDate) and must not collapse to a
+	// single result before pairing (clear FirstResult).
+	legOpts := opts
+	legOpts.ReturnDate = ""
+	legOpts.FirstResult = false
+
+	outbound, outErr := SearchFlightsWithClient(ctx, client, origin, destination, date, legOpts)
+	inbound, inErr := SearchFlightsWithClient(ctx, client, destination, origin, returnDate, legOpts)
+
+	statuses := make([]models.ProviderStatus, 0, 8)
+	var outFlights, inFlights []models.FlightResult
+	if outbound != nil {
+		outFlights = outbound.Flights
+		statuses = append(statuses, prefixLegStatuses("outbound", outbound.ProviderStatuses)...)
+	}
+	if inbound != nil {
+		inFlights = inbound.Flights
+		statuses = append(statuses, prefixLegStatuses("inbound", inbound.ProviderStatuses)...)
+	}
+
+	composed, truncated := composeRoundTrips(outFlights, inFlights, opts)
+
+	statuses = append(statuses, roundTripComposerStatus(len(outFlights), len(inFlights), len(composed), truncated))
+
+	// If neither leg produced any priced option, surface the underlying errors
+	// rather than an empty "success".
+	if len(composed) == 0 {
+		if outErr != nil || inErr != nil {
+			err := joinLegErrors(outErr, inErr)
+			return &models.FlightSearchResult{
+				Error:            err.Error(),
+				TripType:         "round_trip",
+				ProviderStatuses: statuses,
+				Completeness:     models.ComputeCompleteness(statuses),
+			}, err
+		}
+	}
+
+	return &models.FlightSearchResult{
+		Success:          true,
+		Count:            len(composed),
+		TripType:         "round_trip",
+		Flights:          composed,
+		ProviderStatuses: statuses,
+		Completeness:     models.ComputeCompleteness(statuses),
+	}, nil
+}
+
+// composeRoundTrips pairs the cheapest priced outbound options with the cheapest
+// priced inbound options into combined itineraries, summing prices and
+// concatenating legs. It is a pure function (no I/O) so the pairing logic is
+// unit-tested deterministically. The returned slice is sorted cheapest-total
+// first and bounded to roundTripMaxResults; truncated reports whether more
+// pairings existed than were returned.
+func composeRoundTrips(outbound, inbound []models.FlightResult, opts SearchOptions) (composed []models.FlightResult, truncated bool) {
+	out := topPricedFlights(outbound, roundTripLegCandidates)
+	in := topPricedFlights(inbound, roundTripLegCandidates)
+	if len(out) == 0 || len(in) == 0 {
+		return nil, false
+	}
+
+	all := make([]models.FlightResult, 0, len(out)*len(in))
+	for _, o := range out {
+		for _, i := range in {
+			// Only pair like-priced legs. Both directions are normalised to the
+			// session currency upstream, so a mismatch means one leg could not be
+			// converted; summing across currencies would fabricate a total.
+			if o.Currency != i.Currency {
+				continue
+			}
+			all = append(all, composeItinerary(o, i))
+		}
+	}
+	if len(all) == 0 {
+		return nil, false
+	}
+
+	sortFlightResults(all, opts.SortBy)
+
+	if len(all) > roundTripMaxResults {
+		return all[:roundTripMaxResults], true
+	}
+	return all, false
+}
+
+// composeItinerary combines one outbound and one inbound one-way option into a
+// single round-trip FlightResult: legs concatenated outbound-then-inbound, price
+// and duration summed, stops summed. The result is flagged as two separate
+// tickets via a warning and a composed provider label.
+func composeItinerary(out, in models.FlightResult) models.FlightResult {
+	legs := make([]models.FlightLeg, 0, len(out.Legs)+len(in.Legs))
+	legs = append(legs, out.Legs...)
+	legs = append(legs, in.Legs...)
+
+	warnings := []string{"composed round-trip: outbound and inbound are two separate one-way tickets, booked independently"}
+	warnings = append(warnings, out.Warnings...)
+	warnings = append(warnings, in.Warnings...)
+
+	return models.FlightResult{
+		Price:    out.Price + in.Price,
+		Currency: out.Currency,
+		Duration: out.Duration + in.Duration,
+		Stops:    out.Stops + in.Stops,
+		Provider: composedProviderLabel(out.Provider, in.Provider),
+		Legs:     legs,
+		Warnings: warnings,
+	}
+}
+
+// composedProviderLabel builds a transparent provider label for a composed
+// round-trip, e.g. "composed (Google Flights + Ryanair)".
+func composedProviderLabel(outbound, inbound string) string {
+	if outbound == "" {
+		outbound = "unknown"
+	}
+	if inbound == "" {
+		inbound = "unknown"
+	}
+	return fmt.Sprintf("composed (%s + %s)", outbound, inbound)
+}
+
+// topPricedFlights returns up to n cheapest flights that carry a usable price
+// (Price > 0 and a currency). Unpriced options are excluded so a composed total
+// is never a sum that includes a zero.
+func topPricedFlights(flights []models.FlightResult, n int) []models.FlightResult {
+	priced := make([]models.FlightResult, 0, len(flights))
+	for _, f := range flights {
+		if f.PriceForRanking() > 0 && f.Currency != "" {
+			priced = append(priced, f)
+		}
+	}
+	sort.SliceStable(priced, func(i, j int) bool {
+		return compareFlightPrices(priced[i].PriceForRanking(), priced[j].PriceForRanking()) < 0
+	})
+	if len(priced) > n {
+		priced = priced[:n]
+	}
+	return priced
+}
+
+// prefixLegStatuses namespaces a leg's per-provider statuses by direction so a
+// round-trip response shows, e.g., "outbound:google_flights" distinctly from
+// "inbound:google_flights".
+func prefixLegStatuses(direction string, statuses []models.ProviderStatus) []models.ProviderStatus {
+	out := make([]models.ProviderStatus, 0, len(statuses))
+	for _, s := range statuses {
+		s.ID = direction + ":" + s.ID
+		s.Name = direction + " " + s.Name
+		out = append(out, s)
+	}
+	return out
+}
+
+// roundTripComposerStatus reports the composition step itself so callers can see
+// how many one-way options fed the pairing and whether the output was bounded.
+func roundTripComposerStatus(outCount, inCount, composedCount int, truncated bool) models.ProviderStatus {
+	status := models.ProviderStatus{
+		ID:      "roundtrip_composer",
+		Name:    "Round-trip composer",
+		Status:  models.StatusOK,
+		Results: composedCount,
+	}
+	if composedCount == 0 {
+		status.Status = models.StatusCheckedNoHit
+		status.Error = fmt.Sprintf("no priced pairing (outbound priced options=%d, inbound priced options=%d)", outCount, inCount)
+		status.FixHint = "try different dates, or search each direction one-way"
+		return status
+	}
+	if truncated {
+		status.FixHint = fmt.Sprintf("showing cheapest %d composed round-trips; more pairings exist (search one-way for the full per-direction list)", roundTripMaxResults)
+	}
+	return status
+}
+
+// joinLegErrors combines outbound/inbound errors into one, labelling each side.
+func joinLegErrors(outErr, inErr error) error {
+	switch {
+	case outErr != nil && inErr != nil:
+		return fmt.Errorf("outbound: %w; inbound: %v", outErr, inErr)
+	case outErr != nil:
+		return fmt.Errorf("outbound: %w", outErr)
+	default:
+		return fmt.Errorf("inbound: %w", inErr)
+	}
+}

--- a/internal/flights/roundtrip_test.go
+++ b/internal/flights/roundtrip_test.go
@@ -1,0 +1,159 @@
+package flights
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func owFlight(provider, currency string, price float64, dep, arr string) models.FlightResult {
+	return models.FlightResult{
+		Price:    price,
+		Currency: currency,
+		Duration: 120,
+		Stops:    0,
+		Provider: provider,
+		Legs: []models.FlightLeg{{
+			DepartureAirport: models.AirportInfo{Code: dep},
+			ArrivalAirport:   models.AirportInfo{Code: arr},
+			DepartureTime:    "2026-07-01T08:00",
+			ArrivalTime:      "2026-07-01T10:00",
+		}},
+	}
+}
+
+func TestComposeRoundTrips_SumsAndConcatenates(t *testing.T) {
+	out := []models.FlightResult{owFlight("Google Flights", "EUR", 100, "HEL", "BCN")}
+	in := []models.FlightResult{owFlight("Ryanair", "EUR", 60, "BCN", "HEL")}
+
+	composed, truncated := composeRoundTrips(out, in, SearchOptions{})
+	if truncated {
+		t.Fatalf("did not expect truncation for 1x1 pairing")
+	}
+	if len(composed) != 1 {
+		t.Fatalf("composed count: got %d, want 1", len(composed))
+	}
+	rt := composed[0]
+	if rt.Price != 160 {
+		t.Errorf("price: got %v, want 160 (100+60)", rt.Price)
+	}
+	if rt.Duration != 240 {
+		t.Errorf("duration: got %d, want 240", rt.Duration)
+	}
+	if len(rt.Legs) != 2 {
+		t.Fatalf("legs: got %d, want 2 (outbound + inbound)", len(rt.Legs))
+	}
+	if rt.Legs[0].DepartureAirport.Code != "HEL" || rt.Legs[1].DepartureAirport.Code != "BCN" {
+		t.Errorf("leg order wrong: %q then %q", rt.Legs[0].DepartureAirport.Code, rt.Legs[1].DepartureAirport.Code)
+	}
+	if !strings.Contains(rt.Provider, "Google Flights") || !strings.Contains(rt.Provider, "Ryanair") {
+		t.Errorf("provider label missing source providers: %q", rt.Provider)
+	}
+	if len(rt.Warnings) == 0 || !strings.Contains(rt.Warnings[0], "two separate one-way tickets") {
+		t.Errorf("expected separate-tickets warning, got %v", rt.Warnings)
+	}
+}
+
+func TestComposeRoundTrips_CheapestTotalFirst(t *testing.T) {
+	out := []models.FlightResult{
+		owFlight("A", "EUR", 100, "HEL", "BCN"),
+		owFlight("B", "EUR", 200, "HEL", "BCN"),
+	}
+	in := []models.FlightResult{
+		owFlight("C", "EUR", 50, "BCN", "HEL"),
+		owFlight("D", "EUR", 70, "BCN", "HEL"),
+	}
+	composed, _ := composeRoundTrips(out, in, SearchOptions{})
+	if len(composed) != 4 {
+		t.Fatalf("composed count: got %d, want 4 (2x2)", len(composed))
+	}
+	if composed[0].Price != 150 {
+		t.Errorf("cheapest total: got %v, want 150 (100+50)", composed[0].Price)
+	}
+	// Verify ascending order.
+	for i := 1; i < len(composed); i++ {
+		if composed[i].Price < composed[i-1].Price {
+			t.Errorf("not sorted ascending at %d: %v < %v", i, composed[i].Price, composed[i-1].Price)
+		}
+	}
+}
+
+func TestComposeRoundTrips_ExcludesUnpriced(t *testing.T) {
+	out := []models.FlightResult{
+		owFlight("A", "EUR", 100, "HEL", "BCN"),
+		owFlight("B", "", 0, "HEL", "BCN"), // unpriced — must be dropped
+	}
+	in := []models.FlightResult{owFlight("C", "EUR", 50, "BCN", "HEL")}
+	composed, _ := composeRoundTrips(out, in, SearchOptions{})
+	if len(composed) != 1 {
+		t.Fatalf("composed count: got %d, want 1 (unpriced outbound dropped)", len(composed))
+	}
+	if composed[0].Price != 150 {
+		t.Errorf("price: got %v, want 150", composed[0].Price)
+	}
+}
+
+func TestComposeRoundTrips_SkipsCurrencyMismatch(t *testing.T) {
+	out := []models.FlightResult{owFlight("A", "USD", 100, "HEL", "BCN")}
+	in := []models.FlightResult{owFlight("C", "EUR", 50, "BCN", "HEL")}
+	composed, _ := composeRoundTrips(out, in, SearchOptions{})
+	if len(composed) != 0 {
+		t.Fatalf("expected 0 composed (currency mismatch), got %d", len(composed))
+	}
+}
+
+func TestComposeRoundTrips_EmptyInputs(t *testing.T) {
+	if c, _ := composeRoundTrips(nil, []models.FlightResult{owFlight("C", "EUR", 50, "BCN", "HEL")}, SearchOptions{}); len(c) != 0 {
+		t.Errorf("empty outbound should yield 0 composed, got %d", len(c))
+	}
+	if c, _ := composeRoundTrips([]models.FlightResult{owFlight("A", "EUR", 100, "HEL", "BCN")}, nil, SearchOptions{}); len(c) != 0 {
+		t.Errorf("empty inbound should yield 0 composed, got %d", len(c))
+	}
+}
+
+func TestComposeRoundTrips_BoundsAndReportsTruncation(t *testing.T) {
+	// roundTripLegCandidates each side -> up to candidates^2 pairings, bounded to
+	// roundTripMaxResults with truncated=true.
+	var out, in []models.FlightResult
+	for i := 0; i < roundTripLegCandidates+4; i++ {
+		out = append(out, owFlight("A", "EUR", float64(100+i), "HEL", "BCN"))
+		in = append(in, owFlight("C", "EUR", float64(50+i), "BCN", "HEL"))
+	}
+	composed, truncated := composeRoundTrips(out, in, SearchOptions{})
+	if !truncated {
+		t.Errorf("expected truncated=true when pairings exceed roundTripMaxResults")
+	}
+	if len(composed) != roundTripMaxResults {
+		t.Errorf("composed count: got %d, want %d (bounded)", len(composed), roundTripMaxResults)
+	}
+}
+
+func TestRoundTripComposerStatus_TruncationVisible(t *testing.T) {
+	s := roundTripComposerStatus(8, 8, roundTripMaxResults, true)
+	if s.Status != models.StatusOK {
+		t.Errorf("status: got %q, want ok", s.Status)
+	}
+	if !strings.Contains(s.FixHint, "more pairings exist") {
+		t.Errorf("truncation must be visible in fix hint, got %q", s.FixHint)
+	}
+}
+
+func TestRoundTripComposerStatus_NoHit(t *testing.T) {
+	s := roundTripComposerStatus(0, 0, 0, false)
+	if s.Status != models.StatusCheckedNoHit {
+		t.Errorf("status: got %q, want checked_no_hit", s.Status)
+	}
+	if s.Error == "" {
+		t.Errorf("expected diagnostic error on zero pairings")
+	}
+}
+
+func TestComposedProviderLabel(t *testing.T) {
+	if got := composedProviderLabel("Google Flights", "Ryanair"); got != "composed (Google Flights + Ryanair)" {
+		t.Errorf("label: got %q", got)
+	}
+	if got := composedProviderLabel("", ""); got != "composed (unknown + unknown)" {
+		t.Errorf("empty label: got %q", got)
+	}
+}

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -127,6 +127,14 @@ func SearchFlightsWithClient(ctx context.Context, client *batchexec.Client, orig
 		}, fmt.Errorf("client is required")
 	}
 
+	// Round-trip is served by composition (two one-way searches paired) rather
+	// than the native Google round-trip request, which Google rejects (issue
+	// #198). The leg sub-searches re-enter this function with ReturnDate cleared,
+	// so they take the one-way path below.
+	if opts.ReturnDate != "" {
+		return searchRoundTripComposed(ctx, client, origin, destination, date, opts)
+	}
+
 	key := flightSearchKey(origin, destination, date, opts)
 	return doFlightSearchSingleflight(ctx, key, func(sharedCtx context.Context) (*models.FlightSearchResult, error) {
 		return searchFlightsCore(sharedCtx, client, origin, destination, date, opts)


### PR DESCRIPTION
## Summary
Delivers working round-trip flight search. Previously any search with `--return_date` failed with the misleading error `unexpected flight data format` (issue #198).

## Root cause of #198
The one-way Google Flights parser is healthy (locked by the regression fixture added in the companion PR). The failure is specific to round-trip: the native Google Flights round-trip request encoding (`tripType=1` plus two segments) is rejected by Google with a `travel.frontend.flights.ErrorResponse` (~326-byte body). The decoder then yields a nil inner payload and the extractor reports the generic `unexpected flight data format`. So round-trip was a request-encoding problem, not parser drift.

## Approach: composition
Rather than fight the broken native round-trip encoding (which is also unverifiable right now — Google is 429-throttling round-trip probes from this network), round-trip is delivered by composition:

- Run two independent one-way searches: outbound (origin to destination, departure date) and inbound (destination to origin, return date).
- Pair the cheapest priced options from each direction, summing price and concatenating legs.
- Reuses the full one-way provider fan-out (Google, Kiwi, Ryanair, Wizz, ...) for each direction, so round-trips benefit from every working provider instead of a single broken path.

### Honesty guarantees
- Each composed itinerary carries a warning that it is two separate one-way tickets booked independently, plus a transparent provider label, e.g. `composed (Google Flights + Ryanair)`.
- Output is bounded to the cheapest N pairings; when more pairings exist the composer reports it in its provider status (no silent truncation).
- Unpriced options are excluded so a total never includes a zero, and currency-mismatched pairings are skipped so a summed total is never fabricated across currencies.

## Tests
Pure composition logic is unit-tested offline and deterministically (no network): price summation, leg concatenation order, cheapest-total ordering, unpriced exclusion, currency-mismatch skip, empty inputs, bounding with truncation reporting, and the composer status.

## Verification
- `go vet ./...` clean
- `staticcheck ./internal/flights/...` clean
- `go test -short ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
