### PR TITLE
feat(watch): proactive price-drop alerts (innovation #6)

### DIFF
--- a/cmd/trvl/watch.go
+++ b/cmd/trvl/watch.go
@@ -53,6 +53,8 @@ func watchAddCmd() *cobra.Command {
 		webhookURL     string
 		lastMinute     bool
 		lastMinuteDrop float64
+		alertDropPct   float64
+		alertDropAbs   float64
 	)
 
 	cmd := &cobra.Command{
@@ -103,6 +105,8 @@ Examples:
 				WebhookURL:        webhookURL,
 				LastMinuteMode:    lastMinute,
 				LastMinuteDropPct: lastMinuteDrop,
+				AlertDropPct:      alertDropPct,
+				AlertDropAbs:      alertDropAbs,
 			}
 
 			id, err := store.Add(w)
@@ -131,6 +135,16 @@ Examples:
 			if w.LastMinuteMode {
 				fmt.Printf(" [last-minute %.0f%% drop]", w.LastMinuteDropPct)
 			}
+			if w.AlertDropPct > 0 || w.AlertDropAbs > 0 {
+				switch {
+				case w.AlertDropPct > 0 && w.AlertDropAbs > 0:
+					fmt.Printf(" [drop alert %.0f%% or %.0f %s]", w.AlertDropPct, w.AlertDropAbs, w.Currency)
+				case w.AlertDropPct > 0:
+					fmt.Printf(" [drop alert %.0f%%]", w.AlertDropPct)
+				default:
+					fmt.Printf(" [drop alert %.0f %s]", w.AlertDropAbs, w.Currency)
+				}
+			}
 			fmt.Println()
 			return nil
 		},
@@ -146,6 +160,8 @@ Examples:
 	cmd.Flags().StringVar(&webhookURL, "webhook", "", "URL to POST JSON payload on price drop")
 	cmd.Flags().BoolVar(&lastMinute, "last-minute", false, "Hotel watches: alert when sub-48h availability is materially below last seen price")
 	cmd.Flags().Float64Var(&lastMinuteDrop, "last-minute-drop", 25, "Hotel watches: percent drop from last seen price required for last-minute alert")
+	cmd.Flags().Float64Var(&alertDropPct, "alert-drop", 0, "Proactively alert when the fare falls this percent below its baseline (default 10% if no threshold set)")
+	cmd.Flags().Float64Var(&alertDropAbs, "alert-drop-abs", 0, "Proactively alert when the fare falls this many currency units below its baseline")
 	// --depart is optional: route watches monitor next 60 days without specific dates
 
 	return cmd

--- a/internal/pricealert/pricealert.go
+++ b/internal/pricealert/pricealert.go
@@ -1,0 +1,117 @@
+// Package pricealert implements proactive price-drop detection for watched
+// routes. It is deliberately dependency-free and pure: given a persisted
+// baseline, a freshly observed price, and a configurable threshold, it decides
+// whether a drop is large enough — and novel enough — to warrant alerting the
+// user exactly once.
+//
+// The model turns trvl's watch domain from pull (the user asks "what's the
+// price?") into push (trvl says "the price just dropped 12% — book now"). The
+// package owns only the decision logic; persistence and notification live in the
+// watch package that drives it.
+package pricealert
+
+// DefaultDropPercent is the percentage fall from baseline that fires an alert
+// when a watch sets no explicit threshold.
+const DefaultDropPercent = 10.0
+
+// Threshold configures how big a fall from the baseline must be before an alert
+// fires. The two limbs are independent: a drop that satisfies EITHER the
+// percentage OR the absolute limb qualifies. When both limbs are zero the
+// DefaultDropPercent is applied so a watch always has sane proactive behaviour.
+type Threshold struct {
+	// DropPercent is the minimum percentage fall from baseline (e.g. 10 means
+	// "alert when the fare is 10% or more below the baseline"). Ignored when <= 0.
+	DropPercent float64
+	// DropAbsolute is the minimum absolute fall from baseline in the watch's
+	// currency units. Ignored when <= 0.
+	DropAbsolute float64
+}
+
+// effective returns the threshold to apply, substituting the default percentage
+// when the caller configured neither limb.
+func (t Threshold) effective() Threshold {
+	if t.DropPercent <= 0 && t.DropAbsolute <= 0 {
+		return Threshold{DropPercent: DefaultDropPercent}
+	}
+	return t
+}
+
+// State is the persisted, per-watch memory the detector needs across checks.
+// It is plain data so callers can serialise it alongside their own records.
+type State struct {
+	// Baseline is the reference fare a drop is measured against. Zero means
+	// "not yet captured": the next positive observation establishes it. The
+	// baseline tracks the running high-water mark so a recovered (risen) price
+	// re-arms the detector against the new peak.
+	Baseline float64
+	// LastAlertedAt is the price at which the most recent alert fired, used for
+	// deduplication. Zero means "never alerted at the current baseline".
+	LastAlertedAt float64
+}
+
+// Alert describes a fired price-drop event.
+type Alert struct {
+	Baseline    float64 // reference fare the drop was measured against
+	Current     float64 // the freshly observed price
+	Drop        float64 // Baseline - Current (positive == cheaper)
+	DropPercent float64 // Drop / Baseline * 100
+}
+
+// Evaluate folds a new observation into the state and decides whether to alert.
+//
+// It returns the updated state (which the caller must persist), the Alert when
+// one fired, and a boolean for convenient branching. The rules:
+//
+//   - A non-positive price (no data) is a no-op: state is returned unchanged.
+//   - The first positive price captures the baseline and never alerts.
+//   - A price at or above the baseline raises the baseline (new high-water mark)
+//     and re-arms dedup; it never alerts.
+//   - A price below the baseline alerts only when the fall meets the threshold
+//     AND is a new low strictly below the last alerted price — so a single drop
+//     fires exactly one alert, and a flat or partial recovery stays silent. A
+//     further, deeper drop past the threshold fires again, as a genuinely new
+//     event.
+func Evaluate(state State, current float64, t Threshold) (State, Alert, bool) {
+	if current <= 0 {
+		return state, Alert{}, false
+	}
+
+	// First observation establishes the baseline.
+	if state.Baseline <= 0 {
+		state.Baseline = current
+		state.LastAlertedAt = 0
+		return state, Alert{}, false
+	}
+
+	// Price recovered to or above the reference: move the high-water mark up and
+	// re-arm the dedup window against the new peak.
+	if current >= state.Baseline {
+		state.Baseline = current
+		state.LastAlertedAt = 0
+		return state, Alert{}, false
+	}
+
+	drop := state.Baseline - current
+	dropPct := drop / state.Baseline * 100
+
+	eff := t.effective()
+	meetsPct := eff.DropPercent > 0 && dropPct >= eff.DropPercent
+	meetsAbs := eff.DropAbsolute > 0 && drop >= eff.DropAbsolute
+	if !meetsPct && !meetsAbs {
+		return state, Alert{}, false
+	}
+
+	// Dedup: only alert on a genuinely new low. If we already alerted at this
+	// price or higher (a flat hold or partial bounce), stay silent.
+	if state.LastAlertedAt > 0 && current >= state.LastAlertedAt {
+		return state, Alert{}, false
+	}
+
+	state.LastAlertedAt = current
+	return state, Alert{
+		Baseline:    state.Baseline,
+		Current:     current,
+		Drop:        drop,
+		DropPercent: dropPct,
+	}, true
+}

--- a/internal/pricealert/pricealert_test.go
+++ b/internal/pricealert/pricealert_test.go
@@ -1,0 +1,152 @@
+package pricealert
+
+import "testing"
+
+func TestEvaluate_FirstObservationCapturesBaselineNoAlert(t *testing.T) {
+	st, alert, fired := Evaluate(State{}, 200, Threshold{DropPercent: 10})
+	if fired {
+		t.Fatalf("first observation must not alert, got %+v", alert)
+	}
+	if st.Baseline != 200 {
+		t.Fatalf("baseline = %v, want 200", st.Baseline)
+	}
+	if st.LastAlertedAt != 0 {
+		t.Fatalf("LastAlertedAt = %v, want 0", st.LastAlertedAt)
+	}
+}
+
+func TestEvaluate_DropBeyondThresholdFiresExactlyOnce(t *testing.T) {
+	th := Threshold{DropPercent: 10}
+	st := State{Baseline: 200}
+
+	// 180 is a 10% drop — exactly at threshold, should fire.
+	st, alert, fired := Evaluate(st, 180, th)
+	if !fired {
+		t.Fatalf("expected alert at 10%% drop")
+	}
+	if alert.DropPercent < 9.99 || alert.DropPercent > 10.01 {
+		t.Fatalf("DropPercent = %v, want ~10", alert.DropPercent)
+	}
+	if alert.Baseline != 200 || alert.Current != 180 || alert.Drop != 20 {
+		t.Fatalf("alert fields = %+v", alert)
+	}
+
+	// Re-check at the SAME price: must not re-alert (dedup).
+	st2, _, fired2 := Evaluate(st, 180, th)
+	if fired2 {
+		t.Fatalf("same drop must not re-alert")
+	}
+
+	// A partial bounce that is still below baseline must not alert.
+	_, _, fired3 := Evaluate(st2, 185, th)
+	if fired3 {
+		t.Fatalf("partial recovery must not alert")
+	}
+}
+
+func TestEvaluate_DropBelowThresholdIsSilent(t *testing.T) {
+	th := Threshold{DropPercent: 10}
+	st := State{Baseline: 200}
+
+	// 5% drop — below threshold.
+	_, _, fired := Evaluate(st, 190, th)
+	if fired {
+		t.Fatalf("5%% drop must be silent under a 10%% threshold")
+	}
+}
+
+func TestEvaluate_RaisedPriceDoesNotAlertAndRearms(t *testing.T) {
+	th := Threshold{DropPercent: 10}
+	st := State{Baseline: 200}
+
+	// Price rises above baseline: no alert, baseline tracks the new peak.
+	st, _, fired := Evaluate(st, 250, th)
+	if fired {
+		t.Fatalf("rising price must not alert")
+	}
+	if st.Baseline != 250 {
+		t.Fatalf("baseline should rise to 250, got %v", st.Baseline)
+	}
+
+	// Now a 10% drop from the NEW baseline (225) should fire.
+	_, alert, fired := Evaluate(st, 225, th)
+	if !fired {
+		t.Fatalf("expected alert measured from raised baseline")
+	}
+	if alert.Baseline != 250 {
+		t.Fatalf("alert baseline = %v, want 250", alert.Baseline)
+	}
+}
+
+func TestEvaluate_DeeperDropAfterFirstAlertFiresAgain(t *testing.T) {
+	th := Threshold{DropPercent: 10}
+	st := State{Baseline: 200}
+
+	st, _, fired := Evaluate(st, 180, th) // first alert
+	if !fired {
+		t.Fatalf("expected first alert")
+	}
+	// A new, deeper low past threshold is a genuinely new event.
+	_, alert, fired := Evaluate(st, 150, th)
+	if !fired {
+		t.Fatalf("deeper drop should fire a fresh alert")
+	}
+	if alert.Current != 150 {
+		t.Fatalf("alert.Current = %v, want 150", alert.Current)
+	}
+}
+
+func TestEvaluate_AbsoluteThreshold(t *testing.T) {
+	// Only an absolute limb: alert when the fare falls by >= 30 units.
+	th := Threshold{DropAbsolute: 30}
+	st := State{Baseline: 500}
+
+	// 20-unit fall — below absolute threshold.
+	_, _, fired := Evaluate(st, 480, th)
+	if fired {
+		t.Fatalf("20-unit drop must be silent under a 30-unit threshold")
+	}
+	// 40-unit fall — qualifies.
+	_, alert, fired := Evaluate(st, 460, th)
+	if !fired {
+		t.Fatalf("40-unit drop should fire")
+	}
+	if alert.Drop != 40 {
+		t.Fatalf("alert.Drop = %v, want 40", alert.Drop)
+	}
+}
+
+func TestEvaluate_DefaultThresholdWhenUnset(t *testing.T) {
+	var th Threshold // both limbs zero -> DefaultDropPercent (10%)
+	st := State{Baseline: 100}
+
+	_, _, fired := Evaluate(st, 95, th) // 5% — silent
+	if fired {
+		t.Fatalf("5%% drop must be silent under the default 10%% threshold")
+	}
+	_, _, fired = Evaluate(st, 89, th) // 11% — fires
+	if !fired {
+		t.Fatalf("11%% drop should fire under the default threshold")
+	}
+}
+
+func TestEvaluate_NonPositivePriceIsNoOp(t *testing.T) {
+	st := State{Baseline: 200, LastAlertedAt: 180}
+	got, _, fired := Evaluate(st, 0, Threshold{DropPercent: 10})
+	if fired {
+		t.Fatalf("zero price must not alert")
+	}
+	if got != st {
+		t.Fatalf("state mutated on no-data: %+v != %+v", got, st)
+	}
+}
+
+func TestEvaluate_EitherLimbQualifies(t *testing.T) {
+	// Percent not met (5%) but absolute met (25 units).
+	th := Threshold{DropPercent: 10, DropAbsolute: 25}
+	st := State{Baseline: 500}
+	_, _, fired := Evaluate(st, 475, th) // 25 units, 5%
+	if !fired {
+		t.Fatalf("absolute limb alone should qualify")
+	}
+}

--- a/internal/watch/check.go
+++ b/internal/watch/check.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/hotelarb"
+	"github.com/MikkoParkkola/trvl/internal/pricealert"
 )
 
 var webhookHTTPClient = http.DefaultClient
@@ -67,7 +68,13 @@ type CheckResult struct {
 	RoomMatches               []RoomMatch
 	LastMinuteDeal            bool
 	LastMinuteDiscountPercent float64
-	Error                     error
+	// Proactive price-drop alert (innovation #6). PriceDropAlert is true when the
+	// fare fell past the configured threshold below the baseline and this is a
+	// new, deduplicated event. AlertBaseline / AlertDropPercent describe it.
+	PriceDropAlert   bool
+	AlertBaseline    float64
+	AlertDropPercent float64
+	Error            error
 }
 
 // CheckAll checks all watches using the provided price checker and records
@@ -244,6 +251,22 @@ func checkOneWithWebhookContext(checkCtx, webhookCtx context.Context, store *Sto
 		}
 		if w.LowestPrice == 0 || price < w.LowestPrice {
 			w.LowestPrice = price
+		}
+
+		// Proactive price-drop alert: capture/track a baseline and fire exactly
+		// one alert when the fare falls past the configured threshold. State is
+		// stored on the watch so it survives daemon restarts and reloads.
+		alertState, alert, alertFired := pricealert.Evaluate(
+			pricealert.State{Baseline: w.BaselinePrice, LastAlertedAt: w.LastAlertedPrice},
+			price,
+			pricealert.Threshold{DropPercent: w.AlertDropPct, DropAbsolute: w.AlertDropAbs},
+		)
+		w.BaselinePrice = alertState.Baseline
+		w.LastAlertedPrice = alertState.LastAlertedAt
+		if alertFired {
+			result.PriceDropAlert = true
+			result.AlertBaseline = alert.Baseline
+			result.AlertDropPercent = alert.DropPercent
 		}
 
 		// Persist updates.

--- a/internal/watch/notify.go
+++ b/internal/watch/notify.go
@@ -81,6 +81,28 @@ func (n *Notifier) Notify(r CheckResult) {
 		return
 	}
 
+	// Proactive price-drop alert (innovation #6: pull -> push). Fires when the
+	// fare falls past the configured threshold below the captured baseline.
+	if r.PriceDropAlert {
+		line := fmt.Sprintf("PRICE DROP  %s  %s (%.1f%% below baseline %.0f %s)",
+			route, priceStr, r.AlertDropPercent, r.AlertBaseline, r.Currency)
+		_, _ = fmt.Fprintln(n.Out, n.green(line))
+
+		if r.Watch.DepartDate != "" {
+			if url := buildBookingURL(r.Watch); url != "" {
+				_, _ = fmt.Fprintf(n.Out, "      Book: %s\n", url)
+			}
+		}
+
+		if n.Desktop {
+			n.desktopNotify(
+				"trvl: Price Drop!",
+				fmt.Sprintf("%s %s — %.1f%% below baseline", route, priceStr, r.AlertDropPercent),
+			)
+		}
+		return
+	}
+
 	// Regular price report with change indicator.
 	var changeStr string
 	if r.PrevPrice > 0 {

--- a/internal/watch/pricealert_integration_test.go
+++ b/internal/watch/pricealert_integration_test.go
@@ -1,0 +1,153 @@
+package watch
+
+import (
+	"context"
+	"testing"
+)
+
+// sequencePriceChecker returns a scripted sequence of prices across successive
+// CheckPrice calls, letting tests drive a watch through a price trajectory
+// deterministically and offline.
+type sequencePriceChecker struct {
+	prices   []float64
+	currency string
+	idx      int
+}
+
+func (c *sequencePriceChecker) CheckPrice(_ context.Context, _ Watch) (float64, string, string, error) {
+	p := c.prices[c.idx]
+	if c.idx < len(c.prices)-1 {
+		c.idx++
+	}
+	cur := c.currency
+	if cur == "" {
+		cur = "EUR"
+	}
+	return p, cur, "", nil
+}
+
+// checkSeq runs one bounded check round (no inter-check delay) and returns the
+// single result for the lone watch in the store.
+func checkSeq(t *testing.T, store *Store, checker PriceChecker) CheckResult {
+	t.Helper()
+	results := CheckAllBounded(context.Background(), store, checker, nil, BoundedOptions{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	return results[0]
+}
+
+func newAlertWatchStore(t *testing.T, w Watch) *Store {
+	t.Helper()
+	store := NewStore(t.TempDir())
+	if _, err := store.Add(w); err != nil {
+		t.Fatalf("add watch: %v", err)
+	}
+	return store
+}
+
+// TestPriceDropAlert_FiresExactlyOnceBeyondThreshold drives a baseline capture,
+// a qualifying drop (one alert), and a re-check at the same price (silent).
+func TestPriceDropAlert_FiresExactlyOnceBeyondThreshold(t *testing.T) {
+	store := newAlertWatchStore(t, Watch{
+		Type: "flight", Origin: "HEL", Destination: "BCN",
+		Currency: "EUR", AlertDropPct: 10,
+	})
+	checker := &sequencePriceChecker{prices: []float64{200, 180, 180}}
+
+	// First check captures the baseline — no alert.
+	if r := checkSeq(t, store, checker); r.PriceDropAlert {
+		t.Fatalf("baseline capture must not alert")
+	}
+
+	// Second check: 10% drop — exactly one alert.
+	r := checkSeq(t, store, checker)
+	if !r.PriceDropAlert {
+		t.Fatalf("expected a price-drop alert at 10%% drop")
+	}
+	if r.AlertBaseline != 200 {
+		t.Fatalf("AlertBaseline = %v, want 200", r.AlertBaseline)
+	}
+
+	// Third check at the same price — must not re-alert (dedup).
+	if r := checkSeq(t, store, checker); r.PriceDropAlert {
+		t.Fatalf("same drop must not re-alert")
+	}
+}
+
+// TestPriceDropAlert_BelowThresholdSilent verifies a sub-threshold drop is quiet.
+func TestPriceDropAlert_BelowThresholdSilent(t *testing.T) {
+	store := newAlertWatchStore(t, Watch{
+		Type: "flight", Origin: "HEL", Destination: "OUL",
+		Currency: "EUR", AlertDropPct: 10,
+	})
+	checker := &sequencePriceChecker{prices: []float64{200, 190}} // 5% drop
+
+	_ = checkSeq(t, store, checker) // baseline
+	if r := checkSeq(t, store, checker); r.PriceDropAlert {
+		t.Fatalf("5%% drop must be silent under a 10%% threshold")
+	}
+}
+
+// TestPriceDropAlert_RaisedPriceDoesNotAlert verifies a recovered/raised fare
+// never alerts and re-arms the detector against the new peak.
+func TestPriceDropAlert_RaisedPriceDoesNotAlert(t *testing.T) {
+	store := newAlertWatchStore(t, Watch{
+		Type: "flight", Origin: "HEL", Destination: "LHR",
+		Currency: "EUR", AlertDropPct: 10,
+	})
+	checker := &sequencePriceChecker{prices: []float64{200, 250}} // rises
+
+	_ = checkSeq(t, store, checker) // baseline 200
+	if r := checkSeq(t, store, checker); r.PriceDropAlert {
+		t.Fatalf("a rising price must not alert")
+	}
+	// Baseline should track up to the new peak.
+	w, _ := store.Get(store.List()[0].ID)
+	if w.BaselinePrice != 250 {
+		t.Fatalf("baseline should rise to 250, got %v", w.BaselinePrice)
+	}
+}
+
+// TestPriceDropAlert_BaselineSurvivesReload proves the baseline + dedup state is
+// persisted to disk and a reloaded store does not re-alert for the same drop.
+func TestPriceDropAlert_BaselineSurvivesReload(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	id, err := store.Add(Watch{
+		Type: "flight", Origin: "HEL", Destination: "JFK",
+		Currency: "EUR", AlertDropPct: 10,
+	})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	checker := &sequencePriceChecker{prices: []float64{500, 400}} // baseline, then 20% drop
+	_ = checkSeq(t, store, checker)                               // baseline 500
+	r := checkSeq(t, store, checker)                              // 20% drop -> alert
+	if !r.PriceDropAlert {
+		t.Fatalf("expected alert on 20%% drop")
+	}
+
+	// Reload from disk into a fresh store.
+	reloaded := NewStore(dir)
+	if err := reloaded.Load(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	w, ok := reloaded.Get(id)
+	if !ok {
+		t.Fatalf("watch missing after reload")
+	}
+	if w.BaselinePrice != 500 {
+		t.Fatalf("persisted baseline = %v, want 500", w.BaselinePrice)
+	}
+	if w.LastAlertedPrice != 400 {
+		t.Fatalf("persisted LastAlertedPrice = %v, want 400", w.LastAlertedPrice)
+	}
+
+	// Re-checking at the same 400 against the reloaded state must stay silent.
+	sameChecker := &sequencePriceChecker{prices: []float64{400}}
+	if r := checkSeq(t, reloaded, sameChecker); r.PriceDropAlert {
+		t.Fatalf("reloaded state must not re-alert for the same drop")
+	}
+}

--- a/internal/watch/scheduler.go
+++ b/internal/watch/scheduler.go
@@ -150,6 +150,17 @@ func (s *Scheduler) runOnce(ctx context.Context) {
 				"below_goal", r.BelowGoal,
 			)
 		}
+		if r.PriceDropAlert {
+			triggered++
+			slog.Info("scheduler: proactive price drop",
+				"watch_id", r.Watch.ID,
+				"route", r.Watch.Origin+"→"+r.Watch.Destination,
+				"price", r.NewPrice,
+				"baseline", r.AlertBaseline,
+				"drop_percent", r.AlertDropPercent,
+				"currency", r.Currency,
+			)
+		}
 		if r.BelowGoal {
 			triggered++
 			slog.Info("scheduler: price below target",

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -48,6 +48,17 @@ type Watch struct {
 	// payload is POSTed to this URL (fire-and-forget, 10s timeout).
 	WebhookURL string `json:"webhook_url,omitempty"`
 
+	// Proactive price-drop alerting (innovation #6: pull -> push).
+	// AlertDropPct / AlertDropAbs configure how far the fare must fall below the
+	// captured baseline before trvl proactively alerts. Either limb qualifies;
+	// when both are zero a sane default (10%) applies. BaselinePrice is the
+	// reference fare (captured on first observation, tracks the running peak) and
+	// LastAlertedPrice is dedup state so a single drop alerts exactly once.
+	AlertDropPct     float64 `json:"alert_drop_pct,omitempty"`
+	AlertDropAbs     float64 `json:"alert_drop_abs,omitempty"`
+	BaselinePrice    float64 `json:"baseline_price,omitempty"`
+	LastAlertedPrice float64 `json:"last_alerted_price,omitempty"`
+
 	// Room watch fields (Type == "room").
 	HotelName    string   `json:"hotel_name,omitempty"`    // hotel name for room availability lookups
 	RoomKeywords []string `json:"room_keywords,omitempty"` // all keywords must match room name+description


### PR DESCRIPTION
## Innovation #6 — proactive price-drop alerts

Turns trvl's watch domain from **pull** ("what's the price?") to **push** ("the fare just dropped 12% — book now") on watched routes.

### What it does
- **Baseline capture** — the first observed fare for a route becomes the reference; the baseline tracks the running high-water mark, so a price that climbs back up re-arms the detector against the new peak.
- **Delta detection, configurable threshold** — alerts when the fare falls past a percentage (`--alert-drop`, default 10%) or an absolute (`--alert-drop-abs`) limb below baseline; either qualifies.
- **Alert emission** — surfaced through the existing Notifier (stdout + best-effort macOS desktop) and the scheduler's structured slog. Alerts stay **local** — no external push (email/telegram/slack) wired; that is operator-gated and out of scope.
- **Dedup** — a single drop fires exactly one alert; a flat hold or partial bounce stays silent; a deeper drop past the threshold is treated as a new event and fires again.
- **Persistence** — baseline + dedup state live on the Watch record in `~/.trvl`, surviving daemon restarts and store reloads.

### Design
- New dependency-free package `internal/pricealert` holds the pure decision core (`Evaluate(state, price, threshold)`), fully unit-tested in isolation.
- `internal/watch` wires it into the existing checkOne path (baseline state persisted in the same UpdateWatch call), renders via Notifier, and logs via the scheduler. Both the watch daemon (cmd) and the in-process Scheduler share this path.
- `cmd/trvl watch add` gains `--alert-drop` / `--alert-drop-abs`.

### Tests (deterministic, offline via a fake price seam)
- threshold drop fires exactly one alert; re-check at same price is silent
- sub-threshold drop is silent
- a recovered (risen) price does not alert and re-arms the baseline
- deeper drop after a first alert fires a fresh alert
- baseline + dedup state survive a store reload

### Verification
`go vet`, `staticcheck`, `gofmt -l` clean; `go test -race` on internal/watch + internal/pricealert and the full `go test -short` suite all green (GOTOOLCHAIN=go1.26.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
