### PR TITLE
Auto-compose travel-hacks savings into flight and ground search

### DIFF
--- a/internal/flights/hacks_compose.go
+++ b/internal/flights/hacks_compose.go
@@ -1,0 +1,125 @@
+package flights
+
+import (
+	"context"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// hackComposeTimeout bounds the auto-compose savings engine so a slow detector
+// never blocks the naive flight results. The naive search has already returned
+// by the time this runs; if the budget is exceeded we simply surface no saving.
+const hackComposeTimeout = 12 * time.Second
+
+// hacksComposeKey is a context marker set while the savings engine runs. The
+// hack detectors fan out by calling flights.SearchFlights themselves; without
+// this guard each detector search would recursively auto-compose hacks again,
+// exploding into unbounded recursion. A search whose context carries the marker
+// skips auto-compose and behaves as a plain naive search.
+type hacksComposeKey struct{}
+
+func disableHacksCompose(ctx context.Context) context.Context {
+	return context.WithValue(ctx, hacksComposeKey{}, true)
+}
+
+func hacksComposeDisabled(ctx context.Context) bool {
+	v, _ := ctx.Value(hacksComposeKey{}).(bool)
+	return v
+}
+
+// HackComposeRequest is the route/baseline the savings engine evaluates. It is
+// deliberately built from primitives + models types so the flights package does
+// not depend on the hacks package (the hacks detectors import flights, so the
+// dependency must point one way only).
+type HackComposeRequest struct {
+	Origin      string
+	Destination string
+	Date        string
+	ReturnDate  string
+	Currency    string
+	NaivePrice  float64
+	CarryOnOnly bool
+	Passengers  int
+}
+
+// composeHackSaving is the savings-engine seam. It is nil until the hacks package
+// wires it via RegisterHackComposer in its init(), which inverts the import cycle
+// (hacks imports flights, not the reverse). Tests override it directly.
+var composeHackSaving func(ctx context.Context, req HackComposeRequest) *models.HackSaving
+
+// RegisterHackComposer wires the travel-hacks savings engine into flight search.
+// Called once from the hacks package init(). Passing nil disables auto-compose.
+func RegisterHackComposer(fn func(ctx context.Context, req HackComposeRequest) *models.HackSaving) {
+	composeHackSaving = fn
+}
+
+// cheapestFlightPrice returns the lowest strictly-positive headline price across
+// the naive flights, or 0 when none are priced.
+func cheapestFlightPrice(flights []models.FlightResult) float64 {
+	best := 0.0
+	for _, f := range flights {
+		if f.Price <= 0 {
+			continue
+		}
+		if best == 0 || f.Price < best {
+			best = f.Price
+		}
+	}
+	return best
+}
+
+// flightHackCurrency picks the currency to report savings in: the explicit
+// option currency, else the first priced flight's currency, else EUR.
+func flightHackCurrency(flights []models.FlightResult, optCurrency string) string {
+	if optCurrency != "" {
+		return optCurrency
+	}
+	for _, f := range flights {
+		if f.Currency != "" {
+			return f.Currency
+		}
+	}
+	return "EUR"
+}
+
+// attachFlightHackSaving runs the savings engine against a completed naive
+// search and, when a genuinely cheaper synthesized option exists, attaches the
+// single best one to result.HackSaving. The naive Flights are never modified.
+//
+// It is a no-op when the engine is unwired (composeHackSaving == nil), when
+// hacks are opted out (opts.NoHacks), when the search is a nested
+// detector-initiated search (re-entrancy guard), when the result is not a
+// successful priced search, or when the naive cheapest price is unknown.
+func attachFlightHackSaving(ctx context.Context, result *models.FlightSearchResult, origin, destination, date string, opts SearchOptions) {
+	if composeHackSaving == nil || result == nil || !result.Success {
+		return
+	}
+	if opts.NoHacks || hacksComposeDisabled(ctx) {
+		return
+	}
+	naive := cheapestFlightPrice(result.Flights)
+	if naive <= 0 {
+		return
+	}
+
+	req := HackComposeRequest{
+		Origin:      origin,
+		Destination: destination,
+		Date:        date,
+		ReturnDate:  opts.ReturnDate,
+		Currency:    flightHackCurrency(result.Flights, opts.Currency),
+		CarryOnOnly: opts.CarryOnBags > 0 && opts.CheckedBags == 0,
+		NaivePrice:  naive,
+		Passengers:  opts.Adults,
+	}
+
+	// Bound the engine and mark the context so the detectors' own
+	// flights.SearchFlights fan-out does not recursively auto-compose.
+	hctx, cancel := context.WithTimeout(disableHacksCompose(ctx), hackComposeTimeout)
+	defer cancel()
+
+	if saving := composeHackSaving(hctx, req); saving != nil {
+		result.HackSaving = saving
+	}
+}

--- a/internal/flights/hacks_compose_test.go
+++ b/internal/flights/hacks_compose_test.go
@@ -1,0 +1,136 @@
+package flights
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// withStubComposer temporarily installs a deterministic savings-engine seam so
+// the auto-compose wiring is provable offline, then restores the previous one.
+func withStubComposer(t *testing.T, fn func(ctx context.Context, req HackComposeRequest) *models.HackSaving) {
+	t.Helper()
+	prev := composeHackSaving
+	composeHackSaving = fn
+	t.Cleanup(func() { composeHackSaving = prev })
+}
+
+func okFlightResult() *models.FlightSearchResult {
+	return &models.FlightSearchResult{
+		Success: true,
+		Count:   2,
+		Flights: []models.FlightResult{
+			{Price: 250, Currency: "EUR", Provider: "google_flights"},
+			{Price: 300, Currency: "EUR", Provider: "kiwi"},
+		},
+	}
+}
+
+// (a) A search surfaces a hack-derived saving when one exists.
+func TestAttachFlightHackSaving_SurfacesSaving(t *testing.T) {
+	var gotNaive float64
+	withStubComposer(t, func(_ context.Context, req HackComposeRequest) *models.HackSaving {
+		gotNaive = req.NaivePrice
+		return &models.HackSaving{Type: "hidden_city", Price: 200, NaivePrice: req.NaivePrice, Savings: 50, SavingsPct: 20, Currency: "EUR"}
+	})
+
+	res := okFlightResult()
+	attachFlightHackSaving(context.Background(), res, "HEL", "AMS", "2026-09-01", SearchOptions{})
+
+	if gotNaive != 250 {
+		t.Errorf("composer NaivePrice = %v, want 250 (cheapest naive flight)", gotNaive)
+	}
+	if res.HackSaving == nil || res.HackSaving.Type != "hidden_city" {
+		t.Fatalf("HackSaving not surfaced: %+v", res.HackSaving)
+	}
+	if res.HackSaving.Savings != 50 {
+		t.Errorf("Savings = %v, want 50", res.HackSaving.Savings)
+	}
+}
+
+// (b) No saving surfaced when the engine finds none.
+func TestAttachFlightHackSaving_NoneWhenEngineEmpty(t *testing.T) {
+	withStubComposer(t, func(context.Context, HackComposeRequest) *models.HackSaving { return nil })
+	res := okFlightResult()
+	attachFlightHackSaving(context.Background(), res, "HEL", "AMS", "2026-09-01", SearchOptions{})
+	if res.HackSaving != nil {
+		t.Fatalf("expected no HackSaving, got %+v", res.HackSaving)
+	}
+}
+
+// (c) The naive results are never replaced; the saving is purely additive.
+func TestAttachFlightHackSaving_NeverReplacesNaive(t *testing.T) {
+	withStubComposer(t, func(_ context.Context, req HackComposeRequest) *models.HackSaving {
+		return &models.HackSaving{Type: "split", Price: 180, NaivePrice: req.NaivePrice, Savings: 70}
+	})
+	res := okFlightResult()
+	before := append([]models.FlightResult(nil), res.Flights...)
+
+	attachFlightHackSaving(context.Background(), res, "HEL", "AMS", "2026-09-01", SearchOptions{})
+
+	if len(res.Flights) != len(before) {
+		t.Fatalf("Flights length changed: got %d, want %d", len(res.Flights), len(before))
+	}
+	for i := range before {
+		if res.Flights[i].Price != before[i].Price || res.Flights[i].Provider != before[i].Provider {
+			t.Errorf("naive flight %d mutated: %+v != %+v", i, res.Flights[i], before[i])
+		}
+	}
+	if res.HackSaving == nil {
+		t.Fatal("expected additive HackSaving alongside untouched naive flights")
+	}
+	// The cheapest naive flight (250) still leads; the saving does not overwrite it.
+	if res.Flights[0].Price != 250 {
+		t.Errorf("cheapest naive flight = %v, want 250 (unchanged)", res.Flights[0].Price)
+	}
+}
+
+// (d) Opt-out via NoHacks runs a pure naive search.
+func TestAttachFlightHackSaving_OptOut(t *testing.T) {
+	called := false
+	withStubComposer(t, func(context.Context, HackComposeRequest) *models.HackSaving {
+		called = true
+		return &models.HackSaving{Type: "x"}
+	})
+	res := okFlightResult()
+	attachFlightHackSaving(context.Background(), res, "HEL", "AMS", "2026-09-01", SearchOptions{NoHacks: true})
+	if called {
+		t.Error("composer ran despite NoHacks opt-out")
+	}
+	if res.HackSaving != nil {
+		t.Errorf("HackSaving set despite opt-out: %+v", res.HackSaving)
+	}
+}
+
+// (e) Re-entrancy guard: a nested detector-initiated search does not recurse.
+func TestAttachFlightHackSaving_ReentrancyGuard(t *testing.T) {
+	called := false
+	withStubComposer(t, func(context.Context, HackComposeRequest) *models.HackSaving {
+		called = true
+		return &models.HackSaving{Type: "x"}
+	})
+	res := okFlightResult()
+	nested := disableHacksCompose(context.Background())
+	attachFlightHackSaving(nested, res, "HEL", "AMS", "2026-09-01", SearchOptions{})
+	if called {
+		t.Error("composer ran inside a nested (hacks-disabled) search — recursion not guarded")
+	}
+	if res.HackSaving != nil {
+		t.Errorf("HackSaving set in nested search: %+v", res.HackSaving)
+	}
+}
+
+// Unpriced naive results yield no baseline, so no saving is claimed.
+func TestAttachFlightHackSaving_NoNaivePrice(t *testing.T) {
+	called := false
+	withStubComposer(t, func(context.Context, HackComposeRequest) *models.HackSaving {
+		called = true
+		return &models.HackSaving{Type: "x"}
+	})
+	res := &models.FlightSearchResult{Success: true, Flights: []models.FlightResult{{Price: 0, Currency: "EUR"}}}
+	attachFlightHackSaving(context.Background(), res, "HEL", "AMS", "2026-09-01", SearchOptions{})
+	if called || res.HackSaving != nil {
+		t.Error("composer ran / saving surfaced without a priced naive baseline")
+	}
+}

--- a/internal/flights/roundtrip.go
+++ b/internal/flights/roundtrip.go
@@ -48,8 +48,12 @@ func searchRoundTripComposed(ctx context.Context, client *batchexec.Client, orig
 	legOpts.ReturnDate = ""
 	legOpts.FirstResult = false
 
-	outbound, outErr := SearchFlightsWithClient(ctx, client, origin, destination, date, legOpts)
-	inbound, inErr := SearchFlightsWithClient(ctx, client, destination, origin, returnDate, legOpts)
+	// Leg sub-searches run with auto-compose disabled: a single round-trip-level
+	// savings pass is attached to the composed result below, so the two one-way
+	// legs do not each spawn their own (discarded) hack fan-out.
+	legCtx := disableHacksCompose(ctx)
+	outbound, outErr := SearchFlightsWithClient(legCtx, client, origin, destination, date, legOpts)
+	inbound, inErr := SearchFlightsWithClient(legCtx, client, destination, origin, returnDate, legOpts)
 
 	statuses := make([]models.ProviderStatus, 0, 8)
 	var outFlights, inFlights []models.FlightResult
@@ -80,14 +84,19 @@ func searchRoundTripComposed(ctx context.Context, client *batchexec.Client, orig
 		}
 	}
 
-	return &models.FlightSearchResult{
+	result := &models.FlightSearchResult{
 		Success:          true,
 		Count:            len(composed),
 		TripType:         "round_trip",
 		Flights:          composed,
 		ProviderStatuses: statuses,
 		Completeness:     models.ComputeCompleteness(statuses),
-	}, nil
+	}
+	// Round-trip-level savings pass (split / throwaway / hidden-city become
+	// applicable once ReturnDate is known). Uses the original ctx so it is not
+	// suppressed by the leg-level disable above.
+	attachFlightHackSaving(ctx, result, origin, destination, date, opts)
+	return result, nil
 }
 
 // composeRoundTrips pairs the cheapest priced outbound options with the cheapest

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -66,6 +66,12 @@ type SearchOptions struct {
 	// Client-side post-filters (applied after server response).
 	RequireCheckedBag bool // Only show flights with ≥1 free checked bag
 	FirstResult       bool // Return only the first flight with Price > 0 after sorting
+
+	// NoHacks opts out of the auto-composed travel-hacks savings engine. The
+	// engine is ON by default: a normal search also surfaces the single best
+	// cheaper synthesized option (hidden-city, positioning, split, multimodal,
+	// …) in result.HackSaving. Set NoHacks to run a pure naive search.
+	NoHacks bool
 }
 
 // defaults fills in zero-value fields with sensible defaults.
@@ -277,14 +283,19 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	}
 
 	if googleSucceeded || kiwiSucceeded || skiplaggedSucceeded || ryanairSucceeded || wizzairSucceeded || transaviaSucceeded || easyjetSucceeded {
-		return &models.FlightSearchResult{
+		result := &models.FlightSearchResult{
 			Success:          true,
 			Count:            len(mergedFlights),
 			TripType:         tripTypeForSearch(opts),
 			Flights:          mergedFlights,
 			ProviderStatuses: statuses,
 			Completeness:     models.ComputeCompleteness(statuses),
-		}, nil
+		}
+		// Auto-compose the savings engine: surface the single best cheaper
+		// synthesized option (hidden-city, positioning, split, …) alongside the
+		// naive flights, unless opted out or this is a nested detector search.
+		attachFlightHackSaving(ctx, result, origin, destination, date, opts)
+		return result, nil
 	}
 
 	errs := []error{}

--- a/internal/ground/hacks_compose.go
+++ b/internal/ground/hacks_compose.go
@@ -1,0 +1,112 @@
+package ground
+
+import (
+	"context"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// hackComposeTimeout bounds the auto-compose savings engine so a slow detector
+// never blocks the naive ground results.
+const hackComposeTimeout = 12 * time.Second
+
+// hacksComposeKey is a context marker set while the savings engine runs. Several
+// hack detectors fan out by calling ground.SearchByName themselves; without this
+// guard each detector search would recursively auto-compose hacks again. A
+// search whose context carries the marker skips auto-compose.
+type hacksComposeKey struct{}
+
+func disableHacksCompose(ctx context.Context) context.Context {
+	return context.WithValue(ctx, hacksComposeKey{}, true)
+}
+
+func hacksComposeDisabled(ctx context.Context) bool {
+	v, _ := ctx.Value(hacksComposeKey{}).(bool)
+	return v
+}
+
+// HackComposeRequest is the route/baseline the savings engine evaluates. Built
+// from primitives + models types so the ground package does not depend on the
+// hacks package (the hacks detectors import ground, so the dependency points one
+// way only).
+type HackComposeRequest struct {
+	Origin      string
+	Destination string
+	Date        string
+	Currency    string
+	NaivePrice  float64
+}
+
+// composeHackSaving is the savings-engine seam. It is nil until the hacks package
+// wires it via RegisterHackComposer in its init(), inverting the import cycle
+// (hacks imports ground, not the reverse). Tests override it directly.
+var composeHackSaving func(ctx context.Context, req HackComposeRequest) *models.HackSaving
+
+// RegisterHackComposer wires the travel-hacks savings engine into ground search.
+// Called once from the hacks package init(). Passing nil disables auto-compose.
+func RegisterHackComposer(fn func(ctx context.Context, req HackComposeRequest) *models.HackSaving) {
+	composeHackSaving = fn
+}
+
+// cheapestRoutePrice returns the lowest strictly-positive route price, or 0.
+func cheapestRoutePrice(routes []models.GroundRoute) float64 {
+	best := 0.0
+	for _, r := range routes {
+		if r.Price <= 0 {
+			continue
+		}
+		if best == 0 || r.Price < best {
+			best = r.Price
+		}
+	}
+	return best
+}
+
+// groundHackCurrency picks the currency to report savings in.
+func groundHackCurrency(routes []models.GroundRoute, optCurrency string) string {
+	if optCurrency != "" {
+		return optCurrency
+	}
+	for _, r := range routes {
+		if r.Currency != "" {
+			return r.Currency
+		}
+	}
+	return "EUR"
+}
+
+// attachGroundHackSaving runs the savings engine against a completed naive ground
+// search and, when a genuinely cheaper synthesized option exists, attaches the
+// single best one to result.HackSaving. The naive Routes are never modified.
+//
+// No-op when the engine is unwired, when opted out (opts.NoHacks), when this is a
+// nested detector-initiated search (re-entrancy guard), when the result is not a
+// successful priced search, or when the naive cheapest price is unknown.
+func attachGroundHackSaving(ctx context.Context, result *models.GroundSearchResult, from, to, date string, opts SearchOptions) {
+	if composeHackSaving == nil || result == nil || !result.Success {
+		return
+	}
+	if opts.NoHacks || hacksComposeDisabled(ctx) {
+		return
+	}
+	naive := cheapestRoutePrice(result.Routes)
+	if naive <= 0 {
+		return
+	}
+
+	req := HackComposeRequest{
+		Origin:      from,
+		Destination: to,
+		Date:        date,
+		Currency:    groundHackCurrency(result.Routes, opts.Currency),
+		NaivePrice:  naive,
+	}
+
+	hctx, cancel := context.WithTimeout(disableHacksCompose(ctx), hackComposeTimeout)
+	defer cancel()
+
+	if saving := composeHackSaving(hctx, req); saving != nil {
+		result.HackSaving = saving
+	}
+}

--- a/internal/ground/hacks_compose_test.go
+++ b/internal/ground/hacks_compose_test.go
@@ -1,0 +1,102 @@
+package ground
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func withStubComposer(t *testing.T, fn func(ctx context.Context, req HackComposeRequest) *models.HackSaving) {
+	t.Helper()
+	prev := composeHackSaving
+	composeHackSaving = fn
+	t.Cleanup(func() { composeHackSaving = prev })
+}
+
+func okGroundResult() *models.GroundSearchResult {
+	return &models.GroundSearchResult{
+		Success: true,
+		Count:   2,
+		Routes: []models.GroundRoute{
+			{Provider: "flixbus", Price: 39, Currency: "EUR"},
+			{Provider: "regiojet", Price: 55, Currency: "EUR"},
+		},
+	}
+}
+
+// (a) A ground search surfaces a hack-derived saving when one exists.
+func TestAttachGroundHackSaving_SurfacesSaving(t *testing.T) {
+	var gotNaive float64
+	withStubComposer(t, func(_ context.Context, req HackComposeRequest) *models.HackSaving {
+		gotNaive = req.NaivePrice
+		return &models.HackSaving{Type: "cross_border_rail", Price: 25, NaivePrice: req.NaivePrice, Savings: 14, Currency: "EUR"}
+	})
+	res := okGroundResult()
+	attachGroundHackSaving(context.Background(), res, "Helsinki", "Tallinn", "2026-09-01", SearchOptions{})
+
+	if gotNaive != 39 {
+		t.Errorf("composer NaivePrice = %v, want 39 (cheapest route)", gotNaive)
+	}
+	if res.HackSaving == nil || res.HackSaving.Type != "cross_border_rail" {
+		t.Fatalf("HackSaving not surfaced: %+v", res.HackSaving)
+	}
+}
+
+// (b) No saving surfaced when the engine finds none.
+func TestAttachGroundHackSaving_NoneWhenEngineEmpty(t *testing.T) {
+	withStubComposer(t, func(context.Context, HackComposeRequest) *models.HackSaving { return nil })
+	res := okGroundResult()
+	attachGroundHackSaving(context.Background(), res, "Helsinki", "Tallinn", "2026-09-01", SearchOptions{})
+	if res.HackSaving != nil {
+		t.Fatalf("expected no HackSaving, got %+v", res.HackSaving)
+	}
+}
+
+// (c) The naive routes are never replaced; the saving is purely additive.
+func TestAttachGroundHackSaving_NeverReplacesNaive(t *testing.T) {
+	withStubComposer(t, func(_ context.Context, req HackComposeRequest) *models.HackSaving {
+		return &models.HackSaving{Type: "multimodal", Price: 20, NaivePrice: req.NaivePrice, Savings: 19}
+	})
+	res := okGroundResult()
+	before := append([]models.GroundRoute(nil), res.Routes...)
+	attachGroundHackSaving(context.Background(), res, "Helsinki", "Tallinn", "2026-09-01", SearchOptions{})
+
+	if len(res.Routes) != len(before) {
+		t.Fatalf("Routes length changed: got %d, want %d", len(res.Routes), len(before))
+	}
+	if res.Routes[0].Price != 39 || res.Routes[0].Provider != "flixbus" {
+		t.Errorf("cheapest naive route mutated: %+v", res.Routes[0])
+	}
+	if res.HackSaving == nil {
+		t.Fatal("expected additive HackSaving alongside untouched naive routes")
+	}
+}
+
+// (d) Opt-out via NoHacks.
+func TestAttachGroundHackSaving_OptOut(t *testing.T) {
+	called := false
+	withStubComposer(t, func(context.Context, HackComposeRequest) *models.HackSaving {
+		called = true
+		return &models.HackSaving{Type: "x"}
+	})
+	res := okGroundResult()
+	attachGroundHackSaving(context.Background(), res, "Helsinki", "Tallinn", "2026-09-01", SearchOptions{NoHacks: true})
+	if called || res.HackSaving != nil {
+		t.Error("composer ran despite NoHacks opt-out")
+	}
+}
+
+// (e) Re-entrancy guard.
+func TestAttachGroundHackSaving_ReentrancyGuard(t *testing.T) {
+	called := false
+	withStubComposer(t, func(context.Context, HackComposeRequest) *models.HackSaving {
+		called = true
+		return &models.HackSaving{Type: "x"}
+	})
+	res := okGroundResult()
+	attachGroundHackSaving(disableHacksCompose(context.Background()), res, "Helsinki", "Tallinn", "2026-09-01", SearchOptions{})
+	if called || res.HackSaving != nil {
+		t.Error("composer ran inside a nested (hacks-disabled) search — recursion not guarded")
+	}
+}

--- a/internal/ground/search.go
+++ b/internal/ground/search.go
@@ -80,6 +80,12 @@ type SearchOptions struct {
 	Type                  string   // "bus", "train", or empty for all
 	NoCache               bool     // bypass response cache
 	AllowBrowserFallbacks bool     // opt in to browser/curl/cookie-assisted providers
+
+	// NoHacks opts out of the auto-composed travel-hacks savings engine. The
+	// engine is ON by default: a normal search also surfaces the single best
+	// cheaper synthesized option (multimodal, cross-border rail, …) in
+	// result.HackSaving. Set NoHacks to run a pure naive search.
+	NoHacks bool
 }
 
 // SearchByName searches all providers for ground transport between two cities
@@ -434,6 +440,11 @@ func searchByNameCore(ctx context.Context, from, to, date string, opts SearchOpt
 	if len(allRoutes) == 0 && len(errors) > 0 {
 		result.Error = strings.Join(errors, "; ")
 	}
+
+	// Auto-compose the savings engine: surface the single best cheaper
+	// synthesized option alongside the naive routes (before caching so cache
+	// hits carry it too), unless opted out or this is a nested detector search.
+	attachGroundHackSaving(ctx, result, from, to, date, opts)
 
 	// Cache successful results.
 	if result.Success && !opts.NoCache {

--- a/internal/hacks/register.go
+++ b/internal/hacks/register.go
@@ -1,0 +1,39 @@
+package hacks
+
+import (
+	"context"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/ground"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// init wires the travel-hacks savings engine into flight and ground search so
+// savings auto-compose into every naive search (innovation #1). The dependency
+// is registered here — in the hacks package, which already imports flights and
+// ground — to invert what would otherwise be an import cycle: flight/ground
+// search must not import hacks (the detectors import them).
+func init() {
+	flights.RegisterHackComposer(func(ctx context.Context, req flights.HackComposeRequest) *models.HackSaving {
+		return BestSaving(ctx, DetectorInput{
+			Origin:      req.Origin,
+			Destination: req.Destination,
+			Date:        req.Date,
+			ReturnDate:  req.ReturnDate,
+			Currency:    req.Currency,
+			CarryOnOnly: req.CarryOnOnly,
+			NaivePrice:  req.NaivePrice,
+			Passengers:  req.Passengers,
+		}, nil)
+	})
+
+	ground.RegisterHackComposer(func(ctx context.Context, req ground.HackComposeRequest) *models.HackSaving {
+		return BestSaving(ctx, DetectorInput{
+			Origin:      req.Origin,
+			Destination: req.Destination,
+			Date:        req.Date,
+			Currency:    req.Currency,
+			NaivePrice:  req.NaivePrice,
+		}, nil)
+	})
+}

--- a/internal/hacks/savings.go
+++ b/internal/hacks/savings.go
@@ -1,0 +1,79 @@
+package hacks
+
+import (
+	"context"
+	"math"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// DetectFunc is the detector seam used by the auto-compose savings engine.
+// Production passes nil (BestSaving falls back to DetectAll); tests inject a
+// deterministic detector so the savings-surfacing behaviour can be proven
+// offline without any network fan-out.
+type DetectFunc func(ctx context.Context, in DetectorInput) []Hack
+
+// BestSaving runs the hack detectors against the same route/date/naive-price as
+// a just-completed naive search and returns the single best money-saving option,
+// or nil when no detector yields a genuinely cheaper result.
+//
+// It is the integration point that makes savings a default outcome of flight and
+// ground searches rather than a separate opt-in command. Honest by construction:
+//
+//   - requires a positive NaivePrice baseline and a valid route;
+//   - only considers hacks with Savings > 0 (a real, lower-priced option);
+//   - rejects any hack claiming to save the entire fare or more (Savings >=
+//     NaivePrice) as a fabricated / mis-priced result;
+//   - preserves the winning detector's Risks verbatim (hidden-city / throwaway
+//     caveats are never stripped).
+//
+// BestSaving respects ctx cancellation; callers should pass a timeout-scoped
+// context so a slow detector never blocks the naive results.
+func BestSaving(ctx context.Context, in DetectorInput, detect DetectFunc) *models.HackSaving {
+	if detect == nil {
+		detect = DetectAll
+	}
+	if in.NaivePrice <= 0 || !in.valid() {
+		return nil
+	}
+
+	found := detect(ctx, in)
+
+	var best *Hack
+	for i := range found {
+		h := &found[i]
+		// Only a hack with a real, strictly-positive saving represents a lower
+		// price. A saving at or above the whole naive fare cannot be real, so we
+		// drop it rather than surface a fabricated "free or negative" price.
+		if h.Savings <= 0 || h.Savings >= in.NaivePrice {
+			continue
+		}
+		if best == nil || h.Savings > best.Savings {
+			best = h
+		}
+	}
+	if best == nil {
+		return nil
+	}
+
+	currency := best.Currency
+	if currency == "" {
+		currency = in.currency()
+	}
+	price := roundSavings(in.NaivePrice - best.Savings)
+	pct := math.Round(best.Savings/in.NaivePrice*1000) / 10
+
+	return &models.HackSaving{
+		Type:        best.Type,
+		Title:       best.Title,
+		Description: best.Description,
+		Price:       price,
+		NaivePrice:  in.NaivePrice,
+		Savings:     best.Savings,
+		SavingsPct:  pct,
+		Currency:    currency,
+		Risks:       best.Risks,
+		Steps:       best.Steps,
+		Citations:   best.Citations,
+	}
+}

--- a/internal/hacks/savings_test.go
+++ b/internal/hacks/savings_test.go
@@ -1,0 +1,88 @@
+package hacks
+
+import (
+	"context"
+	"testing"
+)
+
+// stubDetect returns a fixed hack set, ignoring the route — a deterministic
+// offline seam so BestSaving's selection/honesty logic is provable without any
+// network fan-out.
+func stubDetect(hacks []Hack) DetectFunc {
+	return func(context.Context, DetectorInput) []Hack { return hacks }
+}
+
+func TestBestSaving_SurfacesCheapestRealSaving(t *testing.T) {
+	in := DetectorInput{Origin: "HEL", Destination: "AMS", Date: "2026-09-01", NaivePrice: 300, Currency: "EUR"}
+	detect := stubDetect([]Hack{
+		{Type: "positioning", Title: "Positioning", Savings: 40, Currency: "EUR", Risks: []string{"r1"}},
+		{Type: "hidden_city", Title: "Hidden city", Savings: 90, Currency: "EUR", Risks: []string{"contract risk"}, Steps: []string{"s1"}},
+		{Type: "split", Title: "Split", Savings: 20, Currency: "EUR"},
+	})
+
+	got := BestSaving(context.Background(), in, detect)
+	if got == nil {
+		t.Fatal("expected a HackSaving, got nil")
+	}
+	if got.Type != "hidden_city" {
+		t.Errorf("Type = %q, want hidden_city (largest real saving)", got.Type)
+	}
+	if got.Savings != 90 {
+		t.Errorf("Savings = %v, want 90", got.Savings)
+	}
+	if got.NaivePrice != 300 {
+		t.Errorf("NaivePrice = %v, want 300", got.NaivePrice)
+	}
+	if got.Price != 210 {
+		t.Errorf("Price = %v, want 210 (300-90)", got.Price)
+	}
+	if got.SavingsPct != 30 {
+		t.Errorf("SavingsPct = %v, want 30.0", got.SavingsPct)
+	}
+	// Risk caveats must be preserved verbatim (honesty requirement).
+	if len(got.Risks) != 1 || got.Risks[0] != "contract risk" {
+		t.Errorf("Risks = %v, want [contract risk]", got.Risks)
+	}
+}
+
+func TestBestSaving_NoSavingWhenNoneReal(t *testing.T) {
+	in := DetectorInput{Origin: "HEL", Destination: "AMS", Date: "2026-09-01", NaivePrice: 300}
+	// Zero / negative savings are advisory tips, not cheaper options.
+	detect := stubDetect([]Hack{
+		{Type: "advance_purchase", Title: "Book earlier", Savings: 0},
+		{Type: "weird", Savings: -10},
+	})
+	if got := BestSaving(context.Background(), in, detect); got != nil {
+		t.Fatalf("expected nil (no real saving), got %+v", got)
+	}
+}
+
+func TestBestSaving_RejectsFabricatedFullFareSaving(t *testing.T) {
+	in := DetectorInput{Origin: "HEL", Destination: "AMS", Date: "2026-09-01", NaivePrice: 300}
+	// A saving >= the whole naive fare cannot be real; it must be dropped, not
+	// surfaced as a free/negative price.
+	detect := stubDetect([]Hack{
+		{Type: "bogus", Title: "Too good", Savings: 300},
+		{Type: "bogus2", Title: "Impossible", Savings: 500},
+	})
+	if got := BestSaving(context.Background(), in, detect); got != nil {
+		t.Fatalf("expected nil (fabricated saving rejected), got %+v", got)
+	}
+}
+
+func TestBestSaving_RequiresPositiveNaivePrice(t *testing.T) {
+	in := DetectorInput{Origin: "HEL", Destination: "AMS", Date: "2026-09-01", NaivePrice: 0}
+	detect := stubDetect([]Hack{{Type: "x", Savings: 50}})
+	if got := BestSaving(context.Background(), in, detect); got != nil {
+		t.Fatalf("expected nil when no naive baseline, got %+v", got)
+	}
+}
+
+func TestBestSaving_DefaultsCurrencyToInput(t *testing.T) {
+	in := DetectorInput{Origin: "HEL", Destination: "AMS", Date: "2026-09-01", NaivePrice: 200, Currency: "GBP"}
+	detect := stubDetect([]Hack{{Type: "split", Savings: 50}}) // no currency on hack
+	got := BestSaving(context.Background(), in, detect)
+	if got == nil || got.Currency != "GBP" {
+		t.Fatalf("Currency = %v, want GBP from input", got)
+	}
+}

--- a/internal/models/flight.go
+++ b/internal/models/flight.go
@@ -107,7 +107,13 @@ type FlightSearchResult struct {
 	// ProviderStatuses. When State != "complete", callers MUST NOT claim
 	// "no flights found" — some providers timed out or failed.
 	Completeness Completeness `json:"completeness,omitempty"`
-	Error        string       `json:"error,omitempty"`
+	// HackSaving, when non-nil, is the single best money-saving option the
+	// travel-hacks savings engine auto-composed from this naive search (e.g. a
+	// hidden-city or positioning fare cheaper than the naive cheapest flight).
+	// It is additive — the naive Flights are never replaced — and is only
+	// populated when a real, lower-priced option exists.
+	HackSaving *HackSaving `json:"hack_saving,omitempty"`
+	Error      string      `json:"error,omitempty"`
 }
 
 // DatePriceResult represents the cheapest price for a single departure date.

--- a/internal/models/ground.go
+++ b/internal/models/ground.go
@@ -5,7 +5,13 @@ type GroundSearchResult struct {
 	Success bool          `json:"success"`
 	Count   int           `json:"count"`
 	Routes  []GroundRoute `json:"routes"`
-	Error   string        `json:"error,omitempty"`
+	// HackSaving, when non-nil, is the single best money-saving option the
+	// travel-hacks savings engine auto-composed from this naive search (e.g. a
+	// multimodal or cross-border-rail option cheaper than the naive cheapest
+	// route). Additive — the naive Routes are never replaced — and only
+	// populated when a real, lower-priced option exists.
+	HackSaving *HackSaving `json:"hack_saving,omitempty"`
+	Error      string      `json:"error,omitempty"`
 }
 
 // GroundRoute represents a single bus or train connection.

--- a/internal/models/hacksaving.go
+++ b/internal/models/hacksaving.go
@@ -1,0 +1,39 @@
+package models
+
+// HackSaving is the single best money-saving option the travel-hacks savings
+// engine found when auto-composed into a normal flight or ground search. It is
+// attached to a search result so savings surface by default, rather than only
+// when the user separately runs the standalone hacks command.
+//
+// Honesty contract: a HackSaving is only ever populated when a detector found a
+// real, lower-priced synthesized option (Savings > 0 and Price < NaivePrice).
+// The naive result is never replaced — the cheapest naive option still leads the
+// result list; HackSaving is an additive "here is a cheaper way" delta that the
+// traveller must verify (see Risks).
+type HackSaving struct {
+	// Type is the detector that produced the option (e.g. "hidden_city",
+	// "split", "positioning", "rail_fly", "multimodal_skip_flight").
+	Type string `json:"type"`
+	// Title is the human-readable hack name.
+	Title string `json:"title"`
+	// Description explains the option to the traveller.
+	Description string `json:"description"`
+	// Price is the synthesized option's total price, strictly below NaivePrice.
+	Price float64 `json:"price"`
+	// NaivePrice is the cheapest naive fare/route the search returned — the
+	// baseline the saving is measured against.
+	NaivePrice float64 `json:"naive_price"`
+	// Savings is NaivePrice - Price, in Currency.
+	Savings float64 `json:"savings"`
+	// SavingsPct is the saving as a percentage of NaivePrice (one decimal).
+	SavingsPct float64 `json:"savings_pct"`
+	// Currency is the currency for Price / NaivePrice / Savings.
+	Currency string `json:"currency"`
+	// Risks carries the detector's caveats verbatim (e.g. hidden-city contract
+	// violations, throwaway return-leg cancellation). Never stripped.
+	Risks []string `json:"risks,omitempty"`
+	// Steps is how to execute the option.
+	Steps []string `json:"steps,omitempty"`
+	// Citations are booking URLs / provider names backing the option.
+	Citations []string `json:"citations,omitempty"`
+}


### PR DESCRIPTION
## Summary

Innovation #1 — auto-compose the travel-hacks savings engine into flight and ground searches so **savings are the default**, not a hidden separate detect_travel_hacks command.

After a naive flight or ground search returns its results, the savings engine runs against the same origin/destination/date and the search cheapest naive price. When a real, lower-priced synthesized option exists, the single best one is attached as result.HackSaving, carrying:

- **(a)** the cheapest synthesized option price,
- **(b)** a "saved EUR X vs naive fare (Y percent)" delta (Savings, SavingsPct, NaivePrice),
- **(c)** which hack produced it (Type/Title) plus the detector risk caveats verbatim.

## Honest by construction

- Only surfaces when Savings greater than 0 AND Price less than NaivePrice — never fabricates a saving.
- Rejects any hack claiming to save the entire fare or more as a bad result.
- The naive results are **never replaced** — HackSaving is purely additive; the cheapest naive option still leads the list.
- Hidden-city and throwaway risk caveats are preserved, never stripped.

## Bounded and safe

- Runs under a **12s timeout** so a slow detector never blocks naive results.
- A context marker (disableHacksCompose) breaks the recursion that would otherwise occur — the detectors fan out by calling the flight and ground search functions themselves; nested detector searches skip auto-compose.
- **Opt-out** via new SearchOptions.NoHacks (engine is **ON by default**).
- The import cycle (hacks already imports flights and ground) is inverted via a RegisterHackComposer seam wired from the hacks package init().

## Tests (TDD, deterministic and offline)

Via a composer seam (no network): a search surfaces a hack-derived saving when one exists; no saving surfaced when none exists; the naive result is never replaced silently without the delta shown; plus opt-out, re-entrancy guard, unpriced-baseline, full-fare rejection, and BestSaving selection and currency honesty.

## Verification

go vet, staticcheck, gofmt all clean; race tests on flights and ground, and the short suite across all packages, green (GOTOOLCHAIN go1.26.4).

## MCP surfacing — registration merge needed

The savings flow on the FlightSearchResult.HackSaving and GroundSearchResult.HackSaving model fields. The MCP flight handler reshapes results into enrichedFlightSearchResult, which does not yet carry the new field. To surface the delta through the MCP tool, add a HackSaving field plus assignment there (and the ground equivalent). Left untouched here per ownership boundaries.

Generated with Claude Code
