### PR TITLE
feat(nlsearch): natural-language travel supertool (innovation #7)

### DIFF
--- a/cmd/trvl/public_claims_test.go
+++ b/cmd/trvl/public_claims_test.go
@@ -141,6 +141,7 @@ func registeredMCPCompatibilityAliasCount(t *testing.T) int {
 	nonAliasCapabilities := map[string]bool{
 		"travel":       true, // the smart router itself
 		"plan_journey": true, // Leave-By Scheduler capability (MIK-5734 B)
+		"plan_natural": true, // NL travel-planner supertool (innovation #7)
 	}
 	count := 0
 	for _, key := range handlers.MapKeys() {

--- a/internal/nlsearch/parser.go
+++ b/internal/nlsearch/parser.go
@@ -142,6 +142,17 @@ func ensureCityIATAIndex() {
 			"riga":          "RIX",
 			"tallinn":       "TLL",
 			"vilnius":       "VNO",
+			// Nordic / Arctic destinations frequently asked for by name but
+			// absent (or ambiguous) in the bundled AirportNames table.
+			"tromso":    "TOS",
+			"tromsø":    "TOS",
+			"reykjavik": "KEF",
+			"bergen":    "BGO",
+			"bodo":      "BOO",
+			"bodø":      "BOO",
+			"kiruna":    "KRN",
+			"rovaniemi": "RVN",
+			"trondheim": "TRD",
 		}
 		for k, v := range manual {
 			cityIATAIndex[k] = v
@@ -339,6 +350,9 @@ var commonEnglishUppercase = map[string]bool{
 	"ITS": true, "LET": true, "PUT": true, "SAY": true, "SHE": true,
 	"TOO": true, "USE": true, "DAD": true, "MOM": true, "MAY": true,
 	"USA": true, // ambiguous: could be a country code, not an airport
+	// Currency codes and travel-jargon fragments that uppercase into apparent
+	// IATA codes ("under EUR 120" → EUR, "red-eye" → RED, "via X" → VIA).
+	"EUR": true, "USD": true, "GBP": true, "RED": true, "VIA": true,
 }
 
 func filterFalsePositiveIATA(codes []string) []string {

--- a/internal/nlsearch/plan.go
+++ b/internal/nlsearch/plan.go
@@ -1,0 +1,364 @@
+package nlsearch
+
+// plan.go strengthens the keyword heuristic parser into a natural-language
+// "supertool": it parses a free-form travel query into a normalized, structured
+// Plan that names the travel mode, endpoints, dates, constraints, and — crucially
+// — which search tool(s) the caller should dispatch with which parameters.
+//
+// It is intentionally deterministic and rule-based (no LLM dependency at
+// runtime) so the CLI, the MCP surface, and tests all produce identical plans
+// for identical input. BuildPlan reuses Heuristic for the base intent / endpoint
+// / date extraction and layers constraint detection, relative-date resolution,
+// destination-only ("to <City>") extraction, round-trip inference, and mode
+// inference on top.
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// Travel modes a Plan can route to.
+const (
+	ModeFlight     = "flight"
+	ModeGround     = "ground"
+	ModeHotel      = "hotel"
+	ModeMultimodal = "multimodal"
+	ModeHacks      = "hacks"
+)
+
+// Canonical constraint tokens. budget<=X is emitted dynamically with the
+// numeric ceiling appended (e.g. "budget<=500").
+const (
+	ConstraintCheapest = "cheapest"
+	ConstraintFastest  = "fastest"
+	ConstraintNonstop  = "nonstop"
+	ConstraintNoRedeye = "no-redeye"
+)
+
+// PlannedSearch names one concrete search the caller should dispatch. Tool is
+// the MCP tool / CLI command name; Params are its arguments. The nlsearch
+// package deliberately does NOT call the search packages itself (that would
+// invert the dependency direction); it only returns the routing decision.
+type PlannedSearch struct {
+	Tool   string         `json:"tool"`
+	Params map[string]any `json:"params"`
+}
+
+// Plan is the normalized routing decision for a natural-language travel query.
+type Plan struct {
+	Query       string          `json:"query"`
+	Mode        string          `json:"mode"` // flight | ground | hotel | multimodal | hacks
+	Origin      string          `json:"origin,omitempty"`
+	Destination string          `json:"destination,omitempty"`
+	Date        string          `json:"date,omitempty"`
+	ReturnDate  string          `json:"return_date,omitempty"`
+	RoundTrip   bool            `json:"round_trip"`
+	MaxBudget   float64         `json:"max_budget,omitempty"`
+	Constraints []string        `json:"constraints"`
+	Searches    []PlannedSearch `json:"searches"`
+	Notes       []string        `json:"notes,omitempty"`
+}
+
+// destPattern variants capture a destination phrase. We try "to <X>" first
+// (directional), then "in <X>" (common for hotel queries). Candidates are only
+// accepted when they resolve to a real airport, so time words like "in May" or
+// "next month" are rejected by construction.
+var (
+	toDestPattern = regexp.MustCompile(`(?i)\bto\s+([A-Za-z][A-Za-z.\-]*(?:\s+[A-Za-z][A-Za-z.\-]*){0,2}?)(?:\s+(?:next|this|on|in|for|by|under|below|over|via|and|avoiding|without|with|before|after|that|so)\b|,|\.|$)`)
+	inDestPattern = regexp.MustCompile(`(?i)\bin\s+([A-Za-z][A-Za-z.\-]*(?:\s+[A-Za-z][A-Za-z.\-]*){0,2}?)(?:\s+(?:next|this|on|for|by|under|below|over|and|with|before|after|that|so)\b|,|\.|$)`)
+)
+
+// extractDestination resolves a destination-only phrase to an IATA code, or "".
+func extractDestination(query string) string {
+	for _, re := range []*regexp.Regexp{toDestPattern, inDestPattern} {
+		if m := re.FindStringSubmatch(query); len(m) == 2 {
+			cand := strings.TrimSpace(m[1])
+			if code := cityToIATA(cand); code != "" {
+				return code
+			}
+			if up := strings.ToUpper(cand); len(up) == 3 && iataPattern.MatchString(up) && !commonEnglishUppercase[up] {
+				return up
+			}
+		}
+	}
+	return ""
+}
+
+// budgetPattern captures a budget ceiling expressed after a trigger word, with
+// an optional currency symbol/code. e.g. "under EUR 500", "budget of 500",
+// "max 1200", "below $300".
+var budgetTriggerPattern = regexp.MustCompile(`(?i)(?:under|below|less than|at most|max(?:imum)?|budget(?:\s+of)?|up to|no more than|<=?)\s*(?:eur|usd|gbp|€|\$|£)?\s*([0-9][0-9.,]*)`)
+
+// currencyAmountPattern captures a currency-prefixed amount anywhere, e.g.
+// "EUR 500", "€500", "$1,200". Used as a fallback when no trigger word matches.
+var currencyAmountPattern = regexp.MustCompile(`(?i)(?:eur|usd|gbp|€|\$|£)\s*([0-9][0-9.,]*)`)
+
+// BuildPlan parses a free-form travel query into a normalized Plan. `today`
+// must be in ISO 8601 calendar form (YYYY-MM-DD). It never errors: an
+// unrecognized query yields a best-effort Plan with empty endpoints and a note.
+func BuildPlan(query, today string) Plan {
+	base := Heuristic(query, today)
+	lower := strings.ToLower(query)
+
+	plan := Plan{
+		Query:       strings.TrimSpace(query),
+		Origin:      base.Origin,
+		Destination: base.Destination,
+		Date:        base.Date,
+		ReturnDate:  base.ReturnDate,
+		MaxBudget:   base.MaxBudget,
+		Constraints: []string{},
+		Searches:    []PlannedSearch{},
+	}
+
+	// Destination-only extraction when Heuristic found no destination (queries
+	// without an explicit "from ... to ..." pair, e.g. "way to Tromso" or
+	// "hotel in Prague").
+	if plan.Destination == "" {
+		plan.Destination = extractDestination(query)
+	}
+
+	// Budget extraction → MaxBudget + dynamic "budget<=X" constraint.
+	if plan.MaxBudget == 0 {
+		plan.MaxBudget = extractBudget(query)
+	}
+
+	// Relative-date resolution for phrasings Heuristic does not cover
+	// ("next week", "next month"). Heuristic already handles weekends + explicit
+	// and natural dates.
+	if plan.Date == "" {
+		if d := resolveRelativeDate(lower, today); d != "" {
+			plan.Date = d
+			plan.Notes = append(plan.Notes, "departure date approximated from relative phrase")
+		}
+	}
+
+	// Round-trip inference.
+	plan.RoundTrip = base.ReturnDate != "" || isRoundTrip(lower)
+	if plan.RoundTrip && plan.ReturnDate == "" && plan.Date != "" {
+		if t, err := models.ParseDate(plan.Date); err == nil {
+			plan.ReturnDate = t.AddDate(0, 0, 7).Format(time.DateOnly)
+			plan.Notes = append(plan.Notes, "return date approximated as one week after departure")
+		}
+	}
+
+	// Constraint detection (deterministic, fixed order).
+	plan.Constraints = detectConstraints(lower, plan.MaxBudget)
+
+	// Mode inference.
+	plan.Mode = inferMode(lower, base.Intent, plan.Origin, plan.Destination)
+
+	// Searches assembly — name which search(es) to dispatch.
+	plan.Searches = buildSearches(plan, base)
+
+	return plan
+}
+
+// extractBudget returns the first budget ceiling found in the query, or 0.
+func extractBudget(query string) float64 {
+	if m := budgetTriggerPattern.FindStringSubmatch(query); len(m) == 2 {
+		if v := parseAmount(m[1]); v > 0 {
+			return v
+		}
+	}
+	if m := currencyAmountPattern.FindStringSubmatch(query); len(m) == 2 {
+		if v := parseAmount(m[1]); v > 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+// parseAmount converts a captured number string ("1,200", "500.00") to a float.
+func parseAmount(s string) float64 {
+	clean := strings.ReplaceAll(s, ",", "")
+	clean = strings.TrimRight(clean, ".")
+	v, err := strconv.ParseFloat(clean, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// resolveRelativeDate maps "next week" / "next month" to a concrete ISO date.
+// Returns "" when no relative phrase is present.
+func resolveRelativeDate(lower, today string) string {
+	t, err := models.ParseDate(today)
+	if err != nil {
+		return ""
+	}
+	switch {
+	case strings.Contains(lower, "next month"):
+		return t.AddDate(0, 1, 0).Format(time.DateOnly)
+	case strings.Contains(lower, "next week"):
+		return t.AddDate(0, 0, 7).Format(time.DateOnly)
+	}
+	return ""
+}
+
+// isRoundTrip reports whether the query phrasing implies a return leg.
+func isRoundTrip(lower string) bool {
+	for _, kw := range []string{"and back", "round trip", "round-trip", "roundtrip", "return trip", "there and back", "both ways", "and return"} {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// detectConstraints extracts the ordered constraint list. budget<=X is appended
+// last when a budget ceiling was found.
+func detectConstraints(lower string, budget float64) []string {
+	out := []string{}
+	if containsAny(lower, "cheapest", "cheap", "lowest price", "lowest fare", "affordable", "budget-friendly", "least expensive", "save money") {
+		out = append(out, ConstraintCheapest)
+	}
+	if containsAny(lower, "fastest", "quickest", "shortest", "asap", "as fast", "quickly", "minimal travel time") {
+		out = append(out, ConstraintFastest)
+	}
+	if containsAny(lower, "nonstop", "non-stop", "non stop", "direct", "no layover", "no layovers", "no stops", "no connection", "no connections") {
+		out = append(out, ConstraintNonstop)
+	}
+	if detectNoRedeye(lower) {
+		out = append(out, ConstraintNoRedeye)
+	}
+	if budget > 0 {
+		out = append(out, fmt.Sprintf("budget<=%s", strconv.FormatFloat(budget, 'f', -1, 64)))
+	}
+	return out
+}
+
+// detectNoRedeye reports whether the query asks to avoid red-eye / overnight
+// departures. Bare "red-eye" is treated as avoidance (the term carries negative
+// connotation); "overnight" only counts when paired with an avoidance verb so
+// "overnight train" (often desired) is not misclassified.
+func detectNoRedeye(lower string) bool {
+	if containsAny(lower, "red-eye", "redeye", "red eye") {
+		return true
+	}
+	if strings.Contains(lower, "overnight") && containsAny(lower, "no ", "avoid", "without", "skip", "not ", "rather not", "don't want") {
+		return true
+	}
+	return false
+}
+
+// inferMode determines the travel mode with a fixed precedence. base is the
+// keyword intent from Heuristic ("hotel"/"flight"/"deals"/"route").
+func inferMode(lower, baseIntent, origin, destination string) string {
+	switch {
+	case baseIntent == "hotel":
+		return ModeHotel
+	case containsAny(lower, "hack", "hacks", "hidden city", "hidden-city", "error fare", "throwaway", "skiplag", "trick", "loophole"):
+		return ModeHacks
+	case containsAny(lower, "train", "rail", "by rail", "bus", "coach", "ferry", "boat", "by sea", "overland"):
+		return ModeGround
+	case containsAny(lower, "multimodal", "multi-modal", "any way", "cheapest way", "best way", "fastest way", "how to get", "way to get", "get to", "get from", "how do i get", "any mode"):
+		return ModeMultimodal
+	case baseIntent == "flight" || containsAny(lower, "fly ", "flying", "flight", "by air"):
+		return ModeFlight
+	default:
+		// Endpoint shape tie-break: two IATA airports with no ground/multimodal
+		// signal reads as air travel; otherwise default to multimodal so the
+		// caller compares options.
+		if isIATA(origin) && isIATA(destination) {
+			return ModeFlight
+		}
+		return ModeMultimodal
+	}
+}
+
+// buildSearches names the concrete search(es) to dispatch for the plan's mode.
+func buildSearches(p Plan, base Params) []PlannedSearch {
+	switch p.Mode {
+	case ModeHotel:
+		location := base.Location
+		if location == "" {
+			location = p.Destination
+		}
+		params := map[string]any{"location": location}
+		if base.CheckIn != "" {
+			params["check_in"] = base.CheckIn
+		} else if p.Date != "" {
+			params["check_in"] = p.Date
+		}
+		if base.CheckOut != "" {
+			params["check_out"] = base.CheckOut
+		} else if p.ReturnDate != "" {
+			params["check_out"] = p.ReturnDate
+		}
+		addBudget(params, "max_price", p.MaxBudget)
+		return []PlannedSearch{{Tool: "search_hotels", Params: params}}
+
+	case ModeFlight:
+		params := map[string]any{"origin": p.Origin, "destination": p.Destination}
+		if p.Date != "" {
+			params["departure_date"] = p.Date
+		}
+		if p.ReturnDate != "" {
+			params["return_date"] = p.ReturnDate
+		}
+		addBudget(params, "max_price", p.MaxBudget)
+		return []PlannedSearch{{Tool: "search_flights", Params: params}}
+
+	case ModeGround:
+		params := map[string]any{"origin": p.Origin, "destination": p.Destination, "avoid": "flight"}
+		if p.Date != "" {
+			params["date"] = p.Date
+		}
+		addBudget(params, "max_price", p.MaxBudget)
+		return []PlannedSearch{{Tool: "search_route", Params: params}}
+
+	case ModeHacks:
+		params := map[string]any{"origin": p.Origin, "destination": p.Destination}
+		if p.Date != "" {
+			params["date"] = p.Date
+		}
+		if p.ReturnDate != "" {
+			params["return_date"] = p.ReturnDate
+		}
+		return []PlannedSearch{{Tool: "detect_travel_hacks", Params: params}}
+
+	default: // ModeMultimodal — compare a multimodal route and direct flights.
+		routeParams := map[string]any{"origin": p.Origin, "destination": p.Destination}
+		if p.Date != "" {
+			routeParams["date"] = p.Date
+		}
+		addBudget(routeParams, "max_price", p.MaxBudget)
+		flightParams := map[string]any{"origin": p.Origin, "destination": p.Destination}
+		if p.Date != "" {
+			flightParams["departure_date"] = p.Date
+		}
+		if p.ReturnDate != "" {
+			flightParams["return_date"] = p.ReturnDate
+		}
+		addBudget(flightParams, "max_price", p.MaxBudget)
+		return []PlannedSearch{
+			{Tool: "search_route", Params: routeParams},
+			{Tool: "search_flights", Params: flightParams},
+		}
+	}
+}
+
+func addBudget(params map[string]any, key string, budget float64) {
+	if budget > 0 {
+		params[key] = budget
+	}
+}
+
+func containsAny(haystack string, needles ...string) bool {
+	for _, n := range needles {
+		if strings.Contains(haystack, n) {
+			return true
+		}
+	}
+	return false
+}
+
+func isIATA(s string) bool {
+	return len(s) == 3 && iataPattern.MatchString(strings.ToUpper(s))
+}

--- a/internal/nlsearch/plan_test.go
+++ b/internal/nlsearch/plan_test.go
@@ -1,0 +1,251 @@
+package nlsearch
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestBuildPlan_Table exercises a dozen real phrasings asserting correct mode,
+// origin/destination, date(s), and constraints. `today` is fixed at a Saturday
+// (2026-06-20) so relative-date resolution is deterministic.
+func TestBuildPlan_Table(t *testing.T) {
+	const today = "2026-06-20"
+
+	cases := []struct {
+		name            string
+		query           string
+		wantMode        string
+		wantOrigin      string
+		wantDest        string
+		wantDate        string // "" = don't assert exact value
+		wantDateNonZero bool   // assert a date was resolved (when exact value is relative)
+		wantReturn      bool   // assert ReturnDate non-empty
+		wantConstraints []string
+		wantBudget      float64
+	}{
+		{
+			name:            "tromso cheapest multimodal avoiding redeye",
+			query:           "cheapest way to Tromso next month avoiding red-eyes",
+			wantMode:        ModeMultimodal,
+			wantOrigin:      "",
+			wantDest:        "TOS",
+			wantDateNonZero: true,
+			wantConstraints: []string{ConstraintCheapest, ConstraintNoRedeye},
+		},
+		{
+			name:            "round trip HEL NRT next week",
+			query:           "HEL to NRT and back next week",
+			wantMode:        ModeFlight,
+			wantOrigin:      "HEL",
+			wantDest:        "NRT",
+			wantDateNonZero: true,
+			wantReturn:      true,
+			wantConstraints: []string{},
+		},
+		{
+			name:            "explicit flight from to with iso date",
+			query:           "cheapest flight from Helsinki to Prague on 2026-05-07",
+			wantMode:        ModeFlight,
+			wantOrigin:      "HEL",
+			wantDest:        "PRG",
+			wantDate:        "2026-05-07",
+			wantConstraints: []string{ConstraintCheapest},
+		},
+		{
+			name:            "nonstop direct flight",
+			query:           "nonstop flight from HEL to LHR next week",
+			wantMode:        ModeFlight,
+			wantOrigin:      "HEL",
+			wantDest:        "LHR",
+			wantDateNonZero: true,
+			wantConstraints: []string{ConstraintNonstop},
+		},
+		{
+			name:            "train ground mode",
+			query:           "train from Amsterdam to Berlin next week",
+			wantMode:        ModeGround,
+			wantOrigin:      "AMS",
+			wantDest:        "BER",
+			wantDateNonZero: true,
+			wantConstraints: []string{},
+		},
+		{
+			name:            "ferry ground mode",
+			query:           "ferry from Helsinki to Tallinn next week",
+			wantMode:        ModeGround,
+			wantOrigin:      "HEL",
+			wantDest:        "TLL",
+			wantDateNonZero: true,
+			wantConstraints: []string{},
+		},
+		{
+			name:            "hotel with budget",
+			query:           "hotel in Prague for 3 nights under EUR 120",
+			wantMode:        ModeHotel,
+			wantDest:        "PRG",
+			wantConstraints: []string{"budget<=120"},
+			wantBudget:      120,
+		},
+		{
+			name:            "multimodal best way phrasing",
+			query:           "best way from Helsinki to Barcelona next month",
+			wantMode:        ModeMultimodal,
+			wantOrigin:      "HEL",
+			wantDest:        "BCN",
+			wantDateNonZero: true,
+			wantConstraints: []string{},
+		},
+		{
+			name:            "fastest constraint",
+			query:           "fastest flight from HEL to CDG next week",
+			wantMode:        ModeFlight,
+			wantOrigin:      "HEL",
+			wantDest:        "CDG",
+			wantDateNonZero: true,
+			wantConstraints: []string{ConstraintFastest},
+		},
+		{
+			name:            "hacks mode hidden city",
+			query:           "find hidden city tricks from HEL to NRT next week",
+			wantMode:        ModeHacks,
+			wantOrigin:      "HEL",
+			wantDest:        "NRT",
+			wantDateNonZero: true,
+			wantConstraints: []string{},
+		},
+		{
+			name:            "budget with currency only and cheapest",
+			query:           "cheapest flight from HEL to BCN under 300 next week",
+			wantMode:        ModeFlight,
+			wantOrigin:      "HEL",
+			wantDest:        "BCN",
+			wantDateNonZero: true,
+			wantConstraints: []string{ConstraintCheapest, "budget<=300"},
+			wantBudget:      300,
+		},
+		{
+			name:            "overnight avoidance maps to no-redeye",
+			query:           "flight from HEL to JFK next week, no overnight layovers",
+			wantMode:        ModeFlight,
+			wantOrigin:      "HEL",
+			wantDest:        "JFK",
+			wantDateNonZero: true,
+			wantConstraints: []string{ConstraintNoRedeye},
+		},
+		{
+			name:            "default endpoints to flight",
+			query:           "HEL to BCN on 2026-07-01",
+			wantMode:        ModeFlight,
+			wantOrigin:      "HEL",
+			wantDest:        "BCN",
+			wantDate:        "2026-07-01",
+			wantConstraints: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := BuildPlan(tc.query, today)
+			if p.Mode != tc.wantMode {
+				t.Errorf("Mode = %q, want %q", p.Mode, tc.wantMode)
+			}
+			if p.Origin != tc.wantOrigin {
+				t.Errorf("Origin = %q, want %q", p.Origin, tc.wantOrigin)
+			}
+			if p.Destination != tc.wantDest {
+				t.Errorf("Destination = %q, want %q", p.Destination, tc.wantDest)
+			}
+			if tc.wantDate != "" && p.Date != tc.wantDate {
+				t.Errorf("Date = %q, want %q", p.Date, tc.wantDate)
+			}
+			if tc.wantDateNonZero && p.Date == "" {
+				t.Errorf("Date should be resolved, got empty")
+			}
+			if tc.wantReturn && p.ReturnDate == "" {
+				t.Errorf("ReturnDate should be set for round-trip, got empty")
+			}
+			if tc.wantBudget != 0 && p.MaxBudget != tc.wantBudget {
+				t.Errorf("MaxBudget = %v, want %v", p.MaxBudget, tc.wantBudget)
+			}
+			if !slices.Equal(p.Constraints, tc.wantConstraints) {
+				t.Errorf("Constraints = %v, want %v", p.Constraints, tc.wantConstraints)
+			}
+			if len(p.Searches) == 0 {
+				t.Errorf("Searches should never be empty")
+			}
+		})
+	}
+}
+
+// TestBuildPlan_TromsoFlagship locks the headline acceptance case end-to-end,
+// including the dispatched search shape.
+func TestBuildPlan_TromsoFlagship(t *testing.T) {
+	p := BuildPlan("cheapest way to Tromso next month avoiding red-eyes", "2026-06-20")
+	if p.Mode != ModeMultimodal {
+		t.Fatalf("Mode = %q, want multimodal", p.Mode)
+	}
+	if p.Destination != "TOS" {
+		t.Fatalf("Destination = %q, want TOS", p.Destination)
+	}
+	if p.Date == "" {
+		t.Fatal("Date should be resolved from 'next month'")
+	}
+	if !slices.Contains(p.Constraints, ConstraintCheapest) || !slices.Contains(p.Constraints, ConstraintNoRedeye) {
+		t.Fatalf("Constraints = %v, want cheapest + no-redeye", p.Constraints)
+	}
+	// Multimodal plans dispatch both a route and a flight comparison.
+	if len(p.Searches) != 2 {
+		t.Fatalf("Searches = %d, want 2 (route + flight)", len(p.Searches))
+	}
+	tools := []string{p.Searches[0].Tool, p.Searches[1].Tool}
+	if !slices.Contains(tools, "search_route") || !slices.Contains(tools, "search_flights") {
+		t.Fatalf("Searches tools = %v, want search_route + search_flights", tools)
+	}
+}
+
+// TestBuildPlan_RoundTripReturnDate verifies that round-trip phrasing without an
+// explicit return date still produces a return leg one week out.
+func TestBuildPlan_RoundTripReturnDate(t *testing.T) {
+	p := BuildPlan("HEL to NRT and back next week", "2026-06-20")
+	if !p.RoundTrip {
+		t.Fatal("RoundTrip should be true for 'and back'")
+	}
+	if p.ReturnDate == "" {
+		t.Fatal("ReturnDate should be derived for round-trip")
+	}
+	if p.Date == "" || p.ReturnDate <= p.Date {
+		t.Fatalf("ReturnDate (%q) should be after Date (%q)", p.ReturnDate, p.Date)
+	}
+}
+
+// TestBuildPlan_BudgetParsing covers the budget extraction variants.
+func TestBuildPlan_BudgetParsing(t *testing.T) {
+	cases := []struct {
+		query string
+		want  float64
+	}{
+		{"flight HEL BCN under EUR 500 next week", 500},
+		{"flight HEL BCN budget of 1,200 next week", 1200},
+		{"flight HEL BCN max 300 next week", 300},
+		{"flight HEL BCN below $250 next week", 250},
+		{"flight HEL BCN next week", 0},
+	}
+	for _, tc := range cases {
+		p := BuildPlan(tc.query, "2026-06-20")
+		if p.MaxBudget != tc.want {
+			t.Errorf("query %q: MaxBudget = %v, want %v", tc.query, p.MaxBudget, tc.want)
+		}
+	}
+}
+
+// TestBuildPlan_NeverErrorsOnGarbage ensures a nonsense query yields a usable
+// best-effort plan rather than panicking.
+func TestBuildPlan_NeverErrorsOnGarbage(t *testing.T) {
+	p := BuildPlan("asdf qwerty zzz", "2026-06-20")
+	if p.Mode == "" {
+		t.Fatal("Mode should always be set")
+	}
+	if p.Constraints == nil || p.Searches == nil {
+		t.Fatal("Constraints and Searches should be non-nil slices")
+	}
+}

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -98,6 +98,13 @@ func registerTools(s *Server) {
 	// not a legacy compatibility alias — registered as a handler but kept out of
 	// the advertised legacyTools surface (see registeredMCPCompatibilityAliasCount).
 	s.handlers["plan_journey"] = s.wrapHandler("plan_journey", handleJourney)
+	// plan_natural (innovation #7 NL supertool) is a smart capability reachable
+	// via the travel router intent and by direct tools/call. Its schema lives in
+	// toolDefs for discoverability/validation but it is deliberately kept out of
+	// the advertised legacyTools surface so the compatibility-alias count is
+	// unchanged.
+	s.toolDefs[nlSupertoolName] = nlSupertoolTool()
+	s.handlers[nlSupertoolName] = s.wrapHandler(nlSupertoolName, handleNLSupertool)
 	s.handlers["search_flights"] = s.wrapHandler("search_flights", handleSearchFlights)
 	s.handlers["plan_flight_bundle"] = s.wrapHandler("plan_flight_bundle", handlePlanFlightBundle)
 	s.handlers["find_interactive"] = s.wrapHandler("find_interactive", handleFindInteractive)

--- a/mcp/tools_nl_supertool.go
+++ b/mcp/tools_nl_supertool.go
@@ -1,0 +1,132 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/nlsearch"
+)
+
+// nlSupertoolName is the registered tool / intent name for the natural-language
+// travel planner ("supertool", innovation #7).
+const nlSupertoolName = "plan_natural"
+
+// nlSupertoolTool returns the MCP tool definition for the natural-language
+// travel planner. Unlike search_natural (which parses then immediately
+// dispatches a single search), this tool returns a normalized, inspectable Plan
+// — travel mode, endpoints, dates, constraints, and the exact search(es) to run
+// with which parameters — so a caller can review the routing decision, confirm,
+// or dispatch the named searches itself. Parsing is deterministic and
+// rule-based (no LLM dependency at runtime).
+func nlSupertoolTool() ToolDef {
+	return ToolDef{
+		Name:  nlSupertoolName,
+		Title: "Natural Language Travel Planner",
+		Description: "Turn one free-form travel request into a structured routing plan. " +
+			"Parses a plain-language query (e.g. \"cheapest way to Tromso next month avoiding " +
+			"red-eyes\", \"HEL to NRT and back next week\", \"train from Amsterdam to Berlin\", " +
+			"\"hotel in Prague under EUR 120\") into a normalized Plan: travel mode " +
+			"(flight, ground, hotel, multimodal, hacks), origin, destination, departure and return " +
+			"dates, constraints (no-redeye, cheapest, fastest, nonstop, budget<=X), and the exact " +
+			"search tool(s) to dispatch with their parameters. Deterministic, no API keys, works on " +
+			"every MCP client. Use this to decide WHICH search to run; then call the named tool " +
+			"(search_flights, search_route, search_hotels, detect_travel_hacks) — or call search_natural " +
+			"to parse-and-dispatch in one step.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"query": {
+					Type:        "string",
+					Description: "Natural language travel request",
+				},
+			},
+			Required: []string{"query"},
+		},
+		OutputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"query":       schemaString(),
+				"mode":        schemaStringDesc("flight | ground | hotel | multimodal | hacks"),
+				"origin":      schemaString(),
+				"destination": schemaString(),
+				"date":        schemaString(),
+				"return_date": schemaString(),
+				"round_trip":  map[string]interface{}{"type": "boolean"},
+				"max_budget":  map[string]interface{}{"type": "number"},
+				"constraints": schemaStringArrayDesc("e.g. no-redeye, cheapest, fastest, nonstop, budget<=500"),
+				"notes":       schemaStringArray(),
+				"searches": schemaArrayDesc("Search tool(s) to dispatch with their parameters", map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"tool":   schemaString(),
+						"params": schemaObject(),
+					},
+				}),
+			},
+			"required": []string{"query", "mode", "constraints", "searches"},
+		},
+		Annotations: &ToolAnnotations{
+			Title:          "Natural Language Travel Planner",
+			ReadOnlyHint:   true,
+			OpenWorldHint:  false,
+			IdempotentHint: true,
+		},
+	}
+}
+
+// handleNLSupertool handles the plan_natural tool: parse a free-form query into
+// a structured Plan and return it (it does NOT dispatch the searches itself).
+func handleNLSupertool(ctx context.Context, args map[string]any, elicit ElicitFunc, sampling SamplingFunc, progress ProgressFunc) ([]ContentBlock, interface{}, error) {
+	query := strings.TrimSpace(argString(args, "query"))
+	if query == "" {
+		return nil, nil, fmt.Errorf("query is required")
+	}
+
+	sendProgress(progress, 0, 100, "Parsing travel query...")
+	today := time.Now().Format("2006-01-02")
+	plan := nlsearch.BuildPlan(query, today)
+	sendProgress(progress, 100, 100, "Plan ready")
+
+	return []ContentBlock{{Type: "text", Text: buildPlanSummary(plan)}}, plan, nil
+}
+
+// buildPlanSummary renders a compact human-readable summary of the Plan.
+func buildPlanSummary(p nlsearch.Plan) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Travel plan for %q\n", p.Query)
+	fmt.Fprintf(&b, "Mode: %s\n", p.Mode)
+	if p.Origin != "" {
+		fmt.Fprintf(&b, "From: %s\n", p.Origin)
+	} else {
+		b.WriteString("From: (unspecified — supply your home origin)\n")
+	}
+	if p.Destination != "" {
+		fmt.Fprintf(&b, "To: %s\n", p.Destination)
+	} else {
+		b.WriteString("To: (unspecified)\n")
+	}
+	if p.Date != "" {
+		fmt.Fprintf(&b, "Depart: %s\n", p.Date)
+	}
+	if p.ReturnDate != "" {
+		fmt.Fprintf(&b, "Return: %s (round trip)\n", p.ReturnDate)
+	}
+	if p.MaxBudget > 0 {
+		fmt.Fprintf(&b, "Budget ceiling: %g\n", p.MaxBudget)
+	}
+	if len(p.Constraints) > 0 {
+		fmt.Fprintf(&b, "Constraints: %s\n", strings.Join(p.Constraints, ", "))
+	}
+	if len(p.Searches) > 0 {
+		b.WriteString("Dispatch:\n")
+		for _, s := range p.Searches {
+			fmt.Fprintf(&b, "  - %s\n", s.Tool)
+		}
+	}
+	for _, n := range p.Notes {
+		fmt.Fprintf(&b, "Note: %s\n", n)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}


### PR DESCRIPTION
## Innovation #7 — NL travel supertool

One free-text travel request becomes a normalized, inspectable routing **Plan**: travel mode, endpoints, dates, constraints, and the exact search(es) to dispatch with which parameters. Deterministic and rule-based, no LLM dependency at runtime.

### What it does
`BuildPlan(query, today)` reuses the existing `Heuristic` parser for base intent, endpoint, and date extraction, then layers:

- **Mode inference** to flight, ground, hotel, multimodal, or hacks
  - train, bus, ferry, rail map to ground
  - "cheapest way", "best way", "any way", "how to get", "way to" map to multimodal
  - hidden-city, error-fare, trick map to hacks
  - two airports with no other signal map to flight
- **Constraints**: cheapest, fastest, nonstop, no-redeye, budget cap
  - red-eye always maps to no-redeye; "overnight" only with an avoidance verb so "overnight train" is not misclassified
- **Destination-only extraction** ("way to Tromso", "hotel in Prague") gated on airport resolution so time words ("in May") are rejected
- **Relative dates** ("next week", "next month") plus round-trip inference ("and back" adds a return leg)
- **Search list** naming the concrete tool and params; the planner returns the routing decision, the caller dispatches (no import coupling into search packages)

### Surface
New `plan_natural` MCP tool returns the Plan without dispatching. Registered as a non-alias smart capability reachable via the `travel` router intent and direct calls, mirroring the `plan_journey` precedent, so the advertised compatibility-alias count is unchanged.

### Tests (TDD)
Table-driven over a dozen real phrasings asserting mode, endpoints, dates, and constraints, including flagship `cheapest way to Tromso next month avoiding red-eyes` and round-trip `HEL to NRT and back next week`, plus budget parsing and garbage-input safety.

### Verification
`go vet`, `staticcheck`, `gofmt` clean, race tests on the new package, full short suite green off latest origin/main.

### Notes for reviewer
Touches `internal/nlsearch` (extended), one new `mcp/tools_nl_supertool.go`, minimal registration in `mcp/tools.go`, and a one-line non-alias classification in `cmd/trvl/public_claims_test.go` to keep the marketed alias count stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZv5teR4PhKropF495LBpW
