### PR TITLE
feat(arbreport): unified arbitrage report (innovation #8)

### DIFF
--- a/cmd/trvl/arbitrage_report.go
+++ b/cmd/trvl/arbitrage_report.go
@@ -1,0 +1,161 @@
+package main
+
+// Innovation #8: trvl arbitrage-report — unified arbitrage lens.
+//
+// Aggregates trvl's independent arbitrage engines (currency, cabin-class,
+// hotel rate/points) into one ranked report for a trip context. Engines that
+// lack the inputs they need for the given context are skipped gracefully and
+// listed, never fabricated.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/arbreport"
+	"github.com/MikkoParkkola/trvl/internal/hotelarb"
+	"github.com/spf13/cobra"
+)
+
+func arbitrageReportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "arbitrage-report <origin> <destination> <depart-date>",
+		Short: "Unified arbitrage report across currency, cabin, and hotel engines",
+		Long: `arbitrage-report runs trvl's arbitrage engines for one trip context and
+prints a single ranked table of opportunities, each with type, description,
+estimated saving, currency, and confidence.
+
+Engines:
+  currency  airline currency arbitrage (live flight lookup; needs depart date)
+  cabin     near-flat cabin-class upgrades (needs a fare ladder via --cabin)
+  hotel     hotel rate re-book savings (needs holds via --rebook)
+
+Engines without the inputs they need for this trip are skipped and listed,
+never guessed.
+
+Cabin fares (repeatable): --cabin cabin:price[:carrier]
+  valid cabins: economy, premium_economy, business, first
+Hotel re-book candidates (repeatable): --rebook name:original:current[:currency]
+
+Examples:
+  trvl arbitrage-report HEL LHR 2026-08-01
+  trvl arbitrage-report HEL BUD 2026-08-01 --cabin economy:500 --cabin premium_economy:540
+  trvl arbitrage-report HEL LHR 2026-08-01 --rebook "Grand:300:240:EUR" --format json`,
+		Args: cobra.ExactArgs(3),
+		RunE: runArbitrageReport,
+	}
+	cmd.Flags().StringArray("cabin", nil, "cabin fare as cabin:price[:carrier] (repeatable)")
+	cmd.Flags().StringArray("rebook", nil, "hotel re-book candidate as name:original:current[:currency] (repeatable)")
+	cmd.Flags().String("currency", "", "trip currency (default EUR)")
+	cmd.Flags().Int("travelers", 1, "number of travelers")
+	return cmd
+}
+
+func runArbitrageReport(cmd *cobra.Command, args []string) error {
+	origin := strings.ToUpper(strings.TrimSpace(args[0]))
+	destination := strings.ToUpper(strings.TrimSpace(args[1]))
+	departDate := strings.TrimSpace(args[2])
+
+	cabinArgs, _ := cmd.Flags().GetStringArray("cabin")
+	rebookArgs, _ := cmd.Flags().GetStringArray("rebook")
+	currency, _ := cmd.Flags().GetString("currency")
+	travelers, _ := cmd.Flags().GetInt("travelers")
+
+	fares, err := parseCabinFares(cabinArgs)
+	if err != nil {
+		return fmt.Errorf("arbitrage-report: %w", err)
+	}
+	rebooks, err := parseRebookCandidates(rebookArgs)
+	if err != nil {
+		return fmt.Errorf("arbitrage-report: %w", err)
+	}
+
+	params := arbreport.Params{
+		Origin:       origin,
+		Destination:  destination,
+		DepartDate:   departDate,
+		Currency:     currency,
+		Travelers:    travelers,
+		CabinFares:   fares,
+		HotelRebooks: rebooks,
+	}
+
+	report := arbreport.Aggregate(context.Background(), params)
+
+	if format == "json" {
+		return json.NewEncoder(os.Stdout).Encode(report)
+	}
+	renderArbReportTableTo(os.Stdout, report)
+	return nil
+}
+
+// parseRebookCandidates parses name:original:current[:currency] tuples.
+func parseRebookCandidates(args []string) ([]arbreport.HotelRebook, error) {
+	out := make([]arbreport.HotelRebook, 0, len(args))
+	for _, arg := range args {
+		parts := strings.SplitN(arg, ":", 4)
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("invalid rebook %q: expected name:original:current[:currency]", arg)
+		}
+		name := strings.TrimSpace(parts[0])
+		if name == "" {
+			return nil, fmt.Errorf("invalid rebook %q: hotel name must not be empty", arg)
+		}
+		original, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid rebook %q: original price must be a number: %w", arg, err)
+		}
+		current, err := strconv.ParseFloat(strings.TrimSpace(parts[2]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid rebook %q: current price must be a number: %w", arg, err)
+		}
+		cur := "EUR"
+		if len(parts) == 4 && strings.TrimSpace(parts[3]) != "" {
+			cur = strings.ToUpper(strings.TrimSpace(parts[3]))
+		}
+		out = append(out, arbreport.HotelRebook{
+			Hold: hotelarb.Hold{
+				HotelName:     name,
+				OriginalPrice: original,
+				Currency:      cur,
+				Refundable:    true,
+			},
+			Quote: hotelarb.PriceQuote{Price: current, Currency: cur},
+		})
+	}
+	return out, nil
+}
+
+func renderArbReportTableTo(out io.Writer, report arbreport.ArbReport) {
+	_, _ = fmt.Fprintf(out, "Unified arbitrage report — %s→%s on %s (%s)\n",
+		report.Origin, report.Destination, report.DepartDate, report.Currency)
+	if report.Count == 0 {
+		_, _ = fmt.Fprintln(out, "\nNo arbitrage opportunities found for this trip context.")
+	} else {
+		_, _ = fmt.Fprintf(out, "\n%d opportunit%s (ranked by estimated saving):\n", report.Count, plural(report.Count))
+		_, _ = fmt.Fprintf(out, "  %-9s %-16s %10s %-9s  %s\n", "Engine", "Type", "Saving", "Confidence", "Description")
+		_, _ = fmt.Fprintf(out, "  %s\n", strings.Repeat("-", 90))
+		for _, o := range report.Opportunities {
+			saving := fmt.Sprintf("%.2f %s", o.EstimatedSaving, o.Currency)
+			_, _ = fmt.Fprintf(out, "  %-9s %-16s %10s %-9s  %s\n",
+				o.Engine, o.Type, saving, o.Confidence, o.Description)
+		}
+	}
+	if len(report.Skipped) > 0 {
+		_, _ = fmt.Fprintf(out, "\nSkipped engines:\n")
+		for _, s := range report.Skipped {
+			_, _ = fmt.Fprintf(out, "  %-9s %s\n", s.Engine, s.Reason)
+		}
+	}
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}

--- a/cmd/trvl/arbitrage_report_test.go
+++ b/cmd/trvl/arbitrage_report_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/arbreport"
+)
+
+func TestParseRebookCandidates(t *testing.T) {
+	rb, err := parseRebookCandidates([]string{"Grand:300:240:EUR", "Plaza:200:180"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rb) != 2 {
+		t.Fatalf("expected 2 rebooks, got %d", len(rb))
+	}
+	if rb[0].Hold.HotelName != "Grand" || rb[0].Quote.Price != 240 || rb[0].Hold.Currency != "EUR" {
+		t.Errorf("first rebook parsed wrong: %+v", rb[0])
+	}
+	if rb[1].Hold.Currency != "EUR" {
+		t.Errorf("default currency should be EUR, got %q", rb[1].Hold.Currency)
+	}
+	if !rb[0].Hold.Refundable {
+		t.Error("rebook holds should default to refundable so savings can surface")
+	}
+}
+
+func TestParseRebookCandidates_Errors(t *testing.T) {
+	cases := []string{"Grand:300", ":300:240", "Grand:x:240", "Grand:300:y"}
+	for _, c := range cases {
+		if _, err := parseRebookCandidates([]string{c}); err == nil {
+			t.Errorf("expected error for %q", c)
+		}
+	}
+}
+
+func TestRenderArbReportTable(t *testing.T) {
+	report := arbreport.ArbReport{
+		Origin:      "HEL",
+		Destination: "LHR",
+		DepartDate:  "2026-08-01",
+		Currency:    "EUR",
+		Opportunities: []arbreport.Opportunity{
+			{Engine: "hotel", Type: "hotel_rebook", Description: "rebook lower", EstimatedSaving: 60, Currency: "EUR", Confidence: "high"},
+		},
+		Skipped: []arbreport.SkippedEngine{
+			{Engine: "currency", Reason: "N/A: no currency arbitrage on this route"},
+		},
+		Count: 1,
+	}
+	var buf bytes.Buffer
+	renderArbReportTableTo(&buf, report)
+	out := buf.String()
+	if !strings.Contains(out, "hotel_rebook") {
+		t.Errorf("table missing opportunity row:\n%s", out)
+	}
+	if !strings.Contains(out, "Skipped engines") || !strings.Contains(out, "currency") {
+		t.Errorf("table missing skipped section:\n%s", out)
+	}
+}
+
+func TestRenderArbReportTable_Empty(t *testing.T) {
+	report := arbreport.ArbReport{
+		Origin: "HEL", Destination: "LHR", DepartDate: "2026-08-01", Currency: "EUR",
+		Opportunities: []arbreport.Opportunity{},
+		Skipped:       []arbreport.SkippedEngine{{Engine: "cabin", Reason: "N/A: no cabin fare ladder supplied for this trip"}},
+	}
+	var buf bytes.Buffer
+	renderArbReportTableTo(&buf, report)
+	if !strings.Contains(buf.String(), "No arbitrage opportunities") {
+		t.Errorf("empty report should state none found:\n%s", buf.String())
+	}
+}
+
+func TestArbitrageReportCmd_Wired(t *testing.T) {
+	cmd := arbitrageReportCmd()
+	if cmd.Use == "" || !strings.HasPrefix(cmd.Use, "arbitrage-report") {
+		t.Errorf("unexpected command use: %q", cmd.Use)
+	}
+	if cmd.RunE == nil {
+		t.Error("command missing RunE")
+	}
+}

--- a/cmd/trvl/commands_test.go
+++ b/cmd/trvl/commands_test.go
@@ -17,7 +17,8 @@ func TestRootCmd_SubcommandCount(t *testing.T) {
 	// 58 -> 61 with `air`, `sun`, `bikes` (free unauthenticated enrichment sources).
 	// 61 -> 62 with `pricetrends` (opt-in Travelpayouts price-signal source).
 	// 64 -> 65 when rental car search (`trvl cars`) landed.
-	const want = 65
+	// 65 -> 66 with `arbitrage-report` (innovation #8 unified arbitrage report).
+	const want = 66
 	got := len(rootCmd.Commands())
 	if got != want {
 		names := make([]string, 0, got)

--- a/cmd/trvl/public_claims_test.go
+++ b/cmd/trvl/public_claims_test.go
@@ -139,9 +139,10 @@ func registeredMCPCompatibilityAliasCount(t *testing.T) int {
 	// router intent but are NOT legacy compatibility aliases, so they must not
 	// inflate the marketed "compatibility aliases" count.
 	nonAliasCapabilities := map[string]bool{
-		"travel":       true, // the smart router itself
-		"plan_journey": true, // Leave-By Scheduler capability (MIK-5734 B)
-		"plan_natural": true, // NL travel-planner supertool (innovation #7)
+		"travel":           true, // the smart router itself
+		"plan_journey":     true, // Leave-By Scheduler capability (MIK-5734 B)
+		"plan_natural":     true, // NL travel-planner supertool (innovation #7)
+		"arbitrage_report": true, // unified arbitrage aggregator (innovation #8) — new capability, not a legacy alias
 	}
 	count := 0
 	for _, key := range handlers.MapKeys() {

--- a/cmd/trvl/root.go
+++ b/cmd/trvl/root.go
@@ -104,6 +104,7 @@ func init() {
 	rootCmd.AddCommand(opportunitiesCmd())
 	rootCmd.AddCommand(awardsCmd())
 	rootCmd.AddCommand(cabinArbCmd())
+	rootCmd.AddCommand(arbitrageReportCmd())
 	rootCmd.AddCommand(multidestCmd())
 	rootCmd.AddCommand(losCmd())
 	rootCmd.AddCommand(railPassCmd())

--- a/internal/arbreport/arbreport.go
+++ b/internal/arbreport/arbreport.go
@@ -1,0 +1,312 @@
+// Package arbreport aggregates trvl's independent arbitrage engines —
+// hotel rate arbitrage (internal/hotelarb), cabin-class arbitrage
+// (internal/cabinarb), and airline currency arbitrage (internal/hacks) —
+// into a single ranked report for a trip context.
+//
+// It is a thin aggregator: it never reimplements engine logic. Each engine
+// is invoked through its existing public API via a swappable seam (Engines),
+// which keeps the real wiring in DefaultEngines and lets tests inject
+// deterministic fakes. When an engine lacks the inputs it needs for a given
+// trip, the aggregator skips it gracefully with an "N/A: <reason>" note and
+// never fabricates an opportunity.
+package arbreport
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/cabinarb"
+	"github.com/MikkoParkkola/trvl/internal/hacks"
+	"github.com/MikkoParkkola/trvl/internal/hotelarb"
+)
+
+// Confidence levels surfaced on each opportunity.
+const (
+	ConfidenceHigh   = "high"
+	ConfidenceMedium = "medium"
+	ConfidenceLow    = "low"
+)
+
+// HotelRebook bundles an existing hold with a fresh quote so the hotel engine
+// can evaluate a lower-price re-book opportunity.
+type HotelRebook struct {
+	Hold  hotelarb.Hold
+	Quote hotelarb.PriceQuote
+	Opts  hotelarb.RebookOptions
+}
+
+// Params is the trip context plus any engine-specific inputs the caller can
+// supply. Engine-specific fields are optional: when absent, that engine is
+// skipped gracefully rather than guessed.
+type Params struct {
+	Origin      string
+	Destination string
+	DepartDate  string // YYYY-MM-DD
+	ReturnDate  string // optional
+	Currency    string // defaults to EUR
+	Travelers   int
+
+	// Optional engine inputs.
+	CabinFares   []cabinarb.CabinFare            // cabin-class fare ladder
+	HotelRebooks []HotelRebook                   // active holds + fresh quotes
+	HotelPoints  []hotelarb.PointsArbitrageInput // cash-vs-points comparisons
+}
+
+// Opportunity is one ranked arbitrage finding in the unified report.
+type Opportunity struct {
+	Engine          string  `json:"engine"`
+	Type            string  `json:"type"`
+	Description     string  `json:"description"`
+	EstimatedSaving float64 `json:"estimated_saving"`
+	Currency        string  `json:"currency"`
+	Confidence      string  `json:"confidence"`
+}
+
+// SkippedEngine records an engine that produced no opportunity and why.
+type SkippedEngine struct {
+	Engine string `json:"engine"`
+	Reason string `json:"reason"`
+}
+
+// ArbReport is the unified, ranked arbitrage report.
+type ArbReport struct {
+	Origin        string          `json:"origin"`
+	Destination   string          `json:"destination"`
+	DepartDate    string          `json:"depart_date"`
+	ReturnDate    string          `json:"return_date,omitempty"`
+	Currency      string          `json:"currency"`
+	Travelers     int             `json:"travelers"`
+	Opportunities []Opportunity   `json:"opportunities"`
+	Skipped       []SkippedEngine `json:"skipped"`
+	Count         int             `json:"count"`
+}
+
+// EngineFunc adapts one underlying engine to the aggregator. It returns the
+// opportunities found, or a non-empty skip reason when the engine could not
+// run (missing inputs, no findings). When skip is non-empty the opportunities
+// slice is ignored.
+type EngineFunc func(ctx context.Context, p Params) (opps []Opportunity, skip string)
+
+// Engines is the swappable set of engine seams the aggregator drives. Tests
+// inject fakes here; DefaultEngines wires the real packages.
+type Engines struct {
+	Currency EngineFunc
+	Cabin    EngineFunc
+	Hotel    EngineFunc
+}
+
+type namedEngine struct {
+	name string
+	fn   EngineFunc
+}
+
+// ordered returns the engines in a deterministic invocation order.
+func (e Engines) ordered() []namedEngine {
+	return []namedEngine{
+		{"currency", e.Currency},
+		{"cabin", e.Cabin},
+		{"hotel", e.Hotel},
+	}
+}
+
+// DefaultEngines returns the production seams wired to the real engines.
+func DefaultEngines() Engines {
+	return Engines{
+		Currency: defaultCurrencyEngine,
+		Cabin:    defaultCabinEngine,
+		Hotel:    defaultHotelEngine,
+	}
+}
+
+// Aggregate runs every default engine for the trip context and returns one
+// ranked report.
+func Aggregate(ctx context.Context, p Params) ArbReport {
+	return AggregateWithEngines(ctx, p, DefaultEngines())
+}
+
+// AggregateWithEngines is Aggregate with caller-supplied engine seams. It is
+// the testable core: it never reaches the network itself, it only drives the
+// seams it is handed.
+func AggregateWithEngines(ctx context.Context, p Params, eng Engines) ArbReport {
+	report := ArbReport{
+		Origin:        p.Origin,
+		Destination:   p.Destination,
+		DepartDate:    p.DepartDate,
+		ReturnDate:    p.ReturnDate,
+		Currency:      currencyOrDefault(p.Currency),
+		Travelers:     p.Travelers,
+		Opportunities: []Opportunity{},
+		Skipped:       []SkippedEngine{},
+	}
+
+	for _, ne := range eng.ordered() {
+		if ne.fn == nil {
+			report.Skipped = append(report.Skipped, SkippedEngine{
+				Engine: ne.name,
+				Reason: "N/A: engine not configured",
+			})
+			continue
+		}
+		opps, skip := ne.fn(ctx, p)
+		if strings.TrimSpace(skip) != "" {
+			report.Skipped = append(report.Skipped, SkippedEngine{Engine: ne.name, Reason: skip})
+			continue
+		}
+		if len(opps) == 0 {
+			report.Skipped = append(report.Skipped, SkippedEngine{
+				Engine: ne.name,
+				Reason: "N/A: no opportunities found",
+			})
+			continue
+		}
+		for _, o := range opps {
+			if o.Engine == "" {
+				o.Engine = ne.name
+			}
+			if o.Currency == "" {
+				o.Currency = report.Currency
+			}
+			report.Opportunities = append(report.Opportunities, o)
+		}
+	}
+
+	// Rank by estimated saving, descending. Deterministic tie-break by engine
+	// then type so the output is stable across runs.
+	sort.SliceStable(report.Opportunities, func(i, j int) bool {
+		a, b := report.Opportunities[i], report.Opportunities[j]
+		if a.EstimatedSaving != b.EstimatedSaving {
+			return a.EstimatedSaving > b.EstimatedSaving
+		}
+		if a.Engine != b.Engine {
+			return a.Engine < b.Engine
+		}
+		return a.Type < b.Type
+	})
+	report.Count = len(report.Opportunities)
+	return report
+}
+
+// --- default engine adapters (reuse existing public APIs only) ---
+
+func defaultCurrencyEngine(ctx context.Context, p Params) ([]Opportunity, string) {
+	if p.Origin == "" || p.Destination == "" {
+		return nil, "N/A: origin and destination required for currency arbitrage"
+	}
+	if p.DepartDate == "" {
+		return nil, "N/A: departure date required for currency arbitrage"
+	}
+	found := hacks.DetectCurrencyArbitrage(ctx, hacks.DetectorInput{
+		Origin:      p.Origin,
+		Destination: p.Destination,
+		Date:        p.DepartDate,
+		ReturnDate:  p.ReturnDate,
+		Currency:    p.Currency,
+		Passengers:  p.Travelers,
+	})
+	if len(found) == 0 {
+		return nil, "N/A: no currency arbitrage on this route"
+	}
+	out := make([]Opportunity, 0, len(found))
+	for _, h := range found {
+		out = append(out, Opportunity{
+			Engine:          "currency",
+			Type:            h.Type,
+			Description:     h.Title,
+			EstimatedSaving: h.Savings,
+			Currency:        h.Currency,
+			Confidence:      ConfidenceMedium,
+		})
+	}
+	return out, ""
+}
+
+func defaultCabinEngine(_ context.Context, p Params) ([]Opportunity, string) {
+	if len(p.CabinFares) == 0 {
+		return nil, "N/A: no cabin fare ladder supplied for this trip"
+	}
+	recs := cabinarb.Detect(p.CabinFares)
+	if len(recs) == 0 {
+		return nil, "N/A: no near-flat cabin upgrades within threshold"
+	}
+	cur := fareCurrency(p)
+	out := make([]Opportunity, 0, len(recs))
+	for _, r := range recs {
+		// A cabin upgrade is a cash saving only when the higher cabin is
+		// priced at or below the baseline; otherwise the upsell is a value
+		// trade, not a saving, so we report it honestly with zero saving.
+		saving := r.BaselinePrice - r.TargetPrice
+		if saving < 0 {
+			saving = 0
+		}
+		out = append(out, Opportunity{
+			Engine:          "cabin",
+			Type:            "cabin_upgrade",
+			Description:     fmt.Sprintf("%s → %s: %s", r.Baseline, r.Target, r.Reason),
+			EstimatedSaving: saving,
+			Currency:        cur,
+			Confidence:      ConfidenceHigh,
+		})
+	}
+	return out, ""
+}
+
+func defaultHotelEngine(_ context.Context, p Params) ([]Opportunity, string) {
+	if len(p.HotelRebooks) == 0 && len(p.HotelPoints) == 0 {
+		return nil, "N/A: no active hotel holds or points offers supplied"
+	}
+	var out []Opportunity
+	for _, rb := range p.HotelRebooks {
+		d := hotelarb.EvaluateRebook(rb.Hold, rb.Quote, rb.Opts)
+		if d.Action == hotelarb.ActionRebookLowerPrice && d.Savings > 0 {
+			out = append(out, Opportunity{
+				Engine:          "hotel",
+				Type:            "hotel_rebook",
+				Description:     fmt.Sprintf("%s: %s", d.HotelName, d.Reason),
+				EstimatedSaving: d.Savings,
+				Currency:        d.Currency,
+				Confidence:      ConfidenceHigh,
+			})
+		}
+	}
+	for _, in := range p.HotelPoints {
+		res, err := hotelarb.ComparePointsArbitrage(in)
+		if err != nil {
+			continue
+		}
+		if res.Recommendation == hotelarb.RecommendUsePoints && res.BestOffer.SavingsVsCash > 0 {
+			out = append(out, Opportunity{
+				Engine:          "hotel",
+				Type:            "hotel_points",
+				Description:     res.Reason,
+				EstimatedSaving: res.BestOffer.SavingsVsCash,
+				Currency:        res.Currency,
+				Confidence:      ConfidenceMedium,
+			})
+		}
+	}
+	if len(out) == 0 {
+		return nil, "N/A: hotel inputs supplied but no profitable rebook or points opportunity"
+	}
+	return out, ""
+}
+
+func currencyOrDefault(c string) string {
+	c = strings.ToUpper(strings.TrimSpace(c))
+	if c == "" {
+		return "EUR"
+	}
+	return c
+}
+
+// fareCurrency picks a sensible currency label for cabin opportunities: the
+// first non-empty fare currency, then the trip currency, then EUR.
+func fareCurrency(p Params) string {
+	for _, f := range p.CabinFares {
+		if strings.TrimSpace(f.Currency) != "" {
+			return strings.ToUpper(strings.TrimSpace(f.Currency))
+		}
+	}
+	return currencyOrDefault(p.Currency)
+}

--- a/internal/arbreport/arbreport_test.go
+++ b/internal/arbreport/arbreport_test.go
@@ -1,0 +1,293 @@
+package arbreport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/cabinarb"
+	"github.com/MikkoParkkola/trvl/internal/hotelarb"
+)
+
+// fakeEngine builds an EngineFunc returning fixed opportunities / skip reason.
+func fakeEngine(opps []Opportunity, skip string) EngineFunc {
+	return func(_ context.Context, _ Params) ([]Opportunity, string) {
+		return opps, skip
+	}
+}
+
+func baseParams() Params {
+	return Params{
+		Origin:      "HEL",
+		Destination: "LHR",
+		DepartDate:  "2026-08-01",
+		Travelers:   2,
+		Currency:    "EUR",
+	}
+}
+
+func TestAggregateCombinesAndRanksBySaving(t *testing.T) {
+	eng := Engines{
+		Currency: fakeEngine([]Opportunity{
+			{Type: "currency_arbitrage", Description: "book in HUF", EstimatedSaving: 40, Currency: "EUR", Confidence: ConfidenceMedium},
+		}, ""),
+		Cabin: fakeEngine([]Opportunity{
+			{Type: "cabin_upgrade", Description: "eco→prem", EstimatedSaving: 120, Currency: "EUR", Confidence: ConfidenceHigh},
+		}, ""),
+		Hotel: fakeEngine([]Opportunity{
+			{Type: "hotel_rebook", Description: "rebook lower", EstimatedSaving: 75, Currency: "EUR", Confidence: ConfidenceHigh},
+		}, ""),
+	}
+
+	got := AggregateWithEngines(context.Background(), baseParams(), eng)
+
+	if got.Count != 3 {
+		t.Fatalf("expected 3 opportunities, got %d", got.Count)
+	}
+	if len(got.Skipped) != 0 {
+		t.Fatalf("expected no skipped engines, got %v", got.Skipped)
+	}
+	// Ranked by saving desc: cabin(120) > hotel(75) > currency(40).
+	wantOrder := []float64{120, 75, 40}
+	for i, w := range wantOrder {
+		if got.Opportunities[i].EstimatedSaving != w {
+			t.Errorf("rank %d: want saving %.0f, got %.0f (%+v)", i, w, got.Opportunities[i].EstimatedSaving, got.Opportunities[i])
+		}
+	}
+	// Engine label is backfilled from the seam name when blank.
+	if got.Opportunities[0].Engine != "cabin" {
+		t.Errorf("expected top opportunity engine 'cabin', got %q", got.Opportunities[0].Engine)
+	}
+}
+
+func TestAggregateSkipsUnavailableEnginesGracefully(t *testing.T) {
+	eng := Engines{
+		Currency: fakeEngine(nil, "N/A: departure date required for currency arbitrage"),
+		Cabin: fakeEngine([]Opportunity{
+			{Type: "cabin_upgrade", EstimatedSaving: 50},
+		}, ""),
+		Hotel: fakeEngine(nil, "N/A: no active hotel holds or points offers supplied"),
+	}
+
+	got := AggregateWithEngines(context.Background(), baseParams(), eng)
+
+	if got.Count != 1 {
+		t.Fatalf("expected 1 opportunity, got %d", got.Count)
+	}
+	if len(got.Skipped) != 2 {
+		t.Fatalf("expected 2 skipped engines, got %d: %v", len(got.Skipped), got.Skipped)
+	}
+	skipByEngine := map[string]string{}
+	for _, s := range got.Skipped {
+		skipByEngine[s.Engine] = s.Reason
+	}
+	if skipByEngine["currency"] == "" || skipByEngine["hotel"] == "" {
+		t.Errorf("expected currency and hotel to be skipped with reasons, got %v", got.Skipped)
+	}
+}
+
+func TestAggregateNoFabricationOnEmpty(t *testing.T) {
+	// Every engine skips: report must be empty, with reasons, never invented.
+	eng := Engines{
+		Currency: fakeEngine(nil, "N/A: no currency arbitrage on this route"),
+		Cabin:    fakeEngine(nil, "N/A: no cabin fare ladder supplied for this trip"),
+		Hotel:    fakeEngine(nil, "N/A: no active hotel holds or points offers supplied"),
+	}
+
+	got := AggregateWithEngines(context.Background(), baseParams(), eng)
+
+	if got.Count != 0 {
+		t.Fatalf("expected 0 opportunities, got %d: %+v", got.Count, got.Opportunities)
+	}
+	if got.Opportunities == nil {
+		t.Error("Opportunities must be a non-nil empty slice, not nil")
+	}
+	if len(got.Skipped) != 3 {
+		t.Errorf("expected all 3 engines skipped, got %d: %v", len(got.Skipped), got.Skipped)
+	}
+}
+
+func TestAggregateEmptyOppsTreatedAsSkip(t *testing.T) {
+	// An engine returning empty opps with no skip reason is recorded as a skip,
+	// not a silent disappearance.
+	eng := Engines{
+		Currency: fakeEngine([]Opportunity{}, ""),
+		Cabin:    fakeEngine(nil, ""),
+		Hotel:    fakeEngine([]Opportunity{{Type: "hotel_points", EstimatedSaving: 10}}, ""),
+	}
+
+	got := AggregateWithEngines(context.Background(), baseParams(), eng)
+
+	if got.Count != 1 {
+		t.Fatalf("expected 1 opportunity, got %d", got.Count)
+	}
+	if len(got.Skipped) != 2 {
+		t.Errorf("expected 2 skipped (currency+cabin), got %v", got.Skipped)
+	}
+}
+
+func TestAggregateNilEngineRecordedAsSkip(t *testing.T) {
+	eng := Engines{} // all nil
+	got := AggregateWithEngines(context.Background(), baseParams(), eng)
+	if got.Count != 0 {
+		t.Fatalf("expected 0 opportunities, got %d", got.Count)
+	}
+	if len(got.Skipped) != 3 {
+		t.Errorf("expected 3 skipped for nil engines, got %v", got.Skipped)
+	}
+}
+
+func TestReportCarriesTripContext(t *testing.T) {
+	p := baseParams()
+	p.ReturnDate = "2026-08-10"
+	p.Currency = "gbp"
+	got := AggregateWithEngines(context.Background(), p, Engines{})
+	if got.Origin != "HEL" || got.Destination != "LHR" {
+		t.Errorf("trip endpoints not carried: %+v", got)
+	}
+	if got.ReturnDate != "2026-08-10" {
+		t.Errorf("return date not carried: %q", got.ReturnDate)
+	}
+	if got.Currency != "GBP" {
+		t.Errorf("currency not normalised to upper: %q", got.Currency)
+	}
+}
+
+// --- default adapter tests (pure engines, fully offline) ---
+
+func TestDefaultCabinEngineRealEngine(t *testing.T) {
+	p := baseParams()
+	p.CabinFares = []cabinarb.CabinFare{
+		{Cabin: cabinarb.CabinEconomy, Price: 500, Currency: "EUR"},
+		{Cabin: cabinarb.CabinPremiumEconomy, Price: 540, Currency: "EUR"}, // 8% upsell, within threshold
+	}
+	opps, skip := defaultCabinEngine(context.Background(), p)
+	if skip != "" {
+		t.Fatalf("expected cabin opportunity, got skip %q", skip)
+	}
+	if len(opps) != 1 {
+		t.Fatalf("expected 1 cabin opp, got %d", len(opps))
+	}
+	if opps[0].Type != "cabin_upgrade" || opps[0].Confidence != ConfidenceHigh {
+		t.Errorf("unexpected cabin opp: %+v", opps[0])
+	}
+	// Upsell (target priced above baseline) => no cash saving reported.
+	if opps[0].EstimatedSaving != 0 {
+		t.Errorf("upsell should report zero saving, got %.2f", opps[0].EstimatedSaving)
+	}
+}
+
+func TestDefaultCabinEngineStrictUpgradeIsSaving(t *testing.T) {
+	p := baseParams()
+	p.CabinFares = []cabinarb.CabinFare{
+		{Cabin: cabinarb.CabinEconomy, Price: 500},
+		{Cabin: cabinarb.CabinPremiumEconomy, Price: 460}, // cheaper than economy
+	}
+	opps, skip := defaultCabinEngine(context.Background(), p)
+	if skip != "" {
+		t.Fatalf("expected cabin opportunity, got skip %q", skip)
+	}
+	if opps[0].EstimatedSaving != 40 {
+		t.Errorf("strict upgrade should save 40, got %.2f", opps[0].EstimatedSaving)
+	}
+}
+
+func TestDefaultCabinEngineSkipsWithoutFares(t *testing.T) {
+	_, skip := defaultCabinEngine(context.Background(), baseParams())
+	if skip == "" {
+		t.Error("expected skip reason when no cabin fares supplied")
+	}
+}
+
+func TestDefaultHotelEngineRebook(t *testing.T) {
+	p := baseParams()
+	p.HotelRebooks = []HotelRebook{{
+		Hold: hotelarb.Hold{
+			ID:            "h1",
+			HotelName:     "Grand",
+			OriginalPrice: 300,
+			Currency:      "EUR",
+			Refundable:    true,
+		},
+		Quote: hotelarb.PriceQuote{Price: 240, Currency: "EUR"},
+		Opts:  hotelarb.RebookOptions{MinSavings: 10},
+	}}
+	opps, skip := defaultHotelEngine(context.Background(), p)
+	if skip != "" {
+		t.Fatalf("expected hotel opportunity, got skip %q", skip)
+	}
+	if len(opps) != 1 || opps[0].Type != "hotel_rebook" {
+		t.Fatalf("expected 1 hotel_rebook opp, got %+v", opps)
+	}
+	if opps[0].EstimatedSaving != 60 {
+		t.Errorf("expected 60 saving, got %.2f", opps[0].EstimatedSaving)
+	}
+}
+
+func TestDefaultHotelEngineSkipsWithoutInputs(t *testing.T) {
+	_, skip := defaultHotelEngine(context.Background(), baseParams())
+	if skip == "" {
+		t.Error("expected skip reason when no hotel inputs supplied")
+	}
+}
+
+func TestDefaultHotelEngineNoProfitableRebook(t *testing.T) {
+	p := baseParams()
+	p.HotelRebooks = []HotelRebook{{
+		Hold:  hotelarb.Hold{ID: "h1", HotelName: "Grand", OriginalPrice: 200, Currency: "EUR", Refundable: true},
+		Quote: hotelarb.PriceQuote{Price: 250, Currency: "EUR"}, // higher, no saving
+	}}
+	_, skip := defaultHotelEngine(context.Background(), p)
+	if skip == "" {
+		t.Error("expected skip when no profitable rebook")
+	}
+}
+
+func TestDefaultCurrencyEngineSkipsWithoutDate(t *testing.T) {
+	// Offline: missing departure date must short-circuit before any network call.
+	p := baseParams()
+	p.DepartDate = ""
+	_, skip := defaultCurrencyEngine(context.Background(), p)
+	if skip == "" {
+		t.Error("expected skip reason when departure date missing")
+	}
+}
+
+func TestDefaultCurrencyEngineSkipsWithoutEndpoints(t *testing.T) {
+	p := baseParams()
+	p.Origin = ""
+	_, skip := defaultCurrencyEngine(context.Background(), p)
+	if skip == "" {
+		t.Error("expected skip reason when origin missing")
+	}
+}
+
+func TestDefaultEnginesWired(t *testing.T) {
+	e := DefaultEngines()
+	if e.Currency == nil || e.Cabin == nil || e.Hotel == nil {
+		t.Fatal("DefaultEngines must wire all three engines")
+	}
+	// Drive through the public Aggregate with inputs that keep every engine
+	// fully offline: cabin gets fares, hotel gets a hold, currency skips on
+	// the missing-date guard before touching the network.
+	p := Params{
+		Origin:      "HEL",
+		Destination: "LHR",
+		// DepartDate intentionally empty -> currency skips offline.
+		CabinFares: []cabinarb.CabinFare{
+			{Cabin: cabinarb.CabinEconomy, Price: 500},
+			{Cabin: cabinarb.CabinPremiumEconomy, Price: 460},
+		},
+		HotelRebooks: []HotelRebook{{
+			Hold:  hotelarb.Hold{ID: "h1", HotelName: "Grand", OriginalPrice: 300, Currency: "EUR", Refundable: true},
+			Quote: hotelarb.PriceQuote{Price: 240, Currency: "EUR"},
+		}},
+	}
+	got := AggregateWithEngines(context.Background(), p, DefaultEngines())
+	if got.Count != 2 {
+		t.Fatalf("expected 2 opportunities (cabin+hotel), got %d: %+v", got.Count, got.Opportunities)
+	}
+	// hotel saving 60 ranks above cabin saving 40.
+	if got.Opportunities[0].Engine != "hotel" {
+		t.Errorf("expected hotel first, got %q", got.Opportunities[0].Engine)
+	}
+}

--- a/internal/hacks/currency_arbitrage_public.go
+++ b/internal/hacks/currency_arbitrage_public.go
@@ -1,0 +1,13 @@
+package hacks
+
+import "context"
+
+// DetectCurrencyArbitrage is the exported entry point for the currency
+// arbitrage detector. It delegates to the unexported detectCurrencyArbitrage
+// implementation so external callers (e.g. internal/arbreport) can reuse the
+// detector in isolation without running the full DetectAll fan-out. The
+// detector logic itself lives in currency_arbitrage.go and is not modified
+// here — this is a thin re-export only.
+func DetectCurrencyArbitrage(ctx context.Context, in DetectorInput) []Hack {
+	return detectCurrencyArbitrage(ctx, in)
+}

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -85,6 +85,7 @@ func registerTools(s *Server) {
 		searchHiddenCityTool(),
 		searchAwardsTool(),
 		nestedRTTool(),
+		arbitrageReportTool(),
 	}
 	s.toolDefs = make(map[string]ToolDef, len(legacyTools)+1)
 	for _, tool := range legacyTools {
@@ -171,6 +172,7 @@ func registerTools(s *Server) {
 	s.handlers["search_hidden_city"] = s.wrapHandler("search_hidden_city", handleSearchHiddenCity)
 	s.handlers["search_awards"] = s.wrapHandler("search_awards", handleSearchAwards)
 	s.handlers["optimize_nested_rt"] = s.wrapHandler("optimize_nested_rt", handleOptimizeNestedRT)
+	s.handlers["arbitrage_report"] = s.wrapHandler("arbitrage_report", handleArbitrageReport)
 }
 
 // wrapHandler returns a ToolHandler that delegates to the inner handler and

--- a/mcp/tools_arbitrage_report.go
+++ b/mcp/tools_arbitrage_report.go
@@ -1,0 +1,213 @@
+package mcp
+
+// Innovation #8: unified arbitrage report MCP tool. Aggregates trvl's
+// currency, cabin-class, and hotel arbitrage engines into one ranked report.
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/arbreport"
+	"github.com/MikkoParkkola/trvl/internal/cabinarb"
+	"github.com/MikkoParkkola/trvl/internal/hotelarb"
+)
+
+func arbitrageReportTool() ToolDef {
+	return ToolDef{
+		Name:        "arbitrage_report",
+		Title:       "Unified Arbitrage Report",
+		Description: "Aggregate trvl's arbitrage engines (airline currency arbitrage, cabin-class upgrades, hotel rate re-book) into one ranked report for a trip. Each opportunity carries type, description, estimated saving, currency, and confidence. Engines that lack inputs for the trip context are skipped and listed, never fabricated.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"origin":      {Type: "string", Description: "Origin IATA airport code (e.g. HEL)"},
+				"destination": {Type: "string", Description: "Destination IATA airport code (e.g. LHR)"},
+				"depart_date": {Type: "string", Description: "Departure date (YYYY-MM-DD); required for the currency engine"},
+				"return_date": {Type: "string", Description: "Return date (YYYY-MM-DD), optional"},
+				"currency":    {Type: "string", Description: "Trip currency (default EUR)"},
+				"travelers":   {Type: "integer", Description: "Number of travelers (default 1)"},
+				"cabin_fares": {Type: "array", Description: "Cabin fare ladder entries as 'cabin:price[:carrier]' (cabins: economy, premium_economy, business, first). Enables the cabin engine.", Items: &Property{Type: "string"}},
+				"rebooks":     {Type: "array", Description: "Hotel re-book candidates as 'name:original:current[:currency]'. Enables the hotel engine.", Items: &Property{Type: "string"}},
+			},
+			Required: []string{"origin", "destination", "depart_date"},
+		},
+		OutputSchema: arbitrageReportOutputSchema(),
+		Annotations: &ToolAnnotations{
+			Title:          "Unified Arbitrage Report",
+			ReadOnlyHint:   true,
+			OpenWorldHint:  true,
+			IdempotentHint: true,
+		},
+	}
+}
+
+func arbitrageReportOutputSchema() interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"origin":      schemaString(),
+			"destination": schemaString(),
+			"depart_date": schemaString(),
+			"return_date": schemaString(),
+			"currency":    schemaString(),
+			"travelers":   schemaInt(),
+			"count":       schemaInt(),
+			"opportunities": schemaArray(map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"engine":           schemaString(),
+					"type":             schemaString(),
+					"description":      schemaString(),
+					"estimated_saving": schemaNum(),
+					"currency":         schemaString(),
+					"confidence":       schemaString(),
+				},
+			}),
+			"skipped": schemaArray(map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"engine": schemaString(),
+					"reason": schemaString(),
+				},
+			}),
+		},
+		"required": []string{"origin", "destination", "depart_date", "currency", "count", "opportunities", "skipped"},
+	}
+}
+
+func handleArbitrageReport(ctx context.Context, args map[string]any, _ ElicitFunc, _ SamplingFunc, progress ProgressFunc) ([]ContentBlock, interface{}, error) {
+	origin := strings.ToUpper(argString(args, "origin"))
+	destination := strings.ToUpper(argString(args, "destination"))
+	departDate := argString(args, "depart_date")
+	returnDate := argString(args, "return_date")
+	currency := argString(args, "currency")
+	travelers := argInt(args, "travelers", 1)
+
+	fares, err := parseCabinFareStrings(argStringSlice(args, "cabin_fares"))
+	if err != nil {
+		return nil, nil, err
+	}
+	rebooks, err := parseRebookStrings(argStringSlice(args, "rebooks"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sendProgress(progress, 0, 100, fmt.Sprintf("Aggregating arbitrage engines for %s→%s...", origin, destination))
+
+	report := arbreport.Aggregate(ctx, arbreport.Params{
+		Origin:       origin,
+		Destination:  destination,
+		DepartDate:   departDate,
+		ReturnDate:   returnDate,
+		Currency:     currency,
+		Travelers:    travelers,
+		CabinFares:   fares,
+		HotelRebooks: rebooks,
+	})
+
+	sendProgress(progress, 100, 100, fmt.Sprintf("Found %d arbitrage opportunit%s", report.Count, arbReportPlural(report.Count)))
+
+	if report.Opportunities == nil {
+		report.Opportunities = []arbreport.Opportunity{}
+	}
+	if report.Skipped == nil {
+		report.Skipped = []arbreport.SkippedEngine{}
+	}
+
+	summary := buildArbReportSummary(report)
+	content, err := buildAnnotatedContentBlocks(summary, report)
+	if err != nil {
+		return nil, nil, err
+	}
+	return content, report, nil
+}
+
+func parseCabinFareStrings(items []string) ([]cabinarb.CabinFare, error) {
+	out := make([]cabinarb.CabinFare, 0, len(items))
+	for _, arg := range items {
+		parts := strings.SplitN(arg, ":", 3)
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("invalid cabin fare %q: expected cabin:price[:carrier]", arg)
+		}
+		cabin := strings.TrimSpace(parts[0])
+		if cabin == "" {
+			return nil, fmt.Errorf("invalid cabin fare %q: cabin must not be empty", arg)
+		}
+		price, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cabin fare %q: price must be a number: %w", arg, err)
+		}
+		carrier := ""
+		if len(parts) == 3 {
+			carrier = strings.TrimSpace(parts[2])
+		}
+		out = append(out, cabinarb.CabinFare{Cabin: cabinarb.Cabin(cabin), Price: price, Carrier: carrier})
+	}
+	return out, nil
+}
+
+func parseRebookStrings(items []string) ([]arbreport.HotelRebook, error) {
+	out := make([]arbreport.HotelRebook, 0, len(items))
+	for _, arg := range items {
+		parts := strings.SplitN(arg, ":", 4)
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("invalid rebook %q: expected name:original:current[:currency]", arg)
+		}
+		name := strings.TrimSpace(parts[0])
+		if name == "" {
+			return nil, fmt.Errorf("invalid rebook %q: hotel name must not be empty", arg)
+		}
+		original, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid rebook %q: original price must be a number: %w", arg, err)
+		}
+		current, err := strconv.ParseFloat(strings.TrimSpace(parts[2]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid rebook %q: current price must be a number: %w", arg, err)
+		}
+		cur := "EUR"
+		if len(parts) == 4 && strings.TrimSpace(parts[3]) != "" {
+			cur = strings.ToUpper(strings.TrimSpace(parts[3]))
+		}
+		out = append(out, arbreport.HotelRebook{
+			Hold: hotelarb.Hold{
+				HotelName:     name,
+				OriginalPrice: original,
+				Currency:      cur,
+				Refundable:    true,
+			},
+			Quote: hotelarb.PriceQuote{Price: current, Currency: cur},
+		})
+	}
+	return out, nil
+}
+
+func buildArbReportSummary(report arbreport.ArbReport) string {
+	var sb strings.Builder
+	_, _ = fmt.Fprintf(&sb, "Unified arbitrage report for %s→%s on %s (%s):\n\n",
+		report.Origin, report.Destination, report.DepartDate, report.Currency)
+	if report.Count == 0 {
+		sb.WriteString("No arbitrage opportunities found for this trip context.\n")
+	} else {
+		for i, o := range report.Opportunities {
+			_, _ = fmt.Fprintf(&sb, "%d. [%s] %s — saves %.2f %s (%s confidence)\n",
+				i+1, o.Engine, o.Description, o.EstimatedSaving, o.Currency, o.Confidence)
+		}
+	}
+	if len(report.Skipped) > 0 {
+		sb.WriteString("\nSkipped engines:\n")
+		for _, s := range report.Skipped {
+			_, _ = fmt.Fprintf(&sb, "  - %s: %s\n", s.Engine, s.Reason)
+		}
+	}
+	return sb.String()
+}
+
+func arbReportPlural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}

--- a/mcp/tools_arbitrage_report_test.go
+++ b/mcp/tools_arbitrage_report_test.go
@@ -1,0 +1,134 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/arbreport"
+)
+
+func TestArbitrageReportTool_Definition(t *testing.T) {
+	td := arbitrageReportTool()
+	if td.Name != "arbitrage_report" {
+		t.Fatalf("unexpected tool name %q", td.Name)
+	}
+	if td.Description == "" {
+		t.Error("tool must have a description")
+	}
+	for _, req := range []string{"origin", "destination", "depart_date"} {
+		if _, ok := td.InputSchema.Properties[req]; !ok {
+			t.Errorf("input schema missing required property %q", req)
+		}
+	}
+	if td.Annotations == nil || !td.Annotations.ReadOnlyHint {
+		t.Error("arbitrage_report should be marked read-only")
+	}
+}
+
+func TestArbitrageReportTool_Registered(t *testing.T) {
+	t.Setenv("TRVL_MCP_TOOL_MODE", "legacy")
+	s := NewServer()
+	if _, ok := s.handlers["arbitrage_report"]; !ok {
+		t.Fatal("arbitrage_report handler not registered")
+	}
+	if !toolRegistered(s.tools, "arbitrage_report") {
+		t.Error("arbitrage_report not advertised in legacy mode")
+	}
+}
+
+func TestParseCabinFareStrings(t *testing.T) {
+	fares, err := parseCabinFareStrings([]string{"economy:500", "premium_economy:540:AY"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fares) != 2 {
+		t.Fatalf("expected 2 fares, got %d", len(fares))
+	}
+	if fares[0].Price != 500 || fares[1].Carrier != "AY" {
+		t.Errorf("parsed fares wrong: %+v", fares)
+	}
+	if _, err := parseCabinFareStrings([]string{"economy"}); err == nil {
+		t.Error("expected error for malformed cabin fare")
+	}
+	if _, err := parseCabinFareStrings([]string{"economy:notanumber"}); err == nil {
+		t.Error("expected error for non-numeric price")
+	}
+}
+
+func TestParseRebookStrings(t *testing.T) {
+	rb, err := parseRebookStrings([]string{"Grand:300:240:EUR"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rb) != 1 {
+		t.Fatalf("expected 1 rebook, got %d", len(rb))
+	}
+	if rb[0].Hold.HotelName != "Grand" || rb[0].Hold.OriginalPrice != 300 || rb[0].Quote.Price != 240 {
+		t.Errorf("parsed rebook wrong: %+v", rb[0])
+	}
+	if !rb[0].Hold.Refundable {
+		t.Error("CLI/MCP rebook holds should be treated as refundable so a saving can surface")
+	}
+	if _, err := parseRebookStrings([]string{"Grand:300"}); err == nil {
+		t.Error("expected error for malformed rebook")
+	}
+	if _, err := parseRebookStrings([]string{"Grand:x:240"}); err == nil {
+		t.Error("expected error for non-numeric original price")
+	}
+}
+
+func TestHandleArbitrageReport_AggregatesCabinAndHotel(t *testing.T) {
+	// Offline-deterministic: cabin + hotel engines need no network. depart_date
+	// is omitted so the currency engine short-circuits on its missing-date guard
+	// before any flight lookup, keeping the test hermetic and fast.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	args := map[string]any{
+		"origin":      "HEL",
+		"destination": "LHR",
+		"cabin_fares": []any{"economy:500", "premium_economy:460"}, // strict upgrade, saves 40
+		"rebooks":     []any{"Grand:300:240:EUR"},                  // saves 60
+	}
+
+	_, structured, err := handleArbitrageReport(ctx, args, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	rep, ok := structured.(arbreport.ArbReport)
+	if !ok {
+		t.Fatalf("expected arbreport.ArbReport, got %T", structured)
+	}
+	if rep.Count < 2 {
+		t.Fatalf("expected at least cabin+hotel opportunities, got %d: %+v", rep.Count, rep.Opportunities)
+	}
+	var sawCabin, sawHotel bool
+	for _, o := range rep.Opportunities {
+		switch o.Engine {
+		case "cabin":
+			sawCabin = true
+		case "hotel":
+			sawHotel = true
+		}
+	}
+	if !sawCabin || !sawHotel {
+		t.Errorf("expected cabin and hotel opportunities, got %+v", rep.Opportunities)
+	}
+	// Hotel saving (60) must rank above cabin saving (40).
+	if rep.Opportunities[0].Engine != "hotel" {
+		t.Errorf("expected hotel ranked first by saving, got %q", rep.Opportunities[0].Engine)
+	}
+}
+
+func TestHandleArbitrageReport_BadCabinFareErrors(t *testing.T) {
+	_, _, err := handleArbitrageReport(context.Background(), map[string]any{
+		"origin":      "HEL",
+		"destination": "LHR",
+		"depart_date": "2026-08-01",
+		"cabin_fares": []any{"economy"},
+	}, nil, nil, nil)
+	if err == nil {
+		t.Error("expected error for malformed cabin fare input")
+	}
+}

--- a/mcp/tools_extra_test.go
+++ b/mcp/tools_extra_test.go
@@ -321,6 +321,7 @@ func TestToolRegistration_AllTools(t *testing.T) {
 		"search_hidden_city",
 		"search_awards",
 		"optimize_nested_rt",
+		"arbitrage_report",
 	}
 
 	if len(s.tools) != len(expectedTools) {

--- a/mcp/tools_smart_test.go
+++ b/mcp/tools_smart_test.go
@@ -44,8 +44,8 @@ func TestLegacyToolModeStillAdvertisesLegacySurface(t *testing.T) {
 
 	s := NewServer()
 
-	if len(s.tools) != 66 {
-		t.Fatalf("legacy tool mode should advertise 66 legacy tools, got %d", len(s.tools))
+	if len(s.tools) != 67 {
+		t.Fatalf("legacy tool mode should advertise 67 legacy tools, got %d", len(s.tools))
 	}
 	if !toolRegistered(s.tools, "search_flights") {
 		t.Fatalf("legacy mode should advertise search_flights")


### PR DESCRIPTION
## Innovation #8 — unified arbitrage report

A thin aggregator that runs trvl's independent arbitrage engines for one trip
context and returns a single ranked report of opportunities. Each opportunity
carries a type, description, estimated saving, currency, and confidence. The
aggregator reuses existing engines only — it does not reimplement any pricing
logic.

### Engines aggregated

- **currency** — airline currency arbitrage (live flight lookup; needs a depart date)
- **cabin** — near-flat cabin-class upgrades (needs a fare ladder)
- **hotel** — hotel rate re-book savings (needs holds)

Engines that lack the inputs they need for the given trip are skipped
gracefully and listed with an "N/A: reason" note. Nothing is fabricated.

### Design

- New package `arbreport` exposes `Aggregate(ctx, params)` returning a ranked
  report. An `Engines` seam (`AggregateWithEngines`) makes the core fully
  offline-testable; `DefaultEngines()` wires the real engine calls.
- Currency reuse goes through a newly exported delegate so the existing
  currency engine file is untouched (read-only respected).
- Ranking is by estimated saving descending, tie-broken by engine then type.
- Cabin savings are honest: an upgrade that costs more surfaces a zero saving,
  only a strictly cheaper option yields a positive number.

### Surfaces

- CLI: `trvl arbitrage-report <origin> <destination> <depart-date>` with
  repeatable cabin and rebook flags, plus a JSON output mode.
- MCP: a new read-only `arbitrage_report` tool (single registration line in the
  tool table; no broad server changes).

### Tests

- Table-driven unit tests for the aggregator, ranking, skip handling, CLI
  parsing and rendering, and MCP handler — all offline-deterministic via faked
  engine seams.
- Count-based tests updated for the one new subcommand and one new tool.

### Verification

- gofmt clean, go vet clean, staticcheck clean on the touched packages.
- `go test -short` green across the module (race-enabled on the new package).
- CLI smoke run produced a correctly ranked two-opportunity report with the
  currency engine skipped on a route with no arbitrage.

Do not merge — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
