### PR TITLE
feat(multimodal): compose end-to-end itineraries from discovery + per-leg pricing

### DIFF
--- a/cmd/trvl/commands_test.go
+++ b/cmd/trvl/commands_test.go
@@ -18,7 +18,8 @@ func TestRootCmd_SubcommandCount(t *testing.T) {
 	// 61 -> 62 with `pricetrends` (opt-in Travelpayouts price-signal source).
 	// 64 -> 65 when rental car search (`trvl cars`) landed.
 	// 65 -> 66 with `arbitrage-report` (innovation #8 unified arbitrage report).
-	const want = 66
+	// 66 -> 67 with `multimodal` (innovation #2 multimodal composer).
+	const want = 67
 	got := len(rootCmd.Commands())
 	if got != want {
 		names := make([]string, 0, got)

--- a/cmd/trvl/multimodal_plan.go
+++ b/cmd/trvl/multimodal_plan.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/multimodal"
+	"github.com/spf13/cobra"
+)
+
+func multimodalPlanCmd() *cobra.Command {
+	var allowBrowserFallbacks bool
+
+	cmd := &cobra.Command{
+		Use:     "multimodal FROM TO DATE",
+		Aliases: []string{"plan", "combo"},
+		Short:   "Compose end-to-end multimodal itineraries (Rome2Rio discovery + real per-leg pricing)",
+		Long: `Compose end-to-end travel itineraries that mix modes (e.g. ferry then fly).
+
+Rome2Rio DISCOVERS candidate mode-chains a single-mode search would never
+surface; trvl then PRICES each leg with its existing flight and ground
+providers, ASSEMBLES the legs into one true total, RANKS by that total, and
+ANNOTATES any travel-hack saving. Legs that cannot be priced fall back to
+Rome2Rio's indicative range and are clearly labelled as estimates — never a
+fabricated fare.
+
+Rome2Rio sits behind Cloudflare; pass --allow-browser-fallbacks to use the
+live browser-assisted discovery path. Without it, discovery returns an honest
+typed status offline.
+
+FROM and TO are place names (e.g. "Helsinki", "London").
+DATE is the departure date in YYYY-MM-DD format.
+
+Examples:
+  trvl multimodal Helsinki London 2026-07-01
+  trvl plan "Stockholm" "Tallinn" 2026-07-01 --allow-browser-fallbacks`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			from, to, date := args[0], args[1], args[2]
+
+			planner := multimodal.NewPlanner(allowBrowserFallbacks)
+			plan, err := planner.Plan(cmd.Context(), from, to, date)
+			if err != nil {
+				return err
+			}
+
+			if format == "json" {
+				return models.FormatJSON(os.Stdout, plan)
+			}
+			printMultimodalPlan(plan)
+
+			if openFlag && len(plan.Itineraries) > 0 && plan.Itineraries[0].BookingURL != "" {
+				_ = openBrowser(plan.Itineraries[0].BookingURL)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&allowBrowserFallbacks, "allow-browser-fallbacks", false, "Allow browser/cookie-assisted Rome2Rio discovery + ground leg pricing")
+	return cmd
+}
+
+func printMultimodalPlan(plan *multimodal.Plan) {
+	if plan.Error != "" {
+		_, _ = fmt.Fprintf(os.Stderr, "No multimodal plan: %s\n", plan.Error)
+		return
+	}
+	if len(plan.Itineraries) == 0 {
+		_, _ = fmt.Fprintf(os.Stderr, "No multimodal itineraries from %s to %s on %s.\n", plan.From, plan.To, plan.Date)
+		for _, n := range plan.Notes {
+			_, _ = fmt.Fprintf(os.Stderr, "  - %s\n", n)
+		}
+		return
+	}
+
+	models.Banner(os.Stdout, "🧭",
+		fmt.Sprintf("Multimodal · %s → %s", plan.From, plan.To),
+		fmt.Sprintf("%d itineraries from %d discovered chains (%s)", len(plan.Itineraries), plan.Discovered, plan.Date))
+	fmt.Println()
+
+	for i, it := range plan.Itineraries {
+		tag := ""
+		if it.Estimated {
+			tag = " " + models.Red("(includes estimate)")
+		}
+		fmt.Printf("%d. %s  %s %.2f  ·  %s%s\n",
+			i+1, it.ModeChain, it.Currency, it.TotalPrice, formatDuration(it.DurationMin), tag)
+		for _, leg := range it.Legs {
+			price := fmt.Sprintf("%s %.2f", leg.Currency, leg.Price)
+			label := leg.Provider
+			if leg.Estimated {
+				label = models.Red("estimate")
+			}
+			fmt.Printf("     • %-6s %-18s %s via %s\n", leg.Mode, leg.From+"→"+leg.To, price, label)
+		}
+		if it.HackSaving != nil {
+			fmt.Printf("     %s %s: save %s %.2f (%s)\n",
+				"💡", it.HackSaving.Title, it.Currency, it.HackSaving.Savings, it.HackSaving.Type)
+		}
+		for _, w := range it.Warnings {
+			fmt.Printf("     %s %s\n", models.Red("⚠"), w)
+		}
+		if it.BookingURL != "" {
+			fmt.Printf("     %s\n", it.BookingURL)
+		}
+		fmt.Println()
+	}
+
+	for _, n := range plan.Notes {
+		fmt.Printf("Note: %s\n", n)
+	}
+}

--- a/cmd/trvl/public_claims_test.go
+++ b/cmd/trvl/public_claims_test.go
@@ -143,6 +143,7 @@ func registeredMCPCompatibilityAliasCount(t *testing.T) int {
 		"plan_journey":     true, // Leave-By Scheduler capability (MIK-5734 B)
 		"plan_natural":     true, // NL travel-planner supertool (innovation #7)
 		"arbitrage_report": true, // unified arbitrage aggregator (innovation #8) — new capability, not a legacy alias
+		"plan_multimodal":  true, // Multimodal composer capability (innovation #2)
 	}
 	count := 0
 	for _, key := range handlers.MapKeys() {

--- a/cmd/trvl/root.go
+++ b/cmd/trvl/root.go
@@ -111,6 +111,7 @@ func init() {
 	rootCmd.AddCommand(expensesCmd())
 	rootCmd.AddCommand(opportunityScoreCmd())
 	rootCmd.AddCommand(rateStatusCmd())
+	rootCmd.AddCommand(multimodalPlanCmd())
 }
 
 // airportCompletion provides IATA code completion for cobra commands.

--- a/internal/multimodal/assemble.go
+++ b/internal/multimodal/assemble.go
@@ -1,0 +1,225 @@
+package multimodal
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// estimatePlaceholder is the leg returned when a real provider could not price a
+// leg. It carries no price yet (Price 0); assembleItinerary fills an indicative
+// figure from the route's Rome2Rio range and keeps Estimated=true.
+func estimatePlaceholder(spec LegSpec) PricedLeg {
+	return PricedLeg{
+		Mode:      spec.Mode,
+		From:      spec.From,
+		To:        spec.To,
+		Estimated: true,
+		Provider:  "rome2rio (estimate)",
+	}
+}
+
+// legSpecsForRoute turns a discovered route into the ordered list of legs to
+// price. Per-leg endpoints come from the GroundLeg stops when present; the first
+// leg's origin defaults to the overall from and the last leg's destination to
+// the overall to, so a chain whose intermediate hubs are unknown still prices
+// its outer legs and estimates the middle.
+func legSpecsForRoute(route models.GroundRoute, from, to, date string) []LegSpec {
+	if len(route.Legs) == 0 {
+		// Single-mode route with no leg breakdown: one leg end-to-end.
+		mode := route.Type
+		if mode == "" {
+			mode = "mixed"
+		}
+		return []LegSpec{{Mode: mode, From: from, To: to, Date: date}}
+	}
+
+	specs := make([]LegSpec, len(route.Legs))
+	for i, leg := range route.Legs {
+		f := leg.Departure.City
+		t := leg.Arrival.City
+		if i == 0 && f == "" {
+			f = from
+		}
+		if i == len(route.Legs)-1 && t == "" {
+			t = to
+		}
+		specs[i] = LegSpec{Mode: leg.Type, From: f, To: t, Date: date}
+	}
+	return specs
+}
+
+// assembleItinerary sums priced legs into one end-to-end itinerary. It is pure
+// (no I/O) so the composition, estimate-fallback and labelling logic is unit
+// tested deterministically.
+//
+// Currency discipline (mirrors flights round-trip composition): legs are summed
+// only in a single currency. The headline currency is the first real priced
+// leg's currency, falling back to the route's indicative currency. A real leg in
+// a different currency cannot be summed honestly, so it is demoted to an
+// estimate with a warning rather than fabricating a converted total.
+//
+// Estimate fallback: any leg that could not be priced (or was demoted) shares
+// the route's indicative remainder — max(0, indicativeLow - realSum) split
+// across the unpriced legs. The whole itinerary is then flagged Estimated.
+//
+// Returns ok=false when the route yields neither a real nor an indicative total
+// (nothing honest to show).
+func assembleItinerary(route models.GroundRoute, from, to, date string, legs []PricedLeg) (Itinerary, bool) {
+	currency := headlineCurrency(legs, route.Currency)
+
+	realSum := 0.0
+	unpriced := 0
+	for i := range legs {
+		l := &legs[i]
+		if !l.Estimated && l.Price > 0 && l.Currency == currency {
+			realSum += l.Price
+			continue
+		}
+		if !l.Estimated && l.Price > 0 && l.Currency != currency {
+			// Real fare in a non-matching currency: cannot be summed honestly.
+			l.Estimated = true
+			l.Detail = strings.TrimSpace(l.Detail + " (priced in " + l.Currency + "; not summed)")
+		}
+		l.Estimated = true
+		unpriced++
+	}
+
+	// Distribute the indicative remainder across unpriced legs.
+	if unpriced > 0 {
+		remainder := route.Price - realSum // route.Price is the indicative low
+		if remainder < 0 {
+			remainder = 0
+		}
+		per := 0.0
+		if remainder > 0 {
+			per = round2(remainder / float64(unpriced))
+		}
+		for i := range legs {
+			if legs[i].Estimated {
+				legs[i].Price = per
+				if legs[i].Currency == "" {
+					legs[i].Currency = currency
+				}
+				if legs[i].Provider == "" {
+					legs[i].Provider = "rome2rio (estimate)"
+				}
+			}
+		}
+	}
+
+	total := 0.0
+	estimated := false
+	durSum := 0
+	durKnown := true
+	var warnings, risks []string
+	for i := range legs {
+		l := legs[i]
+		total += l.Price
+		if l.Estimated {
+			estimated = true
+		}
+		if l.DurationMin > 0 {
+			durSum += l.DurationMin
+		} else {
+			durKnown = false
+		}
+	}
+	total = round2(total)
+
+	// Nothing honest to show: no real legs and no indicative figure.
+	if total <= 0 {
+		return Itinerary{}, false
+	}
+
+	if estimated {
+		warnings = append(warnings, "total includes an estimate: one or more legs use Rome2Rio's indicative price, not a confirmed fare — verify before booking")
+	}
+	if route.Type != "" {
+		// Preserve discovery risk caveats if the route carried any amenity/notes.
+		risks = append(risks, route.Amenities...)
+	}
+
+	duration := route.Duration
+	if durKnown && durSum > 0 {
+		duration = durSum
+	}
+
+	transfers := 0
+	if len(legs) > 1 {
+		transfers = len(legs) - 1
+	}
+
+	return Itinerary{
+		From:        from,
+		To:          to,
+		Date:        date,
+		Legs:        legs,
+		TotalPrice:  total,
+		Currency:    currency,
+		DurationMin: duration,
+		Transfers:   transfers,
+		ModeChain:   modeChain(legs),
+		Estimated:   estimated,
+		Source:      "rome2rio",
+		BookingURL:  route.BookingURL,
+		Warnings:    warnings,
+		Risks:       risks,
+	}, true
+}
+
+// headlineCurrency picks the currency in which legs are summed: the first real
+// priced leg's currency, else the route's indicative currency, else the first
+// leg that has any currency, else EUR.
+func headlineCurrency(legs []PricedLeg, routeCurrency string) string {
+	for _, l := range legs {
+		if !l.Estimated && l.Price > 0 && l.Currency != "" {
+			return l.Currency
+		}
+	}
+	if routeCurrency != "" {
+		return routeCurrency
+	}
+	for _, l := range legs {
+		if l.Currency != "" {
+			return l.Currency
+		}
+	}
+	return "EUR"
+}
+
+// modeChain renders the ordered mode sequence, e.g. "ferry → fly".
+func modeChain(legs []PricedLeg) string {
+	parts := make([]string, 0, len(legs))
+	for _, l := range legs {
+		m := l.Mode
+		if m == "" {
+			m = "mixed"
+		}
+		if len(parts) == 0 || parts[len(parts)-1] != m {
+			parts = append(parts, m)
+		}
+	}
+	return strings.Join(parts, " → ")
+}
+
+// rankItineraries sorts cheapest true-total first. Fully-priced itineraries beat
+// estimated ones on a tie (a confirmed total is worth more than an indicative
+// one), and shorter duration breaks remaining ties.
+func rankItineraries(its []Itinerary) {
+	sort.SliceStable(its, func(i, j int) bool {
+		a, b := its[i], its[j]
+		if a.TotalPrice != b.TotalPrice {
+			return a.TotalPrice < b.TotalPrice
+		}
+		if a.Estimated != b.Estimated {
+			return !a.Estimated // non-estimated first
+		}
+		return a.DurationMin < b.DurationMin
+	})
+}
+
+func round2(v float64) float64 {
+	return float64(int64(v*100+0.5)) / 100
+}

--- a/internal/multimodal/composer.go
+++ b/internal/multimodal/composer.go
@@ -1,0 +1,314 @@
+// Package multimodal composes end-to-end travel itineraries by combining
+// Rome2Rio multimodal route DISCOVERY with trvl's existing per-leg PRICING
+// providers (flights, trains, buses, ferries) and the travel-hacks savings
+// engine.
+//
+// The synthesis (innovation #2 — the multimodal composer):
+//
+//  1. DISCOVER — Rome2Rio surfaces candidate mode-chains between two places
+//     (e.g. "ferry to a hub, then fly"), combinations a single-mode provider
+//     would never reveal. Rome2Rio prices are only indicative RANGES.
+//  2. PRICE — each leg of a discovered chain is priced by the appropriate
+//     existing provider (ground search for train/bus/ferry/drive, flight
+//     search for fly). trvl never reimplements a provider here; it reuses them.
+//  3. ASSEMBLE — legs are summed into an end-to-end itinerary with a single
+//     true total. When a leg cannot be priced, the composer falls back to
+//     Rome2Rio's indicative range for that leg and clearly labels the
+//     itinerary (and the leg) as an ESTIMATE — never a fabricated fare.
+//  4. RANK — itineraries are sorted by true total cost (fully-priced beats
+//     estimated on ties), so the cheapest real way to travel leads.
+//  5. ANNOTATE — the travel-hacks savings engine is run against the cheapest
+//     itinerary so any cheaper synthesized option surfaces alongside.
+//
+// Honesty contract (mirrors the rest of trvl): a priced leg is only ever a
+// real provider fare; estimates are always labelled; risk caveats from
+// discovery and from the hacks engine are preserved verbatim. One leg's
+// pricing failure degrades only that itinerary, never the whole plan.
+package multimodal
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+const (
+	// defaultMaxItineraries bounds how many ranked itineraries a plan returns.
+	defaultMaxItineraries = 8
+	// defaultLegTimeout bounds a single leg's pricing call so one slow provider
+	// never blocks the whole plan.
+	defaultLegTimeout = 20 * time.Second
+	// defaultPlanTimeout bounds the overall discovery+pricing fan-out.
+	defaultPlanTimeout = 45 * time.Second
+	// maxParallelLegs bounds concurrent per-leg pricing calls across the plan.
+	maxParallelLegs = 6
+	// maxRoutesPriced caps how many discovered mode-chains are priced, bounding
+	// the provider fan-out. Excess (cheaper-indicative-first) is reported, not
+	// silently dropped.
+	maxRoutesPriced = 10
+)
+
+// LegSpec identifies one leg to price: a transport mode between two places on a
+// date. From/To are human place names (city or airport) as discovered; the
+// production pricer resolves them to provider-specific identifiers.
+type LegSpec struct {
+	Mode string // "train" | "bus" | "ferry" | "fly" | "drive" | ...
+	From string
+	To   string
+	Date string
+}
+
+// PricedLeg is one leg of an assembled itinerary after pricing (or estimation).
+type PricedLeg struct {
+	Mode        string  `json:"mode"`
+	From        string  `json:"from"`
+	To          string  `json:"to"`
+	Price       float64 `json:"price"`
+	Currency    string  `json:"currency"`
+	DurationMin int     `json:"duration_minutes,omitempty"`
+	// Estimated is true when Price is an indicative Rome2Rio figure rather than
+	// a real provider fare. Such a leg is never presented as bookable.
+	Estimated  bool   `json:"estimated"`
+	Provider   string `json:"provider"`
+	BookingURL string `json:"booking_url,omitempty"`
+	Detail     string `json:"detail,omitempty"`
+}
+
+// Itinerary is an end-to-end multimodal journey with a single true total.
+type Itinerary struct {
+	From        string             `json:"from"`
+	To          string             `json:"to"`
+	Date        string             `json:"date"`
+	Legs        []PricedLeg        `json:"legs"`
+	TotalPrice  float64            `json:"total_price"`
+	Currency    string             `json:"currency"`
+	DurationMin int                `json:"duration_minutes,omitempty"`
+	Transfers   int                `json:"transfers"`
+	ModeChain   string             `json:"mode_chain"` // e.g. "ferry → fly"
+	Estimated   bool               `json:"estimated"`  // any leg estimated
+	Source      string             `json:"source"`     // discovery provider
+	BookingURL  string             `json:"booking_url,omitempty"`
+	HackSaving  *models.HackSaving `json:"hack_saving,omitempty"`
+	Warnings    []string           `json:"warnings,omitempty"`
+	Risks       []string           `json:"risks,omitempty"`
+}
+
+// Plan is the full result of composing a from→to→date query.
+type Plan struct {
+	From        string      `json:"from"`
+	To          string      `json:"to"`
+	Date        string      `json:"date"`
+	Itineraries []Itinerary `json:"itineraries"`
+	Discovered  int         `json:"discovered"` // mode-chains discovered
+	Priced      int         `json:"priced"`     // chains assembled into itineraries
+	Notes       []string    `json:"notes,omitempty"`
+	Error       string      `json:"error,omitempty"`
+}
+
+// Discoverer surfaces candidate mode-chains between two places. Production wraps
+// ground.SearchRome2Rio; tests inject deterministic routes.
+type Discoverer func(ctx context.Context, from, to string, allowBrowser bool) ([]models.GroundRoute, error)
+
+// LegPricer prices a single leg using an existing per-leg provider. It returns
+// ok=false (never an error) when the leg cannot be priced, so the composer can
+// fall back to an honest estimate without failing the whole plan.
+type LegPricer func(ctx context.Context, spec LegSpec) (PricedLeg, bool)
+
+// HackAnnotator runs the travel-hacks savings engine against a naive baseline.
+// Returns nil when no genuinely cheaper option exists. Optional (may be nil).
+type HackAnnotator func(ctx context.Context, from, to, date string, naivePrice float64, currency string) *models.HackSaving
+
+// Planner composes multimodal itineraries from injected seams. The zero value is
+// not usable; construct via NewPlanner (production) or set the seams directly
+// (tests).
+type Planner struct {
+	Discover       Discoverer
+	Price          LegPricer
+	Hacks          HackAnnotator // optional
+	AllowBrowser   bool
+	MaxItineraries int
+	LegTimeout     time.Duration
+	PlanTimeout    time.Duration
+}
+
+func (p *Planner) maxItineraries() int {
+	if p.MaxItineraries > 0 {
+		return p.MaxItineraries
+	}
+	return defaultMaxItineraries
+}
+
+func (p *Planner) legTimeout() time.Duration {
+	if p.LegTimeout > 0 {
+		return p.LegTimeout
+	}
+	return defaultLegTimeout
+}
+
+func (p *Planner) planTimeout() time.Duration {
+	if p.PlanTimeout > 0 {
+		return p.PlanTimeout
+	}
+	return defaultPlanTimeout
+}
+
+// Plan discovers, prices, assembles, ranks and annotates multimodal itineraries
+// for from→to on date. It never returns a nil Plan on a non-empty query; a
+// discovery failure or an empty discovery degrades to an empty (but described)
+// plan rather than an error so callers can always render something honest.
+func (p *Planner) Plan(ctx context.Context, from, to, date string) (*Plan, error) {
+	plan := &Plan{From: from, To: to, Date: date}
+	if strings.TrimSpace(from) == "" || strings.TrimSpace(to) == "" || strings.TrimSpace(date) == "" {
+		plan.Error = "from, to, and date are required"
+		return plan, nil
+	}
+	if p.Discover == nil || p.Price == nil {
+		plan.Error = "multimodal planner is not configured"
+		return plan, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.planTimeout())
+	defer cancel()
+
+	routes, err := p.Discover(ctx, from, to, p.AllowBrowser)
+	if err != nil {
+		// Discovery failure is honest, not fatal: report it and return an empty
+		// plan. The caller surfaces the typed reason (Cloudflare wall, etc.).
+		plan.Error = "route discovery: " + err.Error()
+		return plan, nil
+	}
+	plan.Discovered = len(routes)
+	if len(routes) == 0 {
+		plan.Notes = append(plan.Notes, "no multimodal routes discovered for this pair")
+		return plan, nil
+	}
+
+	// Bound the number of chains priced (cheapest-indicative first), reporting
+	// any truncation rather than silently dropping options.
+	routes = boundRoutes(routes)
+	if plan.Discovered > len(routes) {
+		plan.Notes = append(plan.Notes,
+			"priced the "+itoa(len(routes))+" most promising of "+itoa(plan.Discovered)+" discovered chains")
+	}
+
+	itineraries := p.priceRoutes(ctx, from, to, date, routes)
+	plan.Priced = len(itineraries)
+
+	rankItineraries(itineraries)
+	if len(itineraries) > p.maxItineraries() {
+		itineraries = itineraries[:p.maxItineraries()]
+	}
+
+	// Annotate the cheapest itinerary with any travel-hack saving. The baseline
+	// is its true total; the engine only surfaces a strictly cheaper option.
+	if p.Hacks != nil && len(itineraries) > 0 {
+		best := itineraries[0]
+		if best.TotalPrice > 0 {
+			if s := p.Hacks(ctx, from, to, date, best.TotalPrice, best.Currency); s != nil {
+				itineraries[0].HackSaving = s
+			}
+		}
+	}
+
+	plan.Itineraries = itineraries
+	if len(itineraries) == 0 {
+		plan.Notes = append(plan.Notes, "routes discovered but none could be priced or estimated")
+	}
+	return plan, nil
+}
+
+// priceRoutes prices every leg of every route with bounded parallelism, then
+// assembles each route into an itinerary. A route whose legs all fail to price
+// (and which has no indicative range to estimate from) is dropped with no panic.
+func (p *Planner) priceRoutes(ctx context.Context, from, to, date string, routes []models.GroundRoute) []Itinerary {
+	sem := make(chan struct{}, maxParallelLegs)
+	var mu sync.Mutex
+	out := make([]Itinerary, 0, len(routes))
+
+	var wg sync.WaitGroup
+	for i := range routes {
+		route := routes[i]
+		specs := legSpecsForRoute(route, from, to, date)
+		priced := make([]PricedLeg, len(specs))
+		var legWG sync.WaitGroup
+		for j := range specs {
+			legWG.Add(1)
+			go func(idx int, spec LegSpec) {
+				defer legWG.Done()
+				select {
+				case sem <- struct{}{}:
+					defer func() { <-sem }()
+				case <-ctx.Done():
+					priced[idx] = estimatePlaceholder(spec)
+					return
+				}
+				legCtx, cancel := context.WithTimeout(ctx, p.legTimeout())
+				defer cancel()
+				if pl, ok := p.Price(legCtx, spec); ok {
+					priced[idx] = pl
+					return
+				}
+				priced[idx] = estimatePlaceholder(spec)
+			}(j, specs[j])
+		}
+		wg.Add(1)
+		go func(r models.GroundRoute, legs *[]PricedLeg, wgLeg *sync.WaitGroup) {
+			defer wg.Done()
+			wgLeg.Wait()
+			if it, ok := assembleItinerary(r, from, to, date, *legs); ok {
+				mu.Lock()
+				out = append(out, it)
+				mu.Unlock()
+			}
+		}(route, &priced, &legWG)
+	}
+	wg.Wait()
+	return out
+}
+
+// boundRoutes returns at most maxRoutesPriced routes, preferring those with the
+// lowest indicative price (0-priced routes sort last so priced discovery leads).
+func boundRoutes(routes []models.GroundRoute) []models.GroundRoute {
+	if len(routes) <= maxRoutesPriced {
+		return routes
+	}
+	cp := make([]models.GroundRoute, len(routes))
+	copy(cp, routes)
+	sort.SliceStable(cp, func(i, j int) bool {
+		return indicativeSortKey(cp[i]) < indicativeSortKey(cp[j])
+	})
+	return cp[:maxRoutesPriced]
+}
+
+func indicativeSortKey(r models.GroundRoute) float64 {
+	if r.Price > 0 {
+		return r.Price
+	}
+	return 1e18 // unpriced discovery sorts last
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}

--- a/internal/multimodal/composer_test.go
+++ b/internal/multimodal/composer_test.go
@@ -1,0 +1,271 @@
+package multimodal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// route2 builds a 2-leg discovered mode-chain with explicit per-leg endpoints
+// and an indicative price range (Rome2Rio style).
+func route2(modeA, hub, modeB, from, to string, indicativeLow float64, cur string) models.GroundRoute {
+	return models.GroundRoute{
+		Provider:   "rome2rio",
+		Type:       "mixed",
+		Price:      indicativeLow,
+		Currency:   cur,
+		Duration:   600,
+		Transfers:  1,
+		BookingURL: "https://www.rome2rio.com/map/" + from + "/" + to,
+		Departure:  models.GroundStop{City: from},
+		Arrival:    models.GroundStop{City: to},
+		Legs: []models.GroundLeg{
+			{Type: modeA, Departure: models.GroundStop{City: from}, Arrival: models.GroundStop{City: hub}},
+			{Type: modeB, Departure: models.GroundStop{City: hub}, Arrival: models.GroundStop{City: to}},
+		},
+	}
+}
+
+// fakePricer prices a leg from a lookup keyed by mode; missing modes are
+// unpriceable (ok=false), driving the estimate-fallback path.
+type fakePricer map[string]PricedLeg
+
+func (f fakePricer) price(_ context.Context, spec LegSpec) (PricedLeg, bool) {
+	pl, ok := f[spec.Mode]
+	if !ok {
+		return PricedLeg{}, false
+	}
+	pl.Mode, pl.From, pl.To = spec.Mode, spec.From, spec.To
+	return pl, true
+}
+
+func plannerWith(disc Discoverer, price LegPricer) *Planner {
+	return &Planner{Discover: disc, Price: price}
+}
+
+func discoverFixed(routes ...models.GroundRoute) Discoverer {
+	return func(_ context.Context, _, _ string, _ bool) ([]models.GroundRoute, error) {
+		return routes, nil
+	}
+}
+
+func TestPlan_TwoLegChain_SummedRealPrice(t *testing.T) {
+	r := route2("ferry", "Hub", "fly", "Helsinki", "London", 200, "EUR")
+	pricer := fakePricer{
+		"ferry": {Price: 40, Currency: "EUR", DurationMin: 120, Provider: "tallink"},
+		"fly":   {Price: 90, Currency: "EUR", DurationMin: 150, Provider: "Ryanair"},
+	}
+	p := plannerWith(discoverFixed(r), pricer.price)
+
+	plan, err := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan.Discovered != 1 || plan.Priced != 1 || len(plan.Itineraries) != 1 {
+		t.Fatalf("expected 1 discovered/priced/itinerary, got %d/%d/%d", plan.Discovered, plan.Priced, len(plan.Itineraries))
+	}
+	it := plan.Itineraries[0]
+	if it.Estimated {
+		t.Errorf("itinerary should not be estimated when both legs priced")
+	}
+	if it.TotalPrice != 130 {
+		t.Errorf("expected summed total 130, got %v", it.TotalPrice)
+	}
+	if it.Currency != "EUR" {
+		t.Errorf("expected EUR, got %q", it.Currency)
+	}
+	if it.ModeChain != "ferry → fly" {
+		t.Errorf("expected mode chain 'ferry → fly', got %q", it.ModeChain)
+	}
+	if it.DurationMin != 270 {
+		t.Errorf("expected summed duration 270, got %d", it.DurationMin)
+	}
+	if it.Transfers != 1 {
+		t.Errorf("expected 1 transfer, got %d", it.Transfers)
+	}
+}
+
+func TestPlan_RankByTrueTotal(t *testing.T) {
+	cheap := route2("ferry", "Hub", "fly", "Helsinki", "London", 300, "EUR")
+	cheap.BookingURL = "cheap"
+	expensive := route2("train", "Hub2", "fly", "Helsinki", "London", 300, "EUR")
+	expensive.BookingURL = "expensive"
+
+	pricer := fakePricer{
+		"ferry": {Price: 40, Currency: "EUR"},
+		"train": {Price: 150, Currency: "EUR"},
+		"fly":   {Price: 90, Currency: "EUR"},
+	}
+	p := plannerWith(discoverFixed(expensive, cheap), pricer.price)
+
+	plan, _ := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	if len(plan.Itineraries) != 2 {
+		t.Fatalf("expected 2 itineraries, got %d", len(plan.Itineraries))
+	}
+	if plan.Itineraries[0].TotalPrice != 130 || plan.Itineraries[0].BookingURL != "cheap" {
+		t.Errorf("cheapest (130/cheap) should rank first, got %v/%q", plan.Itineraries[0].TotalPrice, plan.Itineraries[0].BookingURL)
+	}
+	if plan.Itineraries[1].TotalPrice != 240 {
+		t.Errorf("expected second total 240, got %v", plan.Itineraries[1].TotalPrice)
+	}
+}
+
+func TestPlan_EstimateFallback_WhenLegUnpriceable(t *testing.T) {
+	// indicative low 200; ferry priced 40 real; fly unpriceable → estimated
+	// remainder = 200 - 40 = 160 attributed to the fly leg.
+	r := route2("ferry", "Hub", "fly", "Helsinki", "London", 200, "EUR")
+	pricer := fakePricer{
+		"ferry": {Price: 40, Currency: "EUR", DurationMin: 120, Provider: "tallink"},
+		// no "fly" → unpriceable
+	}
+	p := plannerWith(discoverFixed(r), pricer.price)
+
+	plan, _ := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	if len(plan.Itineraries) != 1 {
+		t.Fatalf("expected 1 itinerary, got %d", len(plan.Itineraries))
+	}
+	it := plan.Itineraries[0]
+	if !it.Estimated {
+		t.Fatalf("itinerary must be flagged Estimated when a leg falls back to indicative")
+	}
+	if it.TotalPrice != 200 {
+		t.Errorf("expected total 200 (40 real + 160 indicative remainder), got %v", it.TotalPrice)
+	}
+	var flyLeg *PricedLeg
+	for i := range it.Legs {
+		if it.Legs[i].Mode == "fly" {
+			flyLeg = &it.Legs[i]
+		}
+	}
+	if flyLeg == nil {
+		t.Fatal("fly leg missing")
+	}
+	if !flyLeg.Estimated {
+		t.Errorf("fly leg should be Estimated")
+	}
+	if flyLeg.Price != 160 {
+		t.Errorf("expected fly estimate 160, got %v", flyLeg.Price)
+	}
+	if flyLeg.Provider != "rome2rio (estimate)" {
+		t.Errorf("estimate leg should be labelled rome2rio (estimate), got %q", flyLeg.Provider)
+	}
+	if len(it.Warnings) == 0 {
+		t.Errorf("estimated itinerary must carry a warning")
+	}
+}
+
+func TestPlan_EmptyDiscovery_Graceful(t *testing.T) {
+	p := plannerWith(discoverFixed(), fakePricer{}.price)
+	plan, err := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan.Error != "" {
+		t.Errorf("empty discovery is not an error, got %q", plan.Error)
+	}
+	if len(plan.Itineraries) != 0 {
+		t.Errorf("expected no itineraries, got %d", len(plan.Itineraries))
+	}
+	if len(plan.Notes) == 0 {
+		t.Errorf("expected a note explaining no routes")
+	}
+}
+
+func TestPlan_DiscoveryError_Degrades(t *testing.T) {
+	disc := func(_ context.Context, _, _ string, _ bool) ([]models.GroundRoute, error) {
+		return nil, context.DeadlineExceeded
+	}
+	p := plannerWith(disc, fakePricer{}.price)
+	plan, err := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	if err != nil {
+		t.Fatalf("discovery error must degrade, not propagate: %v", err)
+	}
+	if plan.Error == "" {
+		t.Errorf("expected plan.Error to carry the discovery failure")
+	}
+	if len(plan.Itineraries) != 0 {
+		t.Errorf("expected no itineraries on discovery failure")
+	}
+}
+
+func TestPlan_HackAnnotation_OnCheapest(t *testing.T) {
+	r := route2("ferry", "Hub", "fly", "Helsinki", "London", 200, "EUR")
+	pricer := fakePricer{
+		"ferry": {Price: 40, Currency: "EUR"},
+		"fly":   {Price: 90, Currency: "EUR"},
+	}
+	p := plannerWith(discoverFixed(r), pricer.price)
+	p.Hacks = func(_ context.Context, from, to, date string, naive float64, cur string) *models.HackSaving {
+		if naive != 130 {
+			t.Errorf("hack baseline should be the true total 130, got %v", naive)
+		}
+		return &models.HackSaving{Type: "multimodal_skip_flight", Savings: 20, Price: 110, NaivePrice: naive, Currency: cur}
+	}
+
+	plan, _ := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	if len(plan.Itineraries) != 1 || plan.Itineraries[0].HackSaving == nil {
+		t.Fatalf("expected a hack saving annotated on the cheapest itinerary")
+	}
+	if plan.Itineraries[0].HackSaving.Savings != 20 {
+		t.Errorf("expected saving 20, got %v", plan.Itineraries[0].HackSaving.Savings)
+	}
+}
+
+func TestPlan_MissingArgs(t *testing.T) {
+	p := plannerWith(discoverFixed(), fakePricer{}.price)
+	plan, _ := p.Plan(context.Background(), "", "London", "2026-07-01")
+	if plan.Error == "" {
+		t.Errorf("expected an error for missing origin")
+	}
+}
+
+func TestAssemble_CurrencyMismatchDemotesToEstimate(t *testing.T) {
+	r := route2("ferry", "Hub", "fly", "Helsinki", "London", 200, "EUR")
+	legs := []PricedLeg{
+		{Mode: "ferry", Price: 40, Currency: "EUR"},
+		{Mode: "fly", Price: 100, Currency: "GBP"}, // mismatched real fare
+	}
+	it, ok := assembleItinerary(r, "Helsinki", "London", "2026-07-01", legs)
+	if !ok {
+		t.Fatal("expected an assembled itinerary")
+	}
+	if !it.Estimated {
+		t.Errorf("currency-mismatched leg must demote the itinerary to estimated")
+	}
+	if it.Currency != "EUR" {
+		t.Errorf("headline currency should be the first real EUR leg, got %q", it.Currency)
+	}
+	// remainder = 200 - 40 = 160 on the demoted fly leg → total 200.
+	if it.TotalPrice != 200 {
+		t.Errorf("expected total 200, got %v", it.TotalPrice)
+	}
+}
+
+func TestLegSpecsForRoute_BoundaryFill(t *testing.T) {
+	r := models.GroundRoute{
+		Type: "mixed",
+		Legs: []models.GroundLeg{
+			{Type: "ferry"}, // no endpoints
+			{Type: "fly"},   // no endpoints
+		},
+	}
+	specs := legSpecsForRoute(r, "Helsinki", "London", "2026-07-01")
+	if len(specs) != 2 {
+		t.Fatalf("expected 2 specs, got %d", len(specs))
+	}
+	if specs[0].From != "Helsinki" {
+		t.Errorf("first leg origin should default to overall from, got %q", specs[0].From)
+	}
+	if specs[1].To != "London" {
+		t.Errorf("last leg destination should default to overall to, got %q", specs[1].To)
+	}
+}
+
+func TestLegSpecsForRoute_SingleModeNoLegs(t *testing.T) {
+	r := models.GroundRoute{Type: "train"}
+	specs := legSpecsForRoute(r, "Paris", "Lyon", "2026-07-01")
+	if len(specs) != 1 || specs[0].Mode != "train" || specs[0].From != "Paris" || specs[0].To != "Lyon" {
+		t.Errorf("single-mode route should yield one end-to-end leg, got %+v", specs)
+	}
+}

--- a/internal/multimodal/pricing.go
+++ b/internal/multimodal/pricing.go
@@ -1,0 +1,199 @@
+package multimodal
+
+import (
+	"context"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/ground"
+	"github.com/MikkoParkkola/trvl/internal/hacks"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// NewPlanner returns a Planner wired to trvl's production seams:
+//
+//   - DISCOVERY via Rome2Rio (ground.SearchRome2Rio);
+//   - per-leg PRICING via the existing flight and ground searches — never a
+//     reimplemented provider;
+//   - savings ANNOTATION via the travel-hacks engine (hacks.BestSaving).
+//
+// allowBrowser threads through to Rome2Rio (its live Cloudflare path is gated by
+// --allow-browser-fallbacks) and to the ground leg pricer.
+func NewPlanner(allowBrowser bool) *Planner {
+	return &Planner{
+		Discover:     ground.SearchRome2Rio,
+		Price:        productionLegPricer(allowBrowser),
+		Hacks:        productionHackAnnotator,
+		AllowBrowser: allowBrowser,
+	}
+}
+
+// productionLegPricer dispatches a leg to the right existing provider by mode:
+// "fly" → flight search (with IATA resolution); everything else → ground search.
+// It returns ok=false whenever a real fare cannot be obtained, so the composer
+// falls back to an honest estimate rather than fabricating a price.
+func productionLegPricer(allowBrowser bool) LegPricer {
+	return func(ctx context.Context, spec LegSpec) (PricedLeg, bool) {
+		switch normalizeMode(spec.Mode) {
+		case "fly":
+			return priceFlightLeg(ctx, spec)
+		case "drive", "walk", "":
+			// No bookable provider for self-driving / walking legs.
+			return PricedLeg{}, false
+		default:
+			return priceGroundLeg(ctx, spec, allowBrowser)
+		}
+	}
+}
+
+func normalizeMode(m string) string {
+	switch strings.ToLower(strings.TrimSpace(m)) {
+	case "fly", "flight", "plane", "air":
+		return "fly"
+	case "train", "rail":
+		return "train"
+	case "bus", "coach":
+		return "bus"
+	case "ferry", "boat", "car ferry":
+		return "ferry"
+	case "drive", "car":
+		return "drive"
+	case "walk":
+		return "walk"
+	default:
+		return strings.ToLower(strings.TrimSpace(m))
+	}
+}
+
+// priceFlightLeg resolves the leg endpoints to IATA codes and prices the
+// cheapest flight via the existing flight search (hacks disabled — savings are
+// annotated once at plan level).
+func priceFlightLeg(ctx context.Context, spec LegSpec) (PricedLeg, bool) {
+	origin, ok := resolveAirport(spec.From)
+	if !ok {
+		return PricedLeg{}, false
+	}
+	dest, ok := resolveAirport(spec.To)
+	if !ok {
+		return PricedLeg{}, false
+	}
+	res, err := flights.SearchFlights(ctx, origin, dest, spec.Date, flights.SearchOptions{NoHacks: true})
+	if err != nil || res == nil || !res.Success {
+		return PricedLeg{}, false
+	}
+	best, ok := cheapestFlight(res.Flights)
+	if !ok {
+		return PricedLeg{}, false
+	}
+	return PricedLeg{
+		Mode:        "fly",
+		From:        spec.From,
+		To:          spec.To,
+		Price:       best.PriceForRanking(),
+		Currency:    best.Currency,
+		DurationMin: best.Duration,
+		Provider:    flightProvider(best),
+		BookingURL:  best.BookingURL,
+		Detail:      origin + "→" + dest,
+	}, true
+}
+
+// priceGroundLeg prices the cheapest ground option for the leg via the existing
+// ground search (hacks disabled to avoid a nested savings fan-out).
+func priceGroundLeg(ctx context.Context, spec LegSpec, allowBrowser bool) (PricedLeg, bool) {
+	if strings.TrimSpace(spec.From) == "" || strings.TrimSpace(spec.To) == "" {
+		return PricedLeg{}, false
+	}
+	opts := ground.SearchOptions{
+		NoHacks:               true,
+		AllowBrowserFallbacks: allowBrowser,
+	}
+	switch normalizeMode(spec.Mode) {
+	case "bus", "train":
+		opts.Type = normalizeMode(spec.Mode)
+	}
+	res, err := ground.SearchByName(ctx, spec.From, spec.To, spec.Date, opts)
+	if err != nil || res == nil || !res.Success {
+		return PricedLeg{}, false
+	}
+	best, ok := cheapestRoute(res.Routes)
+	if !ok {
+		return PricedLeg{}, false
+	}
+	mode := best.Type
+	if mode == "" {
+		mode = normalizeMode(spec.Mode)
+	}
+	return PricedLeg{
+		Mode:        mode,
+		From:        spec.From,
+		To:          spec.To,
+		Price:       best.Price,
+		Currency:    best.Currency,
+		DurationMin: best.Duration,
+		Provider:    best.Provider,
+		BookingURL:  best.BookingURL,
+	}, true
+}
+
+// resolveAirport turns a place name into a bookable IATA code: an explicit IATA
+// passes through; a city name resolves to its primary airport. Returns ok=false
+// when no airport is known, so the flight leg is estimated rather than guessed.
+func resolveAirport(place string) (string, bool) {
+	p := strings.ToUpper(strings.TrimSpace(place))
+	if models.IsIATACode(p) {
+		return p, true
+	}
+	if codes := models.ResolveCityToAirports(place); len(codes) > 0 {
+		return codes[0], true
+	}
+	return "", false
+}
+
+func cheapestFlight(fs []models.FlightResult) (models.FlightResult, bool) {
+	var best models.FlightResult
+	found := false
+	for _, f := range fs {
+		if f.PriceForRanking() <= 0 || f.Currency == "" {
+			continue
+		}
+		if !found || f.PriceForRanking() < best.PriceForRanking() {
+			best, found = f, true
+		}
+	}
+	return best, found
+}
+
+func cheapestRoute(rs []models.GroundRoute) (models.GroundRoute, bool) {
+	var best models.GroundRoute
+	found := false
+	for _, r := range rs {
+		if r.Price <= 0 || r.Currency == "" {
+			continue
+		}
+		if !found || r.Price < best.Price {
+			best, found = r, true
+		}
+	}
+	return best, found
+}
+
+func flightProvider(f models.FlightResult) string {
+	if f.Provider != "" {
+		return f.Provider
+	}
+	return "flights"
+}
+
+// productionHackAnnotator runs the travel-hacks savings engine against the
+// itinerary's true total as the naive baseline. It returns nil unless a strictly
+// cheaper synthesized option exists (BestSaving enforces the honesty contract).
+func productionHackAnnotator(ctx context.Context, from, to, date string, naivePrice float64, currency string) *models.HackSaving {
+	return hacks.BestSaving(ctx, hacks.DetectorInput{
+		Origin:      from,
+		Destination: to,
+		Date:        date,
+		Currency:    currency,
+		NaivePrice:  naivePrice,
+	}, nil)
+}

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -39,6 +39,7 @@ func registerTools(s *Server) {
 		localEventsTool(),
 		searchGroundTool(),
 		searchAirportTransfersTool(),
+		planMultimodalTool(),
 		searchCarsTool(),
 		searchRestaurantsTool(),
 		searchDealsTool(),
@@ -126,6 +127,7 @@ func registerTools(s *Server) {
 	s.handlers["local_events"] = s.wrapHandler("local_events", handleLocalEvents)
 	s.handlers["search_ground"] = s.wrapHandler("search_ground", handleSearchGround)
 	s.handlers["search_airport_transfers"] = s.wrapHandler("search_airport_transfers", handleSearchAirportTransfers)
+	s.handlers["plan_multimodal"] = s.wrapHandler("plan_multimodal", handlePlanMultimodal)
 	s.handlers["search_cars"] = s.wrapHandler("search_cars", handleSearchCars)
 	s.handlers["search_restaurants"] = s.wrapHandler("search_restaurants", handleSearchRestaurants)
 	s.handlers["search_deals"] = s.wrapHandler("search_deals", handleSearchDeals)

--- a/mcp/tools_extra_test.go
+++ b/mcp/tools_extra_test.go
@@ -276,7 +276,7 @@ func TestToolRegistration_AllTools(t *testing.T) {
 		"hotel_reviews", "destination_info", "calculate_trip_cost",
 		"weekend_getaway", "suggest_dates", "optimize_multi_city",
 		"nearby_places", "travel_guide", "local_events",
-		"search_ground", "search_airport_transfers", "search_cars", "search_restaurants", "search_deals",
+		"search_ground", "search_airport_transfers", "plan_multimodal", "search_cars", "search_restaurants", "search_deals",
 		"plan_trip",
 		"search_route",
 		"hotel_rooms",

--- a/mcp/tools_flights.go
+++ b/mcp/tools_flights.go
@@ -493,14 +493,15 @@ func handleSearchFlights(ctx context.Context, args map[string]any, elicit Elicit
 
 	// Build structured response.
 	type enrichedFlightSearchResult struct {
-		Success        bool             `json:"success"`
-		Count          int              `json:"count"`
-		TripType       string           `json:"trip_type"`
-		Flights        []enrichedFlight `json:"flights"`
-		Error          string           `json:"error,omitempty"`
-		Suggestions    []Suggestion     `json:"suggestions,omitempty"`
-		Hacks          []hacks.Hack     `json:"hacks,omitempty"`
-		BookingContext *bookingContext  `json:"booking_context,omitempty"`
+		Success        bool               `json:"success"`
+		Count          int                `json:"count"`
+		TripType       string             `json:"trip_type"`
+		Flights        []enrichedFlight   `json:"flights"`
+		Error          string             `json:"error,omitempty"`
+		Suggestions    []Suggestion       `json:"suggestions,omitempty"`
+		Hacks          []hacks.Hack       `json:"hacks,omitempty"`
+		HackSaving     *models.HackSaving `json:"hack_saving,omitempty"`
+		BookingContext *bookingContext    `json:"booking_context,omitempty"`
 	}
 	resp := enrichedFlightSearchResult{
 		Success:        result.Success,
@@ -510,6 +511,7 @@ func handleSearchFlights(ctx context.Context, args map[string]any, elicit Elicit
 		Error:          result.Error,
 		Suggestions:    suggestions,
 		Hacks:          flightHacks,
+		HackSaving:     result.HackSaving,
 		BookingContext: buildBookingContext(date, primaryOrigin, originSource),
 	}
 

--- a/mcp/tools_multimodal.go
+++ b/mcp/tools_multimodal.go
@@ -1,0 +1,154 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/multimodal"
+)
+
+func planMultimodalTool() ToolDef {
+	return ToolDef{
+		Name:        "plan_multimodal",
+		Title:       "Multimodal Itinerary Composer",
+		Description: "Compose end-to-end multimodal itineraries (e.g. ferry then fly). Rome2Rio discovers candidate mode-chains; trvl prices each leg with its existing flight and ground providers, sums them into a true total, ranks by that total, and annotates travel-hack savings. Legs that cannot be priced fall back to Rome2Rio's indicative range, clearly labelled as estimates — never fabricated fares.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"from":                    {Type: "string", Description: "Origin place name (e.g. Helsinki, London)"},
+				"to":                      {Type: "string", Description: "Destination place name"},
+				"date":                    {Type: "string", Description: "Departure date (YYYY-MM-DD)"},
+				"allow_browser_fallbacks": {Type: "boolean", Description: "Allow browser/cookie-assisted Rome2Rio discovery + ground leg pricing (default: false; offline returns a typed status)"},
+			},
+			Required: []string{"from", "to", "date"},
+		},
+		OutputSchema: multimodalPlanOutputSchema(),
+		Annotations: &ToolAnnotations{
+			Title:          "Multimodal Itinerary Composer",
+			ReadOnlyHint:   true,
+			OpenWorldHint:  true,
+			IdempotentHint: true,
+		},
+	}
+}
+
+func multimodalPlanOutputSchema() interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"from":        schemaString(),
+			"to":          schemaString(),
+			"date":        schemaString(),
+			"discovered":  schemaInt(),
+			"priced":      schemaInt(),
+			"notes":       schemaStringArray(),
+			"error":       schemaString(),
+			"itineraries": multimodalItinerariesOutputSchema(),
+		},
+		"required": []string{"from", "to", "date", "discovered", "priced"},
+	}
+}
+
+func multimodalItinerariesOutputSchema() interface{} {
+	return schemaArray(map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"from":             schemaString(),
+			"to":               schemaString(),
+			"date":             schemaString(),
+			"total_price":      schemaNum(),
+			"currency":         schemaString(),
+			"duration_minutes": schemaInt(),
+			"transfers":        schemaInt(),
+			"mode_chain":       schemaString(),
+			"estimated":        schemaBool(),
+			"source":           schemaString(),
+			"booking_url":      schemaString(),
+			"warnings":         schemaStringArray(),
+			"risks":            schemaStringArray(),
+			"legs": schemaArray(map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"mode":             schemaString(),
+					"from":             schemaString(),
+					"to":               schemaString(),
+					"price":            schemaNum(),
+					"currency":         schemaString(),
+					"duration_minutes": schemaInt(),
+					"estimated":        schemaBool(),
+					"provider":         schemaString(),
+					"booking_url":      schemaString(),
+					"detail":           schemaString(),
+				},
+			}),
+		},
+	})
+}
+
+func handlePlanMultimodal(ctx context.Context, args map[string]any, elicit ElicitFunc, sampling SamplingFunc, progress ProgressFunc) ([]ContentBlock, interface{}, error) {
+	from := argString(args, "from")
+	to := argString(args, "to")
+	date := argString(args, "date")
+	if from == "" || to == "" || date == "" {
+		return nil, nil, fmt.Errorf("from, to, and date are required")
+	}
+	allowBrowser := argBool(args, "allow_browser_fallbacks", false)
+
+	planner := multimodal.NewPlanner(allowBrowser)
+	plan, err := planner.Plan(ctx, from, to, date)
+	if err != nil {
+		return nil, nil, toolExecutionError("Multimodal plan", err)
+	}
+	if plan.Error != "" {
+		return nil, nil, toolResultError("Multimodal plan", plan.Error)
+	}
+	if len(plan.Itineraries) == 0 {
+		msg := fmt.Sprintf("No multimodal itineraries from %s to %s on %s", from, to, date)
+		if len(plan.Notes) > 0 {
+			msg += " — " + strings.Join(plan.Notes, "; ")
+		}
+		return []ContentBlock{{Type: "text", Text: msg}}, plan, nil
+	}
+
+	content, err := buildAnnotatedContentBlocks(multimodalPlanSummary(plan), plan)
+	if err != nil {
+		return nil, nil, err
+	}
+	return content, plan, nil
+}
+
+func multimodalPlanSummary(plan *multimodal.Plan) string {
+	var sb strings.Builder
+	_, _ = fmt.Fprintf(&sb, "%d multimodal itineraries from %s to %s on %s (from %d discovered chains):\n\n",
+		len(plan.Itineraries), plan.From, plan.To, plan.Date, plan.Discovered)
+
+	limit := len(plan.Itineraries)
+	if limit > 10 {
+		limit = 10
+	}
+	for i, it := range plan.Itineraries[:limit] {
+		tag := ""
+		if it.Estimated {
+			tag = " [includes estimate]"
+		}
+		_, _ = fmt.Fprintf(&sb, "%d. **%s %.2f** %s | %dh%02dm%s\n",
+			i+1, it.Currency, it.TotalPrice, it.ModeChain, it.DurationMin/60, it.DurationMin%60, tag)
+		for _, leg := range it.Legs {
+			label := leg.Provider
+			if leg.Estimated {
+				label = "estimate"
+			}
+			_, _ = fmt.Fprintf(&sb, "   - %s %s→%s: %s %.2f via %s\n",
+				leg.Mode, leg.From, leg.To, leg.Currency, leg.Price, label)
+		}
+		if it.HackSaving != nil {
+			_, _ = fmt.Fprintf(&sb, "   💡 %s: save %s %.2f (%s)\n",
+				it.HackSaving.Title, it.Currency, it.HackSaving.Savings, it.HackSaving.Type)
+		}
+	}
+	if len(plan.Notes) > 0 {
+		_, _ = fmt.Fprintf(&sb, "\n%s", strings.Join(plan.Notes, "\n"))
+	}
+	return sb.String()
+}

--- a/mcp/tools_smart_test.go
+++ b/mcp/tools_smart_test.go
@@ -44,8 +44,8 @@ func TestLegacyToolModeStillAdvertisesLegacySurface(t *testing.T) {
 
 	s := NewServer()
 
-	if len(s.tools) != 67 {
-		t.Fatalf("legacy tool mode should advertise 67 legacy tools, got %d", len(s.tools))
+	if len(s.tools) != 68 {
+		t.Fatalf("legacy tool mode should advertise 68 legacy tools, got %d", len(s.tools))
 	}
 	if !toolRegistered(s.tools, "search_flights") {
 		t.Fatalf("legacy mode should advertise search_flights")


### PR DESCRIPTION
## Summary

Adds **innovation #2: the multimodal composer** — a new capability that assembles
end-to-end, multi-modal itineraries by combining route *discovery* with per-leg
*pricing* from the providers trvl already ships.

Pipeline: Rome2Rio **discovers** mode-chains (e.g. ferry then fly then train) →
existing per-leg providers **price** each leg (flights via Google Flights/Kiwi/etc,
ground via the ground providers) → legs are **assembled** into a summed total →
itineraries are **ranked** by true total price → the cheapest is **annotated**
with any applicable travel-hack saving.

Honesty discipline throughout: legs that can't be priced from a real provider
fall back to Rome2Rio's *indicative* figure, are clearly labelled
`Estimated` / `rome2rio (estimate)`, and flag the whole itinerary with a verify
warning. Currency mismatch demotes a leg to an estimate rather than fabricating a
converted total (mirrors the existing flights round-trip composition rules).

### Surface

- New package `internal/multimodal/` (composer, assembler, production pricing
  seam) — seam-based design (Discoverer / LegPricer / HackAnnotator fn types)
  for deterministic offline tests.
- CLI: `trvl multimodal FROM TO DATE` (aliases `plan`, `combo`;
  `--allow-browser-fallbacks`).
- MCP: `plan_multimodal` tool, registered as a **non-alias smart capability**
  (same precedent as `plan_journey` / `plan_natural`) — the marketed
  compatibility-alias count stays **66**, zero doc churn.
- Follow-up to #215: the MCP flight handler now surfaces `hack_saving` in its
  enriched result (the ground handler already did).

### Verification

- gofmt / go vet / staticcheck clean
- `go test -race ./internal/multimodal/` — green
- `go test -short ./...` — green (incl. public-docs count test, legacy-tool-mode
  count, CLI subcommand count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
