### PR TITLE
Confidence + freshness scoring on search results (innovation #3)

### DIFF
--- a/internal/fareintel/confidence.go
+++ b/internal/fareintel/confidence.go
@@ -1,0 +1,322 @@
+// confidence.go — bookability confidence scoring (innovation #3).
+//
+// ScoreConfidence converts the evidence trvl already has about a result —
+// price freshness, provider reliability, multi-source corroboration, hotel
+// price verification, and (optionally) historical price position — into an
+// honest 0..1 "likely bookable" score plus a high/medium/low label. It REUSES
+// the existing engines rather than reimplementing them:
+//
+//   - models.ClassifyFreshness / models.SourceProfileFor — freshness + API-vs-scrape
+//   - dealquality.ScoreAgainst                            — historical price position
+//   - fareintel.Analyze (this package)                    — fare-history verdict + confidence
+//
+// When the available signal is too thin to judge, ScoreConfidence returns an
+// honest unrated assessment (models.ConfidenceUnrated). It NEVER fabricates a
+// number from nothing.
+package fareintel
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/dealquality"
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// Signal weights. Each contributes only when its evidence is actually present,
+// so a result is scored on the signals it has, not penalised for ones it lacks.
+const (
+	weightFreshness     = 0.40 // how fresh the quoted price is
+	weightProvider      = 0.25 // structured API vs scrape/browser-assisted
+	weightCorroboration = 0.20 // how many distinct sources returned the same result
+	weightVerification  = 0.10 // hotel price basis confidence (unverified..verified)
+	weightDealPosition  = 0.15 // sane market position from historical samples
+
+	// minRatedWeight is the minimum total active-signal weight required before
+	// trvl will commit to a score. Below this we are honest and return unrated.
+	minRatedWeight = 0.45
+	// minRatedSignals is the minimum number of independent signals required.
+	minRatedSignals = 2
+
+	// Label thresholds on the 0..1 score.
+	thresholdHigh   = 0.75
+	thresholdMedium = 0.50
+)
+
+// ConfidenceInput captures the evidence available to assess one result. All
+// fields are optional; omit what you do not have and the scorer degrades
+// honestly rather than inventing signal.
+type ConfidenceInput struct {
+	Price       float64
+	Currency    string
+	Provider    string               // headline provider id, e.g. "kiwi", "google_flights"
+	RetrievedAt time.Time            // when the headline price was obtained (zero = unknown)
+	Now         time.Time            // evaluation time (zero => derived from sources / treated as unknown)
+	Sources     []models.PriceSource // every source that returned this same physical result
+	// PriceVerification is the hotel price-basis confidence
+	// (unverified|room_level|verified); "" when not applicable (flights/ground).
+	PriceVerification string
+	// SeparateTickets marks a synthetic book-direct / self-connect itinerary whose
+	// legs are booked on separate tickets — inherently less certain to hold.
+	SeparateTickets bool
+
+	// Optional historical price context. Provide DealSamples (dealquality) and/or
+	// FareHistory (fareintel.Analyze) to add a price-position signal. Omit both
+	// when no history exists.
+	DealSamples []dealquality.Sample
+	FareHistory []watch.PricePoint
+}
+
+// ScoreConfidence assesses how likely the result is bookable at the shown price.
+func ScoreConfidence(in ConfidenceInput) models.Confidence {
+	if in.Price <= 0 {
+		return models.UnratedConfidence("no price to assess")
+	}
+
+	now := in.Now
+	if now.IsZero() {
+		now = freshestSourceTime(in.Sources)
+	}
+
+	var sum, total float64
+	var nSignals int
+	var tags []string
+	add := func(value, weight float64, tag string) {
+		sum += value * weight
+		total += weight
+		nSignals++
+		tags = append(tags, tag)
+	}
+
+	// ── Freshness ──────────────────────────────────────────────────────────
+	retrievedAt, freshKnown := in.RetrievedAt, !in.RetrievedAt.IsZero()
+	if !freshKnown {
+		if t := freshestSourceTime(in.Sources); !t.IsZero() {
+			retrievedAt, freshKnown = t, true
+		}
+	}
+	freshness := ""
+	if freshKnown {
+		evalNow := now
+		if evalNow.IsZero() {
+			evalNow = retrievedAt
+		}
+		freshness = models.ClassifyFreshness(in.Provider, retrievedAt, evalNow)
+		add(freshnessValue(freshness), weightFreshness, "freshness:"+freshness)
+	}
+
+	// ── Provider reliability (API vs scrape) ───────────────────────────────
+	if prof := models.SourceProfileFor(in.Provider); prof.ID != "" {
+		if prof.API {
+			add(1.0, weightProvider, "provider:api")
+		} else {
+			add(0.5, weightProvider, "provider:scrape")
+		}
+	}
+
+	// ── Multi-source corroboration ─────────────────────────────────────────
+	if n := distinctSourceCount(in.Sources, in.Provider); n > 0 {
+		add(corroborationValue(n), weightCorroboration, fmt.Sprintf("sources:%d", n))
+	}
+
+	// ── Hotel price verification ───────────────────────────────────────────
+	if v := verificationValue(in.PriceVerification); v >= 0 {
+		add(v, weightVerification, "verification:"+strings.ToLower(in.PriceVerification))
+	}
+
+	// ── Historical price position (dealquality / fareintel) ────────────────
+	if v, tag, ok := dealPositionValue(in); ok {
+		add(v, weightDealPosition, tag)
+	}
+
+	// Honest unrated when signal is too thin.
+	if total < minRatedWeight || nSignals < minRatedSignals {
+		c := models.UnratedConfidence("insufficient signal to assess bookability")
+		c.Freshness = freshness
+		if len(tags) > 0 {
+			c.Signals = tags
+		}
+		return c
+	}
+
+	score := sum / total
+
+	// Separate-tickets itineraries carry real booking risk: cap and discount.
+	if in.SeparateTickets {
+		score *= 0.7
+		tags = append(tags, "separate_tickets_risk")
+	}
+	if score < 0 {
+		score = 0
+	}
+	if score > 1 {
+		score = 1
+	}
+
+	c := models.Confidence{
+		Rated:     true,
+		Score:     score,
+		Label:     labelFor(score),
+		Freshness: freshness,
+		Signals:   tags,
+	}
+	c.Basis = basisFor(c)
+	return c
+}
+
+func freshnessValue(freshness string) float64 {
+	switch freshness {
+	case models.FreshnessLive:
+		return 1.0
+	case models.FreshnessRecent:
+		return 0.6
+	case models.FreshnessStale:
+		return 0.15
+	default:
+		return 0.6
+	}
+}
+
+func corroborationValue(n int) float64 {
+	switch {
+	case n >= 3:
+		return 1.0
+	case n == 2:
+		return 0.75
+	default:
+		return 0.45
+	}
+}
+
+// verificationValue maps a hotel price-basis confidence to [0,1]; returns -1
+// when there is no verification signal.
+func verificationValue(v string) float64 {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "verified":
+		return 1.0
+	case "room_level":
+		return 0.7
+	case "unverified":
+		return 0.3
+	default:
+		return -1
+	}
+}
+
+// dealPositionValue derives a bookability-plausibility signal from historical
+// price context. A price in a sane market band is most plausible; a price wildly
+// below history is treated as slightly less certain (it may be stale or an
+// error). Prefers dealquality samples; falls back to fareintel.Analyze.
+func dealPositionValue(in ConfidenceInput) (value float64, tag string, ok bool) {
+	if len(in.DealSamples) > 0 {
+		score := dealquality.ScoreAgainst(in.Price, in.DealSamples)
+		if score.Reason == "insufficient_history" {
+			return 0, "", false
+		}
+		// score.Total is 0..100 deal quality; map to a plausibility curve.
+		return plausibilityFromDeal(score.Total), fmt.Sprintf("deal:%s", score.Reason), true
+	}
+	if len(in.FareHistory) > 0 {
+		res := Analyze(in.Price, in.Currency, in.FareHistory)
+		if res.HistoryCount < 3 {
+			return 0, "", false
+		}
+		// Reuse fareintel's own confidence + percent-vs-median.
+		return plausibilityFromPercent(res.PercentVsMedian), fmt.Sprintf("fare:%s", res.Verdict), true
+	}
+	return 0, "", false
+}
+
+// plausibilityFromDeal turns a 0..100 deal-quality score into a 0..1
+// bookability-plausibility value. Mid-market prices are most plausible; a price
+// far below history (deal≈100) is discounted as possibly-too-good-to-be-true.
+func plausibilityFromDeal(total int) float64 {
+	switch {
+	case total >= 95:
+		return 0.6 // suspiciously cheap
+	case total >= 20:
+		return 1.0 // healthy market band
+	default:
+		return 0.75 // expensive but real
+	}
+}
+
+func plausibilityFromPercent(pctVsMedian float64) float64 {
+	switch {
+	case pctVsMedian <= -40:
+		return 0.6 // far below median — possibly stale/error
+	case pctVsMedian <= 25:
+		return 1.0 // around the typical band
+	default:
+		return 0.8 // above median but plausible
+	}
+}
+
+func labelFor(score float64) string {
+	switch {
+	case score >= thresholdHigh:
+		return models.ConfidenceHigh
+	case score >= thresholdMedium:
+		return models.ConfidenceMedium
+	default:
+		return models.ConfidenceLow
+	}
+}
+
+func basisFor(c models.Confidence) string {
+	parts := make([]string, 0, 3)
+	if c.Freshness != "" {
+		parts = append(parts, c.Freshness+" price")
+	}
+	for _, s := range c.Signals {
+		switch {
+		case s == "provider:api":
+			parts = append(parts, "structured API source")
+		case s == "provider:scrape":
+			parts = append(parts, "scraped source")
+		case strings.HasPrefix(s, "sources:"):
+			parts = append(parts, strings.TrimPrefix(s, "sources:")+"-source corroboration")
+		case s == "separate_tickets_risk":
+			parts = append(parts, "separate-tickets risk")
+		}
+	}
+	if len(parts) == 0 {
+		return fmt.Sprintf("%d%% likely bookable", c.Percent())
+	}
+	return fmt.Sprintf("%d%% likely bookable — %s", c.Percent(), strings.Join(parts, ", "))
+}
+
+// distinctSourceCount counts unique source providers, including the headline
+// provider when sources are absent or do not list it.
+func distinctSourceCount(sources []models.PriceSource, headline string) int {
+	seen := map[string]struct{}{}
+	for _, s := range sources {
+		id := strings.ToLower(strings.TrimSpace(s.Provider))
+		if id == "" {
+			continue
+		}
+		seen[id] = struct{}{}
+	}
+	if h := strings.ToLower(strings.TrimSpace(headline)); h != "" {
+		seen[h] = struct{}{}
+	}
+	return len(seen)
+}
+
+// freshestSourceTime returns the most recent non-zero RetrievedAt across sources.
+func freshestSourceTime(sources []models.PriceSource) time.Time {
+	times := make([]time.Time, 0, len(sources))
+	for _, s := range sources {
+		if !s.RetrievedAt.IsZero() {
+			times = append(times, s.RetrievedAt)
+		}
+	}
+	if len(times) == 0 {
+		return time.Time{}
+	}
+	sort.Slice(times, func(i, j int) bool { return times[i].After(times[j]) })
+	return times[0]
+}

--- a/internal/fareintel/confidence_test.go
+++ b/internal/fareintel/confidence_test.go
@@ -1,0 +1,214 @@
+package fareintel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/dealquality"
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// highSignal: live API price corroborated by several sources should score high.
+func TestScoreConfidence_HighSignal(t *testing.T) {
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	in := ConfidenceInput{
+		Price:       120,
+		Currency:    "EUR",
+		Provider:    "kiwi", // structured API
+		RetrievedAt: now,    // just fetched -> live
+		Now:         now,
+		Sources: []models.PriceSource{
+			{Provider: "kiwi", Price: 120, RetrievedAt: now},
+			{Provider: "ryanair", Price: 125, RetrievedAt: now},
+			{Provider: "skiplagged", Price: 130, RetrievedAt: now},
+		},
+	}
+	c := ScoreConfidence(in)
+	if !c.Rated {
+		t.Fatalf("expected rated, got unrated: %+v", c)
+	}
+	if c.Label != models.ConfidenceHigh {
+		t.Fatalf("expected high label, got %q (score %.3f)", c.Label, c.Score)
+	}
+	if c.Freshness != models.FreshnessLive {
+		t.Errorf("expected live freshness, got %q", c.Freshness)
+	}
+	if c.Percent() < 75 {
+		t.Errorf("expected >=75%%, got %d", c.Percent())
+	}
+	if c.Basis == "" {
+		t.Error("expected a non-empty basis explanation")
+	}
+}
+
+// staleLowSignal: a stale scraped single-source price should score low.
+func TestScoreConfidence_StaleLowSignal(t *testing.T) {
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	// booking has StaleMinutes=720 (12h); 13h old -> stale.
+	retrieved := now.Add(-13 * time.Hour)
+	in := ConfidenceInput{
+		Price:       300,
+		Currency:    "EUR",
+		Provider:    "booking", // scrape
+		RetrievedAt: retrieved,
+		Now:         now,
+		Sources:     []models.PriceSource{{Provider: "booking", Price: 300, RetrievedAt: retrieved}},
+	}
+	c := ScoreConfidence(in)
+	if !c.Rated {
+		t.Fatalf("expected rated, got unrated: %+v", c)
+	}
+	if c.Label != models.ConfidenceLow {
+		t.Fatalf("expected low label, got %q (score %.3f)", c.Label, c.Score)
+	}
+	if c.Freshness != models.FreshnessStale {
+		t.Errorf("expected stale freshness, got %q", c.Freshness)
+	}
+}
+
+// noSignal: no provider, no freshness, no sources -> honest unrated, never faked.
+func TestScoreConfidence_UnratedWhenNoSignal(t *testing.T) {
+	c := ScoreConfidence(ConfidenceInput{Price: 100, Currency: "EUR"})
+	if c.Rated {
+		t.Fatalf("expected unrated, got rated: %+v", c)
+	}
+	if c.Label != models.ConfidenceUnrated {
+		t.Errorf("expected unrated label, got %q", c.Label)
+	}
+	if c.Score != 0 {
+		t.Errorf("unrated score must be 0 (never fabricated), got %.3f", c.Score)
+	}
+	if c.Percent() != 0 {
+		t.Errorf("unrated Percent() must be 0, got %d", c.Percent())
+	}
+}
+
+// noPrice: a missing price can never be assessed.
+func TestScoreConfidence_UnratedWhenNoPrice(t *testing.T) {
+	c := ScoreConfidence(ConfidenceInput{Price: 0, Provider: "kiwi"})
+	if c.Rated || c.Label != models.ConfidenceUnrated {
+		t.Fatalf("expected unrated for zero price, got %+v", c)
+	}
+}
+
+// singleScrapeFresh: a just-fetched single scraped source is plausibly bookable
+// but not high — should land medium.
+func TestScoreConfidence_SingleScrapeFreshIsMedium(t *testing.T) {
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	c := ScoreConfidence(ConfidenceInput{
+		Price:       200,
+		Currency:    "EUR",
+		Provider:    "google_flights", // scrape
+		RetrievedAt: now,
+		Now:         now,
+		Sources:     []models.PriceSource{{Provider: "google_flights", Price: 200, RetrievedAt: now}},
+	})
+	if !c.Rated {
+		t.Fatalf("expected rated, got %+v", c)
+	}
+	if c.Label != models.ConfidenceMedium {
+		t.Errorf("expected medium, got %q (score %.3f)", c.Label, c.Score)
+	}
+}
+
+// separateTickets: a synthetic book-direct itinerary is discounted vs the same
+// signals without the separate-tickets risk.
+func TestScoreConfidence_SeparateTicketsDiscount(t *testing.T) {
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	base := ConfidenceInput{
+		Price:       120,
+		Currency:    "EUR",
+		Provider:    "kiwi",
+		RetrievedAt: now,
+		Now:         now,
+		Sources: []models.PriceSource{
+			{Provider: "kiwi", Price: 120, RetrievedAt: now},
+			{Provider: "ryanair", Price: 125, RetrievedAt: now},
+		},
+	}
+	whole := ScoreConfidence(base)
+	base.SeparateTickets = true
+	split := ScoreConfidence(base)
+	if split.Score >= whole.Score {
+		t.Fatalf("separate-tickets score %.3f should be < whole-fare %.3f", split.Score, whole.Score)
+	}
+	if !containsSignal(split.Signals, "separate_tickets_risk") {
+		t.Error("expected separate_tickets_risk signal tag")
+	}
+}
+
+// dealHistory: a healthy historical price band contributes a deal-position
+// signal via dealquality without being faked when history is too sparse.
+func TestScoreConfidence_DealPositionSignal(t *testing.T) {
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	samples := make([]dealquality.Sample, 0, 12)
+	for i := 0; i < 12; i++ {
+		samples = append(samples, dealquality.Sample{Route: "HEL-BCN", Season: "Q2", Date: "2026-05-01", Price: 100 + float64(i*5), Kind: "flight"})
+	}
+	in := ConfidenceInput{
+		Price:       120, // mid-band -> plausible
+		Currency:    "EUR",
+		Provider:    "kiwi",
+		RetrievedAt: now,
+		Now:         now,
+		Sources:     []models.PriceSource{{Provider: "kiwi", Price: 120, RetrievedAt: now}},
+		DealSamples: samples,
+	}
+	c := ScoreConfidence(in)
+	if !c.Rated {
+		t.Fatalf("expected rated, got %+v", c)
+	}
+	if !hasSignalPrefix(c.Signals, "deal:") {
+		t.Errorf("expected a deal: signal from dealquality, got %v", c.Signals)
+	}
+
+	// Sparse history must NOT fabricate a deal signal.
+	in.DealSamples = samples[:3]
+	c2 := ScoreConfidence(in)
+	if hasSignalPrefix(c2.Signals, "deal:") {
+		t.Errorf("sparse history must not produce a deal signal, got %v", c2.Signals)
+	}
+}
+
+// fareHistory: fareintel.Analyze is reused as the price-position signal when
+// fare history (not dealquality samples) is supplied.
+func TestScoreConfidence_FareHistorySignal(t *testing.T) {
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	hist := []watch.PricePoint{
+		Point(100, "EUR", now.Add(-72*time.Hour)),
+		Point(110, "EUR", now.Add(-48*time.Hour)),
+		Point(105, "EUR", now.Add(-24*time.Hour)),
+		Point(108, "EUR", now.Add(-12*time.Hour)),
+	}
+	c := ScoreConfidence(ConfidenceInput{
+		Price:       104,
+		Currency:    "EUR",
+		Provider:    "kiwi",
+		RetrievedAt: now,
+		Now:         now,
+		Sources:     []models.PriceSource{{Provider: "kiwi", Price: 104, RetrievedAt: now}},
+		FareHistory: hist,
+	})
+	if !hasSignalPrefix(c.Signals, "fare:") {
+		t.Errorf("expected a fare: signal from fareintel.Analyze, got %v", c.Signals)
+	}
+}
+
+func containsSignal(sigs []string, want string) bool {
+	for _, s := range sigs {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSignalPrefix(sigs []string, prefix string) bool {
+	for _, s := range sigs {
+		if len(s) >= len(prefix) && s[:len(prefix)] == prefix {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/flights/confidence_test.go
+++ b/internal/flights/confidence_test.go
@@ -1,0 +1,48 @@
+package flights
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// annotateFlightConfidence must attach an honest Confidence to every flight:
+// a live multi-source API fare scores high; a synthetic separate-tickets
+// itinerary is discounted relative to the same signals.
+func TestAnnotateFlightConfidence(t *testing.T) {
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	flights := []models.FlightResult{
+		{
+			Price:    120,
+			Currency: "EUR",
+			Provider: "kiwi",
+			Sources: []models.PriceSource{
+				{Provider: "kiwi", Price: 120, RetrievedAt: now},
+				{Provider: "ryanair", Price: 125, RetrievedAt: now},
+				{Provider: "skiplagged", Price: 130, RetrievedAt: now},
+			},
+		},
+		{
+			Price:      140,
+			Currency:   "EUR",
+			Provider:   "kiwi",
+			BookDirect: true,
+			Sources: []models.PriceSource{
+				{Provider: "kiwi", Price: 140, RetrievedAt: now},
+				{Provider: "ryanair", Price: 145, RetrievedAt: now},
+			},
+		},
+	}
+	annotateFlightConfidence(flights, now)
+
+	if flights[0].Confidence == nil || !flights[0].Confidence.Rated {
+		t.Fatalf("flight 0 should be rated, got %+v", flights[0].Confidence)
+	}
+	if flights[0].Confidence.Label != models.ConfidenceHigh {
+		t.Errorf("flight 0 expected high, got %q", flights[0].Confidence.Label)
+	}
+	if flights[1].Confidence == nil || flights[1].Confidence.Score >= flights[0].Confidence.Score {
+		t.Errorf("separate-tickets flight should score below the whole fare")
+	}
+}

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
 	"github.com/MikkoParkkola/trvl/internal/destinations"
+	"github.com/MikkoParkkola/trvl/internal/fareintel"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/searchctx"
 	"golang.org/x/sync/singleflight"
@@ -283,6 +284,7 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	}
 
 	if googleSucceeded || kiwiSucceeded || skiplaggedSucceeded || ryanairSucceeded || wizzairSucceeded || transaviaSucceeded || easyjetSucceeded {
+		annotateFlightConfidence(mergedFlights, time.Now())
 		result := &models.FlightSearchResult{
 			Success:          true,
 			Count:            len(mergedFlights),
@@ -332,6 +334,31 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 		Error:            "unreachable flight search state",
 		ProviderStatuses: statuses,
 	}, fmt.Errorf("unreachable flight search state")
+}
+
+// annotateFlightConfidence attaches an honest bookability Confidence to every
+// flight (innovation #3). Prices are scored from the freshness of the just-
+// fetched quote, provider reliability, and multi-source corroboration via the
+// shared fareintel scorer. Synthetic separate-ticket itineraries are flagged as
+// higher risk. Results with no usable signal are left unrated, never faked.
+func annotateFlightConfidence(flights []models.FlightResult, now time.Time) {
+	for i := range flights {
+		f := &flights[i]
+		provider := f.Provider
+		if provider == "" {
+			provider = f.CheapestSource
+		}
+		c := fareintel.ScoreConfidence(fareintel.ConfidenceInput{
+			Price:           f.PriceForRanking(),
+			Currency:        f.Currency,
+			Provider:        provider,
+			RetrievedAt:     now,
+			Now:             now,
+			Sources:         f.Sources,
+			SeparateTickets: f.BookDirect || f.SelfConnect,
+		})
+		f.Confidence = &c
+	}
 }
 
 func cloneFlightSearchResult(shared *models.FlightSearchResult) *models.FlightSearchResult {

--- a/internal/ground/confidence_test.go
+++ b/internal/ground/confidence_test.go
@@ -1,0 +1,44 @@
+package ground
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// annotateGroundConfidence must attach an honest Confidence to every route.
+// A just-fetched route from a known provider is rated; a route with no
+// provider signal is left unrated rather than faked.
+func TestAnnotateGroundConfidence(t *testing.T) {
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	routes := []models.GroundRoute{
+		{
+			Provider: "flixbus",
+			Type:     "bus",
+			Price:    19.99,
+			Currency: "EUR",
+			Sources: []models.PriceSource{
+				{Provider: "flixbus", Price: 19.99, RetrievedAt: now},
+				{Provider: "omio", Price: 21.50, RetrievedAt: now},
+			},
+		},
+		{
+			// No provider, no sources -> unrated, never faked.
+			Type:     "bus",
+			Price:    25,
+			Currency: "EUR",
+		},
+	}
+	annotateGroundConfidence(routes, now)
+
+	if routes[0].Confidence == nil || !routes[0].Confidence.Rated {
+		t.Fatalf("route 0 should be rated, got %+v", routes[0].Confidence)
+	}
+	if routes[1].Confidence == nil || routes[1].Confidence.Rated {
+		t.Fatalf("route 1 should be unrated, got %+v", routes[1].Confidence)
+	}
+	if routes[1].Confidence.Label != models.ConfidenceUnrated {
+		t.Errorf("route 1 expected unrated label, got %q", routes[1].Confidence.Label)
+	}
+}

--- a/internal/ground/search.go
+++ b/internal/ground/search.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/cache"
+	"github.com/MikkoParkkola/trvl/internal/fareintel"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/searchctx"
 	"golang.org/x/sync/singleflight"
@@ -432,6 +433,8 @@ func searchByNameCore(ctx context.Context, from, to, date string, opts SearchOpt
 		return allRoutes[i].Price < allRoutes[j].Price
 	})
 
+	annotateGroundConfidence(allRoutes, time.Now())
+
 	result := &models.GroundSearchResult{
 		Success: len(allRoutes) > 0,
 		Count:   len(allRoutes),
@@ -460,6 +463,26 @@ func searchByNameCore(ctx context.Context, from, to, date string, opts SearchOpt
 // simply does not serve the requested route (e.g. "no DB station for Helsinki")
 // or that the provider was throttled during a burst of calls. Both are expected
 // during broad multi-provider searches and should be logged at DEBUG level
+// annotateGroundConfidence attaches an honest bookability Confidence to every
+// ground route (innovation #3), scored from the just-fetched quote freshness,
+// provider reliability, and multi-source corroboration via the shared fareintel
+// scorer. Routes with no usable signal are left unrated, never faked.
+func annotateGroundConfidence(routes []models.GroundRoute, now time.Time) {
+	for i := range routes {
+		r := &routes[i]
+		c := fareintel.ScoreConfidence(fareintel.ConfidenceInput{
+			Price:           r.Price,
+			Currency:        r.Currency,
+			Provider:        r.Provider,
+			RetrievedAt:     now,
+			Now:             now,
+			Sources:         r.Sources,
+			SeparateTickets: r.Transfers > 0 && r.Type == "mixed",
+		})
+		r.Confidence = &c
+	}
+}
+
 // rather than WARN to avoid polluting normal operation output.
 func isProviderNotApplicable(err error) bool {
 	if err == nil {

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/fareintel"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/providers"
 	"github.com/MikkoParkkola/trvl/internal/searchctx"
@@ -849,6 +850,8 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 
 	providerStatuses = coalesceProviderStatuses(providerStatuses)
 
+	annotateHotelConfidence(hotels, time.Now())
+
 	return &models.HotelSearchResult{
 		Success:          true,
 		Count:            len(hotels),
@@ -859,11 +862,39 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	}, nil
 }
 
+// annotateHotelConfidence attaches an honest bookability Confidence to every
+// hotel (innovation #3), scored via the shared fareintel scorer from the
+// property's price freshness, provider reliability, multi-source corroboration,
+// and price-basis verification. Hotels with no usable signal are left unrated,
+// never faked.
+func annotateHotelConfidence(hotels []models.HotelResult, now time.Time) {
+	for i := range hotels {
+		h := &hotels[i]
+		provider := h.CheapestSource
+		if provider == "" && len(h.Sources) > 0 {
+			provider = h.Sources[0].Provider
+		}
+		retrievedAt := h.RetrievedAt
+		if retrievedAt.IsZero() {
+			retrievedAt = now
+		}
+		c := fareintel.ScoreConfidence(fareintel.ConfidenceInput{
+			Price:             h.Price,
+			Currency:          h.Currency,
+			Provider:          provider,
+			RetrievedAt:       retrievedAt,
+			Now:               now,
+			Sources:           h.Sources,
+			PriceVerification: h.PriceConfidence,
+		})
+		h.Confidence = &c
+	}
+}
+
 func cloneHotelSearchResult(shared *models.HotelSearchResult) *models.HotelSearchResult {
 	if shared == nil {
 		return nil
 	}
-
 	// singleflight.Do shares the winner's *HotelSearchResult pointer across all
 	// callers. Trip planning and preference filters rewrite Count / Hotels and may
 	// mutate nested hotel slices, so each caller needs an independent deep copy.

--- a/internal/models/confidence.go
+++ b/internal/models/confidence.go
@@ -1,0 +1,63 @@
+// Package models — confidence.go: an honest, evidence-based assessment of how
+// likely a quoted result is to be bookable at the shown price. It is distinct
+// from deal quality ("is this cheap?") — it answers "can I trust this price
+// right now?". The score is computed by internal/fareintel from existing
+// signals (price freshness, provider reliability, multi-source corroboration,
+// and — when available — historical price position). When trvl lacks the signal
+// to judge, Rated is false and Label is ConfidenceUnrated: trvl never fabricates
+// a confidence number.
+//
+// Tracking: innovation #3 (confidence + freshness scoring).
+package models
+
+// Confidence label constants.
+const (
+	ConfidenceHigh    = "high"
+	ConfidenceMedium  = "medium"
+	ConfidenceLow     = "low"
+	ConfidenceUnrated = "unrated"
+)
+
+// Confidence is a per-result bookability assessment. The zero value is an
+// honest "unrated" (Rated=false, Label==""); callers should treat an empty or
+// unrated Confidence as "no signal", never as a low score.
+type Confidence struct {
+	// Rated is false when there was insufficient signal to score the result.
+	// When false, Score is meaningless and Label is ConfidenceUnrated.
+	Rated bool `json:"rated"`
+	// Score is the 0..1 likelihood the price is bookable as shown. Only
+	// meaningful when Rated is true; omitted from JSON when unrated/zero.
+	Score float64 `json:"score,omitempty"`
+	// Label is a coarse bucket: high|medium|low|unrated.
+	Label string `json:"label"`
+	// Freshness classifies the assessed price (live|recent|stale); empty when
+	// the price age is unknown.
+	Freshness string `json:"freshness,omitempty"`
+	// Basis is a short human-readable explanation, e.g.
+	// "live API price corroborated by 3 sources".
+	Basis string `json:"basis"`
+	// Signals lists the machine-readable signal tags that fed the score, so a
+	// caller can see exactly why a result scored as it did.
+	Signals []string `json:"signals,omitempty"`
+}
+
+// Percent renders the score as an integer percentage 0..100. Returns 0 when
+// unrated (callers should check Rated before showing a percentage).
+func (c Confidence) Percent() int {
+	if !c.Rated {
+		return 0
+	}
+	p := int(c.Score*100 + 0.5)
+	if p < 0 {
+		p = 0
+	}
+	if p > 100 {
+		p = 100
+	}
+	return p
+}
+
+// UnratedConfidence returns an honest unrated assessment with the given reason.
+func UnratedConfidence(reason string) Confidence {
+	return Confidence{Rated: false, Label: ConfidenceUnrated, Basis: reason}
+}

--- a/internal/models/flight.go
+++ b/internal/models/flight.go
@@ -67,6 +67,11 @@ type FlightResult struct {
 	// BookDirect marks this FlightResult as a synthetic separate-tickets
 	// alternative assembled from SegmentSources, not a single bookable fare.
 	BookDirect bool `json:"book_direct,omitempty"`
+
+	// Confidence is an honest bookability assessment of the headline Price
+	// (innovation #3). Nil when not scored; an unrated Confidence means trvl
+	// lacked the signal to judge — it is never a fabricated number.
+	Confidence *Confidence `json:"confidence,omitempty"`
 }
 
 // PriceForRanking returns ComparablePrice when computed, else the base Price.

--- a/internal/models/ground.go
+++ b/internal/models/ground.go
@@ -35,6 +35,10 @@ type GroundRoute struct {
 	Sources        []PriceSource `json:"sources,omitempty"`
 	Savings        float64       `json:"savings,omitempty"`
 	CheapestSource string        `json:"cheapest_source,omitempty"`
+	// Confidence is an honest bookability assessment of the headline Price
+	// (innovation #3). Nil when not scored; an unrated Confidence means trvl
+	// lacked the signal to judge — it is never a fabricated number.
+	Confidence *Confidence `json:"confidence,omitempty"`
 }
 
 // GroundStop represents a departure or arrival point.

--- a/internal/models/hotel.go
+++ b/internal/models/hotel.go
@@ -108,6 +108,10 @@ type HotelResult struct {
 	RetrievedAt     time.Time     `json:"retrieved_at,omitempty"`     // checked time for primary Price
 	Freshness       string        `json:"freshness,omitempty"`        // freshness for primary Price
 	PriceWarnings   []string      `json:"price_warnings,omitempty"`   // machine-readable caveats, e.g. mixed_source_currencies
+	// Confidence is an honest bookability assessment of the headline Price
+	// (innovation #3). Nil when not scored; an unrated Confidence means trvl
+	// lacked the signal to judge — it is never a fabricated number.
+	Confidence *Confidence `json:"confidence,omitempty"`
 }
 
 // ProviderStatus reports the outcome of a single external provider query.

--- a/mcp/tools_deals_test.go
+++ b/mcp/tools_deals_test.go
@@ -41,7 +41,7 @@ func TestHandleSearchDeals_Success(t *testing.T) {
 	testutil.RequireLiveProbe(t)
 	content, structured, err := handleSearchDeals(context.Background(), map[string]any{
 		"origins": "HEL",
-		"type": "deal",
+		"type":    "deal",
 	}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## What

Adds an honest, evidence-based **bookability confidence + freshness** signal to every flight, ground, and hotel result so an assistant can say "85% likely bookable" instead of presenting a stale lead-in price as fact.

The score is computed by **reusing trvl's existing engines** — it does not reimplement scoring:

- `models.ClassifyFreshness` / `models.SourceProfileFor` — price freshness (live/recent/stale) and API-vs-scrape reliability
- `dealquality.ScoreAgainst` — historical price position (when samples exist)
- `fareintel.Analyze` — fare-history verdict (when fare history exists)

## How it scores

`fareintel.ScoreConfidence` takes the signals a result actually has and computes a weighted 0–1 score:

| Signal | Weight | Source |
|---|---|---|
| Price freshness | 0.40 | `ClassifyFreshness` |
| Provider reliability (API vs scrape) | 0.25 | `SourceProfileFor` |
| Multi-source corroboration | 0.20 | result `Sources` |
| Hotel price verification | 0.10 | `PriceConfidence` |
| Historical price position | 0.15 | `dealquality` / `fareintel` |

Only signals that are present contribute. Below a minimum signal threshold the result is marked **`unrated`** with score `0` — trvl never fabricates a confidence number when it lacks evidence. Labels: `high` (≥0.75), `medium` (≥0.50), `low`, `unrated`. Synthetic separate-tickets / self-connect itineraries are discounted as higher booking risk.

## Surface

New optional `Confidence` field (`rated`, `score`, `label`, `freshness`, `basis`, `signals`) on `FlightResult`, `HotelResult`, and `GroundRoute`, populated during flight, ground, and hotel search result assembly.

## Tests (TDD, deterministic + offline)

- Live multi-source API fare → **high**
- Stale single scraped price → **low**
- No provider / no freshness / no sources → **unrated**, score 0 (never faked)
- Missing price → unrated
- Single fresh scraped source → medium
- Separate-tickets itinerary scored below the equivalent whole fare
- Sparse history produces **no** deal signal (no fabrication)
- Flight + ground annotators verified end-to-end

## Verification

`go vet ./...` · `staticcheck ./...` · `gofmt -l` clean (incl. the folded-in gofmt of `mcp/tools_deals_test.go`) · `go test -race ./internal/flights/ ./internal/ground/ ./internal/scoring/ ./internal/fareintel/` · `go test -short ./...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)