### PR TITLE
Unified trip coalescer: one plan-all fans flights+hotels+ground concurrently (innovation #5)

### DIFF
--- a/cmd/trvl/commands_test.go
+++ b/cmd/trvl/commands_test.go
@@ -19,7 +19,8 @@ func TestRootCmd_SubcommandCount(t *testing.T) {
 	// 64 -> 65 when rental car search (`trvl cars`) landed.
 	// 65 -> 66 with `arbitrage-report` (innovation #8 unified arbitrage report).
 	// 66 -> 67 with `multimodal` (innovation #2 multimodal composer).
-	const want = 67
+	// 67 -> 68 with `plan-all` (innovation #5 unified trip coalescer).
+	const want = 68
 	got := len(rootCmd.Commands())
 	if got != want {
 		names := make([]string, 0, got)

--- a/cmd/trvl/plan_trip_unified.go
+++ b/cmd/trvl/plan_trip_unified.go
@@ -1,0 +1,156 @@
+package main
+
+// Innovation #5: trvl plan-all — unified trip coalescer.
+//
+// Today a user runs `trvl flights`, `trvl hotels`, and `trvl ground` as three
+// separate commands. plan-all fans all three out concurrently through the
+// bounded coalescer and prints one combined plan with a floor cost estimate.
+// One domain failing yields a partial plan, never an aborted run.
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/tripcoalesce"
+	"github.com/spf13/cobra"
+)
+
+func planAllCmd() *cobra.Command {
+	var (
+		returnDate    string
+		hotelLocation string
+		nights        int
+		travelers     int
+		currency      string
+		allowBrowser  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "plan-all <origin> <destination> <depart-date>",
+		Short: "Coalesce flights, hotels, and ground into one trip plan (concurrent fan-out)",
+		Long: `plan-all issues trvl's flight, hotel, and ground searches concurrently for a
+single origin→destination trip and assembles one combined plan: the cheapest
+priced option per domain plus a floor total-cost estimate.
+
+Each domain runs in isolation — if one provider fails or times out, the other
+domains still return, clearly flagged in the per-domain status list. Nothing is
+fabricated: a domain with no priced result is reported, never guessed.
+
+origin and destination are IATA airport codes for flights; the same values seed
+the ground "from"/"to" and the hotel location (override the hotel location with
+--hotel).
+
+Examples:
+  trvl plan-all HEL LHR 2026-07-01
+  trvl plan-all HEL LHR 2026-07-01 --return 2026-07-08 --nights 7 --travelers 2
+  trvl plan-all HEL BCN 2026-08-01 --hotel "Barcelona" --format json`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			origin := strings.ToUpper(strings.TrimSpace(args[0]))
+			destination := strings.ToUpper(strings.TrimSpace(args[1]))
+			departDate := strings.TrimSpace(args[2])
+
+			plan := tripcoalesce.Plan(cmd.Context(), tripcoalesce.Params{
+				Origin:                origin,
+				Destination:           destination,
+				DepartDate:            departDate,
+				ReturnDate:            strings.TrimSpace(returnDate),
+				HotelLocation:         strings.TrimSpace(hotelLocation),
+				Nights:                nights,
+				Travelers:             travelers,
+				Currency:              currency,
+				AllowBrowserFallbacks: allowBrowser,
+			})
+
+			if format == "json" {
+				return models.FormatJSON(os.Stdout, plan)
+			}
+			printCoalescedPlan(plan)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&returnDate, "return", "", "return date (YYYY-MM-DD) for round-trip flights / hotel checkout")
+	cmd.Flags().StringVar(&hotelLocation, "hotel", "", "hotel search location (default: destination)")
+	cmd.Flags().IntVar(&nights, "nights", 0, "nights for the hotel cost estimate (0 = per-night only)")
+	cmd.Flags().IntVar(&travelers, "travelers", 1, "number of travelers")
+	cmd.Flags().StringVar(&currency, "currency", "EUR", "trip currency")
+	cmd.Flags().BoolVar(&allowBrowser, "allow-browser-fallbacks", false, "allow browser/cookie-assisted ground providers")
+
+	_ = cmd.RegisterFlagCompletionFunc("hotel", cobra.NoFileCompletions)
+	cmd.ValidArgsFunction = airportCompletion
+	return cmd
+}
+
+func printCoalescedPlan(plan *tripcoalesce.TripPlan) {
+	header := fmt.Sprintf("Trip plan · %s → %s", plan.Origin, plan.Destination)
+	sub := plan.DepartDate
+	if plan.ReturnDate != "" {
+		sub += " → " + plan.ReturnDate
+	}
+	models.Banner(os.Stdout, "🧳", header, sub)
+	fmt.Println()
+
+	if plan.CheapestFlight != nil {
+		f := plan.CheapestFlight
+		fmt.Printf("✈  Flights   cheapest %s %.2f  ·  %s, %s\n",
+			f.Currency, f.Price, formatStops(f.Stops), formatDuration(f.Duration))
+	} else {
+		fmt.Printf("✈  Flights   %s\n", domainNote(plan, "flights"))
+	}
+
+	if plan.CheapestHotel != nil {
+		h := plan.CheapestHotel
+		fmt.Printf("🏨 Hotels    cheapest %s %.2f/night  ·  %s\n", h.Currency, h.Price, h.Name)
+	} else {
+		fmt.Printf("🏨 Hotels    %s\n", domainNote(plan, "hotels"))
+	}
+
+	if plan.CheapestGround != nil {
+		r := plan.CheapestGround
+		fmt.Printf("🚆 Ground    cheapest %s %.2f  ·  %s (%s)\n", r.Currency, r.Price, r.Provider, r.Type)
+	} else {
+		fmt.Printf("🚆 Ground    %s\n", domainNote(plan, "ground"))
+	}
+
+	fmt.Println()
+	if plan.TotalCostEstimate > 0 {
+		fmt.Printf("Floor estimate: %s %.2f\n", plan.Currency, plan.TotalCostEstimate)
+		for _, c := range plan.CostBreakdown {
+			note := ""
+			if c.Currency != plan.Currency {
+				note = "  (not in trip currency; excluded from floor)"
+			}
+			fmt.Printf("   • %-8s %-26s %s %.2f%s\n", c.Domain, c.Label, c.Currency, c.Amount, note)
+		}
+	} else {
+		fmt.Println("No priced options to total — see per-domain status below.")
+	}
+
+	if len(plan.Notes) > 0 {
+		fmt.Println()
+		for _, n := range plan.Notes {
+			fmt.Printf("Note: %s\n", n)
+		}
+	}
+}
+
+// domainNote returns a short status string for a domain that produced no
+// cheapest pick, distinguishing a failure from a clean empty.
+func domainNote(plan *tripcoalesce.TripPlan, domain string) string {
+	for _, s := range plan.Statuses {
+		if s.Domain != domain {
+			continue
+		}
+		if s.Error != "" {
+			return "unavailable: " + s.Error
+		}
+		if !s.OK {
+			return "unavailable"
+		}
+		return "no priced results"
+	}
+	return "no results"
+}

--- a/cmd/trvl/public_claims_test.go
+++ b/cmd/trvl/public_claims_test.go
@@ -144,6 +144,7 @@ func registeredMCPCompatibilityAliasCount(t *testing.T) int {
 		"plan_natural":     true, // NL travel-planner supertool (innovation #7)
 		"arbitrage_report": true, // unified arbitrage aggregator (innovation #8) — new capability, not a legacy alias
 		"plan_multimodal":  true, // Multimodal composer capability (innovation #2)
+		"coalesce_trip":    true, // unified trip coalescer (innovation #5) — new capability, not a legacy alias
 	}
 	count := 0
 	for _, key := range handlers.MapKeys() {

--- a/cmd/trvl/root.go
+++ b/cmd/trvl/root.go
@@ -112,6 +112,7 @@ func init() {
 	rootCmd.AddCommand(opportunityScoreCmd())
 	rootCmd.AddCommand(rateStatusCmd())
 	rootCmd.AddCommand(multimodalPlanCmd())
+	rootCmd.AddCommand(planAllCmd())
 }
 
 // airportCompletion provides IATA code completion for cobra commands.

--- a/internal/tripcoalesce/coalesce.go
+++ b/internal/tripcoalesce/coalesce.go
@@ -1,0 +1,182 @@
+// Package tripcoalesce fans a single "plan A→B" request out across trvl's
+// existing flight, hotel, and ground search engines concurrently, then
+// assembles one combined TripPlan with a best-effort total-cost estimate.
+//
+// Innovation #5: today a user runs `trvl flights`, `trvl hotels`, and
+// `trvl ground` as three separate commands and stitches the answers together
+// by hand. The coalescer issues all three searches at once through a bounded
+// errgroup (mirroring the cap-bounded fan-out pattern already used in
+// internal/flights/concurrency.go), isolates per-domain failures so one slow
+// or failing domain never aborts the others, and returns whatever succeeded.
+//
+// It REUSES the existing exported search entrypoints — it never reimplements a
+// provider or edits a provider package. The real search functions are injected
+// as seams (see New) so tests can fake them deterministically and offline.
+package tripcoalesce
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/ground"
+	"github.com/MikkoParkkola/trvl/internal/hotels"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// FlightSearchFunc matches flights.SearchFlights — the flight search seam.
+type FlightSearchFunc func(ctx context.Context, origin, destination, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error)
+
+// HotelSearchFunc matches hotels.SearchHotels — the hotel search seam.
+type HotelSearchFunc func(ctx context.Context, location string, opts hotels.HotelSearchOptions) (*models.HotelSearchResult, error)
+
+// GroundSearchFunc matches ground.SearchByName — the ground search seam.
+type GroundSearchFunc func(ctx context.Context, from, to, date string, opts ground.SearchOptions) (*models.GroundSearchResult, error)
+
+// defaultDomainConcurrency mirrors the bounded cap used elsewhere (the flight
+// fan-out caps at 6, multi.go at 5). Three domains never exceed it today, but
+// the cap keeps the contract explicit and future-proof.
+const defaultDomainConcurrency = 5
+
+// defaultPerDomainTimeout bounds how long any single domain may run inside the
+// fan-out so one stalled engine cannot hold the combined plan hostage. A domain
+// that exceeds it is reported as a timeout, never silently dropped.
+const defaultPerDomainTimeout = 45 * time.Second
+
+// Params describes one trip to coalesce. Only Origin, Destination and
+// DepartDate are required; the rest refine the per-domain searches.
+type Params struct {
+	Origin      string // flight origin (IATA, e.g. HEL) and ground "from" fallback
+	Destination string // flight destination (IATA) and ground "to" / hotel-location fallback
+	DepartDate  string // YYYY-MM-DD
+	ReturnDate  string // optional round-trip return date (flights)
+
+	// HotelLocation overrides the hotel search location. When empty, the hotel
+	// search uses Destination.
+	HotelLocation string
+	GroundFrom    string // overrides ground "from"; empty uses Origin
+	GroundTo      string // overrides ground "to"; empty uses Destination
+
+	CheckIn  string // hotel check-in (YYYY-MM-DD); empty uses DepartDate
+	CheckOut string // hotel check-out (YYYY-MM-DD); empty uses ReturnDate
+	Nights   int    // nights for the hotel cost estimate; <=0 means per-night only
+
+	Travelers int    // passengers / guests (default 1)
+	Currency  string // shared currency hint (default EUR)
+
+	// AllowBrowserFallbacks opts ground search into browser/cookie-assisted
+	// providers (mirrors ground.SearchOptions.AllowBrowserFallbacks).
+	AllowBrowserFallbacks bool
+}
+
+func (p Params) hotelLocation() string {
+	if strings.TrimSpace(p.HotelLocation) != "" {
+		return p.HotelLocation
+	}
+	return p.Destination
+}
+
+func (p Params) groundFrom() string {
+	if strings.TrimSpace(p.GroundFrom) != "" {
+		return p.GroundFrom
+	}
+	return p.Origin
+}
+
+func (p Params) groundTo() string {
+	if strings.TrimSpace(p.GroundTo) != "" {
+		return p.GroundTo
+	}
+	return p.Destination
+}
+
+func (p Params) travelers() int {
+	if p.Travelers <= 0 {
+		return 1
+	}
+	return p.Travelers
+}
+
+func (p Params) currency() string {
+	if c := strings.TrimSpace(p.Currency); c != "" {
+		return strings.ToUpper(c)
+	}
+	return "EUR"
+}
+
+// DomainStatus is the per-domain outcome surfaced so a caller can tell a clean
+// "0 results" apart from a failure or timeout — never a fabricated empty.
+type DomainStatus struct {
+	Domain    string `json:"domain"` // "flights", "hotels", or "ground"
+	OK        bool   `json:"ok"`     // true when the search returned without error
+	Count     int    `json:"count"`  // number of results found
+	Error     string `json:"error,omitempty"`
+	ElapsedMs int64  `json:"elapsed_ms"`
+}
+
+// CostComponent is one priced leg of the combined estimate.
+type CostComponent struct {
+	Domain   string  `json:"domain"`
+	Label    string  `json:"label"`
+	Amount   float64 `json:"amount"`
+	Currency string  `json:"currency"`
+}
+
+// TripPlan is the assembled result of one coalesced trip search.
+type TripPlan struct {
+	Origin      string `json:"origin"`
+	Destination string `json:"destination"`
+	DepartDate  string `json:"depart_date"`
+	ReturnDate  string `json:"return_date,omitempty"`
+	Currency    string `json:"currency"`
+
+	Flights *models.FlightSearchResult `json:"flights,omitempty"`
+	Hotels  *models.HotelSearchResult  `json:"hotels,omitempty"`
+	Ground  *models.GroundSearchResult `json:"ground,omitempty"`
+
+	// Cheapest picks per domain (nil when the domain found nothing priced).
+	CheapestFlight *models.FlightResult `json:"cheapest_flight,omitempty"`
+	CheapestHotel  *models.HotelResult  `json:"cheapest_hotel,omitempty"`
+	CheapestGround *models.GroundRoute  `json:"cheapest_ground,omitempty"`
+
+	// TotalCostEstimate sums the cheapest priced pick from each domain that
+	// returned one. It is a floor estimate, not a quote; CostBreakdown lists
+	// exactly which components contributed so nothing is implied silently.
+	TotalCostEstimate float64         `json:"total_cost_estimate"`
+	CostBreakdown     []CostComponent `json:"cost_breakdown,omitempty"`
+
+	Statuses []DomainStatus `json:"statuses"`
+	Notes    []string       `json:"notes,omitempty"`
+}
+
+// Coalescer holds the injectable search seams plus fan-out tuning. Use New for
+// the production wiring; override the *Search fields in tests with fakes.
+type Coalescer struct {
+	FlightSearch FlightSearchFunc
+	HotelSearch  HotelSearchFunc
+	GroundSearch GroundSearchFunc
+
+	Concurrency      int
+	PerDomainTimeout time.Duration
+
+	// now is an injectable clock for deterministic elapsed-time tests.
+	now func() time.Time
+}
+
+// New returns a Coalescer wired to the real exported search entrypoints.
+func New() *Coalescer {
+	return &Coalescer{
+		FlightSearch:     flights.SearchFlights,
+		HotelSearch:      hotels.SearchHotels,
+		GroundSearch:     ground.SearchByName,
+		Concurrency:      defaultDomainConcurrency,
+		PerDomainTimeout: defaultPerDomainTimeout,
+		now:              time.Now,
+	}
+}
+
+// Plan coalesces one trip using the default (real) search seams.
+func Plan(ctx context.Context, p Params) *TripPlan {
+	return New().Plan(ctx, p)
+}

--- a/internal/tripcoalesce/coalesce_test.go
+++ b/internal/tripcoalesce/coalesce_test.go
@@ -1,0 +1,265 @@
+package tripcoalesce
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/ground"
+	"github.com/MikkoParkkola/trvl/internal/hotels"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func baseParams() Params {
+	return Params{
+		Origin:      "HEL",
+		Destination: "LHR",
+		DepartDate:  "2026-07-01",
+		ReturnDate:  "2026-07-08",
+		Travelers:   2,
+		Currency:    "EUR",
+	}
+}
+
+// newTestCoalescer returns a Coalescer wired to the supplied fake seams with a
+// short timeout so timeout paths are fast.
+func newTestCoalescer(f FlightSearchFunc, h HotelSearchFunc, g GroundSearchFunc) *Coalescer {
+	return &Coalescer{
+		FlightSearch:     f,
+		HotelSearch:      h,
+		GroundSearch:     g,
+		Concurrency:      defaultDomainConcurrency,
+		PerDomainTimeout: 500 * time.Millisecond,
+		now:              time.Now,
+	}
+}
+
+func okFlights() FlightSearchFunc {
+	return func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+		return &models.FlightSearchResult{
+			Success: true,
+			Flights: []models.FlightResult{
+				{Price: 350, Currency: "EUR"},
+				{Price: 220, Currency: "EUR"},
+			},
+		}, nil
+	}
+}
+
+func okHotels() HotelSearchFunc {
+	return func(_ context.Context, _ string, _ hotels.HotelSearchOptions) (*models.HotelSearchResult, error) {
+		return &models.HotelSearchResult{
+			Success: true,
+			Hotels: []models.HotelResult{
+				{Name: "Grand", Price: 180, Currency: "EUR"},
+				{Name: "Budget Inn", Price: 95, Currency: "EUR"},
+			},
+		}, nil
+	}
+}
+
+func okGround() GroundSearchFunc {
+	return func(_ context.Context, _, _, _ string, _ ground.SearchOptions) (*models.GroundSearchResult, error) {
+		return &models.GroundSearchResult{
+			Success: true,
+			Routes: []models.GroundRoute{
+				{Provider: "flixbus", Price: 40, Currency: "EUR"},
+				{Provider: "rail", Price: 65, Currency: "EUR"},
+			},
+		}, nil
+	}
+}
+
+// TestPlanConcurrentFanOut proves the three domain searches run concurrently
+// rather than sequentially. Each fake blocks on a barrier until all three have
+// started; if the fan-out were sequential the barrier would deadlock and the
+// per-call timeout would fire, leaving zero successful domains.
+func TestPlanConcurrentFanOut(t *testing.T) {
+	const domains = 3
+	var started sync.WaitGroup
+	started.Add(domains)
+	release := make(chan struct{})
+	var maxConcurrent int64
+	var current int64
+
+	enter := func() {
+		started.Done()
+		n := atomic.AddInt64(&current, 1)
+		for {
+			old := atomic.LoadInt64(&maxConcurrent)
+			if n <= old || atomic.CompareAndSwapInt64(&maxConcurrent, old, n) {
+				break
+			}
+		}
+		<-release
+		atomic.AddInt64(&current, -1)
+	}
+
+	c := newTestCoalescer(
+		func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			enter()
+			return &models.FlightSearchResult{Success: true, Flights: []models.FlightResult{{Price: 200, Currency: "EUR"}}}, nil
+		},
+		func(_ context.Context, _ string, _ hotels.HotelSearchOptions) (*models.HotelSearchResult, error) {
+			enter()
+			return &models.HotelSearchResult{Success: true, Hotels: []models.HotelResult{{Price: 100, Currency: "EUR"}}}, nil
+		},
+		func(_ context.Context, _, _, _ string, _ ground.SearchOptions) (*models.GroundSearchResult, error) {
+			enter()
+			return &models.GroundSearchResult{Success: true, Routes: []models.GroundRoute{{Price: 30, Currency: "EUR"}}}, nil
+		},
+	)
+	c.PerDomainTimeout = 5 * time.Second
+
+	// Release the barrier once all three goroutines have entered concurrently.
+	go func() {
+		started.Wait()
+		close(release)
+	}()
+
+	plan := c.Plan(context.Background(), baseParams())
+
+	if got := atomic.LoadInt64(&maxConcurrent); got != domains {
+		t.Fatalf("max concurrent domains = %d, want %d (searches did not fan out concurrently)", got, domains)
+	}
+	okCount := 0
+	for _, s := range plan.Statuses {
+		if s.OK {
+			okCount++
+		}
+	}
+	if okCount != domains {
+		t.Fatalf("ok domains = %d, want %d", okCount, domains)
+	}
+}
+
+// TestPlanCombinedAssembly proves all three domains are assembled into one plan
+// with the cheapest pick per domain and a summed floor estimate.
+func TestPlanCombinedAssembly(t *testing.T) {
+	c := newTestCoalescer(okFlights(), okHotels(), okGround())
+	plan := c.Plan(context.Background(), baseParams())
+
+	if plan.Flights == nil || plan.Hotels == nil || plan.Ground == nil {
+		t.Fatalf("expected all three raw results attached: flights=%v hotels=%v ground=%v",
+			plan.Flights != nil, plan.Hotels != nil, plan.Ground != nil)
+	}
+	if plan.CheapestFlight == nil || plan.CheapestFlight.Price != 220 {
+		t.Fatalf("cheapest flight = %+v, want price 220", plan.CheapestFlight)
+	}
+	if plan.CheapestHotel == nil || plan.CheapestHotel.Price != 95 {
+		t.Fatalf("cheapest hotel = %+v, want price 95", plan.CheapestHotel)
+	}
+	if plan.CheapestGround == nil || plan.CheapestGround.Price != 40 {
+		t.Fatalf("cheapest ground = %+v, want price 40", plan.CheapestGround)
+	}
+	want := 220.0 + 95.0 + 40.0
+	if plan.TotalCostEstimate != want {
+		t.Fatalf("total estimate = %.2f, want %.2f", plan.TotalCostEstimate, want)
+	}
+	if len(plan.CostBreakdown) != 3 {
+		t.Fatalf("cost breakdown len = %d, want 3", len(plan.CostBreakdown))
+	}
+}
+
+// TestPlanPartialResultOnDomainFailure proves one domain failing yields a
+// partial plan with the other two intact — failure isolation, never an abort.
+func TestPlanPartialResultOnDomainFailure(t *testing.T) {
+	failingHotels := func(_ context.Context, _ string, _ hotels.HotelSearchOptions) (*models.HotelSearchResult, error) {
+		return nil, errors.New("hotels upstream 503")
+	}
+	c := newTestCoalescer(okFlights(), failingHotels, okGround())
+	plan := c.Plan(context.Background(), baseParams())
+
+	if plan.CheapestFlight == nil {
+		t.Fatal("flights should survive a hotel failure")
+	}
+	if plan.CheapestGround == nil {
+		t.Fatal("ground should survive a hotel failure")
+	}
+	if plan.CheapestHotel != nil {
+		t.Fatalf("hotels failed; cheapest hotel should be nil, got %+v", plan.CheapestHotel)
+	}
+
+	var hotelStatus *DomainStatus
+	for i := range plan.Statuses {
+		if plan.Statuses[i].Domain == "hotels" {
+			hotelStatus = &plan.Statuses[i]
+		}
+	}
+	if hotelStatus == nil || hotelStatus.OK {
+		t.Fatalf("hotel status should be present and not OK, got %+v", hotelStatus)
+	}
+	if hotelStatus.Error == "" {
+		t.Fatal("hotel status should carry the failure reason")
+	}
+	// Total still sums the two surviving domains (220 + 40).
+	if plan.TotalCostEstimate != 260 {
+		t.Fatalf("total estimate = %.2f, want 260 (flights+ground only)", plan.TotalCostEstimate)
+	}
+}
+
+// TestPlanTimeoutIsolation proves a domain that exceeds its per-domain timeout
+// is reported as a typed failure without aborting the fast domains.
+func TestPlanTimeoutIsolation(t *testing.T) {
+	slowGround := func(ctx context.Context, _, _, _ string, _ ground.SearchOptions) (*models.GroundSearchResult, error) {
+		select {
+		case <-time.After(2 * time.Second):
+			return okGround()(ctx, "", "", "", ground.SearchOptions{})
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	c := newTestCoalescer(okFlights(), okHotels(), slowGround)
+	c.PerDomainTimeout = 100 * time.Millisecond
+
+	plan := c.Plan(context.Background(), baseParams())
+	if plan.CheapestFlight == nil || plan.CheapestHotel == nil {
+		t.Fatal("fast domains should complete despite a slow ground domain")
+	}
+	if plan.CheapestGround != nil {
+		t.Fatalf("slow ground should have timed out, got %+v", plan.CheapestGround)
+	}
+	var groundOK bool
+	for _, s := range plan.Statuses {
+		if s.Domain == "ground" {
+			groundOK = s.OK
+		}
+	}
+	if groundOK {
+		t.Fatal("ground domain should be reported not OK after timeout")
+	}
+}
+
+// TestPlanMixedCurrencyNotSummed proves a component in a different currency is
+// itemised but not folded into the headline same-currency floor.
+func TestPlanMixedCurrencyNotSummed(t *testing.T) {
+	usdHotels := func(_ context.Context, _ string, _ hotels.HotelSearchOptions) (*models.HotelSearchResult, error) {
+		return &models.HotelSearchResult{Success: true, Hotels: []models.HotelResult{{Price: 100, Currency: "USD"}}}, nil
+	}
+	c := newTestCoalescer(okFlights(), usdHotels, okGround())
+	plan := c.Plan(context.Background(), baseParams())
+
+	// EUR flight (220) + EUR ground (40) summed; USD hotel itemised only.
+	if plan.TotalCostEstimate != 260 {
+		t.Fatalf("total estimate = %.2f, want 260 (USD hotel excluded from EUR floor)", plan.TotalCostEstimate)
+	}
+	if len(plan.CostBreakdown) != 3 {
+		t.Fatalf("cost breakdown len = %d, want 3 (USD hotel still itemised)", len(plan.CostBreakdown))
+	}
+}
+
+// TestPackagePlanUsesRealSeams smoke-checks the package-level Plan wiring builds
+// a Coalescer with non-nil seams (does not invoke network).
+func TestNewWiresRealSeams(t *testing.T) {
+	c := New()
+	if c.FlightSearch == nil || c.HotelSearch == nil || c.GroundSearch == nil {
+		t.Fatal("New() must wire all three real search seams")
+	}
+	if c.Concurrency != defaultDomainConcurrency {
+		t.Fatalf("concurrency = %d, want %d", c.Concurrency, defaultDomainConcurrency)
+	}
+}

--- a/internal/tripcoalesce/plan.go
+++ b/internal/tripcoalesce/plan.go
@@ -1,0 +1,275 @@
+package tripcoalesce
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/ground"
+	"github.com/MikkoParkkola/trvl/internal/hotels"
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"golang.org/x/sync/errgroup"
+)
+
+// domainResult is the self-contained outcome of one domain goroutine. Each
+// goroutine writes to its own slot (no shared mutable state) so the fan-out is
+// race-free without locks, mirroring internal/flights/concurrency.go.
+type domainResult struct {
+	status DomainStatus
+	flight *models.FlightSearchResult
+	hotel  *models.HotelSearchResult
+	ground *models.GroundSearchResult
+}
+
+// Plan issues the flight, hotel, and ground searches concurrently through a
+// bounded errgroup, isolates per-domain failures and timeouts, and assembles
+// one combined TripPlan. A single domain failing yields a partial plan with the
+// other domains intact — it never aborts the peers (the group func always
+// returns nil, so errgroup is used purely for bounded concurrency).
+func (c *Coalescer) Plan(ctx context.Context, p Params) *TripPlan {
+	plan := &TripPlan{
+		Origin:      p.Origin,
+		Destination: p.Destination,
+		DepartDate:  p.DepartDate,
+		ReturnDate:  p.ReturnDate,
+		Currency:    p.currency(),
+	}
+
+	clock := c.now
+	if clock == nil {
+		clock = time.Now
+	}
+	timeout := c.PerDomainTimeout
+	if timeout <= 0 {
+		timeout = defaultPerDomainTimeout
+	}
+	limit := c.Concurrency
+	if limit <= 0 {
+		limit = defaultDomainConcurrency
+	}
+
+	// Three independent domain tasks. Each returns a self-contained result and
+	// never mutates caller state, so they are safe to run concurrently.
+	tasks := []struct {
+		domain string
+		run    func(ctx context.Context) domainResult
+	}{
+		{"flights", func(ctx context.Context) domainResult { return c.runFlights(ctx, p) }},
+		{"hotels", func(ctx context.Context) domainResult { return c.runHotels(ctx, p) }},
+		{"ground", func(ctx context.Context) domainResult { return c.runGround(ctx, p) }},
+	}
+
+	results := make([]domainResult, len(tasks))
+
+	g := new(errgroup.Group)
+	g.SetLimit(limit)
+	for i, task := range tasks {
+		i, task := i, task
+		g.Go(func() error {
+			start := clock()
+			tctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+
+			done := make(chan domainResult, 1)
+			go func() { done <- task.run(tctx) }()
+
+			select {
+			case res := <-done:
+				res.status.Domain = task.domain
+				res.status.ElapsedMs = clock().Sub(start).Milliseconds()
+				results[i] = res
+			case <-tctx.Done():
+				// The domain exceeded its slice of the budget. Record a typed
+				// timeout outcome rather than a fabricated empty; the orphaned
+				// goroutine drains into the buffered channel and exits.
+				results[i] = domainResult{status: DomainStatus{
+					Domain:    task.domain,
+					OK:        false,
+					Error:     tctx.Err().Error(),
+					ElapsedMs: clock().Sub(start).Milliseconds(),
+				}}
+			}
+			// Always nil: one domain's failure must not cancel its peers.
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	assemble(plan, results, p.Nights)
+	return plan
+}
+
+func (c *Coalescer) runFlights(ctx context.Context, p Params) domainResult {
+	res, err := c.FlightSearch(ctx, p.Origin, p.Destination, p.DepartDate, flights.SearchOptions{
+		ReturnDate: p.ReturnDate,
+		Adults:     p.travelers(),
+		Currency:   p.currency(),
+	})
+	st := DomainStatus{Domain: "flights"}
+	if err != nil {
+		st.Error = err.Error()
+		return domainResult{status: st, flight: res}
+	}
+	if res != nil {
+		st.OK = true
+		st.Count = len(res.Flights)
+		if res.Error != "" {
+			st.Error = res.Error
+		}
+	}
+	return domainResult{status: st, flight: res}
+}
+
+func (c *Coalescer) runHotels(ctx context.Context, p Params) domainResult {
+	checkIn := p.CheckIn
+	if checkIn == "" {
+		checkIn = p.DepartDate
+	}
+	checkOut := p.CheckOut
+	if checkOut == "" {
+		checkOut = p.ReturnDate
+	}
+	res, err := c.HotelSearch(ctx, p.hotelLocation(), hotels.HotelSearchOptions{
+		CheckIn:  checkIn,
+		CheckOut: checkOut,
+		Guests:   p.travelers(),
+		Currency: p.currency(),
+	})
+	st := DomainStatus{Domain: "hotels"}
+	if err != nil {
+		st.Error = err.Error()
+		return domainResult{status: st, hotel: res}
+	}
+	if res != nil {
+		st.OK = true
+		st.Count = len(res.Hotels)
+		if res.Error != "" {
+			st.Error = res.Error
+		}
+	}
+	return domainResult{status: st, hotel: res}
+}
+
+func (c *Coalescer) runGround(ctx context.Context, p Params) domainResult {
+	res, err := c.GroundSearch(ctx, p.groundFrom(), p.groundTo(), p.DepartDate, ground.SearchOptions{
+		Currency:              p.currency(),
+		AllowBrowserFallbacks: p.AllowBrowserFallbacks,
+	})
+	st := DomainStatus{Domain: "ground"}
+	if err != nil {
+		st.Error = err.Error()
+		return domainResult{status: st, ground: res}
+	}
+	if res != nil {
+		st.OK = true
+		st.Count = len(res.Routes)
+		if res.Error != "" {
+			st.Error = res.Error
+		}
+	}
+	return domainResult{status: st, ground: res}
+}
+
+// assemble folds the per-domain results into the plan: attaches raw results,
+// picks the cheapest priced option per domain, and sums them into a floor
+// total-cost estimate with an explicit breakdown.
+func assemble(plan *TripPlan, results []domainResult, nights int) {
+	for _, r := range results {
+		plan.Statuses = append(plan.Statuses, r.status)
+		switch r.status.Domain {
+		case "flights":
+			plan.Flights = r.flight
+		case "hotels":
+			plan.Hotels = r.hotel
+		case "ground":
+			plan.Ground = r.ground
+		}
+		if r.status.Error != "" {
+			plan.Notes = append(plan.Notes, fmt.Sprintf("%s: %s", r.status.Domain, r.status.Error))
+		}
+	}
+
+	if plan.Flights != nil {
+		if f := cheapestFlight(plan.Flights.Flights); f != nil {
+			plan.CheapestFlight = f
+			plan.addCost("flights", "cheapest flight", f.Price, f.Currency)
+		}
+	}
+	if plan.Hotels != nil {
+		if h := cheapestHotel(plan.Hotels.Hotels); h != nil {
+			plan.CheapestHotel = h
+			if nights > 0 {
+				plan.addCost("hotels", fmt.Sprintf("cheapest stay (%d nights)", nights), h.Price*float64(nights), h.Currency)
+			} else {
+				plan.addCost("hotels", "cheapest stay (per night)", h.Price, h.Currency)
+			}
+		}
+	}
+	if plan.Ground != nil {
+		if r := cheapestGround(plan.Ground.Routes); r != nil {
+			plan.CheapestGround = r
+			plan.addCost("ground", "cheapest ground route", r.Price, r.Currency)
+		}
+	}
+}
+
+func (plan *TripPlan) addCost(domain, label string, amount float64, currency string) {
+	if amount <= 0 {
+		return
+	}
+	cur := currency
+	if cur == "" {
+		cur = plan.Currency
+	}
+	plan.CostBreakdown = append(plan.CostBreakdown, CostComponent{
+		Domain:   domain,
+		Label:    label,
+		Amount:   amount,
+		Currency: cur,
+	})
+	// Only same-currency components are summed into the headline floor; mixed
+	// currencies stay itemised so we never fabricate a cross-currency total.
+	if cur == plan.Currency {
+		plan.TotalCostEstimate += amount
+	}
+}
+
+func cheapestFlight(fs []models.FlightResult) *models.FlightResult {
+	var best *models.FlightResult
+	for i := range fs {
+		if fs[i].Price <= 0 {
+			continue
+		}
+		if best == nil || fs[i].Price < best.Price {
+			best = &fs[i]
+		}
+	}
+	return best
+}
+
+func cheapestHotel(hs []models.HotelResult) *models.HotelResult {
+	var best *models.HotelResult
+	for i := range hs {
+		if hs[i].Price <= 0 {
+			continue
+		}
+		if best == nil || hs[i].Price < best.Price {
+			best = &hs[i]
+		}
+	}
+	return best
+}
+
+func cheapestGround(rs []models.GroundRoute) *models.GroundRoute {
+	var best *models.GroundRoute
+	for i := range rs {
+		if rs[i].Price <= 0 {
+			continue
+		}
+		if best == nil || rs[i].Price < best.Price {
+			best = &rs[i]
+		}
+	}
+	return best
+}

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -87,6 +87,7 @@ func registerTools(s *Server) {
 		searchAwardsTool(),
 		nestedRTTool(),
 		arbitrageReportTool(),
+		coalesceTripTool(),
 	}
 	s.toolDefs = make(map[string]ToolDef, len(legacyTools)+1)
 	for _, tool := range legacyTools {
@@ -175,6 +176,7 @@ func registerTools(s *Server) {
 	s.handlers["search_awards"] = s.wrapHandler("search_awards", handleSearchAwards)
 	s.handlers["optimize_nested_rt"] = s.wrapHandler("optimize_nested_rt", handleOptimizeNestedRT)
 	s.handlers["arbitrage_report"] = s.wrapHandler("arbitrage_report", handleArbitrageReport)
+	s.handlers["coalesce_trip"] = s.wrapHandler("coalesce_trip", handleCoalesceTrip)
 }
 
 // wrapHandler returns a ToolHandler that delegates to the inner handler and

--- a/mcp/tools_coalesce.go
+++ b/mcp/tools_coalesce.go
@@ -1,0 +1,170 @@
+package mcp
+
+// Innovation #5: unified trip coalescer MCP tool. Fans flights, hotels, and
+// ground search out concurrently for a single trip and returns one combined
+// plan with a floor cost estimate. Reuses the existing search engines via
+// internal/tripcoalesce; one domain failing yields a partial plan, never an
+// aborted call.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/tripcoalesce"
+)
+
+func coalesceTripTool() ToolDef {
+	return ToolDef{
+		Name:        "coalesce_trip",
+		Title:       "Unified Trip Coalescer",
+		Description: "Plan one origin→destination trip by fanning trvl's flight, hotel, and ground searches out concurrently and assembling a single combined plan: the cheapest priced option per domain plus a floor total-cost estimate. Each domain is failure-isolated — one provider failing or timing out yields a partial plan with the others intact, never a fabricated empty.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"origin":                  {Type: "string", Description: "Origin IATA airport code (e.g. HEL); also seeds the ground 'from'"},
+				"destination":             {Type: "string", Description: "Destination IATA airport code (e.g. LHR); also seeds the ground 'to' and hotel location"},
+				"depart_date":             {Type: "string", Description: "Departure date (YYYY-MM-DD)"},
+				"return_date":             {Type: "string", Description: "Return date (YYYY-MM-DD), optional; used for round-trip flights and hotel checkout"},
+				"hotel_location":          {Type: "string", Description: "Hotel search location override (default: destination)"},
+				"nights":                  {Type: "integer", Description: "Nights for the hotel cost estimate (0 = per-night only)"},
+				"travelers":               {Type: "integer", Description: "Number of travelers (default 1)"},
+				"currency":                {Type: "string", Description: "Trip currency (default EUR)"},
+				"allow_browser_fallbacks": {Type: "boolean", Description: "Allow browser/cookie-assisted ground providers (default false)"},
+			},
+			Required: []string{"origin", "destination", "depart_date"},
+		},
+		OutputSchema: coalesceTripOutputSchema(),
+		Annotations: &ToolAnnotations{
+			Title:          "Unified Trip Coalescer",
+			ReadOnlyHint:   true,
+			OpenWorldHint:  true,
+			IdempotentHint: true,
+		},
+	}
+}
+
+func coalesceTripOutputSchema() interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"origin":              schemaString(),
+			"destination":         schemaString(),
+			"depart_date":         schemaString(),
+			"return_date":         schemaString(),
+			"currency":            schemaString(),
+			"total_cost_estimate": schemaNum(),
+			"cost_breakdown": schemaArray(map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"domain":   schemaString(),
+					"label":    schemaString(),
+					"amount":   schemaNum(),
+					"currency": schemaString(),
+				},
+			}),
+			"statuses": schemaArray(map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"domain":     schemaString(),
+					"ok":         schemaBool(),
+					"count":      schemaInt(),
+					"error":      schemaString(),
+					"elapsed_ms": schemaInt(),
+				},
+			}),
+			"notes": schemaStringArray(),
+		},
+		"required": []string{"origin", "destination", "depart_date", "currency", "total_cost_estimate", "statuses"},
+	}
+}
+
+func handleCoalesceTrip(ctx context.Context, args map[string]any, _ ElicitFunc, _ SamplingFunc, progress ProgressFunc) ([]ContentBlock, interface{}, error) {
+	origin := strings.ToUpper(argString(args, "origin"))
+	destination := strings.ToUpper(argString(args, "destination"))
+	departDate := argString(args, "depart_date")
+	if origin == "" || destination == "" || departDate == "" {
+		return nil, nil, fmt.Errorf("origin, destination, and depart_date are required")
+	}
+
+	sendProgress(progress, 0, 100, fmt.Sprintf("Coalescing flights + hotels + ground for %s→%s...", origin, destination))
+
+	plan := tripcoalesce.Plan(ctx, tripcoalesce.Params{
+		Origin:                origin,
+		Destination:           destination,
+		DepartDate:            departDate,
+		ReturnDate:            argString(args, "return_date"),
+		HotelLocation:         argString(args, "hotel_location"),
+		Nights:                argInt(args, "nights", 0),
+		Travelers:             argInt(args, "travelers", 1),
+		Currency:              argString(args, "currency"),
+		AllowBrowserFallbacks: argBool(args, "allow_browser_fallbacks", false),
+	})
+
+	okCount := 0
+	for _, s := range plan.Statuses {
+		if s.OK {
+			okCount++
+		}
+	}
+	sendProgress(progress, 100, 100, fmt.Sprintf("%d/%d domains returned", okCount, len(plan.Statuses)))
+
+	if plan.Notes == nil {
+		plan.Notes = []string{}
+	}
+
+	summary := buildCoalesceTripSummary(plan)
+	content, err := buildAnnotatedContentBlocks(summary, plan)
+	if err != nil {
+		return nil, nil, err
+	}
+	return content, plan, nil
+}
+
+func buildCoalesceTripSummary(plan *tripcoalesce.TripPlan) string {
+	var sb strings.Builder
+	_, _ = fmt.Fprintf(&sb, "Trip plan %s→%s on %s (%s):\n\n", plan.Origin, plan.Destination, plan.DepartDate, plan.Currency)
+
+	if plan.CheapestFlight != nil {
+		_, _ = fmt.Fprintf(&sb, "✈ Flights: cheapest %s %.2f (%d stops)\n",
+			plan.CheapestFlight.Currency, plan.CheapestFlight.Price, plan.CheapestFlight.Stops)
+	} else {
+		_, _ = fmt.Fprintf(&sb, "✈ Flights: %s\n", coalesceDomainNote(plan, "flights"))
+	}
+	if plan.CheapestHotel != nil {
+		_, _ = fmt.Fprintf(&sb, "🏨 Hotels: cheapest %s %.2f/night (%s)\n",
+			plan.CheapestHotel.Currency, plan.CheapestHotel.Price, plan.CheapestHotel.Name)
+	} else {
+		_, _ = fmt.Fprintf(&sb, "🏨 Hotels: %s\n", coalesceDomainNote(plan, "hotels"))
+	}
+	if plan.CheapestGround != nil {
+		_, _ = fmt.Fprintf(&sb, "🚆 Ground: cheapest %s %.2f via %s\n",
+			plan.CheapestGround.Currency, plan.CheapestGround.Price, plan.CheapestGround.Provider)
+	} else {
+		_, _ = fmt.Fprintf(&sb, "🚆 Ground: %s\n", coalesceDomainNote(plan, "ground"))
+	}
+
+	if plan.TotalCostEstimate > 0 {
+		_, _ = fmt.Fprintf(&sb, "\nFloor estimate: %s %.2f\n", plan.Currency, plan.TotalCostEstimate)
+	}
+	if len(plan.Notes) > 0 {
+		_, _ = fmt.Fprintf(&sb, "\nNotes: %s\n", strings.Join(plan.Notes, "; "))
+	}
+	return sb.String()
+}
+
+func coalesceDomainNote(plan *tripcoalesce.TripPlan, domain string) string {
+	for _, s := range plan.Statuses {
+		if s.Domain != domain {
+			continue
+		}
+		if s.Error != "" {
+			return "unavailable (" + s.Error + ")"
+		}
+		if !s.OK {
+			return "unavailable"
+		}
+		return "no priced results"
+	}
+	return "no results"
+}

--- a/mcp/tools_extra_test.go
+++ b/mcp/tools_extra_test.go
@@ -322,6 +322,7 @@ func TestToolRegistration_AllTools(t *testing.T) {
 		"search_awards",
 		"optimize_nested_rt",
 		"arbitrage_report",
+		"coalesce_trip",
 	}
 
 	if len(s.tools) != len(expectedTools) {

--- a/mcp/tools_smart_test.go
+++ b/mcp/tools_smart_test.go
@@ -44,8 +44,8 @@ func TestLegacyToolModeStillAdvertisesLegacySurface(t *testing.T) {
 
 	s := NewServer()
 
-	if len(s.tools) != 68 {
-		t.Fatalf("legacy tool mode should advertise 68 legacy tools, got %d", len(s.tools))
+	if len(s.tools) != 69 {
+		t.Fatalf("legacy tool mode should advertise 69 legacy tools, got %d", len(s.tools))
 	}
 	if !toolRegistered(s.tools, "search_flights") {
 		t.Fatalf("legacy mode should advertise search_flights")


### PR DESCRIPTION
## What

Innovation #5 — a unified trip coalescer. Today a user runs flights, hotels, and ground as three separate commands and stitches the answers together by hand. This adds one "plan A to B" request that fans all three out concurrently and returns a single combined plan.

## How

New package `internal` tripcoalesce:
- `Plan(ctx, Params)` issues the flight, hotel, and ground searches at once through a bounded errgroup (SetLimit), mirroring the cap and per-task-timeout pattern already used by the flight concurrency helper.
- **Failure isolation**: each domain runs under its own timeout context; the group func always returns nil, so one domain failing or timing out yields a partial plan with the others intact — never an aborted run, never a fabricated empty.
- **Assembly**: picks the cheapest priced option per domain and sums same-currency components into a floor total-cost estimate with an explicit per-component breakdown. Mixed-currency components are itemised, never summed.
- **Reuse, not reimplementation**: calls the existing SearchFlights, SearchHotels, SearchByName entrypoints via injectable seams. No provider package is touched. The seams make fan-out, partial-result, timeout, and assembly all testable deterministically offline.

## Surfaces

- **CLI**: `trvl plan-all <origin> <destination> <depart-date>` (flags: return, hotel, nights, travelers, currency, allow-browser-fallbacks)
- **MCP**: `coalesce_trip` — a non-alias smart capability (kept out of the marketed compatibility-alias count, which stays 66)

## Tests (TDD, deterministic and offline, race-clean)

- concurrent fan-out (barrier proves all three domains run simultaneously)
- combined assembly (cheapest pick per domain plus summed floor)
- partial result on one domain failing
- per-domain timeout isolation
- mixed-currency component not folded into the floor

## Count changes

- legacy advertised MCP surface: 68 to 69
- legacy-mode expected-tools list: adds coalesce_trip
- CLI subcommands: 67 to 68
- non-alias capability allowlist: adds coalesce_trip (marketed alias count stays 66, zero doc-string edits)

## Verification

go vet, staticcheck, gofmt all clean; race tests on the new package and the full short suite green (including all count tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
