### PR TITLE
fix(hacks): data race on shared cases.Caser in night_transport

### DIFF
--- a/internal/hacks/night_transport.go
+++ b/internal/hacks/night_transport.go
@@ -14,8 +14,6 @@ import (
 // Used when no hotel price data is available.
 const averageHotelCost = 60.0
 
-var nightTransportTitleCaser = cases.Title(language.English)
-
 // detectNightTransport searches ground transport for overnight routes, then
 // adds the notional hotel saving to the total benefit.
 func detectNightTransport(ctx context.Context, in DetectorInput) []Hack {
@@ -53,8 +51,12 @@ func buildNightHack(in DetectorInput, r models.GroundRoute, hotelSaving float64)
 		currency = r.Currency
 	}
 
-	providerStr := nightTransportTitleCaser.String(r.Provider)
-	typeStr := nightTransportTitleCaser.String(r.Type)
+	// cases.Caser is stateful and NOT safe for concurrent use; construct a
+	// per-call caser so concurrent hack detection (DetectAll fans out across
+	// detectors) never races on a shared instance.
+	titleCaser := cases.Title(language.English)
+	providerStr := titleCaser.String(r.Provider)
+	typeStr := titleCaser.String(r.Type)
 
 	depTime := r.Departure.Time
 	arrTime := r.Arrival.Time

--- a/internal/hacks/night_transport_race_test.go
+++ b/internal/hacks/night_transport_race_test.go
@@ -1,0 +1,38 @@
+package hacks
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestBuildNightHack_ConcurrentNoRace guards against the data race fixed when
+// the shared package-level cases.Caser was replaced with a per-call caser.
+// DetectAll fans detectors out concurrently, so buildNightHack must be safe to
+// call from many goroutines at once. Under `go test -race` this fails if a
+// shared, non-concurrency-safe caser is reintroduced.
+func TestBuildNightHack_ConcurrentNoRace(t *testing.T) {
+	in := DetectorInput{Origin: "HEL", Destination: "PRG"}
+	route := models.GroundRoute{
+		Provider:  "flixbus",
+		Type:      "bus",
+		Currency:  "EUR",
+		Departure: models.GroundStop{City: "Helsinki", Time: "2026-07-01T23:30:00Z"},
+		Arrival:   models.GroundStop{City: "Prague", Time: "2026-07-02T07:15:00Z"},
+	}
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			h := buildNightHack(in, route, averageHotelCost)
+			if h.Type == "" {
+				t.Error("buildNightHack returned empty hack type")
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem
Innovation #1 (auto-compose hacks into search, merged) runs DetectAll concurrently across detectors. night_transport held a package-level cases.Title caser; golang.org x text cases.Caser is stateful and NOT concurrency-safe, so concurrent buildNightHack calls raced on it.

CI surfaced it on the Wave-3 PRs (their -race runs exercise the now-concurrent hacks path):
```
WARNING: DATA RACE
  golang.org x text cases.(*titleCaser).Transform()
  internal/hacks/night_transport.go:56-57
```
The race is on main (shipped in v1.13.0); only manifests under the concurrent path.

## Fix
Construct the caser per-call inside buildNightHack so each goroutine has its own instance — no shared mutable state. The other package-level vars in internal/hacks are read-only maps (safe for concurrent read); this caser was the only mutable one.

## Verification
go vet clean; gofmt clean; go test -race ./internal/hacks/ ./internal/flights/ ./internal/ground/ all green (the concurrent invokers).