### PR TITLE
Speculative prefetch + negative-result cache (innovation #4)

### DIFF
--- a/internal/cache/negcache.go
+++ b/internal/cache/negcache.go
@@ -1,0 +1,134 @@
+package cache
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// defaultNegMaxEntries bounds the negative cache so a long-running process that
+// probes many routes cannot grow it without limit.
+const defaultNegMaxEntries = 4000
+
+// NegativeCache records (provider, origin, destination, date-class) tuples that
+// a provider has *definitively* reported as having no service, so the same
+// provider is not re-queried for the same route within a TTL window.
+//
+// Conservative by construction: callers must only Mark a CLEAN no-result — a
+// provider that ran successfully and returned zero results. Errors, timeouts,
+// rate-limits, and filtered-empty results must NOT be marked: those should
+// retry on the next search. A negative entry is a small, honest "we checked
+// recently and there was genuinely nothing", not "the request failed".
+//
+// Safe for concurrent use. The clock is injectable for deterministic tests.
+type NegativeCache struct {
+	mu         sync.RWMutex
+	entries    map[string]time.Time // key -> expiry
+	ttl        time.Duration
+	maxEntries int
+	now        func() time.Time
+}
+
+// NewNegativeCache creates a negative cache with the given TTL and the default
+// entry cap, using the wall clock.
+func NewNegativeCache(ttl time.Duration) *NegativeCache {
+	return NewNegativeCacheWithClock(ttl, time.Now)
+}
+
+// NewNegativeCacheWithClock is like NewNegativeCache but takes an explicit clock
+// function, which lets tests advance time deterministically without sleeping.
+// A nil clock falls back to time.Now.
+func NewNegativeCacheWithClock(ttl time.Duration, now func() time.Time) *NegativeCache {
+	if now == nil {
+		now = time.Now
+	}
+	if ttl <= 0 {
+		ttl = time.Minute
+	}
+	return &NegativeCache{
+		entries:    make(map[string]time.Time),
+		ttl:        ttl,
+		maxEntries: defaultNegMaxEntries,
+		now:        now,
+	}
+}
+
+// DateClass buckets a YYYY-MM-DD date into a coarse year-month class. A route is
+// served or not at roughly seasonal granularity, so bucketing by month keeps the
+// negative cache compact while still respecting summer-only / winter-only routes
+// (a no-service entry for 2026-07 never suppresses a 2026-08 query). Malformed
+// or empty dates fall back to the raw string so callers never key on "".
+func DateClass(date string) string {
+	d := strings.TrimSpace(date)
+	if len(d) >= 7 && d[4] == '-' {
+		return d[:7] // "YYYY-MM"
+	}
+	return d
+}
+
+// NegativeKey builds the canonical negative-cache key from a provider id, an
+// origin, a destination, and a date. The date is reduced to its DateClass.
+func NegativeKey(provider, origin, destination, date string) string {
+	return strings.ToLower(strings.TrimSpace(provider)) + "|" +
+		strings.ToUpper(strings.TrimSpace(origin)) + "|" +
+		strings.ToUpper(strings.TrimSpace(destination)) + "|" +
+		DateClass(date)
+}
+
+// Seen reports whether key has a live (unexpired) negative entry. Expired
+// entries are treated as absent and lazily removed.
+func (n *NegativeCache) Seen(key string) bool {
+	n.mu.RLock()
+	expiry, ok := n.entries[key]
+	n.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	if !n.now().Before(expiry) {
+		n.mu.Lock()
+		// Re-check under the write lock: a concurrent Mark may have refreshed it.
+		if exp, ok := n.entries[key]; ok && !n.now().Before(exp) {
+			delete(n.entries, key)
+		}
+		n.mu.Unlock()
+		return false
+	}
+	return true
+}
+
+// Mark records key as a negative result, valid for the cache TTL from now.
+// When the cache is at capacity, one expired entry (or, failing that, an
+// arbitrary entry) is evicted first so the map stays bounded.
+func (n *NegativeCache) Mark(key string) {
+	now := n.now()
+	n.mu.Lock()
+	if len(n.entries) >= n.maxEntries {
+		n.evictLocked(now)
+	}
+	n.entries[key] = now.Add(n.ttl)
+	n.mu.Unlock()
+}
+
+// evictLocked removes one entry to make room. It prefers an already-expired
+// entry; if none are expired it drops an arbitrary one (map iteration order).
+// Caller must hold n.mu.
+func (n *NegativeCache) evictLocked(now time.Time) {
+	var anyKey string
+	for k, exp := range n.entries {
+		anyKey = k
+		if !now.Before(exp) {
+			delete(n.entries, k)
+			return
+		}
+	}
+	if anyKey != "" {
+		delete(n.entries, anyKey)
+	}
+}
+
+// Len returns the number of entries (including expired ones not yet reaped).
+func (n *NegativeCache) Len() int {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return len(n.entries)
+}

--- a/internal/cache/negcache_test.go
+++ b/internal/cache/negcache_test.go
@@ -1,0 +1,108 @@
+package cache
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDateClass(t *testing.T) {
+	cases := map[string]string{
+		"2026-07-15":    "2026-07",
+		"2026-12-01":    "2026-12",
+		"  2026-03-09 ": "2026-03",
+		"":              "",
+		"garbage":       "garbage",
+		"2026/07/15":    "2026/07/15", // wrong separator => raw fallback
+	}
+	for in, want := range cases {
+		if got := DateClass(in); got != want {
+			t.Errorf("DateClass(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNegativeKey_NormalizesAndBuckets(t *testing.T) {
+	a := NegativeKey("Ryanair", "hel", "agp", "2026-07-15")
+	b := NegativeKey("ryanair", "HEL", "AGP", "2026-07-28") // same month
+	if a != b {
+		t.Errorf("keys for same provider/route/month should match:\n a=%q\n b=%q", a, b)
+	}
+	if a != "ryanair|HEL|AGP|2026-07" {
+		t.Errorf("unexpected key form: %q", a)
+	}
+
+	// Different month must produce a different key (seasonal safety).
+	if NegativeKey("ryanair", "HEL", "AGP", "2026-08-01") == a {
+		t.Error("different month should produce a different key")
+	}
+}
+
+func TestNegativeCache_StoreAndServe(t *testing.T) {
+	c := NewNegativeCache(30 * time.Minute)
+	key := NegativeKey("wizzair", "HEL", "BUD", "2026-07-10")
+
+	if c.Seen(key) {
+		t.Fatal("fresh cache should not report a hit")
+	}
+	c.Mark(key)
+	if !c.Seen(key) {
+		t.Fatal("expected a hit after Mark")
+	}
+	if c.Len() != 1 {
+		t.Errorf("Len() = %d, want 1", c.Len())
+	}
+}
+
+func TestNegativeCache_TTLExpiry(t *testing.T) {
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	c := NewNegativeCacheWithClock(30*time.Minute, clock)
+
+	key := NegativeKey("ryanair", "HEL", "AGP", "2026-07-15")
+	c.Mark(key)
+	if !c.Seen(key) {
+		t.Fatal("expected hit immediately after Mark")
+	}
+
+	// Advance to just before expiry — still a hit.
+	now = now.Add(29 * time.Minute)
+	if !c.Seen(key) {
+		t.Fatal("expected hit just before TTL expiry")
+	}
+
+	// Advance past expiry — miss, and the entry is reaped.
+	now = now.Add(2 * time.Minute)
+	if c.Seen(key) {
+		t.Fatal("expected miss after TTL expiry")
+	}
+	if c.Len() != 0 {
+		t.Errorf("expired entry should be reaped on access; Len() = %d", c.Len())
+	}
+}
+
+func TestNegativeCache_BoundedEviction(t *testing.T) {
+	c := NewNegativeCache(time.Hour)
+	c.maxEntries = 10
+	for i := 0; i < 50; i++ {
+		c.Mark(NegativeKey("p", "AAA", "BBB", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, i, 0).Format("2006-01-02")))
+	}
+	if c.Len() > 10 {
+		t.Errorf("Len() = %d, want <= 10 (bounded)", c.Len())
+	}
+}
+
+func TestNegativeCache_ConcurrentAccess(t *testing.T) {
+	c := NewNegativeCache(time.Hour)
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := NegativeKey("p", "AAA", "BBB", "2026-07-15")
+			c.Mark(key)
+			c.Seen(key)
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/flights/prefetch_negcache_test.go
+++ b/internal/flights/prefetch_negcache_test.go
@@ -1,0 +1,178 @@
+package flights
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/cache"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func TestFlightNegCache_StoresAndServesCleanNoResult(t *testing.T) {
+	t.Setenv("TRVL_NEGCACHE", "1")
+
+	key := "ryanair|HEL|AGP|2026-07"
+	flightNegCache.Mark(key) // simulate a prior clean no-result
+	t.Cleanup(func() { flightNegCache = cache.NewNegativeCache(flightNegCacheTTL) })
+
+	var ran atomic.Int32
+	run := withFlightNegCache("ryanair", "HEL", "AGP", "2026-07-15", func(ctx context.Context) providerOutcome {
+		ran.Add(1)
+		return providerOutcome{succeeded: true, flights: []models.FlightResult{{Provider: "ryanair"}}}
+	})
+
+	out := run(context.Background())
+	if ran.Load() != 0 {
+		t.Fatal("provider should NOT be queried when route is negatively cached")
+	}
+	if out.status.Status != models.StatusCheckedNoHit {
+		t.Errorf("served status = %q, want %q", out.status.Status, models.StatusCheckedNoHit)
+	}
+	if !out.succeeded || len(out.flights) != 0 {
+		t.Error("served outcome should be a clean empty (succeeded, 0 flights)")
+	}
+}
+
+func TestFlightNegCache_MarksOnlyCleanNoResult(t *testing.T) {
+	t.Setenv("TRVL_NEGCACHE", "1")
+
+	tests := []struct {
+		name     string
+		outcome  providerOutcome
+		wantMark bool
+	}{
+		{"clean no result", providerOutcome{succeeded: true, flights: nil}, true},
+		{"has results", providerOutcome{succeeded: true, flights: []models.FlightResult{{}}}, false},
+		{"error", providerOutcome{succeeded: false, err: context.DeadlineExceeded}, false},
+		{"failed empty", providerOutcome{succeeded: false}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flightNegCache = cache.NewNegativeCache(flightNegCacheTTL)
+			key := cache.NegativeKey("wizzair", "HEL", "TLL", "2026-09-01")
+			run := withFlightNegCache("wizzair", "HEL", "TLL", "2026-09-01", func(ctx context.Context) providerOutcome {
+				return tt.outcome
+			})
+			run(context.Background())
+			if got := flightNegCache.Seen(key); got != tt.wantMark {
+				t.Errorf("Seen() = %v, want %v", got, tt.wantMark)
+			}
+		})
+	}
+}
+
+func TestFlightNegCache_Disabled(t *testing.T) {
+	t.Setenv("TRVL_NEGCACHE", "0")
+	flightNegCache = cache.NewNegativeCache(flightNegCacheTTL)
+	t.Cleanup(func() { flightNegCache = cache.NewNegativeCache(flightNegCacheTTL) })
+
+	var ran atomic.Int32
+	flightNegCache.Mark("ryanair|HEL|AGP|2026-07")
+	run := withFlightNegCache("ryanair", "HEL", "AGP", "2026-07-15", func(ctx context.Context) providerOutcome {
+		ran.Add(1)
+		return providerOutcome{succeeded: true}
+	})
+	run(context.Background())
+	if ran.Load() != 1 {
+		t.Fatal("provider MUST run when negative cache is disabled")
+	}
+}
+
+func TestFlightPrefetchTargets(t *testing.T) {
+	targets := flightPrefetchTargets("HEL", "AGP", "2026-07-15")
+	if len(targets) != 3 {
+		t.Fatalf("got %d targets, want 3", len(targets))
+	}
+	// Return leg: reversed route, +7 days.
+	if targets[0].origin != "AGP" || targets[0].destination != "HEL" || targets[0].date != "2026-07-22" {
+		t.Errorf("return-leg target wrong: %+v", targets[0])
+	}
+	// Adjacent days, same route.
+	if targets[1].date != "2026-07-16" || targets[2].date != "2026-07-14" {
+		t.Errorf("adjacent-day targets wrong: %+v %+v", targets[1], targets[2])
+	}
+
+	if got := flightPrefetchTargets("HEL", "AGP", "not-a-date"); got != nil {
+		t.Errorf("unparseable date should yield no targets, got %v", got)
+	}
+}
+
+func TestRunFlightPrefetch_BestEffortAndBounded(t *testing.T) {
+	orig := flightPrefetchFn
+	t.Cleanup(func() { flightPrefetchFn = orig })
+
+	var calls atomic.Int32
+	var inFlight, maxInFlight atomic.Int32
+	flightPrefetchFn = func(ctx context.Context, client *batchexec.Client, target flightPrefetchTarget, opts SearchOptions) {
+		n := inFlight.Add(1)
+		for {
+			old := maxInFlight.Load()
+			if n <= old || maxInFlight.CompareAndSwap(old, n) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+		calls.Add(1)
+		inFlight.Add(-1)
+		panic("prefetch boom") // must be swallowed
+	}
+
+	targets := flightPrefetchTargets("HEL", "AGP", "2026-07-15")
+	// Must return cleanly despite every warm panicking.
+	runFlightPrefetch(context.Background(), nil, targets, SearchOptions{})
+
+	if calls.Load() != 3 {
+		t.Errorf("ran %d warms, want 3", calls.Load())
+	}
+	if maxInFlight.Load() > int32(flightPrefetchConcurrency) {
+		t.Errorf("max concurrency %d exceeded cap %d", maxInFlight.Load(), flightPrefetchConcurrency)
+	}
+}
+
+func TestMaybePrefetchFlights_GatedOffByDefault(t *testing.T) {
+	orig := flightPrefetchFn
+	t.Cleanup(func() { flightPrefetchFn = orig })
+
+	var calls atomic.Int32
+	var wg sync.WaitGroup
+	flightPrefetchFn = func(ctx context.Context, client *batchexec.Client, target flightPrefetchTarget, opts SearchOptions) {
+		defer wg.Done()
+		calls.Add(1)
+	}
+
+	// Default (env unset) => prefetch disabled, no warms.
+	t.Setenv("TRVL_PREFETCH", "")
+	maybePrefetchFlights(context.Background(), nil, "HEL", "AGP", "2026-07-15", SearchOptions{})
+	time.Sleep(20 * time.Millisecond)
+	if calls.Load() != 0 {
+		t.Fatalf("prefetch must be OFF by default, got %d warms", calls.Load())
+	}
+
+	// Enabled => warms dispatched.
+	t.Setenv("TRVL_PREFETCH", "1")
+	wg.Add(3)
+	maybePrefetchFlights(context.Background(), nil, "HEL", "AGP", "2026-07-15", SearchOptions{})
+	wg.Wait()
+	if calls.Load() != 3 {
+		t.Errorf("enabled prefetch ran %d warms, want 3", calls.Load())
+	}
+}
+
+func TestMaybePrefetchFlights_NoRecursion(t *testing.T) {
+	orig := flightPrefetchFn
+	t.Cleanup(func() { flightPrefetchFn = orig })
+	t.Setenv("TRVL_PREFETCH", "1")
+
+	flightPrefetchFn = func(ctx context.Context, client *batchexec.Client, target flightPrefetchTarget, opts SearchOptions) {
+		// A prefetch-spawned search must not itself dispatch more prefetch.
+		if prefetchDisabled(ctx) {
+			return
+		}
+		t.Error("prefetch context should have prefetch disabled")
+	}
+	runFlightPrefetch(context.Background(), nil, flightPrefetchTargets("HEL", "AGP", "2026-07-15"), SearchOptions{})
+}

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/cache"
 	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/fareintel"
 	"github.com/MikkoParkkola/trvl/internal/models"
@@ -142,9 +146,182 @@ func SearchFlightsWithClient(ctx context.Context, client *batchexec.Client, orig
 	}
 
 	key := flightSearchKey(origin, destination, date, opts)
-	return doFlightSearchSingleflight(ctx, key, func(sharedCtx context.Context) (*models.FlightSearchResult, error) {
+	result, err := doFlightSearchSingleflight(ctx, key, func(sharedCtx context.Context) (*models.FlightSearchResult, error) {
 		return searchFlightsCore(sharedCtx, client, origin, destination, date, opts)
 	})
+
+	// Speculative prefetch: warm the cache for the likely next query (return leg
+	// and +/-1 day around this date). Best-effort and non-blocking — it never
+	// affects the result we just computed. Disabled inside prefetch-spawned and
+	// round-trip leg calls so it cannot recurse.
+	maybePrefetchFlights(ctx, client, origin, destination, date, opts)
+
+	return result, err
+}
+
+// --- Negative-result cache + speculative prefetch (innovation #4) ---------
+
+// flightNegCacheTTL bounds how long a clean "no service" from a point-to-point
+// carrier suppresses re-querying that carrier for the same route+month. Short
+// enough that a newly opened route surfaces within half an hour.
+const flightNegCacheTTL = 30 * time.Minute
+
+// flightNegCache records (carrier, origin, destination, month) tuples that a
+// direct point-to-point carrier reported as genuinely unserved. Only the direct
+// carriers (Ryanair, Wizz Air, Transavia, easyJet) participate: a clean empty
+// from them is a route-structural fact (they don't fly A->B), unlike an
+// aggregator's empty result which is usually date-specific (sold out). On by
+// default; set TRVL_NEGCACHE=0 to disable.
+var flightNegCache = cache.NewNegativeCache(flightNegCacheTTL)
+
+func negCacheEnabled() bool {
+	return envBool("TRVL_NEGCACHE", true)
+}
+
+// flightPrefetchEnabled gates speculative prefetch. Off by default: prefetch
+// adds provider load (extra background searches), so it is opt-in via
+// TRVL_PREFETCH=1.
+func flightPrefetchEnabled() bool {
+	return envBool("TRVL_PREFETCH", false)
+}
+
+// envBool parses a boolean env var, returning def when unset / unparseable.
+func envBool(name string, def bool) bool {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+// withFlightNegCache wraps a point-to-point carrier's run function with the
+// negative-result cache. On a recent clean "no service" it returns a synthetic
+// checked_no_hit outcome without re-querying. Otherwise it runs the provider and
+// marks the route negative only on a CLEAN no-result (succeeded with zero
+// flights). An error / timeout / rate-limit / skip is never marked.
+func withFlightNegCache(provider, origin, destination, date string, run func(context.Context) providerOutcome) func(context.Context) providerOutcome {
+	key := cache.NegativeKey(provider, origin, destination, date)
+	return func(ctx context.Context) providerOutcome {
+		if negCacheEnabled() && flightNegCache.Seen(key) {
+			return providerOutcome{
+				succeeded: true,
+				status: models.ProviderStatus{
+					ID:      provider,
+					Name:    provider,
+					Status:  models.StatusCheckedNoHit,
+					Results: 0,
+				},
+			}
+		}
+		out := run(ctx)
+		if negCacheEnabled() && out.succeeded && len(out.flights) == 0 {
+			flightNegCache.Mark(key)
+		}
+		return out
+	}
+}
+
+// prefetchCtxKey marks a context as belonging to a prefetch (also any nested)
+// search so speculative prefetch does not recurse.
+type prefetchCtxKey struct{}
+
+func prefetchDisabled(ctx context.Context) bool {
+	return ctx.Value(prefetchCtxKey{}) != nil
+}
+
+// flightPrefetchTarget is one likely-next one-way search to warm.
+type flightPrefetchTarget struct {
+	origin      string
+	destination string
+	date        string
+}
+
+// flightPrefetchTargets computes the likely-next one-way searches to warm given
+// a just-completed one-way search: the return leg (reverse route, +7 days) plus
+// the two adjacent days (date plus one, date minus one) on the same route. Pure
+// and deterministic; targets that cannot be derived (unparseable date) are
+// omitted.
+func flightPrefetchTargets(origin, destination, date string) []flightPrefetchTarget {
+	var targets []flightPrefetchTarget
+	t, err := models.ParseDate(date)
+	if err != nil {
+		return targets
+	}
+	plus1 := t.AddDate(0, 0, 1).Format("2006-01-02")
+	minus1 := t.AddDate(0, 0, -1).Format("2006-01-02")
+	ret := t.AddDate(0, 0, 7).Format("2006-01-02")
+	targets = append(targets,
+		flightPrefetchTarget{origin: destination, destination: origin, date: ret}, // return leg
+		flightPrefetchTarget{origin: origin, destination: destination, date: plus1},
+		flightPrefetchTarget{origin: origin, destination: destination, date: minus1},
+	)
+	return targets
+}
+
+// flightPrefetchConcurrency bounds simultaneous prefetch searches so warming
+// never opens an unbounded number of upstream connections.
+const flightPrefetchConcurrency = 2
+
+// flightPrefetchFn performs a single warm search. It is a seam so tests can
+// observe prefetch without hitting the network. The default warms the shared
+// client cache via the normal one-way search path, with prefetch disabled on the
+// detached context to prevent recursion. Assigned in init to break the static
+// initialization cycle with SearchFlightsWithClient.
+var flightPrefetchFn func(ctx context.Context, client *batchexec.Client, t flightPrefetchTarget, opts SearchOptions)
+
+func init() {
+	flightPrefetchFn = func(ctx context.Context, client *batchexec.Client, t flightPrefetchTarget, opts SearchOptions) {
+		_, _ = SearchFlightsWithClient(ctx, client, t.origin, t.destination, t.date, opts)
+	}
+}
+
+// maybePrefetchFlights dispatches best-effort speculative prefetch. It returns
+// immediately; warming runs in the background where a prefetch failure (panic
+// included) can never affect the primary search.
+func maybePrefetchFlights(ctx context.Context, client *batchexec.Client, origin, destination, date string, opts SearchOptions) {
+	if !flightPrefetchEnabled() || prefetchDisabled(ctx) || opts.ReturnDate != "" {
+		return
+	}
+	targets := flightPrefetchTargets(origin, destination, date)
+	if len(targets) == 0 {
+		return
+	}
+
+	// Warm one-way legs only, without the heavy hacks engine: prefetch fills the
+	// cache, it does not need to compute savings.
+	warmOpts := opts
+	warmOpts.ReturnDate = ""
+	warmOpts.NoHacks = true
+
+	go runFlightPrefetch(ctx, client, targets, warmOpts)
+}
+
+// runFlightPrefetch warms the given targets with bounded concurrency. Each warm
+// is isolated: a panic in one never affects its peers nor the caller. Kept as a
+// single unexported function so tests can drive it directly with a fake
+// flightPrefetchFn.
+func runFlightPrefetch(parent context.Context, client *batchexec.Client, targets []flightPrefetchTarget, opts SearchOptions) {
+	detached, cancel := searchctx.DetachedWithin(parent, sharedFlightSearchTimeout)
+	defer cancel()
+	prefetchCtx := context.WithValue(detached, prefetchCtxKey{}, struct{}{})
+
+	sem := make(chan struct{}, flightPrefetchConcurrency)
+	var wg sync.WaitGroup
+	for _, t := range targets {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(t flightPrefetchTarget) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			defer func() { _ = recover() }() // best-effort: never propagate
+			flightPrefetchFn(prefetchCtx, client, t, opts)
+		}(t)
+	}
+	wg.Wait()
 }
 
 func doFlightSearchSingleflight(ctx context.Context, key string, fn func(context.Context) (*models.FlightSearchResult, error)) (*models.FlightSearchResult, error) {
@@ -202,18 +379,18 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 		{name: "skiplagged", run: func(ctx context.Context) providerOutcome {
 			return runSkiplaggedProvider(ctx, client, origin, destination, date, opts)
 		}},
-		{name: "ryanair", run: func(ctx context.Context) providerOutcome {
+		{name: "ryanair", run: withFlightNegCache("ryanair", origin, destination, date, func(ctx context.Context) providerOutcome {
 			return runRyanairProvider(ctx, client, origin, destination, date, currency, opts)
-		}},
-		{name: "wizzair", run: func(ctx context.Context) providerOutcome {
+		})},
+		{name: "wizzair", run: withFlightNegCache("wizzair", origin, destination, date, func(ctx context.Context) providerOutcome {
 			return runWizzairProvider(ctx, client, origin, destination, date, currency, opts)
-		}},
-		{name: "transavia", run: func(ctx context.Context) providerOutcome {
+		})},
+		{name: "transavia", run: withFlightNegCache("transavia", origin, destination, date, func(ctx context.Context) providerOutcome {
 			return runTransaviaProvider(ctx, client, origin, destination, date, currency, opts)
-		}},
-		{name: "easyjet", run: func(ctx context.Context) providerOutcome {
+		})},
+		{name: "easyjet", run: withFlightNegCache("easyjet", origin, destination, date, func(ctx context.Context) providerOutcome {
 			return runEasyjetProvider(ctx, client, origin, destination, date, currency, opts)
-		}},
+		})},
 	}
 	outcomes := runProviderTasks(ctx, tasks, providerConcurrencyLimit, perProviderTimeout)
 	kiwiOut := outcomes[0]

--- a/internal/ground/prefetch_negcache_test.go
+++ b/internal/ground/prefetch_negcache_test.go
@@ -1,0 +1,146 @@
+package ground
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/cache"
+)
+
+func TestGroundNegKey_FilteredSearchesIneligible(t *testing.T) {
+	if _, ok := groundNegKey("Berlin", "Prague", "2026-07-15", SearchOptions{}, "all"); !ok {
+		t.Error("unfiltered search should be negative-cache eligible")
+	}
+	if _, ok := groundNegKey("Berlin", "Prague", "2026-07-15", SearchOptions{MaxPrice: 50}, "all"); ok {
+		t.Error("MaxPrice filter must make a search ineligible (filtered-empty != no service)")
+	}
+	if _, ok := groundNegKey("Berlin", "Prague", "2026-07-15", SearchOptions{Type: "train"}, "all"); ok {
+		t.Error("Type filter must make a search ineligible")
+	}
+}
+
+func TestGroundNegCache_ServesCleanNoResult(t *testing.T) {
+	t.Setenv("TRVL_NEGCACHE", "1")
+	t.Setenv("TRVL_PREFETCH", "0")
+	groundNegCache = cache.NewNegativeCache(groundNegCacheTTL)
+	t.Cleanup(func() { groundNegCache = cache.NewNegativeCache(groundNegCacheTTL) })
+
+	key, ok := groundNegKey("Atlantis", "El Dorado", "2026-07-15", SearchOptions{Currency: "EUR"}, "all")
+	if !ok {
+		t.Fatal("expected eligible key")
+	}
+	groundNegCache.Mark(key)
+
+	// A negatively-cached route must short-circuit to a clean empty without
+	// running the provider fan-out (which would hit the network).
+	res, err := SearchByName(context.Background(), "Atlantis", "El Dorado", "2026-07-15", SearchOptions{Currency: "EUR"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.Success || res.Count != 0 {
+		t.Errorf("expected clean empty result, got %+v", res)
+	}
+}
+
+func TestGroundNegCache_DisabledDoesNotShortCircuit(t *testing.T) {
+	// With negcache disabled, Seen must never be consulted. We assert the gate
+	// directly to avoid a live fan-out.
+	t.Setenv("TRVL_NEGCACHE", "0")
+	if negCacheEnabled() {
+		t.Fatal("negCacheEnabled() must be false when TRVL_NEGCACHE=0")
+	}
+	t.Setenv("TRVL_NEGCACHE", "")
+	if !negCacheEnabled() {
+		t.Fatal("negCacheEnabled() must default to true when unset")
+	}
+}
+
+func TestGroundPrefetchTargets(t *testing.T) {
+	targets := groundPrefetchTargets("Berlin", "Prague", "2026-07-15")
+	if len(targets) != 3 {
+		t.Fatalf("got %d targets, want 3", len(targets))
+	}
+	if targets[0].from != "Prague" || targets[0].to != "Berlin" || targets[0].date != "2026-07-22" {
+		t.Errorf("return-leg target wrong: %+v", targets[0])
+	}
+	if targets[1].date != "2026-07-16" || targets[2].date != "2026-07-14" {
+		t.Errorf("adjacent-day targets wrong: %+v %+v", targets[1], targets[2])
+	}
+	if got := groundPrefetchTargets("Berlin", "Prague", "bad"); got != nil {
+		t.Errorf("unparseable date should yield no targets, got %v", got)
+	}
+}
+
+func TestRunGroundPrefetch_BestEffortAndBounded(t *testing.T) {
+	orig := groundPrefetchFn
+	t.Cleanup(func() { groundPrefetchFn = orig })
+
+	var calls atomic.Int32
+	var inFlight, maxInFlight atomic.Int32
+	groundPrefetchFn = func(ctx context.Context, target groundPrefetchTarget, opts SearchOptions) {
+		n := inFlight.Add(1)
+		for {
+			old := maxInFlight.Load()
+			if n <= old || maxInFlight.CompareAndSwap(old, n) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+		calls.Add(1)
+		inFlight.Add(-1)
+		panic("ground prefetch boom") // must be swallowed
+	}
+
+	runGroundPrefetch(context.Background(), groundPrefetchTargets("Berlin", "Prague", "2026-07-15"), SearchOptions{})
+
+	if calls.Load() != 3 {
+		t.Errorf("ran %d warms, want 3", calls.Load())
+	}
+	if maxInFlight.Load() > int32(groundPrefetchConcurrency) {
+		t.Errorf("max concurrency %d exceeded cap %d", maxInFlight.Load(), groundPrefetchConcurrency)
+	}
+}
+
+func TestMaybePrefetchGround_GatedOffByDefault(t *testing.T) {
+	orig := groundPrefetchFn
+	t.Cleanup(func() { groundPrefetchFn = orig })
+
+	var calls atomic.Int32
+	var wg sync.WaitGroup
+	groundPrefetchFn = func(ctx context.Context, target groundPrefetchTarget, opts SearchOptions) {
+		defer wg.Done()
+		calls.Add(1)
+	}
+
+	t.Setenv("TRVL_PREFETCH", "")
+	maybePrefetchGround(context.Background(), "Berlin", "Prague", "2026-07-15", SearchOptions{})
+	time.Sleep(20 * time.Millisecond)
+	if calls.Load() != 0 {
+		t.Fatalf("prefetch must be OFF by default, got %d warms", calls.Load())
+	}
+
+	t.Setenv("TRVL_PREFETCH", "1")
+	wg.Add(3)
+	maybePrefetchGround(context.Background(), "Berlin", "Prague", "2026-07-15", SearchOptions{})
+	wg.Wait()
+	if calls.Load() != 3 {
+		t.Errorf("enabled prefetch ran %d warms, want 3", calls.Load())
+	}
+}
+
+func TestMaybePrefetchGround_NoRecursion(t *testing.T) {
+	orig := groundPrefetchFn
+	t.Cleanup(func() { groundPrefetchFn = orig })
+	t.Setenv("TRVL_PREFETCH", "1")
+
+	groundPrefetchFn = func(ctx context.Context, target groundPrefetchTarget, opts SearchOptions) {
+		if groundPrefetchDisabled(ctx) {
+			return
+		}
+		t.Error("prefetch context should have prefetch disabled")
+	}
+	runGroundPrefetch(context.Background(), groundPrefetchTargets("Berlin", "Prague", "2026-07-15"), SearchOptions{})
+}

--- a/internal/ground/search.go
+++ b/internal/ground/search.go
@@ -35,6 +35,135 @@ const groundCacheTTL = 10 * time.Minute
 
 const sharedGroundSearchTimeout = 30 * time.Second
 
+// --- Negative-result cache + speculative prefetch (innovation #4) ---------
+
+// groundNegCacheTTL bounds how long a clean "no ground service" for a route+month
+// suppresses re-running the full provider fan-out for that route.
+const groundNegCacheTTL = 30 * time.Minute
+
+// groundNegCache records routes for which the whole provider fan-out returned no
+// routes CLEANLY (every provider that ran was not-applicable or definitively
+// empty — no hard errors, timeouts, rate-limits). That is a genuine "nothing
+// runs here", safe to cache briefly. A run with any error is never cached, so
+// transient failures always retry. On by default; set TRVL_NEGCACHE=0 to disable.
+var groundNegCache = cache.NewNegativeCache(groundNegCacheTTL)
+
+func negCacheEnabled() bool {
+	return groundEnvBool("TRVL_NEGCACHE", true)
+}
+
+// groundPrefetchEnabled gates speculative prefetch. Off by default: prefetch adds
+// provider load (extra background searches), so it is opt-in via TRVL_PREFETCH=1.
+func groundPrefetchEnabled() bool {
+	return groundEnvBool("TRVL_PREFETCH", false)
+}
+
+func groundEnvBool(name string, def bool) bool {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+// groundNegKey returns the negative-cache key for a search and whether the search
+// is eligible for negative caching. Only unfiltered searches qualify: a MaxPrice
+// or Type filter can make a served route look empty, which is NOT a "no service"
+// fact and must never be negative-cached. The provider set is folded into the key
+// so restricting providers cannot poison the all-providers result.
+func groundNegKey(from, to, date string, opts SearchOptions, providerKey string) (string, bool) {
+	if opts.MaxPrice > 0 || opts.Type != "" {
+		return "", false
+	}
+	return cache.NegativeKey("ground|"+providerKey, from, to, date), true
+}
+
+// groundPrefetchCtxKey marks a context as a prefetch (or nested) search so
+// speculative prefetch does not recurse.
+type groundPrefetchCtxKey struct{}
+
+func groundPrefetchDisabled(ctx context.Context) bool {
+	return ctx.Value(groundPrefetchCtxKey{}) != nil
+}
+
+// groundPrefetchTarget is one likely-next search to warm.
+type groundPrefetchTarget struct {
+	from string
+	to   string
+	date string
+}
+
+// groundPrefetchTargets computes the likely-next searches to warm: the return
+// leg (reverse route, +7 days) plus the two adjacent days. Pure and
+// deterministic; an unparseable date yields no targets.
+func groundPrefetchTargets(from, to, date string) []groundPrefetchTarget {
+	t, err := models.ParseDate(date)
+	if err != nil {
+		return nil
+	}
+	plus1 := t.AddDate(0, 0, 1).Format("2006-01-02")
+	minus1 := t.AddDate(0, 0, -1).Format("2006-01-02")
+	ret := t.AddDate(0, 0, 7).Format("2006-01-02")
+	return []groundPrefetchTarget{
+		{from: to, to: from, date: ret}, // return leg
+		{from: from, to: to, date: plus1},
+		{from: from, to: to, date: minus1},
+	}
+}
+
+// groundPrefetchConcurrency bounds simultaneous prefetch searches.
+const groundPrefetchConcurrency = 2
+
+// groundPrefetchFn warms a single target. Seam for tests; the default calls the
+// normal search with prefetch disabled to prevent recursion.
+var groundPrefetchFn func(ctx context.Context, t groundPrefetchTarget, opts SearchOptions)
+
+func init() {
+	groundPrefetchFn = func(ctx context.Context, t groundPrefetchTarget, opts SearchOptions) {
+		_, _ = SearchByName(ctx, t.from, t.to, t.date, opts)
+	}
+}
+
+// maybePrefetchGround dispatches best-effort speculative prefetch. It returns
+// immediately; a prefetch failure (panic included) can never affect the primary
+// search.
+func maybePrefetchGround(ctx context.Context, from, to, date string, opts SearchOptions) {
+	if !groundPrefetchEnabled() || groundPrefetchDisabled(ctx) {
+		return
+	}
+	targets := groundPrefetchTargets(from, to, date)
+	if len(targets) == 0 {
+		return
+	}
+	go runGroundPrefetch(ctx, targets, opts)
+}
+
+// runGroundPrefetch warms targets with bounded concurrency. Each warm is
+// isolated; a panic in one never affects its peers nor the caller.
+func runGroundPrefetch(parent context.Context, targets []groundPrefetchTarget, opts SearchOptions) {
+	detached, cancel := searchctx.DetachedWithin(parent, sharedGroundSearchTimeout)
+	defer cancel()
+	prefetchCtx := context.WithValue(detached, groundPrefetchCtxKey{}, struct{}{})
+
+	sem := make(chan struct{}, groundPrefetchConcurrency)
+	var wg sync.WaitGroup
+	for _, t := range targets {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(t groundPrefetchTarget) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			defer func() { _ = recover() }()
+			groundPrefetchFn(prefetchCtx, t, opts)
+		}(t)
+	}
+	wg.Wait()
+}
+
 // httpClient is a shared HTTP client with sensible timeouts for FlixBus/RegioJet.
 var httpClient = &http.Client{
 	Timeout: 30 * time.Second,
@@ -98,14 +227,10 @@ func SearchByName(ctx context.Context, from, to, date string, opts SearchOptions
 	allowBrowserFallbacks := browserFallbacksEnabled(opts)
 
 	// Build cache key from search parameters.
-	providerKey := "all"
-	if len(opts.Providers) > 0 {
-		sorted := make([]string, len(opts.Providers))
-		copy(sorted, opts.Providers)
-		sort.Strings(sorted)
-		providerKey = strings.Join(sorted, ",")
-	}
+	providerKey := groundProviderKey(opts)
 	cacheKey := cache.Key("ground", fmt.Sprintf("%s|%s|%s|%s|%s|%.2f|%s|%t", from, to, date, opts.Currency, providerKey, opts.MaxPrice, opts.Type, allowBrowserFallbacks))
+
+	negKey, negEligible := groundNegKey(from, to, date, opts, providerKey)
 
 	// Check cache unless bypassed.
 	if !opts.NoCache {
@@ -113,17 +238,33 @@ func SearchByName(ctx context.Context, from, to, date string, opts SearchOptions
 			var cached models.GroundSearchResult
 			if err := json.Unmarshal(data, &cached); err == nil {
 				slog.Debug("ground cache hit", "from", from, "to", to, "date", date)
+				maybePrefetchGround(ctx, from, to, date, opts)
 				return &cached, nil
 			}
+		}
+
+		// Negative-result cache: a recent CLEAN "no service" short-circuits the
+		// whole provider fan-out for this route+month. Only unfiltered searches
+		// participate (negEligible).
+		if negEligible && negCacheEnabled() && groundNegCache.Seen(negKey) {
+			slog.Debug("ground negative cache hit", "from", from, "to", to, "date", date)
+			maybePrefetchGround(ctx, from, to, date, opts)
+			return &models.GroundSearchResult{Success: false, Count: 0}, nil
 		}
 	}
 
 	// Deduplicate concurrent identical in-flight searches. The cache check above
 	// already handles TTL-based reuse; singleflight only coalesces truly concurrent
 	// requests that both missed the cache.
-	return doGroundSearchSingleflight(ctx, cacheKey, func(sharedCtx context.Context) (*models.GroundSearchResult, error) {
+	result, err := doGroundSearchSingleflight(ctx, cacheKey, func(sharedCtx context.Context) (*models.GroundSearchResult, error) {
 		return searchByNameCore(sharedCtx, from, to, date, opts, cacheKey, allowBrowserFallbacks)
 	})
+
+	// Speculative prefetch: warm the cache for the likely next query. Best-effort
+	// and non-blocking.
+	maybePrefetchGround(ctx, from, to, date, opts)
+
+	return result, err
 }
 
 func doGroundSearchSingleflight(ctx context.Context, key string, fn func(context.Context) (*models.GroundSearchResult, error)) (*models.GroundSearchResult, error) {
@@ -456,7 +597,28 @@ func searchByNameCore(ctx context.Context, from, to, date string, opts SearchOpt
 		}
 	}
 
+	// Negative-result cache: mark a route as "no service" only on a CLEAN empty —
+	// zero routes AND no provider errors/timeouts. A run with any error is left
+	// uncached so it retries. Filtered searches are excluded by groundNegKey.
+	if !opts.NoCache && len(allRoutes) == 0 && len(errors) == 0 && negCacheEnabled() {
+		if negKey, ok := groundNegKey(from, to, date, opts, groundProviderKey(opts)); ok {
+			groundNegCache.Mark(negKey)
+		}
+	}
+
 	return result, nil
+}
+
+// groundProviderKey returns the canonical provider-set component of the cache
+// key (sorted provider list, or "all").
+func groundProviderKey(opts SearchOptions) string {
+	if len(opts.Providers) == 0 {
+		return "all"
+	}
+	sorted := make([]string, len(opts.Providers))
+	copy(sorted, opts.Providers)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ",")
 }
 
 // isProviderNotApplicable returns true when the error indicates that a provider


### PR DESCRIPTION
## Summary

Innovation #4: a shared **negative-result cache** plus opt-in **speculative prefetch** on the flight and ground search paths. Same providers, fewer wasted round-trips — searches get cheaper and faster without changing what we query.

- **Negative-result cache** — when a provider, route and month come back cleanly empty, remember it and serve an honest `checked_no_hit` instead of re-querying the provider. Reduces provider load.
- **Speculative prefetch** — warm adjacent-day and return-leg searches ahead of the user's likely next query, reusing the existing response cache.

## How it works

`internal/cache/negcache.go` (new): a `NegativeCache` keyed by provider, origin, destination and year-month (a month bucket for seasonal safety; malformed dates fall back to raw). TTL-based with an injectable clock seam, bounded eviction, and lazy reaping.

**Flights** (`internal/flights/search.go`): wraps point-to-point carriers (ryanair, wizzair, transavia, easyjet) only. Aggregators (google, kiwi, skiplagged) are excluded because their empties are date-specific, not structural. The cache is marked only on a clean no-result (succeeded with zero flights) — never on error, timeout, ratelimit or skip.

**Ground** (`internal/ground/search.go`): a whole-search negative cache, marked only when the fan-out is cleanly empty and the search is unfiltered. MaxPrice and Type filters make a search ineligible, since a filtered-empty is not a no-service signal.

Prefetch in both paths is concurrency-capped, best-effort (panics are recovered), and recursion-guarded via context so a prefetch-spawned search never dispatches more prefetch.

## Defaults and flags

| Feature | Default | Flag |
|---|---|---|
| Negative-result cache | ON | `TRVL_NEGCACHE=0` to disable |
| Speculative prefetch | OFF | `TRVL_PREFETCH=1` to enable |

The negative cache is on by default because it only ever reduces provider load and degrades safely. Prefetch is off by default because it adds provider load — opt-in only.

## Safety

The central correctness guard: the negative cache is populated only on a clean, complete no-result. Errors, timeouts, rate-limits, skipped providers, and filtered-empty ground searches are never cached as no-service. Worst case if a route genuinely gains service mid-TTL (30 minutes): a stale empty for up to 30 minutes, self-healing on expiry.

## Testing

- `internal/cache/negcache_test.go` covers date bucketing, key normalization, store-and-serve, TTL expiry, bounded eviction, concurrent access.
- `internal/flights/prefetch_negcache_test.go` covers serve-on-hit, mark-only-on-clean-no-result, disabled bypass, prefetch targets, bounded and best-effort dispatch, no-recursion, and gated-off-by-default.
- `internal/ground/prefetch_negcache_test.go` covers filtered-ineligible, clean-no-result serve, the disabled gate, prefetch targets, dispatch and recursion.

All green under the race detector; `gofmt`, `go vet` and `staticcheck` clean; the full short test suite passes.

## Scope

Touches only the `internal/cache` package plus `internal/flights/search.go` and `internal/ground/search.go`. No changes to providers, models, MCP handlers, or the CLI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
