### PR TITLE
Headless-first browser challenge resolution (MIK-6218)

### DIFF
--- a/internal/providers/auth.go
+++ b/internal/providers/auth.go
@@ -224,6 +224,27 @@ func tryBrowserEscapeHatch(ctx context.Context, pc *providerClient, auth *AuthCo
 	targetURL := auth.PreflightURL
 	browserPref := pc.config.Cookies.Browser
 
+	// Headless-first (MIK-6218): try to clear the challenge SILENTLY by driving
+	// the user's installed browser headless (no window, no focus steal). Only if
+	// an interactive captcha remains do we fall through to the visible-window
+	// path below. A cleared challenge means the user never sees a popup.
+	if res, err := headlessFirstResolve(ctx, targetURL); err == nil && res != nil {
+		switch res.Status {
+		case ChallengeCleared:
+			if finishEscapeHatch(ctx, pc, auth, res.Cookies) {
+				slog.Info("browser escape hatch: cleared headlessly, no window shown",
+					"provider", pc.config.ID)
+				return true
+			}
+			// Headless cleared the page but the preflight retry still failed —
+			// fall through to the visible window as a last resort.
+		case ChallengeNeedsHuman:
+			slog.Info("browser escape hatch: interactive captcha detected, opening visible window",
+				"provider", pc.config.ID, "captcha", res.Marker)
+			// fall through to the visible-window path
+		}
+	}
+
 	// If elicitation is available, ask the user to confirm before opening
 	// the browser. This turns a silent 15s timeout into an explicit user
 	// action that actually succeeds.
@@ -277,11 +298,29 @@ func tryBrowserEscapeHatch(ctx context.Context, pc *providerClient, auth *AuthCo
 	if pc.client == nil || pc.client.Jar == nil {
 		return false
 	}
-	u, err := url.Parse(targetURL)
+	if !finishEscapeHatch(ctx, pc, auth, fresh) {
+		return false
+	}
+	slog.Info("browser escape hatch: preflight recovered", "provider", pc.config.ID)
+	return true
+}
+
+// finishEscapeHatch seeds the recovered cookies into the client jar, retries the
+// preflight, and (on a clean 2xx that is not another challenge page) refreshes
+// the provider's auth values. It is the shared tail of the Tier-4 escape hatch,
+// used by both the silent headless-first path and the visible-window fallback.
+// Returns true when the preflight retry succeeds and yields usable auth state.
+func finishEscapeHatch(ctx context.Context, pc *providerClient, auth *AuthConfig, fresh []*http.Cookie) bool {
+	if pc.client == nil || pc.client.Jar == nil {
+		return false
+	}
+	u, err := url.Parse(auth.PreflightURL)
 	if err != nil {
 		return false
 	}
-	pc.client.Jar.SetCookies(u, fresh)
+	if len(fresh) > 0 {
+		pc.client.Jar.SetCookies(u, fresh)
+	}
 
 	resp2, body2, err2 := doPreflightRequest(ctx, pc.client, auth)
 	if err2 != nil || resp2.StatusCode < 200 || resp2.StatusCode >= 300 {
@@ -300,7 +339,6 @@ func tryBrowserEscapeHatch(ctx context.Context, pc *providerClient, auth *AuthCo
 	}
 	applyExtractions(auth.Extractions, resp2, body2, pc.authValues)
 	applyURLExtractions(ctx, pc.client, auth.Extractions, pc.authValues)
-	slog.Info("browser escape hatch: preflight recovered", "provider", pc.config.ID)
 	return true
 }
 

--- a/internal/providers/challenge.go
+++ b/internal/providers/challenge.go
@@ -1,0 +1,232 @@
+// challenge.go implements HEADLESS-FIRST anti-bot challenge resolution. When a
+// provider preflight is blocked by a JS/WAF interstitial, we first drive the
+// user's installed Chrome/Brave HEADLESS (no visible window, no focus steal) via
+// the Chrome DevTools Protocol to let the challenge solve itself silently. Only
+// when a genuinely interactive captcha (Datadome / hCaptcha / reCAPTCHA) remains
+// — something a headless browser cannot clear without a human — does the caller
+// fall back to opening a VISIBLE window.
+//
+// This is the implementation of MIK-6218: make browser-assisted challenge
+// resolution headless-first so the focus-stealing window is a last resort.
+package providers
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/chromedp"
+)
+
+// ChallengeStatus is the outcome of a headless-first challenge resolution.
+type ChallengeStatus int
+
+const (
+	// ChallengeUnresolved means the headless attempt neither cleared the
+	// challenge nor positively identified an interactive captcha (e.g. the
+	// browser errored or produced an inconclusive page).
+	ChallengeUnresolved ChallengeStatus = iota
+	// ChallengeCleared means the headless browser silently solved the challenge
+	// and usable cookies are ready — NO visible window is needed.
+	ChallengeCleared
+	// ChallengeNeedsHuman means an interactive captcha interstitial remains that
+	// a headless browser cannot solve; the caller may open a visible window so a
+	// human can complete it.
+	ChallengeNeedsHuman
+)
+
+// String renders the status for logs.
+func (s ChallengeStatus) String() string {
+	switch s {
+	case ChallengeCleared:
+		return "cleared"
+	case ChallengeNeedsHuman:
+		return "needs_human"
+	default:
+		return "unresolved"
+	}
+}
+
+// ChallengeResult is the typed outcome returned by ResolveChallenge. On
+// ChallengeCleared the Cookies are ready (and have been persisted to the
+// ~/.trvl/cookies cache). On ChallengeNeedsHuman, Marker names the detected
+// captcha vendor.
+type ChallengeResult struct {
+	Status  ChallengeStatus
+	Cookies []*http.Cookie
+	Marker  string
+}
+
+// captchaMarker pairs a captcha vendor with substrings that, when present in a
+// post-headless page, indicate an INTERACTIVE interstitial requiring a human.
+type captchaMarker struct {
+	Vendor  string
+	Needles []string
+}
+
+// interactiveCaptchaMarkers lists the known interactive-interstitial signatures.
+// These are vendors whose challenge cannot be cleared headlessly because they
+// demand a human gesture (image grid, slider, checkbox). Lower-cased needles.
+var interactiveCaptchaMarkers = []captchaMarker{
+	// Datadome serves its interactive captcha from geo.captcha-delivery.com.
+	{Vendor: "datadome", Needles: []string{"geo.captcha-delivery.com", "captcha-delivery.com"}},
+	// hCaptcha widget host + the rendered container class.
+	{Vendor: "hcaptcha", Needles: []string{"hcaptcha.com", "h-captcha"}},
+	// Google reCAPTCHA api script + the rendered container class.
+	{Vendor: "recaptcha", Needles: []string{"google.com/recaptcha", "recaptcha/api.js", "g-recaptcha"}},
+}
+
+// DetectInteractiveCaptcha reports whether body contains markers of a known
+// interactive captcha interstitial (Datadome, hCaptcha, reCAPTCHA) that a
+// headless browser cannot clear and which therefore requires a human. When it
+// returns true, the second value names the matched vendor.
+//
+// Pure and deterministic — the testable gate that decides CLEARED vs
+// NEEDS_HUMAN. A clean page (no markers) returns (false, "").
+func DetectInteractiveCaptcha(body []byte) (bool, string) {
+	if len(body) == 0 {
+		return false, ""
+	}
+	lower := strings.ToLower(string(body))
+	for _, m := range interactiveCaptchaMarkers {
+		for _, needle := range m.Needles {
+			if strings.Contains(lower, needle) {
+				return true, m.Vendor
+			}
+		}
+	}
+	return false, ""
+}
+
+// cdpChallengeRunner drives an installed browser HEADLESS and returns both the
+// harvested cookies AND the final page HTML so the caller can decide CLEARED vs
+// NEEDS_HUMAN. Overridable in tests so the orchestration can be exercised
+// offline without spawning a real browser.
+var cdpChallengeRunner = runCDPChallenge
+
+// ResolveChallenge launches the user's installed browser HEADLESS (no window, no
+// focus steal), lets the anti-bot challenge at targetURL resolve, then inspects
+// the resulting page:
+//
+//   - If an interactive captcha interstitial remains (Datadome / hCaptcha /
+//     reCAPTCHA), it returns ChallengeNeedsHuman with the detected vendor — the
+//     caller may then open a VISIBLE window for a human to finish.
+//   - Otherwise it treats the challenge as silently cleared, persists the
+//     harvested cookies to the ~/.trvl/cookies cache for Tier-1 reuse, and
+//     returns ChallengeCleared.
+//
+// Like RefreshCookiesViaCDP it is gated: without the opt-in (TRVL_TIER2_CDP=1 or
+// WithTier2Force) it returns ErrTier2Disabled. It reuses the Tier2Option set so
+// callers configure it the same way as the lower-level CDP refresh.
+func ResolveChallenge(ctx context.Context, targetURL string, opts ...Tier2Option) (*ChallengeResult, error) {
+	cfg := tier2Config{challengeWait: defaultChallengeWait}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	if !cfg.force && !Tier2Enabled() {
+		return nil, ErrTier2Disabled
+	}
+
+	if _, err := url.Parse(targetURL); err != nil {
+		return nil, err
+	}
+
+	execPath := cfg.execPath
+	if execPath == "" {
+		p, ok := detectInstalledBrowser()
+		if !ok {
+			return nil, ErrNoBrowserFound
+		}
+		execPath = p
+	}
+
+	rawCookies, html, err := cdpChallengeRunner(ctx, execPath, targetURL, cfg.challengeWait)
+	if err != nil {
+		return nil, err
+	}
+
+	cookies := convertNetworkCookies(rawCookies)
+
+	if needsHuman, marker := DetectInteractiveCaptcha([]byte(html)); needsHuman {
+		// The headless pass could not clear an interactive captcha. Do NOT
+		// persist — the session is not authenticated. Signal the caller to open
+		// a visible window.
+		return &ChallengeResult{Status: ChallengeNeedsHuman, Cookies: cookies, Marker: marker}, nil
+	}
+
+	// No interactive interstitial remained — treat as silently cleared and make
+	// the cookies available to Tier-1 on the next request.
+	persistCookiesToCache(targetURL, cookies)
+	return &ChallengeResult{Status: ChallengeCleared, Cookies: cookies}, nil
+}
+
+// runCDPChallenge is the production cdpChallengeRunner: it drives an installed
+// browser headlessly via chromedp and returns the cookies plus the final page
+// HTML present after the challenge wait. No window is shown and focus is never
+// stolen (Headless + DefaultExecAllocatorOptions; no activation/foreground
+// flags).
+func runCDPChallenge(ctx context.Context, execPath, targetURL string, challengeWait time.Duration) ([]*network.Cookie, string, error) {
+	allocOpts := append([]chromedp.ExecAllocatorOption{},
+		chromedp.DefaultExecAllocatorOptions[:]...)
+	allocOpts = append(allocOpts,
+		chromedp.ExecPath(execPath),
+		chromedp.Headless,
+		chromedp.NoFirstRun,
+		chromedp.NoDefaultBrowserCheck,
+		chromedp.Flag("disable-background-networking", true),
+		chromedp.Flag("disable-extensions", true),
+	)
+
+	allocCtx, cancelAlloc := chromedp.NewExecAllocator(ctx, allocOpts...)
+	defer cancelAlloc()
+
+	taskCtx, cancelTask := chromedp.NewContext(allocCtx)
+	defer cancelTask()
+
+	var cookies []*network.Cookie
+	var html string
+	err := chromedp.Run(taskCtx,
+		network.Enable(),
+		chromedp.Navigate(targetURL),
+		chromedp.Sleep(challengeWait),
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			c, err := network.GetCookies().Do(ctx)
+			if err != nil {
+				return err
+			}
+			cookies = c
+			return nil
+		}),
+		// Best-effort outer HTML capture for captcha-marker detection. A failure
+		// here must not abort the harvest, so it is tolerated.
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			_ = chromedp.OuterHTML("html", &html, chromedp.ByQuery).Do(ctx)
+			return nil
+		}),
+	)
+	if err != nil {
+		return nil, "", err
+	}
+	return cookies, html, nil
+}
+
+// headlessFirstResolve is the seam used by tryBrowserEscapeHatch to attempt a
+// silent headless resolution before falling back to a visible window.
+// Overridable in tests. The default refuses to spawn a real browser inside a
+// `go test` binary so the default suite stays offline/deterministic (mirrors
+// the browserCookiesForURL test guard).
+var headlessFirstResolve = defaultHeadlessFirstResolve
+
+func defaultHeadlessFirstResolve(ctx context.Context, targetURL string) (*ChallengeResult, error) {
+	if os.Getenv("TRVL_ALLOW_BROWSER_COOKIES") == "" && isTestBinary() {
+		return nil, ErrTier2Disabled
+	}
+	// Force past the env opt-in: the Tier-4 caller has already gated this on
+	// per-provider BrowserEscapeHatch + an interactive context.
+	return ResolveChallenge(ctx, targetURL, WithTier2Force())
+}

--- a/internal/providers/challenge_test.go
+++ b/internal/providers/challenge_test.go
@@ -1,0 +1,304 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto/network"
+)
+
+// ---------------------------------------------------------------------------
+// DetectInteractiveCaptcha — pure marker-detection table
+// ---------------------------------------------------------------------------
+
+func TestDetectInteractiveCaptcha(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		wantHuman  bool
+		wantVendor string
+	}{
+		{"clean page", `<html><body>Welcome, here are your flights</body></html>`, false, ""},
+		{"empty", ``, false, ""},
+		{"datadome iframe", `<iframe src="https://geo.captcha-delivery.com/captcha/?initialCid=x"></iframe>`, true, "datadome"},
+		{"datadome bare host", `please solve at captcha-delivery.com`, true, "datadome"},
+		{"hcaptcha widget", `<div class="h-captcha" data-sitekey="abc"></div>`, true, "hcaptcha"},
+		{"hcaptcha host", `<script src="https://hcaptcha.com/1/api.js"></script>`, true, "hcaptcha"},
+		{"recaptcha api", `<script src="https://www.google.com/recaptcha/api.js"></script>`, true, "recaptcha"},
+		{"recaptcha container", `<div class="g-recaptcha" data-sitekey="x"></div>`, true, "recaptcha"},
+		{"case insensitive", `<DIV CLASS="H-CAPTCHA"></DIV>`, true, "hcaptcha"},
+		{"unrelated captcha word", `we use a captcha-free login`, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotHuman, gotVendor := DetectInteractiveCaptcha([]byte(tc.body))
+			if gotHuman != tc.wantHuman || gotVendor != tc.wantVendor {
+				t.Fatalf("DetectInteractiveCaptcha(%q) = (%v,%q), want (%v,%q)",
+					tc.body, gotHuman, gotVendor, tc.wantHuman, tc.wantVendor)
+			}
+		})
+	}
+}
+
+func TestChallengeStatusString(t *testing.T) {
+	cases := map[ChallengeStatus]string{
+		ChallengeCleared:    "cleared",
+		ChallengeNeedsHuman: "needs_human",
+		ChallengeUnresolved: "unresolved",
+		ChallengeStatus(99): "unresolved",
+	}
+	for s, want := range cases {
+		if got := s.String(); got != want {
+			t.Errorf("%d.String() = %q, want %q", s, got, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveChallenge — gating + CLEARED vs NEEDS_HUMAN decision (offline)
+// ---------------------------------------------------------------------------
+
+func TestResolveChallenge_DisabledByDefault(t *testing.T) {
+	t.Setenv(tier2EnableEnv, "")
+	_, err := ResolveChallenge(context.Background(), "https://example.com/")
+	if !errors.Is(err, ErrTier2Disabled) {
+		t.Fatalf("err = %v, want ErrTier2Disabled", err)
+	}
+}
+
+func TestResolveChallenge_NoBrowserFound(t *testing.T) {
+	prevExists := fileExists
+	fileExists = func(string) bool { return false }
+	defer func() { fileExists = prevExists }()
+
+	_, err := ResolveChallenge(context.Background(), "https://example.com/", WithTier2Force())
+	if !errors.Is(err, ErrNoBrowserFound) {
+		t.Fatalf("err = %v, want ErrNoBrowserFound", err)
+	}
+}
+
+func TestResolveChallenge_RunnerError(t *testing.T) {
+	prevExists := fileExists
+	fileExists = func(string) bool { return true }
+	defer func() { fileExists = prevExists }()
+
+	prevRunner := cdpChallengeRunner
+	wantErr := errors.New("boom")
+	cdpChallengeRunner = func(ctx context.Context, execPath, targetURL string, wait time.Duration) ([]*network.Cookie, string, error) {
+		return nil, "", wantErr
+	}
+	defer func() { cdpChallengeRunner = prevRunner }()
+
+	_, err := ResolveChallenge(context.Background(), "https://example.com/", WithTier2Force())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want boom", err)
+	}
+}
+
+func TestResolveChallenge_ClearedPersistsCookies(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	prevExists := fileExists
+	fileExists = func(string) bool { return true }
+	defer func() { fileExists = prevExists }()
+
+	prevRunner := cdpChallengeRunner
+	cdpChallengeRunner = func(ctx context.Context, execPath, targetURL string, wait time.Duration) ([]*network.Cookie, string, error) {
+		cookies := []*network.Cookie{
+			{Name: "cf_clearance", Value: "headless-token", Domain: "example.com", Path: "/", Secure: true, Expires: float64(time.Now().Add(time.Hour).Unix())},
+		}
+		// Clean page — challenge solved, no captcha markers.
+		return cookies, `<html><body>flights</body></html>`, nil
+	}
+	defer func() { cdpChallengeRunner = prevRunner }()
+
+	target := "https://example.com/"
+	res, err := ResolveChallenge(context.Background(), target, WithTier2Force())
+	if err != nil {
+		t.Fatalf("ResolveChallenge: %v", err)
+	}
+	if res.Status != ChallengeCleared {
+		t.Fatalf("status = %v, want cleared", res.Status)
+	}
+	// Cleared path must persist cookies for Tier-1 reuse.
+	cached := cachedCookiesForURL(target)
+	found := false
+	for _, c := range cached {
+		if c.Name == "cf_clearance" && c.Value == "headless-token" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("cf_clearance not persisted on cleared: %+v", cached)
+	}
+}
+
+func TestResolveChallenge_NeedsHumanDoesNotPersist(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	prevExists := fileExists
+	fileExists = func(string) bool { return true }
+	defer func() { fileExists = prevExists }()
+
+	prevRunner := cdpChallengeRunner
+	cdpChallengeRunner = func(ctx context.Context, execPath, targetURL string, wait time.Duration) ([]*network.Cookie, string, error) {
+		cookies := []*network.Cookie{
+			{Name: "datadome", Value: "partial", Domain: "example.com", Path: "/"},
+		}
+		// Interactive Datadome captcha still present.
+		return cookies, `<iframe src="https://geo.captcha-delivery.com/captcha/"></iframe>`, nil
+	}
+	defer func() { cdpChallengeRunner = prevRunner }()
+
+	target := "https://example.com/"
+	res, err := ResolveChallenge(context.Background(), target, WithTier2Force())
+	if err != nil {
+		t.Fatalf("ResolveChallenge: %v", err)
+	}
+	if res.Status != ChallengeNeedsHuman {
+		t.Fatalf("status = %v, want needs_human", res.Status)
+	}
+	if res.Marker != "datadome" {
+		t.Fatalf("marker = %q, want datadome", res.Marker)
+	}
+	// NEEDS_HUMAN must NOT persist cookies (session not authenticated).
+	if cached := cachedCookiesForURL(target); len(cached) != 0 {
+		t.Fatalf("expected no cookies persisted on needs_human, got %+v", cached)
+	}
+}
+
+func TestDefaultHeadlessFirstResolve_SkipsInTestBinary(t *testing.T) {
+	// Without TRVL_ALLOW_BROWSER_COOKIES the default must refuse to spawn a real
+	// browser inside the test binary, so the visible-window fallback can run.
+	t.Setenv("TRVL_ALLOW_BROWSER_COOKIES", "")
+	_, err := defaultHeadlessFirstResolve(context.Background(), "https://example.com/")
+	if !errors.Is(err, ErrTier2Disabled) {
+		t.Fatalf("err = %v, want ErrTier2Disabled (skip in test binary)", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// tryBrowserEscapeHatch wiring — headless-first vs visible-window fallback
+// ---------------------------------------------------------------------------
+
+// withHeadlessResolve swaps the headlessFirstResolve seam for the test duration.
+func withHeadlessResolve(t *testing.T, fn func(ctx context.Context, targetURL string) (*ChallengeResult, error)) {
+	t.Helper()
+	prev := headlessFirstResolve
+	headlessFirstResolve = fn
+	t.Cleanup(func() { headlessFirstResolve = prev })
+}
+
+// TestTryBrowserEscapeHatch_HeadlessClears_NoVisibleWindow proves that when the
+// headless pass clears the challenge and the preflight retry succeeds, the
+// VISIBLE opener is NEVER called.
+func TestTryBrowserEscapeHatch_HeadlessClears_NoVisibleWindow(t *testing.T) {
+	// Preflight server that returns a clean 2xx so finishEscapeHatch succeeds.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	jar, _ := cookiejar.New(nil)
+	pc := &providerClient{
+		config:     &ProviderConfig{ID: "headless-clear", Name: "HeadlessClear"},
+		client:     &http.Client{Jar: jar},
+		authValues: make(map[string]string),
+	}
+	auth := &AuthConfig{PreflightURL: srv.URL, BrowserEscapeHatch: true}
+
+	withHeadlessResolve(t, func(ctx context.Context, targetURL string) (*ChallengeResult, error) {
+		return &ChallengeResult{
+			Status:  ChallengeCleared,
+			Cookies: []*http.Cookie{{Name: "cf_clearance", Value: "x"}},
+		}, nil
+	})
+
+	var openerCalls int
+	withOpener(t, func(goos, pref, target string) error {
+		openerCalls++
+		return nil
+	})
+
+	if got := tryBrowserEscapeHatch(context.Background(), pc, auth); !got {
+		t.Fatal("expected true when headless clears and preflight retry succeeds")
+	}
+	if openerCalls != 0 {
+		t.Fatalf("visible opener called %d times, want 0 (headless cleared silently)", openerCalls)
+	}
+}
+
+// TestTryBrowserEscapeHatch_NeedsHuman_OpensVisibleOnce proves that when an
+// interactive captcha remains after the headless pass, the visible opener is
+// invoked exactly once.
+func TestTryBrowserEscapeHatch_NeedsHuman_OpensVisibleOnce(t *testing.T) {
+	jar, _ := cookiejar.New(nil)
+	pc := &providerClient{
+		config:     &ProviderConfig{ID: "needs-human", Name: "NeedsHuman"},
+		client:     &http.Client{Jar: jar},
+		authValues: make(map[string]string),
+	}
+	auth := &AuthConfig{PreflightURL: "https://example.com/page", BrowserEscapeHatch: true}
+
+	withHeadlessResolve(t, func(ctx context.Context, targetURL string) (*ChallengeResult, error) {
+		return &ChallengeResult{Status: ChallengeNeedsHuman, Marker: "datadome"}, nil
+	})
+
+	var openerCalls int
+	withOpener(t, func(goos, pref, target string) error {
+		openerCalls++
+		return nil
+	})
+	// No cookie change → waitForFreshCookies times out fast; keep the test quick
+	// by cancelling the context shortly.
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	// Cookie source returns a stable (unchanged) set so the wait reports no change.
+	withCookieSource(t, func(string) []*http.Cookie { return nil })
+
+	got := tryBrowserEscapeHatch(ctx, pc, auth)
+	if got {
+		t.Fatal("expected false: visible path opened but no cookie change observed")
+	}
+	if openerCalls != 1 {
+		t.Fatalf("visible opener called %d times, want exactly 1", openerCalls)
+	}
+}
+
+// TestTryBrowserEscapeHatch_HeadlessUnresolved_FallsThrough proves that when the
+// headless seam errors (e.g. no browser), the visible-window fallback still runs.
+func TestTryBrowserEscapeHatch_HeadlessUnresolved_FallsThrough(t *testing.T) {
+	jar, _ := cookiejar.New(nil)
+	pc := &providerClient{
+		config:     &ProviderConfig{ID: "fallthrough", Name: "FallThrough"},
+		client:     &http.Client{Jar: jar},
+		authValues: make(map[string]string),
+	}
+	auth := &AuthConfig{PreflightURL: "https://example.com/page", BrowserEscapeHatch: true}
+
+	withHeadlessResolve(t, func(ctx context.Context, targetURL string) (*ChallengeResult, error) {
+		return nil, ErrNoBrowserFound
+	})
+
+	var openerCalls int
+	withOpener(t, func(goos, pref, target string) error {
+		openerCalls++
+		return nil
+	})
+	withCookieSource(t, func(string) []*http.Cookie { return nil })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	_ = tryBrowserEscapeHatch(ctx, pc, auth)
+	if openerCalls != 1 {
+		t.Fatalf("visible opener called %d times, want exactly 1 (headless errored)", openerCalls)
+	}
+}

--- a/internal/providers/challenge_test.go
+++ b/internal/providers/challenge_test.go
@@ -102,6 +102,9 @@ func TestResolveChallenge_RunnerError(t *testing.T) {
 
 func TestResolveChallenge_ClearedPersistsCookies(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	// os.UserHomeDir reads USERPROFILE on Windows, not HOME — isolate both so
+	// the ~/.trvl cookie cache is per-test on every OS.
+	t.Setenv("USERPROFILE", t.TempDir())
 
 	prevExists := fileExists
 	fileExists = func(string) bool { return true }
@@ -140,6 +143,9 @@ func TestResolveChallenge_ClearedPersistsCookies(t *testing.T) {
 
 func TestResolveChallenge_NeedsHumanDoesNotPersist(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	// os.UserHomeDir reads USERPROFILE on Windows, not HOME — isolate both so a
+	// prior test's persisted cookies cannot leak into this absence assertion.
+	t.Setenv("USERPROFILE", t.TempDir())
 
 	prevExists := fileExists
 	fileExists = func(string) bool { return true }


### PR DESCRIPTION
## Summary

Makes browser-assisted anti-bot challenge resolution **headless-first**: no visible focus-stealing window unless a real interactive captcha needs a human.

When a provider preflight is blocked by a JavaScript or WAF interstitial, the Tier-4 escape hatch now first drives the user's installed Chrome or Brave **headless** (`chromedp.Headless` — no window, no focus steal) to let the challenge solve itself silently, then inspects the post-headless page to decide whether the challenge cleared or an interactive captcha remains. Only the `NEEDS_HUMAN` branch opens a visible window.

No new third-party dependency (chromedp already a dep).

## New API

- `providers.ResolveChallenge(ctx, targetURL, opts ...Tier2Option) (*ChallengeResult, error)` — headless-first resolver. Returns a typed `ChallengeResult{Status, Cookies, Marker}` where `Status` is `ChallengeCleared` (cookies ready and persisted to the trvl cookie cache, no window needed) or `ChallengeNeedsHuman` (interactive captcha remains). Gated like `RefreshCookiesViaCDP` (`TRVL_TIER2_CDP=1` or `WithTier2Force`).
- `providers.DetectInteractiveCaptcha(body []byte) (bool, string)` — pure, testable gate.

## Captcha-detection markers

| Vendor | Needles (lower-cased) |
|---|---|
| datadome | geo.captcha-delivery.com, captcha-delivery.com |
| hcaptcha | hcaptcha.com, h-captcha |
| recaptcha | google.com recaptcha, recaptcha api.js, g-recaptcha |

## Wired vs deferred

- **Wired**: `auth.go` Tier-4 `tryBrowserEscapeHatch` attempts headless-first before `OpenURLInBrowser`; visible open only on `NEEDS_HUMAN` (or if a headless-cleared preflight retry still fails). Shared cookie-retry-extract tail extracted into `finishEscapeHatch`.
- **Deferred (HB.6)**: `internal/ground` callers left untouched until ground-reliability merges; the new helper is available for them to adopt.

## Compatibility

All existing exported signatures unchanged (`OpenURLInBrowser`, `BrowserCookiesForURL`, `RefreshCookiesViaCDP`) — additive only.

## Verification

Deterministic offline TDD via fake `cdpChallengeRunner` + `headlessFirstResolve` + opener seams:
- headless-clears: visible opener never called
- interactive-captcha: visible opener called exactly once
- headless-error: falls through to visible window
- marker-detection table (datadome, hcaptcha, recaptcha vs clean)

go vet, staticcheck (touched pkgs), gofmt clean, go test -race on internal/providers and internal/cookies, and go test -short on all packages: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)