### PR TITLE
HB.6 ground headless-first escalation, MIK-6218

### DIFF
--- a/internal/ground/sncf.go
+++ b/internal/ground/sncf.go
@@ -18,6 +18,7 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/cookies"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	trvlnab "github.com/MikkoParkkola/trvl/internal/nab"
+	"github.com/MikkoParkkola/trvl/internal/providers"
 )
 
 // SNCF calendar prices endpoint (public, no auth).
@@ -25,6 +26,10 @@ import (
 // (oui.sncf/proposition/rest/search-travels/outward) now requires Cloudflare
 // JS challenge, but the calendar API may still work for price lookups.
 const sncfCalendarEndpoint = "https://www.sncf-connect.com/calendar/cdp/api/public/calendar/v4/outward"
+
+// sncfHomeURL is the origin used to harvest cookies via a headless challenge
+// resolution before any visible browser window is opened.
+const sncfHomeURL = "https://www.sncf-connect.com/en-en"
 
 // sncfLimiter enforces a conservative rate limit: 10 req/min.
 var sncfLimiter = newProviderLimiter(6 * time.Second)
@@ -37,6 +42,18 @@ var (
 	sncfDo             = func(req *http.Request) (*http.Response, error) { return sncfClient.Do(req) }
 	sncfFetchViaNab    = fetchSNCFViaNab
 	sncfBrowserCookies = cookies.BrowserCookies
+	// sncfViaCurlFn shells out to the system curl binary for the curl-assisted BFF
+	// fallback. Overridable in tests so the browser-fallback chain runs offline.
+	sncfViaCurlFn = sncfViaCurl
+
+	// sncfResolveChallenge escalates SNCF's anti-bot wall HEADLESS-first (no
+	// window, no focus steal) via providers.ResolveChallenge. Overridable in tests.
+	sncfResolveChallenge = func(ctx context.Context, targetURL string) (*providers.ChallengeResult, error) {
+		return providers.ResolveChallenge(ctx, targetURL, providers.WithTier2Force())
+	}
+	// sncfOpenBrowser opens a VISIBLE browser window so a human can solve an
+	// interactive captcha. Only invoked on ChallengeNeedsHuman. Overridable in tests.
+	sncfOpenBrowser = cookies.OpenBrowserForAuth
 )
 
 type sncfHeader struct {
@@ -479,7 +496,7 @@ func SearchSNCF(ctx context.Context, from, to, date, currency string, allowBrows
 	}
 
 	// Optional browser/curl-assisted API fallback.
-	if cRoutes, cErr := sncfViaCurl(ctx, fromStation.Code, toStation.Code, date, currency); cErr == nil && len(cRoutes) > 0 {
+	if cRoutes, cErr := sncfViaCurlFn(ctx, fromStation.Code, toStation.Code, date, currency); cErr == nil && len(cRoutes) > 0 {
 		// Populate city/station names that parseSNCFBFFResponse cannot fill in.
 		for i := range cRoutes {
 			if cRoutes[i].Departure.City == "" {
@@ -496,8 +513,27 @@ func SearchSNCF(ctx context.Context, from, to, date, currency string, allowBrows
 		slog.Debug("sncf curl fallback failed", "err", cErr)
 	}
 
-	_, _ = fmt.Fprintf(os.Stderr, "⚠️  SNCF browser fallbacks enabled. Opening browser — complete verification, then retry.\n")
-	_ = cookies.OpenBrowserForAuth("https://www.sncf-connect.com/en-en")
+	// Headless-first challenge escalation (MIK-6218): try to clear SNCF's
+	// Cloudflare/Datadome wall in a HEADLESS browser (no window, no focus steal).
+	// If it clears, retry the calendar API silently with the harvested cookies.
+	// Only an interactive captcha that a headless browser cannot solve falls
+	// through to a VISIBLE window for the user.
+	if res, rErr := sncfResolveChallenge(ctx, sncfHomeURL); rErr != nil {
+		slog.Debug("sncf headless challenge resolve failed", "err", rErr)
+	} else if res != nil && res.Status == providers.ChallengeCleared {
+		if ch := cookieSliceToHeader(res.Cookies); ch != "" {
+			slog.Debug("sncf challenge cleared headlessly — retrying calendar with harvested cookies")
+			if hRoutes, hErr := sncfCalendarWithCookies(ctx, fromStation, toStation, date, currency, ch); hErr == nil && len(hRoutes) > 0 {
+				return hRoutes, nil
+			} else if hErr != nil {
+				slog.Debug("sncf headless-cleared retry failed", "err", hErr)
+			}
+		}
+	} else if res != nil && res.Status == providers.ChallengeNeedsHuman {
+		slog.Warn("sncf requires human verification — opening browser", "vendor", res.Marker)
+		_, _ = fmt.Fprintf(os.Stderr, "⚠️  SNCF requires verification. Opening browser — complete verification, then retry.\n")
+		_ = sncfOpenBrowser(sncfHomeURL)
+	}
 
 	if bRoutes, bErr := BrowserScrapeRoutes(ctx, "sncf", from, to, date, currency); bErr == nil && len(bRoutes) > 0 {
 		return bRoutes, nil
@@ -583,6 +619,37 @@ func searchSNCFCalendar(ctx context.Context, fromStation, toStation SNCFStation,
 		return nil, fmt.Errorf("sncf calendar api: HTTP %d: %s", resp.StatusCode, respBody)
 	}
 
+	return parseSNCFResponse(resp.Body, fromStation, toStation, date, currency)
+}
+
+// sncfCalendarWithCookies issues a single calendar-API GET carrying the cookie
+// header harvested by a HEADLESS challenge resolution (MIK-6218). It is the
+// silent retry after providers.ResolveChallenge reports ChallengeCleared — no
+// visible window is involved. Returns a typed error when the wall persists.
+func sncfCalendarWithCookies(ctx context.Context, fromStation, toStation SNCFStation, date, currency, cookieHeader string) ([]models.GroundRoute, error) {
+	apiURL := fmt.Sprintf("%s/%s/%s/%s/26-NO_CARD/2/en?onlyDirectTrains=false&currency=%s",
+		sncfCalendarEndpoint,
+		fromStation.Code,
+		toStation.Code,
+		date,
+		url.QueryEscape(strings.ToUpper(currency)),
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	applySNCFHeaders(req, cookieHeader)
+
+	resp, err := sncfDo(req)
+	if err != nil {
+		return nil, fmt.Errorf("sncf calendar retry: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("sncf calendar retry: HTTP %d", resp.StatusCode)
+	}
 	return parseSNCFResponse(resp.Body, fromStation, toStation, date, currency)
 }
 

--- a/internal/ground/sncf_test.go
+++ b/internal/ground/sncf_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/providers"
 	"github.com/MikkoParkkola/trvl/internal/testutil"
 	"golang.org/x/time/rate"
 )
@@ -239,5 +240,152 @@ func TestSearchSNCFCalendar_UsesNabFallbackOn403(t *testing.T) {
 	}
 	if routes[0].Departure.City != "Paris" || routes[0].Arrival.City != "Lyon" {
 		t.Fatalf("unexpected route cities: %+v", routes[0])
+	}
+}
+
+// sncfCalendarOKBody is a minimal calendar-API JSON body for date 2026-04-10.
+const sncfCalendarOKBody = `[{"date":"2026-04-10","price":4500}]`
+
+// resetSNCFSeams stubs the calendar/curl/nab tiers ahead of the headless
+// escalation so SearchSNCF reaches the headless step deterministically offline.
+func resetSNCFSeams(t *testing.T) {
+	t.Helper()
+	origDo := sncfDo
+	origNab := sncfFetchViaNab
+	origCookies := sncfBrowserCookies
+	origCurl := sncfViaCurlFn
+	origResolve := sncfResolveChallenge
+	origOpen := sncfOpenBrowser
+	origLimiter := sncfLimiter
+	t.Cleanup(func() {
+		sncfDo = origDo
+		sncfFetchViaNab = origNab
+		sncfBrowserCookies = origCookies
+		sncfViaCurlFn = origCurl
+		sncfResolveChallenge = origResolve
+		sncfOpenBrowser = origOpen
+		sncfLimiter = origLimiter
+	})
+	sncfLimiter = rate.NewLimiter(rate.Inf, 1)
+	sncfBrowserCookies = func(string) string { return "" }
+	sncfFetchViaNab = func(context.Context, string, SNCFStation, SNCFStation, string, string) ([]models.GroundRoute, error) {
+		return nil, errStubbedFallback
+	}
+	sncfViaCurlFn = func(context.Context, string, string, string, string) ([]models.GroundRoute, error) {
+		return nil, errStubbedFallback
+	}
+	sncfResolveChallenge = func(context.Context, string) (*providers.ChallengeResult, error) {
+		return nil, errStubbedFallback
+	}
+	sncfOpenBrowser = func(string) error { return nil }
+	t.Setenv("TRVL_SCRAPER_PATH", "/nonexistent/trvl-test-scraper.py")
+}
+
+// TestSearchSNCF_HeadlessClearedRetriesSilently verifies a ChallengeCleared
+// headless resolution triggers a silent calendar retry with the harvested
+// cookies and opens NO visible window.
+func TestSearchSNCF_HeadlessClearedRetriesSilently(t *testing.T) {
+	resetSNCFSeams(t)
+
+	var calls int
+	sncfDo = func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader("blocked")),
+				Header:     make(http.Header),
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(sncfCalendarOKBody)),
+			Header:     make(http.Header),
+		}, nil
+	}
+	var resolveCalled bool
+	sncfResolveChallenge = func(context.Context, string) (*providers.ChallengeResult, error) {
+		resolveCalled = true
+		return &providers.ChallengeResult{
+			Status:  providers.ChallengeCleared,
+			Cookies: []*http.Cookie{{Name: "datadome", Value: "cleared"}},
+		}, nil
+	}
+	var openCalled bool
+	sncfOpenBrowser = func(string) error { openCalled = true; return nil }
+
+	routes, err := SearchSNCF(context.Background(), "Paris", "Lyon", "2026-04-10", "EUR", true)
+	if err != nil {
+		t.Fatalf("SearchSNCF returned error: %v", err)
+	}
+	if !resolveCalled {
+		t.Error("expected headless challenge resolution to be attempted")
+	}
+	if openCalled {
+		t.Error("visible browser window must NOT open when challenge cleared headlessly")
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route from silent retry, got %d", len(routes))
+	}
+	if routes[0].Price != 45.0 {
+		t.Errorf("price = %v, want 45.0", routes[0].Price)
+	}
+}
+
+// TestSearchSNCF_NeedsHumanOpensVisibleWindow verifies an interactive captcha
+// escalates to the VISIBLE browser path.
+func TestSearchSNCF_NeedsHumanOpensVisibleWindow(t *testing.T) {
+	resetSNCFSeams(t)
+
+	sncfDo = func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader("blocked")),
+			Header:     make(http.Header),
+		}, nil
+	}
+	sncfResolveChallenge = func(context.Context, string) (*providers.ChallengeResult, error) {
+		return &providers.ChallengeResult{Status: providers.ChallengeNeedsHuman, Marker: "datadome"}, nil
+	}
+	var openCalled bool
+	sncfOpenBrowser = func(string) error { openCalled = true; return nil }
+
+	_, err := SearchSNCF(context.Background(), "Paris", "Lyon", "2026-04-10", "EUR", true)
+	if err == nil {
+		t.Fatal("expected an error after needs-human fallback exhausts")
+	}
+	if !openCalled {
+		t.Error("expected the visible browser window to open on ChallengeNeedsHuman")
+	}
+}
+
+// TestSearchSNCF_NoFallbackHonestError verifies that without browser fallbacks
+// the headless escalation never runs and the typed API error is returned.
+func TestSearchSNCF_NoFallbackHonestError(t *testing.T) {
+	resetSNCFSeams(t)
+
+	sncfDo = func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader("blocked")),
+			Header:     make(http.Header),
+		}, nil
+	}
+	var resolveCalled, openCalled bool
+	sncfResolveChallenge = func(context.Context, string) (*providers.ChallengeResult, error) {
+		resolveCalled = true
+		return nil, errStubbedFallback
+	}
+	sncfOpenBrowser = func(string) error { openCalled = true; return nil }
+
+	_, err := SearchSNCF(context.Background(), "Paris", "Lyon", "2026-04-10", "EUR", false)
+	if err == nil {
+		t.Fatal("expected an error when browser fallbacks are disallowed")
+	}
+	if resolveCalled {
+		t.Error("headless challenge resolution must NOT run without browser fallbacks")
+	}
+	if openCalled {
+		t.Error("visible browser window must NOT open without browser fallbacks")
 	}
 }

--- a/internal/ground/trainline.go
+++ b/internal/ground/trainline.go
@@ -47,6 +47,9 @@ var (
 	trainlineDo             = func(req *http.Request) (*http.Response, error) { return trainlineClient.Do(req) }
 	trainlineFetchViaNab    = fetchTrainlineViaNab
 	trainlineBrowserCookies = cookies.BrowserCookies
+	// trainlineViaCurlFn shells out to the system curl binary for the curl-assisted
+	// fallback. Overridable in tests so the 403 escalation chain runs offline.
+	trainlineViaCurlFn = trainlineViaCurl
 
 	// trainlineNewTier1 builds a Chrome-impersonating TLS client (browser JA3).
 	// Overridable in tests so the Tier-1 fallback can be pointed at httptest.
@@ -54,6 +57,18 @@ var (
 	// trainlineTier1Cookies harvests the user's live browser cookies for a URL
 	// (datadome clearance via kooky). Overridable in tests.
 	trainlineTier1Cookies = providers.BrowserCookiesForURL
+
+	// trainlineResolveChallenge escalates an anti-bot challenge HEADLESS-first
+	// (no visible window, no focus steal) via providers.ResolveChallenge. It runs
+	// above the visible-window fallback: only if it reports ChallengeNeedsHuman
+	// do we open a real window. Overridable in tests so the orchestration is
+	// exercised offline without spawning a browser.
+	trainlineResolveChallenge = func(ctx context.Context, targetURL string) (*providers.ChallengeResult, error) {
+		return providers.ResolveChallenge(ctx, targetURL, providers.WithTier2Force())
+	}
+	// trainlineOpenBrowser opens a VISIBLE browser window so a human can solve an
+	// interactive captcha. Only invoked on ChallengeNeedsHuman. Overridable in tests.
+	trainlineOpenBrowser = cookies.OpenBrowserForAuth
 )
 
 type trainlineHeader struct {
@@ -471,18 +486,37 @@ func SearchTrainline(ctx context.Context, from, to, date, currency string, allow
 			slog.Debug("trainline nab fallback failed", "err", nErr)
 		}
 
-		if cRoutes, cErr := trainlineViaCurl(ctx, fromID, toID, date, currency); cErr == nil && len(cRoutes) > 0 {
+		if cRoutes, cErr := trainlineViaCurlFn(ctx, fromID, toID, date, currency); cErr == nil && len(cRoutes) > 0 {
 			populateTrainlineCities(cRoutes, from, to)
 			return cRoutes, nil
 		} else if cErr != nil {
 			slog.Debug("trainline curl fallback failed", "err", cErr)
 		}
 
-		isCaptcha, captchaURL := cookies.IsCaptchaResponse(http.StatusForbidden, firstBody)
-		if isCaptcha {
-			slog.Warn("trainline requires browser verification — opening browser", "captcha_url", captchaURL)
+		// Headless-first challenge escalation (MIK-6218): drive the user's
+		// installed browser HEADLESS (no window, no focus steal) to let the
+		// anti-bot challenge resolve. If it clears silently, retry with the
+		// harvested cookies — NO window. Only an interactive captcha that a
+		// headless browser cannot solve falls through to a VISIBLE window.
+		if res, rErr := trainlineResolveChallenge(ctx, trainlineHomeURL); rErr != nil {
+			slog.Debug("trainline headless challenge resolve failed", "err", rErr)
+		} else if res != nil && res.Status == providers.ChallengeCleared {
+			if ch := cookieSliceToHeader(res.Cookies); ch != "" {
+				slog.Debug("trainline challenge cleared headlessly — retrying with harvested cookies")
+				if reqC, errC := newTrainlineRequest(ch); errC == nil {
+					if respC, errC := trainlineDo(reqC); errC == nil {
+						defer func() { _ = respC.Body.Close() }()
+						if respC.StatusCode == http.StatusOK {
+							return readAndParseTrainlineResponse(respC.Body, from, to, date, currency)
+						}
+						slog.Debug("trainline headless-cleared retry still blocked", "status", respC.StatusCode)
+					}
+				}
+			}
+		} else if res != nil && res.Status == providers.ChallengeNeedsHuman {
+			slog.Warn("trainline requires human verification — opening browser", "vendor", res.Marker)
 			_, _ = fmt.Fprintf(os.Stderr, "⚠️  Trainline requires verification. Opening browser — please solve the challenge, then retry.\n")
-			_ = cookies.OpenBrowserForAuth("https://www.thetrainline.com/")
+			_ = trainlineOpenBrowser(trainlineHomeURL)
 		}
 
 		// Last resort: browser scraper via Playwright.
@@ -684,4 +718,25 @@ func extractDatadomeCookie(cookies []*http.Cookie) string {
 		}
 	}
 	return ""
+}
+
+// cookieSliceToHeader renders a slice of cookies into a single Cookie request
+// header value ("name=value; name2=value2"). Empty-named/valued cookies are
+// skipped. Returns "" when no usable cookies are present. Used to replay the
+// cookies harvested by a HEADLESS challenge resolution (MIK-6218) on a silent
+// retry — no visible window required.
+func cookieSliceToHeader(cks []*http.Cookie) string {
+	var b strings.Builder
+	for _, c := range cks {
+		if c == nil || c.Name == "" || c.Value == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("; ")
+		}
+		b.WriteString(c.Name)
+		b.WriteString("=")
+		b.WriteString(c.Value)
+	}
+	return b.String()
 }

--- a/internal/ground/trainline_test.go
+++ b/internal/ground/trainline_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/providers"
 	"golang.org/x/time/rate"
 )
 
@@ -372,6 +373,189 @@ func TestExtractDatadomeCookie(t *testing.T) {
 func TestTrainlineRateLimiterConfiguration(t *testing.T) {
 	assertLimiterConfiguration(t, trainlineLimiter, 12*time.Second, 1)
 }
+
+// resetTrainlineSeams stubs every fallback tier ahead of the headless escalation
+// so SearchTrainline's 403 path reaches the headless step deterministically and
+// offline. Callers override trainlineResolveChallenge / trainlineOpenBrowser /
+// trainlineDo as needed for the specific scenario under test.
+func resetTrainlineSeams(t *testing.T) {
+	t.Helper()
+	origDo := trainlineDo
+	origNab := trainlineFetchViaNab
+	origCookies := trainlineBrowserCookies
+	origCurl := trainlineViaCurlFn
+	origTier1Cookies := trainlineTier1Cookies
+	origResolve := trainlineResolveChallenge
+	origOpen := trainlineOpenBrowser
+	origLimiter := trainlineLimiter
+	t.Cleanup(func() {
+		trainlineDo = origDo
+		trainlineFetchViaNab = origNab
+		trainlineBrowserCookies = origCookies
+		trainlineViaCurlFn = origCurl
+		trainlineTier1Cookies = origTier1Cookies
+		trainlineResolveChallenge = origResolve
+		trainlineOpenBrowser = origOpen
+		trainlineLimiter = origLimiter
+	})
+	trainlineLimiter = rate.NewLimiter(rate.Inf, 1)
+	trainlineBrowserCookies = func(string) string { return "" }
+	trainlineTier1Cookies = func(string) []*http.Cookie { return nil }
+	trainlineFetchViaNab = func(context.Context, []byte, string, string, string, string) ([]models.GroundRoute, error) {
+		return nil, errStubbedFallback
+	}
+	trainlineViaCurlFn = func(context.Context, string, string, string, string) ([]models.GroundRoute, error) {
+		return nil, errStubbedFallback
+	}
+	// Default: no browser window, no challenge resolution. Scenario tests override.
+	trainlineResolveChallenge = func(context.Context, string) (*providers.ChallengeResult, error) {
+		return nil, errStubbedFallback
+	}
+	trainlineOpenBrowser = func(string) error { return nil }
+	// Neutralise the Playwright scraper last-resort so it cannot shell out.
+	t.Setenv("TRVL_SCRAPER_PATH", "/nonexistent/trvl-test-scraper.py")
+}
+
+// TestSearchTrainline_HeadlessClearedRetriesSilently verifies that when the
+// HEADLESS challenge resolution reports ChallengeCleared, SearchTrainline retries
+// with the harvested cookies and NEVER opens a visible browser window.
+func TestSearchTrainline_HeadlessClearedRetriesSilently(t *testing.T) {
+	resetTrainlineSeams(t)
+
+	var calls int
+	trainlineDo = func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader("blocked")),
+				Header:     make(http.Header),
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(mockTrainlineResponse)),
+			Header:     make(http.Header),
+		}, nil
+	}
+
+	var resolveCalled bool
+	trainlineResolveChallenge = func(context.Context, string) (*providers.ChallengeResult, error) {
+		resolveCalled = true
+		return &providers.ChallengeResult{
+			Status:  providers.ChallengeCleared,
+			Cookies: []*http.Cookie{{Name: "datadome", Value: "cleared"}},
+		}, nil
+	}
+
+	var openCalled bool
+	trainlineOpenBrowser = func(string) error { openCalled = true; return nil }
+
+	routes, err := SearchTrainline(context.Background(), "Paris", "Amsterdam", "2026-06-15", "EUR", true)
+	if err != nil {
+		t.Fatalf("SearchTrainline returned error: %v", err)
+	}
+	if !resolveCalled {
+		t.Error("expected headless challenge resolution to be attempted")
+	}
+	if openCalled {
+		t.Error("visible browser window must NOT open when challenge cleared headlessly")
+	}
+	if len(routes) == 0 {
+		t.Fatal("expected routes from silent headless-cleared retry")
+	}
+	if calls != 2 {
+		t.Errorf("expected exactly 2 HTTP attempts (initial 403 + silent retry), got %d", calls)
+	}
+}
+
+// TestSearchTrainline_NeedsHumanOpensVisibleWindow verifies that an interactive
+// captcha (ChallengeNeedsHuman) escalates to the VISIBLE browser path.
+func TestSearchTrainline_NeedsHumanOpensVisibleWindow(t *testing.T) {
+	resetTrainlineSeams(t)
+
+	trainlineDo = func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader("blocked")),
+			Header:     make(http.Header),
+		}, nil
+	}
+	trainlineResolveChallenge = func(context.Context, string) (*providers.ChallengeResult, error) {
+		return &providers.ChallengeResult{Status: providers.ChallengeNeedsHuman, Marker: "datadome"}, nil
+	}
+	var openCalled bool
+	trainlineOpenBrowser = func(string) error { openCalled = true; return nil }
+
+	_, err := SearchTrainline(context.Background(), "Paris", "Amsterdam", "2026-06-15", "EUR", true)
+	if err == nil {
+		t.Fatal("expected an error after needs-human fallback exhausts")
+	}
+	if !openCalled {
+		t.Error("expected the visible browser window to open on ChallengeNeedsHuman")
+	}
+}
+
+// TestSearchTrainline_NoFallbackHonest403 verifies that without browser fallbacks
+// the headless escalation is never attempted and an honest typed 403 is returned.
+func TestSearchTrainline_NoFallbackHonest403(t *testing.T) {
+	resetTrainlineSeams(t)
+
+	trainlineDo = func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader("blocked")),
+			Header:     make(http.Header),
+		}, nil
+	}
+	var resolveCalled, openCalled bool
+	trainlineResolveChallenge = func(context.Context, string) (*providers.ChallengeResult, error) {
+		resolveCalled = true
+		return nil, errStubbedFallback
+	}
+	trainlineOpenBrowser = func(string) error { openCalled = true; return nil }
+
+	_, err := SearchTrainline(context.Background(), "Paris", "Amsterdam", "2026-06-15", "EUR", false)
+	if err == nil {
+		t.Fatal("expected honest 403 error when browser fallbacks are disallowed")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected a 403 error, got %v", err)
+	}
+	if resolveCalled {
+		t.Error("headless challenge resolution must NOT run without browser fallbacks")
+	}
+	if openCalled {
+		t.Error("visible browser window must NOT open without browser fallbacks")
+	}
+}
+
+func TestCookieSliceToHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []*http.Cookie
+		want string
+	}{
+		{"nil", nil, ""},
+		{"single", []*http.Cookie{{Name: "datadome", Value: "x"}}, "datadome=x"},
+		{"multiple", []*http.Cookie{{Name: "a", Value: "1"}, {Name: "b", Value: "2"}}, "a=1; b=2"},
+		{"skips empty", []*http.Cookie{{Name: "", Value: "1"}, {Name: "b", Value: ""}, {Name: "c", Value: "3"}}, "c=3"},
+		{"skips nil entry", []*http.Cookie{nil, {Name: "ok", Value: "v"}}, "ok=v"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cookieSliceToHeader(tt.in); got != tt.want {
+				t.Errorf("cookieSliceToHeader() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+var errStubbedFallback = stubErr("stubbed fallback unavailable")
+
+type stubErr string
+
+func (e stubErr) Error() string { return string(e) }
 
 func TestParseTrainlineResults_BusOnlyLegs(t *testing.T) {
 	resp := trainlineJourneySearchResponse{


### PR DESCRIPTION
## HB.6 — headless-first browser escalation for trainline + sncf (MIK-6218)

### What

When the `trainline` and `sncf` ground providers hit a Datadome/Cloudflare **403** and browser fallbacks are allowed, they now escalate via `providers.ResolveChallenge` **headless-first** (no visible window, no focus steal) instead of opening a visible browser window directly.

### Escalation ladder (unchanged tiers stay ahead of the new step)

1. Tier-1 client + harvested browser cookies (trainline #225), nab, curl — **unchanged**, still run first.
2. **NEW** headless challenge resolution (`providers.ResolveChallenge(ctx, homeURL, providers.WithTier2Force())`):
   - `ChallengeCleared` → retry the request **silently** with the cookies the headless pass harvested. **No window opens.**
   - `ChallengeNeedsHuman` → fall back to the existing visible `cookies.OpenBrowserForAuth` path so a human can solve the interactive captcha, then retry via the browser scraper.
3. No browser fallback (or none of the above resolves) → preserve the existing **honest typed 403 / API error**. No silent success.

### Why

The prior behaviour opened a visible browser window unconditionally on 403 — focus-stealing and noisy. Headless-first clears the common Datadome cookie-wall invisibly and only surfaces a window when a human is genuinely required.

### Per-provider wiring

- **trainline.go**: 403 path now calls `trainlineResolveChallenge` → on `Cleared`, `cookieSliceToHeader` renders the harvested cookies into a fresh request via `newTrainlineRequest`/`trainlineDo` and parses a 200; on `NeedsHuman`, `trainlineOpenBrowser`. Falls through to the existing `BrowserScrapeRoutes` last resort + final `trainline: HTTP 403`.
- **sncf.go**: after the calendar 403 + curl tiers, `sncfResolveChallenge` → on `Cleared`, new `sncfCalendarWithCookies` issues the cookie-bearing calendar GET and parses routes; on `NeedsHuman`, `sncfOpenBrowser`. Falls through to `BrowserScrapeRoutes` + `sncf: no routes found`.

### Test seams (deterministic, offline)

Added stubbable func vars (`*ResolveChallenge`, `*OpenBrowser`, `*ViaCurlFn`) so the 403 chain never shells out to a live host under test. New shared helper `cookieSliceToHeader([]*http.Cookie) string` (skips nil/empty), reused by both providers.

### Verification

- `go test -race ./internal/ground/` — green (37.9s)
- 6 new scenario tests pass: cleared→silent retry + **no** visible window; needs-human→visible opener invoked; no-fallback→honest 403 (both providers) + `TestCookieSliceToHeader` table
- `gofmt -l` clean · `go vet ./internal/ground/` clean · `staticcheck ./internal/ground/` clean
- `go test -short ./...` — exit 0 (full repo)

### Scope

Touches **only** `internal/ground/{trainline,sncf}.go` + their `_test.go`. No changes to `internal/providers`, `flights`, `hotels`, `mcp`, `cmd`, or `internal/models`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
