### PR TITLE
chore(meta): unify value prop + SEO + smithery listing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ curl -fsSL https://github.com/MikkoParkkola/trvl/releases/latest/download/trvl_$
 
 ### Step 2: Register as MCP server
 
+One command auto-configures any of 10 MCP clients (Claude Desktop, Cursor, Claude Code, Windsurf, Codex, VS Code Copilot, Gemini CLI, Amazon Q, Zed, LM Studio) — no JSON hand-editing. Add `--dry-run` to preview the change first.
+
 ```bash
 trvl mcp install                       # Claude Desktop (default)
 trvl mcp install --client cursor       # Cursor / Windsurf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## What To Do
 
-You are setting up `trvl` — a travel MCP server that gives you real-time Google Flights and Google Hotels data. No API keys needed. Run these steps in order:
+You are setting up `trvl` — a travel MCP server + CLI for flights, hotels, trains, cars, and ferries, with no API keys required. It reads real-time Google Flights and Google Hotels directly, ships as a single Go binary, and works with any MCP client. Run these steps in order:
 
 ### Step 1: Install
 

--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Two providers (NS, Digitransit/VR) use public API keys that are embedded in the 
 - **No API keys required** — Google Flights and Google Hotels are read directly, so it works the moment it's installed. No signup, no billing, no key rotation.
 - **Multi-modal in one place** — flights, hotels, trains, buses, ferries, and rental cars behind one `travel` tool, not five separate integrations.
 - **Single Go binary, any MCP client** — one static binary runs as a stdio MCP server for Claude, Cursor, Windsurf, Codex, or any MCP-compatible assistant, and doubles as a standalone CLI. No runtime, no container required.
+- **One-command setup** — `trvl mcp install` auto-configures 10 MCP clients (Claude Desktop, Cursor, Claude Code, Windsurf, Codex, VS Code Copilot, Gemini CLI, Amazon Q, Zed, LM Studio) with no JSON hand-editing; add `--dry-run` to preview the change first.
 
 For the agent-focused comparison against Google Flights, KAYAK, ChatGPT search, and other travel MCPs, see [`docs/COMPARISON.md`](docs/COMPARISON.md).
 

--- a/README.md
+++ b/README.md
@@ -412,6 +412,12 @@ Two providers (NS, Digitransit/VR) use public API keys that are embedded in the 
 
 ## How trvl Compares
 
+**Why trvl:** Most travel MCP servers wrap a single provider and require you to bring your own paid API key. trvl is different on three axes that matter for AI assistants:
+
+- **No API keys required** — Google Flights and Google Hotels are read directly, so it works the moment it's installed. No signup, no billing, no key rotation.
+- **Multi-modal in one place** — flights, hotels, trains, buses, ferries, and rental cars behind one `travel` tool, not five separate integrations.
+- **Single Go binary, any MCP client** — one static binary runs as a stdio MCP server for Claude, Cursor, Windsurf, Codex, or any MCP-compatible assistant, and doubles as a standalone CLI. No runtime, no container required.
+
 For the agent-focused comparison against Google Flights, KAYAK, ChatGPT search, and other travel MCPs, see [`docs/COMPARISON.md`](docs/COMPARISON.md).
 
 | Feature | trvl | fli | Google Flights | Skyscanner | Kiwi |

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,14 +1,14 @@
 {
   "name": "trvl-mcp",
   "version": "1.10.0",
-  "description": "AI travel agent — 1 smart MCP tool plus 66 compatibility aliases for flights, hotels, rental cars, ground transport, price alerts. No API keys required.",
+  "description": "Travel MCP server + CLI for flights, hotels, trains, cars, and ferries — no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart MCP tool plus 66 compatibility aliases.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MikkoParkkola/trvl"
   },
   "homepage": "https://github.com/MikkoParkkola/trvl",
-  "keywords": ["mcp", "travel", "flights", "hotels", "ai", "claude", "model-context-protocol"],
+  "keywords": ["mcp", "mcp-server", "travel", "flights", "flight-search", "hotels", "hotel-search", "trains", "rail", "ferries", "ground-transport", "no-api-key", "travel-agent", "google-flights", "google-hotels", "price-alerts", "ai", "claude", "cli", "model-context-protocol"],
   "bin": {
     "trvl-mcp": "bin/trvl-mcp.js"
   },

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
-  "description": "AI travel agent for flights, hotels, rental cars, ground transport, price alerts, and award travel.",
+  "description": "Travel MCP server for flight search and hotels with no API keys required — flights, hotels, trains, rental cars, ferries, ground transport, and price alerts in a single Go binary that works with any MCP client (Claude, Cursor, Windsurf, Codex).",
   "version": "1.10.0",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
-  "description": "Travel MCP server for flight search and hotels with no API keys required — flights, hotels, trains, rental cars, ferries, ground transport, and price alerts in a single Go binary that works with any MCP client (Claude, Cursor, Windsurf, Codex).",
+  "description": "Travel MCP server for flight search and hotels with no API keys required — flights, hotels, trains, rental cars, ferries, ground transport, and price alerts in a single Go binary that works with any MCP client (Claude, Cursor, Windsurf, Codex). One-command install (`trvl mcp install`) auto-configures 10 MCP clients with no JSON editing.",
   "version": "1.10.0",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,8 +1,17 @@
+# Smithery configuration for trvl — the travel MCP server.
+# Docs: https://smithery.ai/docs/build/project-config
+#
+# trvl requires no API keys, so the config schema is empty and the server
+# starts over stdio via the published `trvl-mcp` npm wrapper.
 startCommand:
   type: stdio
   configSchema:
     type: object
     properties: {}
-  commandFunction:
-    - trvl
-    - mcp
+    additionalProperties: false
+  commandFunction: |-
+    (config) => ({
+      command: 'npx',
+      args: ['-y', 'trvl-mcp']
+    })
+  exampleConfig: {}


### PR DESCRIPTION
## What & why

Metadata work to fix trvl discoverability gaps on **owned surfaces only** (no third-party writes). Three surfaces previously disagreed on the value prop (a stale "43 MCP tools" claim in places, divergent npm and server description copy). This unifies them and improves SEO.

## Unified value prop

> Travel MCP server + CLI for flights, hotels, trains, cars and ferries — no API keys, single Go binary, works with any MCP client.

Emphasis: **no API key** + **multi-modal** (flights, hotels, trains, cars, ferries) + **single Go binary** + **works with any MCP client**. Truthful to the current surface (1 smart `travel` tool + 66 compatibility aliases — the stale "43 tools" framing is not resurrected).

## Changes per file

- **server.json** — description rewritten keyword-rich and honest, leading with head terms ("Travel MCP server for flight search and hotels with no API keys required").
- **npm package.json** — description matched to the unified line; keywords expanded 7 to 20 (adds no-api-key, flight-search, hotel-search, trains, rail, ferries, ground-transport, travel-agent, google-flights, google-hotels, price-alerts, mcp-server, cli).
- **README.md** — added a quotable **"Why trvl"** block (no API keys, multi-modal, single binary, any MCP client) at the top of the existing *How trvl Compares* section. Neutral framing, no competitor disparagement.
- **AGENTS.md** — intro line reframed to multi-modal + any MCP client. Validated count strings untouched.
- **smithery.yaml** — the existing file had a malformed commandFunction (a YAML array, which the Smithery stdio schema does not accept). Replaced with a valid JS commandFunction returning a stdio start command via `npx -y trvl-mcp` + empty configSchema (no API keys) + exampleConfig.

## Constraints honored

- The public-claims test (TestPublicDocsAdvertiseCurrentCounts) — every validated count substring left intact; only surrounding prose added.
- No changes to Go code or the ground-transport package (separate in-flight work).

## Verification

- `GOTOOLCHAIN=go1.26.4 go test` on the cmd and mcp packages -> both **ok**
- `go vet` over all packages -> clean
- server and npm JSON valid; smithery YAML valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
