### PR TITLE
feat(status): operational health surface — trvl status CLI + /dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,17 @@ trvl also works as a standalone CLI tool with 50 commands:
 
 All search commands accept `--currency <CODE>` (e.g. `--currency EUR`) to convert displayed prices. trvl detects the actual API currency and converts at the display layer — no hardcoded currencies.
 
+### Operational status
+
+See which data providers are healthy, degraded, rate-limited, or circuit-broken at a glance. `trvl status` aggregates the local health log (`~/.trvl/health.jsonl`) into per-provider success rate, latency, and freshness, then overlays live circuit-breaker state. It reads only local files — no network calls, no credentials touched.
+
+```bash
+trvl status                 # table: every provider that has been called
+trvl status --format json   # machine-readable, same data
+```
+
+When running as an HTTP server (`trvl mcp --http`), the same view is served as a read-only HTML dashboard at `/dashboard` (auto-refreshing). It honors the server's bearer token when one is configured; an unauthenticated server is loopback-only by design, so the dashboard is safe to open locally. AI assistants get the identical data via the `provider_health` MCP tool.
+
 ### Flights
 
 ```bash

--- a/cmd/trvl/commands_test.go
+++ b/cmd/trvl/commands_test.go
@@ -20,7 +20,8 @@ func TestRootCmd_SubcommandCount(t *testing.T) {
 	// 65 -> 66 with `arbitrage-report` (innovation #8 unified arbitrage report).
 	// 66 -> 67 with `multimodal` (innovation #2 multimodal composer).
 	// 67 -> 68 with `plan-all` (innovation #5 unified trip coalescer).
-	const want = 68
+	// 68 -> 69 with `status` (operational health/circuit/rate-limit snapshot).
+	const want = 69
 	got := len(rootCmd.Commands())
 	if got != want {
 		names := make([]string, 0, got)

--- a/cmd/trvl/status.go
+++ b/cmd/trvl/status.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/providers"
+	"github.com/spf13/cobra"
+)
+
+// statusCmd is the top-level operational snapshot: per-provider health from the
+// ~/.trvl/health.jsonl call log merged with live circuit-breaker state. Unlike
+// `trvl providers status` (which lists only configured opt-in providers), this
+// surfaces every provider that has actually been called — the built-in Google
+// Flights/Hotels, Kiwi, ground transport, and any custom providers alike. It is
+// the CLI mirror of the MCP `provider_health` tool and the /dashboard route.
+func statusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show provider health, circuit breakers, and rate-limit pressure",
+		Long: `Show an operational snapshot of trvl's data providers.
+
+Aggregates the local health log (~/.trvl/health.jsonl) into per-provider
+success rate, latency, freshness, and result counts, then overlays live
+circuit-breaker state so you can see at a glance which providers are healthy,
+degraded, rate-limited, or tripped open.
+
+This reads only local files — no network calls, no credentials touched.
+
+Examples:
+  trvl status
+  trvl status --format json`,
+		Args: cobra.NoArgs,
+		RunE: runStatus,
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(statusCmd())
+}
+
+func runStatus(cmd *cobra.Command, _ []string) error {
+	dir, err := providers.HealthLogDir()
+	if err != nil {
+		return fmt.Errorf("status: %w", err)
+	}
+
+	// reg may be nil-safe: a missing/empty registry just means no circuit
+	// state for built-in providers, which is fine.
+	reg, _ := providers.NewRegistry()
+	rows := providers.BuildStatusReport(reg, dir, time.Now())
+
+	f, _ := cmd.Flags().GetString("format")
+	if f == "json" {
+		return models.FormatJSON(os.Stdout, map[string]any{"providers": rows})
+	}
+
+	if len(rows) == 0 {
+		fmt.Println("No provider activity recorded yet.")
+		fmt.Println("Run a search (e.g. 'trvl flights HEL CDG') to populate the health log.")
+		return nil
+	}
+
+	headers := []string{"Provider", "Calls", "OK%", "Avg ms", "Fresh", "Circuit", "Last error"}
+	tableRows := make([][]string, 0, len(rows))
+	var healthy, degraded, open, rateLimited, stale int
+
+	for _, r := range rows {
+		okPct := "-"
+		if r.TotalCalls > 0 {
+			okPct = fmt.Sprintf("%.0f%%", r.SuccessRate*100)
+		}
+		lastErr := "-"
+		if r.LastErrorClass != "" {
+			lastErr = r.LastErrorClass
+		} else if r.LastError != "" {
+			lastErr = truncateStr(r.LastError, 40)
+		}
+
+		tableRows = append(tableRows, []string{
+			r.Provider,
+			fmt.Sprintf("%d", r.TotalCalls),
+			okPct,
+			fmt.Sprintf("%d", r.AvgLatencyMs),
+			colorFreshness(r.Freshness),
+			colorCircuit(r.CircuitState),
+			lastErr,
+		})
+
+		switch {
+		case r.CircuitState == "open":
+			open++
+		case !r.IsHealthy():
+			degraded++
+		default:
+			healthy++
+		}
+		if r.RateLimited() {
+			rateLimited++
+		}
+		if r.Freshness == "stale" {
+			stale++
+		}
+	}
+
+	models.Banner(os.Stdout, "\U0001F4E1", "trvl status", fmt.Sprintf("%d provider(s) seen", len(rows)))
+	fmt.Println()
+	models.FormatTable(os.Stdout, headers, tableRows)
+	fmt.Println()
+
+	fmt.Printf("  %s %d healthy   %s %d degraded   %s %d circuit-open\n",
+		models.Green("●"), healthy,
+		models.Yellow("●"), degraded,
+		models.Red("●"), open)
+	if rateLimited > 0 {
+		fmt.Printf("  %s %d provider(s) rate-limited (HTTP 429) on last failure\n", models.Yellow("!"), rateLimited)
+	}
+	if stale > 0 {
+		fmt.Printf("  %s %d provider(s) stale (no activity in 24h)\n", models.Yellow("!"), stale)
+	}
+
+	return nil
+}
+
+// colorFreshness renders a freshness label with a status color.
+func colorFreshness(freshness string) string {
+	switch freshness {
+	case "fresh":
+		return models.Green(freshness)
+	case "stale":
+		return models.Yellow(freshness)
+	default:
+		return freshness
+	}
+}
+
+// colorCircuit renders a circuit-breaker state with a status color.
+func colorCircuit(state string) string {
+	switch state {
+	case "closed":
+		return models.Green(state)
+	case "half_open":
+		return models.Yellow(state)
+	case "open":
+		return models.Red(state)
+	default:
+		return state
+	}
+}

--- a/cmd/trvl/status_test.go
+++ b/cmd/trvl/status_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/providers"
+	"github.com/spf13/cobra"
+)
+
+// seedStatusHealthLog points HOME at a temp dir holding a health.jsonl with one
+// successful "kiwi" call, so runStatus has deterministic input.
+func seedStatusHealthLog(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	dir := filepath.Join(tmp, ".trvl")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(filepath.Join(dir, "health.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	entry := providers.HealthEntry{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Provider:  "kiwi",
+		Operation: "search",
+		Status:    "ok",
+		LatencyMs: 95,
+		Results:   12,
+	}
+	line, _ := json.Marshal(entry)
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// captureStdout is defined in display_coverage_test.go and reused here.
+
+func newStatusTestCmd(format string) *cobra.Command {
+	cmd := &cobra.Command{Use: "status"}
+	cmd.Flags().String("format", format, "output format")
+	return cmd
+}
+
+func TestRunStatus_Table(t *testing.T) {
+	seedStatusHealthLog(t)
+
+	out := captureStdout(t, func() {
+		if err := runStatus(newStatusTestCmd("table"), nil); err != nil {
+			t.Errorf("runStatus: %v", err)
+		}
+	})
+
+	for _, want := range []string{"trvl status", "kiwi", "healthy"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunStatus_JSON(t *testing.T) {
+	seedStatusHealthLog(t)
+
+	out := captureStdout(t, func() {
+		if err := runStatus(newStatusTestCmd("json"), nil); err != nil {
+			t.Errorf("runStatus: %v", err)
+		}
+	})
+
+	var parsed struct {
+		Providers []providers.StatusRow `json:"providers"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("status --format json is not valid JSON: %v\n%s", err, out)
+	}
+	if len(parsed.Providers) != 1 || parsed.Providers[0].Provider != "kiwi" {
+		t.Fatalf("providers = %+v, want one kiwi row", parsed.Providers)
+	}
+	if parsed.Providers[0].SuccessCount != 1 {
+		t.Errorf("kiwi success count = %d, want 1", parsed.Providers[0].SuccessCount)
+	}
+}
+
+func TestRunStatus_NoData(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	out := captureStdout(t, func() {
+		if err := runStatus(newStatusTestCmd("table"), nil); err != nil {
+			t.Errorf("runStatus: %v", err)
+		}
+	})
+	if !strings.Contains(out, "No provider activity recorded yet") {
+		t.Errorf("empty-log output missing guidance:\n%s", out)
+	}
+}

--- a/internal/flights/grid.go
+++ b/internal/flights/grid.go
@@ -100,10 +100,21 @@ func SearchPriceGrid(ctx context.Context, origin, dest string, opts GridOptions)
 	}
 
 	cells, err := parsePriceGridResponse(body)
-	if err != nil || len(cells) == 0 {
+	if err != nil {
 		return &models.PriceGrid{
 			Error: fmt.Sprintf("parse grid response: %v", err),
 		}, fmt.Errorf("parse grid response: %w", err)
+	}
+	if len(cells) == 0 {
+		// Google returned a parseable but empty grid (no priced cells for the
+		// requested ranges — common when the departure×return window is wide).
+		// Return a clear, descriptive error rather than fmt.Errorf("...: %w", nil),
+		// which renders as the bogus "%!w(<nil>)".
+		return &models.PriceGrid{
+				Error: fmt.Sprintf("no priced grid cells for departure %s..%s / return %s..%s (try a narrower date range)",
+					opts.DepartFrom, opts.DepartTo, opts.ReturnFrom, opts.ReturnTo),
+			}, fmt.Errorf("grid: no priced cells for departure %s..%s return %s..%s",
+				opts.DepartFrom, opts.DepartTo, opts.ReturnFrom, opts.ReturnTo)
 	}
 
 	// Detect the actual API currency and stamp all cells.

--- a/internal/flights/grid_test.go
+++ b/internal/flights/grid_test.go
@@ -2,6 +2,7 @@ package flights
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -105,6 +106,31 @@ func TestParsePriceGridResponse_TooSmall(t *testing.T) {
 	_, err := parsePriceGridResponse(body)
 	if err == nil {
 		t.Error("expected error for small response")
+	}
+}
+
+// TestParsePriceGridResponse_ValidButEmpty guards the empty-grid contract:
+// a parseable response carrying no priced offers must return (empty, nil),
+// NOT an error. Google returns this for wide departure×return windows.
+// The (empty, nil) result is what made the old SearchPriceGrid path render
+// the bogus "%!w(<nil>)" via fmt.Errorf("...: %w", nil); the parser must keep
+// returning a nil error here so the caller can emit a clear "no priced cells"
+// message instead. Regression guard for the grid.go empty-cells fix.
+func TestParsePriceGridResponse_ValidButEmpty(t *testing.T) {
+	innerJSON := `[null,[]]` // valid grid section with zero offers
+	// Pad the outer line past the 200-byte floor with an element the parser
+	// ignores (only entry[2] is read for offers).
+	pad := strings.Repeat("x", 240)
+	entry := []any{[]any{"wrb.fr", nil, innerJSON, pad}}
+	entryJSON, _ := json.Marshal(entry)
+	body := []byte(")]}'\n" + string(entryJSON))
+
+	cells, err := parsePriceGridResponse(body)
+	if err != nil {
+		t.Fatalf("valid-but-empty grid must not error, got: %v", err)
+	}
+	if len(cells) != 0 {
+		t.Fatalf("expected 0 cells for offerless grid, got %d", len(cells))
 	}
 }
 

--- a/internal/providers/status_report.go
+++ b/internal/providers/status_report.go
@@ -1,0 +1,128 @@
+package providers
+
+import (
+	"sort"
+	"time"
+)
+
+// StatusRow is one provider's operational status: health-log aggregates merged
+// with live circuit-breaker state. It is the single source of truth rendered by
+// the MCP provider_health tool, the `trvl status` CLI, and the /dashboard route.
+//
+// The JSON tags are a stable wire contract — MCP clients parse them — so do not
+// rename them without bumping the tool surface.
+type StatusRow struct {
+	Provider           string  `json:"provider"`
+	Name               string  `json:"name,omitempty"`
+	TotalCalls         int     `json:"total_calls"`
+	SuccessCount       int     `json:"success_count"`
+	ErrorCount         int     `json:"error_count"`
+	TimeoutCount       int     `json:"timeout_count"`
+	SuccessRate        float64 `json:"success_rate"`
+	AvgLatencyMs       int64   `json:"avg_latency_ms"`
+	TotalResults       int     `json:"total_results"`
+	AvgResults         float64 `json:"avg_results"`
+	LastResults        int     `json:"last_results"`
+	LastSeen           string  `json:"last_seen,omitempty"`
+	LastSuccess        string  `json:"last_success,omitempty"`
+	LastFailure        string  `json:"last_failure,omitempty"`
+	Freshness          string  `json:"freshness"`
+	LastError          string  `json:"last_error,omitempty"`
+	LastErrorClass     string  `json:"last_error_class,omitempty"`
+	LastHintCode       string  `json:"last_hint_code,omitempty"`
+	CircuitState       string  `json:"circuit_state"`
+	CircuitErrorCount  int     `json:"circuit_error_count,omitempty"`
+	CircuitReason      string  `json:"circuit_reason,omitempty"`
+	CircuitNextRetryAt string  `json:"circuit_next_retry_at,omitempty"`
+	FixHint            string  `json:"fix_hint,omitempty"`
+}
+
+// IsHealthy reports whether the provider is currently usable: circuit closed
+// (or recovering via half-open) and, when calls have been made, a success rate
+// at or above 50%. Providers with no recorded calls are treated as healthy
+// (nothing has failed yet).
+func (r StatusRow) IsHealthy() bool {
+	if r.CircuitState == "open" {
+		return false
+	}
+	if r.TotalCalls == 0 {
+		return true
+	}
+	return r.SuccessRate >= 0.5
+}
+
+// RateLimited reports whether the provider's most recent failure was a
+// rate-limit (HTTP 429 / typed RATE_LIMITED) signal.
+func (r StatusRow) RateLimited() bool {
+	return r.LastErrorClass == string(FixHintRateLimited)
+}
+
+// BuildStatusReport merges the per-provider health summary (from the
+// health.jsonl log in dir) with live circuit-breaker state (from reg) into a
+// stable, provider-sorted slice.
+//
+// reg may be nil (health-only view); dir is the ~/.trvl directory. now anchors
+// circuit-cooldown math — pass the zero Time to default to time.Now().
+func BuildStatusReport(reg *Registry, dir string, now time.Time) []StatusRow {
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	summary := HealthSummary(dir)
+	configs := map[string]*ProviderConfig{}
+	if reg != nil {
+		for _, cfg := range reg.List() {
+			configs[cfg.ID] = cfg
+		}
+	}
+
+	ids := make(map[string]bool, len(summary)+len(configs))
+	for id := range summary {
+		ids[id] = true
+	}
+	for id := range configs {
+		ids[id] = true
+	}
+
+	rows := make([]StatusRow, 0, len(ids))
+	for id := range ids {
+		h := summary[id]
+		if h.Provider == "" {
+			h.Provider = id
+			h.Freshness = "unknown"
+		}
+		cfg := configs[id]
+		circuit := CircuitBreakerHealth(cfg, now)
+		name := ""
+		if cfg != nil {
+			name = cfg.Name
+		}
+		rows = append(rows, StatusRow{
+			Provider:           h.Provider,
+			Name:               name,
+			TotalCalls:         h.TotalCalls,
+			SuccessCount:       h.SuccessCount,
+			ErrorCount:         h.ErrorCount,
+			TimeoutCount:       h.TimeoutCount,
+			SuccessRate:        h.SuccessRate,
+			AvgLatencyMs:       h.AvgLatencyMs,
+			TotalResults:       h.TotalResults,
+			AvgResults:         h.AvgResults,
+			LastResults:        h.LastResults,
+			LastSeen:           h.LastSeen,
+			LastSuccess:        h.LastSuccess,
+			LastFailure:        h.LastFailure,
+			Freshness:          h.Freshness,
+			LastError:          h.LastError,
+			LastErrorClass:     h.LastErrorClass,
+			LastHintCode:       h.LastHintCode,
+			CircuitState:       circuit.State,
+			CircuitErrorCount:  circuit.ErrorCount,
+			CircuitReason:      circuit.Reason,
+			CircuitNextRetryAt: circuit.NextRetryAt,
+			FixHint:            circuit.FixHint,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Provider < rows[j].Provider })
+	return rows
+}

--- a/internal/providers/status_report_test.go
+++ b/internal/providers/status_report_test.go
@@ -1,0 +1,152 @@
+package providers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeHealthLog writes the given entries as JSONL into dir/health.jsonl.
+func writeHealthLog(t *testing.T, dir string, entries []HealthEntry) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(filepath.Join(dir, "health.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	for _, e := range entries {
+		line, _ := json.Marshal(e)
+		if _, err := f.Write(append(line, '\n')); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestBuildStatusReport_MergesHealthAndCircuit(t *testing.T) {
+	tmp := t.TempDir()
+	reg, err := NewRegistryAt(filepath.Join(tmp, "providers"))
+	if err != nil {
+		t.Fatalf("NewRegistryAt: %v", err)
+	}
+	now := time.Now().UTC()
+
+	// A provider with a tripped breaker (>= threshold consecutive errors).
+	if err := reg.Save(&ProviderConfig{
+		ID:          "flaky",
+		Name:        "Flaky Provider",
+		Category:    "hotel",
+		Endpoint:    "https://example.com/search",
+		Method:      "GET",
+		ErrorCount:  5,
+		LastError:   "http 429",
+		LastErrorAt: now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	dir := filepath.Join(tmp, ".trvl")
+	writeHealthLog(t, dir, []HealthEntry{
+		{
+			Timestamp: now.Add(-2 * time.Minute).Format(time.RFC3339),
+			Provider:  "flaky",
+			Operation: "search",
+			Status:    "ok",
+			LatencyMs: 120,
+			Results:   6,
+		},
+		{
+			Timestamp:  now.Add(-time.Minute).Format(time.RFC3339),
+			Provider:   "flaky",
+			Operation:  "search",
+			Status:     "error",
+			LatencyMs:  250,
+			Error:      "http 429 for https://example.com?api_key=secret123",
+			ErrorClass: string(FixHintRateLimited),
+		},
+		{
+			Timestamp: now.Add(-30 * time.Second).Format(time.RFC3339),
+			Provider:  "solid",
+			Operation: "search",
+			Status:    "ok",
+			LatencyMs: 80,
+			Results:   10,
+		},
+	})
+
+	rows := BuildStatusReport(reg, dir, now)
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2 (flaky + solid): %+v", len(rows), rows)
+	}
+
+	// Sorted by provider: "flaky" before "solid".
+	if rows[0].Provider != "flaky" || rows[1].Provider != "solid" {
+		t.Fatalf("rows not sorted by provider: %q, %q", rows[0].Provider, rows[1].Provider)
+	}
+
+	flaky := rows[0]
+	if flaky.Name != "Flaky Provider" {
+		t.Errorf("flaky.Name = %q, want %q", flaky.Name, "Flaky Provider")
+	}
+	if flaky.TotalCalls != 2 || flaky.SuccessCount != 1 || flaky.ErrorCount != 1 {
+		t.Errorf("flaky call counts = %+v", flaky)
+	}
+	if flaky.CircuitState != "open" {
+		t.Errorf("flaky.CircuitState = %q, want open", flaky.CircuitState)
+	}
+	if !flaky.RateLimited() {
+		t.Errorf("flaky.RateLimited() = false, want true (last error class %q)", flaky.LastErrorClass)
+	}
+	if flaky.IsHealthy() {
+		t.Errorf("flaky.IsHealthy() = true, want false (circuit open)")
+	}
+	// Secret redaction is applied by HealthSummary upstream.
+	if flaky.LastError == "http 429 for https://example.com?api_key=secret123" {
+		t.Errorf("flaky.LastError not redacted: %q", flaky.LastError)
+	}
+
+	solid := rows[1]
+	if solid.CircuitState != "unknown" {
+		// No registry config for "solid" => circuit state unknown.
+		t.Errorf("solid.CircuitState = %q, want unknown", solid.CircuitState)
+	}
+	if !solid.IsHealthy() {
+		t.Errorf("solid.IsHealthy() = false, want true (100%% success, no breaker)")
+	}
+	if solid.RateLimited() {
+		t.Errorf("solid.RateLimited() = true, want false")
+	}
+}
+
+func TestBuildStatusReport_Empty(t *testing.T) {
+	tmp := t.TempDir()
+	rows := BuildStatusReport(nil, filepath.Join(tmp, ".trvl"), time.Time{})
+	if len(rows) != 0 {
+		t.Fatalf("rows = %d, want 0 for empty log + nil registry", len(rows))
+	}
+}
+
+func TestStatusRow_IsHealthy(t *testing.T) {
+	cases := []struct {
+		name string
+		row  StatusRow
+		want bool
+	}{
+		{"no calls is healthy", StatusRow{CircuitState: "closed"}, true},
+		{"open circuit unhealthy", StatusRow{CircuitState: "open", TotalCalls: 3, SuccessRate: 1.0}, false},
+		{"high success healthy", StatusRow{CircuitState: "closed", TotalCalls: 10, SuccessRate: 0.9}, true},
+		{"low success unhealthy", StatusRow{CircuitState: "closed", TotalCalls: 10, SuccessRate: 0.2}, false},
+		{"half_open with good rate healthy", StatusRow{CircuitState: "half_open", TotalCalls: 4, SuccessRate: 0.75}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.row.IsHealthy(); got != tc.want {
+				t.Errorf("IsHealthy() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/mcp/http.go
+++ b/mcp/http.go
@@ -79,6 +79,7 @@ func (h *HTTPServer) ListenAndServe() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mcp", h.handleMCP)
 	mux.HandleFunc("/health", h.handleHealth)
+	mux.HandleFunc("/dashboard", h.handleDashboard)
 
 	addr := net.JoinHostPort(h.host, strconv.Itoa(h.port))
 	log.Printf("trvl MCP server listening on http://%s/mcp", addr)

--- a/mcp/http_dashboard.go
+++ b/mcp/http_dashboard.go
@@ -1,0 +1,159 @@
+package mcp
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/providers"
+)
+
+// dashboardTemplate renders a self-contained, dependency-free operational view.
+// No external CSS/JS, no framework — a single server-rendered HTML page, in
+// keeping with trvl's no-frameworks rule. Values are auto-escaped by
+// html/template; provider error strings are already secret-redacted upstream.
+var dashboardTemplate = template.Must(template.New("dashboard").Funcs(template.FuncMap{
+	"pct": formatPct,
+}).Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="refresh" content="30">
+<title>trvl status</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 2rem auto; max-width: 1100px; padding: 0 1rem; }
+  h1 { font-size: 1.4rem; margin: 0 0 .25rem; }
+  .meta { color: #888; margin: 0 0 1.5rem; font-size: .85rem; }
+  .summary { display: flex; gap: 1.5rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+  .summary span { font-weight: 600; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { text-align: left; padding: .4rem .6rem; border-bottom: 1px solid #8884; white-space: nowrap; }
+  th { font-weight: 600; border-bottom: 2px solid #8886; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  td.err { white-space: normal; color: #b00; font-size: .85rem; }
+  .dot { display: inline-block; width: .7rem; height: .7rem; border-radius: 50%; margin-right: .35rem; vertical-align: middle; }
+  .ok { background: #2e9e44; } .warn { background: #d99e00; } .bad { background: #d12f2f; } .idle { background: #999; }
+  .pill { padding: .1rem .45rem; border-radius: .6rem; font-size: .8rem; }
+  .pill.closed { background: #2e9e4422; color: #2e9e44; }
+  .pill.half_open { background: #d99e0022; color: #b8860b; }
+  .pill.open { background: #d12f2f22; color: #d12f2f; }
+  .pill.unknown { background: #8884; color: #888; }
+  footer { color: #888; font-size: .8rem; margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>trvl status</h1>
+<p class="meta">{{.Server}} v{{.Version}} &middot; {{len .Rows}} provider(s) &middot; refreshed {{.Now}} &middot; auto-refresh 30s</p>
+
+<div class="summary">
+  <span><span class="dot ok"></span>{{.Healthy}} healthy</span>
+  <span><span class="dot warn"></span>{{.Degraded}} degraded</span>
+  <span><span class="dot bad"></span>{{.Open}} circuit-open</span>
+  {{if .RateLimited}}<span><span class="dot warn"></span>{{.RateLimited}} rate-limited</span>{{end}}
+  {{if .Stale}}<span><span class="dot idle"></span>{{.Stale}} stale</span>{{end}}
+</div>
+
+{{if .Rows}}
+<table>
+<thead><tr>
+  <th>Provider</th><th class="num">Calls</th><th class="num">OK%</th><th class="num">Avg ms</th>
+  <th>Freshness</th><th>Circuit</th><th>Last error</th>
+</tr></thead>
+<tbody>
+{{range .Rows}}
+<tr>
+  <td>{{.Provider}}{{if and .Name (ne .Name .Provider)}} <small>({{.Name}})</small>{{end}}</td>
+  <td class="num">{{.TotalCalls}}</td>
+  <td class="num">{{if .TotalCalls}}{{pct .SuccessRate}}{{else}}&mdash;{{end}}</td>
+  <td class="num">{{.AvgLatencyMs}}</td>
+  <td>{{.Freshness}}</td>
+  <td><span class="pill {{.CircuitState}}">{{.CircuitState}}</span></td>
+  <td class="err">{{if .LastErrorClass}}{{.LastErrorClass}}{{else if .LastError}}{{.LastError}}{{else}}&mdash;{{end}}</td>
+</tr>
+{{end}}
+</tbody>
+</table>
+{{else}}
+<p>No provider activity recorded yet. Run a search (e.g. <code>trvl flights HEL CDG</code>) to populate the health log.</p>
+{{end}}
+
+<footer>Read-only. Reads ~/.trvl/health.jsonl and live circuit-breaker state. No credentials are exposed; error strings are secret-redacted.</footer>
+</body>
+</html>`))
+
+// formatPct renders a success rate (0.0–1.0) as a one-decimal percentage,
+// e.g. "92.3%". Used by the dashboard template's {{pct}} helper.
+func formatPct(f float64) string {
+	return fmt.Sprintf("%.1f%%", f*100)
+}
+
+// dashboardData is the view model rendered by dashboardTemplate.
+type dashboardData struct {
+	Server      string
+	Version     string
+	Now         string
+	Rows        []providers.StatusRow
+	Healthy     int
+	Degraded    int
+	Open        int
+	RateLimited int
+	Stale       int
+}
+
+// handleDashboard serves a read-only HTML operational dashboard: per-provider
+// health from ~/.trvl/health.jsonl merged with live circuit-breaker state.
+//
+// Auth posture: when authentication is configured (mandatory for any non-
+// loopback bind via requireRemoteAuth), a valid read token is required. An
+// unauthenticated server is, by that same startup invariant, loopback-only —
+// safe to serve without a token.
+func (h *HTTPServer) handleDashboard(w http.ResponseWriter, r *http.Request) {
+	if h.auth != nil && h.auth.Configured() {
+		if _, ok := h.authorize(r); !ok {
+			h.audit.denied.Add(1)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	dir, err := providers.HealthLogDir()
+	if err != nil {
+		http.Error(w, "status unavailable", http.StatusInternalServerError)
+		return
+	}
+	reg, _ := providers.NewRegistry()
+	rows := providers.BuildStatusReport(reg, dir, time.Now())
+
+	data := dashboardData{
+		Server:  serverName,
+		Version: serverVersion,
+		Now:     time.Now().UTC().Format(time.RFC3339),
+		Rows:    rows,
+	}
+	for _, row := range rows {
+		switch {
+		case row.CircuitState == "open":
+			data.Open++
+		case !row.IsHealthy():
+			data.Degraded++
+		default:
+			data.Healthy++
+		}
+		if row.RateLimited() {
+			data.RateLimited++
+		}
+		if row.Freshness == "stale" {
+			data.Stale++
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	if err := dashboardTemplate.Execute(w, data); err != nil {
+		// Headers may already be flushed; best-effort.
+		http.Error(w, "render error", http.StatusInternalServerError)
+	}
+}

--- a/mcp/http_dashboard_test.go
+++ b/mcp/http_dashboard_test.go
@@ -1,0 +1,92 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/providers"
+)
+
+func seedDashboardHealthLog(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	dir := filepath.Join(tmp, ".trvl")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(filepath.Join(dir, "health.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	entry := providers.HealthEntry{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Provider:  "kiwi",
+		Operation: "search",
+		Status:    "ok",
+		LatencyMs: 95,
+		Results:   12,
+	}
+	line, _ := json.Marshal(entry)
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHandleDashboard_RendersHTML(t *testing.T) {
+	seedDashboardHealthLog(t)
+
+	hs := NewHTTPServer(0) // no auth configured => loopback-only => served
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+
+	hs.handleDashboard(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{"<!DOCTYPE html>", "trvl status", "kiwi", "healthy"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("dashboard body missing %q", want)
+		}
+	}
+}
+
+func TestHandleDashboard_RequiresAuthWhenConfigured(t *testing.T) {
+	seedDashboardHealthLog(t)
+
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{Port: 0, Token: "secret-token"})
+
+	// No token => unauthorized.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	hs.handleDashboard(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("no-token status = %d, want 401", rr.Code)
+	}
+
+	// Valid token => served.
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	hs.handleDashboard(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("valid-token status = %d, want 200", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "trvl status") {
+		t.Error("authorized dashboard body missing title")
+	}
+}


### PR DESCRIPTION
## What

Adds a holistic operational view of trvl's data providers, plus a small flight-grid bug fix.

Until now the rich provider-health aggregation (success rate, latency, freshness, circuit-breaker state, rate-limit pressure) was reachable only through the MCP `provider_health` tool. There was no CLI or web surface, and `trvl providers status` only lists configured opt-in providers — not the actual `~/.trvl/health.jsonl` call log where the built-in Google/Kiwi/hotel providers live. This closes that gap.

### `trvl status` (CLI)
- Table of every provider that has been called, with success rate, avg latency, freshness, circuit state, and last error class.
- Summary line: healthy / degraded / circuit-open counts, plus rate-limited and stale callouts.
- `--format json` for machine-readable output.
- Reads only local files — no network calls, no credentials touched.

### `/dashboard` (HTTP)
- Read-only, dependency-free HTML view served on the existing MCP HTTP mux (`trvl mcp --http`), auto-refreshing every 30s.
- Auth-gated when a bearer token is configured. An unauthenticated server is loopback-only by the existing `requireRemoteAuth` startup invariant, so the dashboard is safe to serve locally without a token.

### Shared aggregation
- New `internal/providers.BuildStatusReport` is the single source of provider aggregation (health summary + live circuit state). The CLI and dashboard both render it; the MCP tool's JSON contract is preserved.

### Bug fix
- `fix(flights)`: when Google returns a parseable grid with zero priced cells (common for wide date windows), `SearchPriceGrid` previously hit `fmt.Errorf("...: %w", nil)` and rendered the bogus `%!w(<nil>)`. Now returns a clear "no priced grid cells … try a narrower date range" message.

## Tests
- `BuildStatusReport` merge logic + `IsHealthy`/`RateLimited` matrix.
- CLI table / json / empty-log paths.
- Dashboard render + auth gating (401 without token, 200 with).
- Grid empty-cells regression guard.
- Subcommand-count assertion updated (68 → 69). `status` is operational tooling (like `version`/`providers`), so the marketed CLI command count is unchanged.

Verified live: `trvl status` renders against the real health log; `/dashboard` returns 401 without a token and 200 with one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)