### PR TITLE
feat(dashboard): serve /dashboard token-free on loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.1] - 2026-06-20
+
+### Changed
+- **`/dashboard` is now browser-native on localhost.** A loopback bind serves the dashboard without a bearer token (read-only, secret-redacted, local-only — the same posture as `/health`), so `trvl mcp --http` then opening <http://127.0.0.1:8080/dashboard> just works. Non-loopback binds (`--host 0.0.0.0`) still require the token.
+
 ## [1.14.0] - 2026-06-20
 
 Operational visibility release.

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ trvl status                 # table: every provider that has been called
 trvl status --format json   # machine-readable, same data
 ```
 
-When running as an HTTP server (`trvl mcp --http`), the same view is served as a read-only HTML dashboard at `/dashboard` (auto-refreshing). It honors the server's bearer token when one is configured; an unauthenticated server is loopback-only by design, so the dashboard is safe to open locally. AI assistants get the identical data via the `provider_health` MCP tool.
+When running as an HTTP server (`trvl mcp --http`), the same view is served as a read-only, auto-refreshing HTML dashboard at `/dashboard`. On a local (loopback) bind it needs no token — just open <http://127.0.0.1:8080/dashboard> in a browser. A non-loopback bind (`--host 0.0.0.0`) requires the server's bearer token, like every other remote route. AI assistants get the identical data via the `provider_health` MCP tool.
 
 ### Flights
 

--- a/mcp/http_dashboard.go
+++ b/mcp/http_dashboard.go
@@ -106,12 +106,13 @@ type dashboardData struct {
 // handleDashboard serves a read-only HTML operational dashboard: per-provider
 // health from ~/.trvl/health.jsonl merged with live circuit-breaker state.
 //
-// Auth posture: when authentication is configured (mandatory for any non-
-// loopback bind via requireRemoteAuth), a valid read token is required. An
-// unauthenticated server is, by that same startup invariant, loopback-only —
-// safe to serve without a token.
+// Auth posture: a loopback bind serves the dashboard without a token — it is
+// read-only, secret-redacted, and reachable only from the local machine, the
+// same posture as /health. A non-loopback bind requires a valid read token;
+// requireRemoteAuth guarantees one is configured before such a bind starts, so
+// remote exposure is never unauthenticated.
 func (h *HTTPServer) handleDashboard(w http.ResponseWriter, r *http.Request) {
-	if h.auth != nil && h.auth.Configured() {
+	if isRemoteBindHost(h.host) {
 		if _, ok := h.authorize(r); !ok {
 			h.audit.denied.Add(1)
 			http.Error(w, "unauthorized", http.StatusUnauthorized)

--- a/mcp/http_dashboard_test.go
+++ b/mcp/http_dashboard_test.go
@@ -65,17 +65,37 @@ func TestHandleDashboard_RendersHTML(t *testing.T) {
 	}
 }
 
-func TestHandleDashboard_RequiresAuthWhenConfigured(t *testing.T) {
+func TestHandleDashboard_LoopbackServesWithoutToken(t *testing.T) {
 	seedDashboardHealthLog(t)
 
-	hs := NewHTTPServerWithOptions(HTTPServerOptions{Port: 0, Token: "secret-token"})
+	// Loopback bind with a token configured: the dashboard is still served
+	// token-free (read-only, secret-redacted, local-only — same as /health),
+	// so it opens in a browser without an Authorization header.
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{Host: "127.0.0.1", Port: 0, Token: "secret-token"})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	hs.handleDashboard(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("loopback no-token status = %d, want 200", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "trvl status") {
+		t.Error("loopback dashboard body missing title")
+	}
+}
+
+func TestHandleDashboard_RemoteBindRequiresToken(t *testing.T) {
+	seedDashboardHealthLog(t)
+
+	// A non-loopback bind must require a valid read token.
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{Host: "0.0.0.0", Port: 0, Token: "secret-token"})
 
 	// No token => unauthorized.
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
 	hs.handleDashboard(rr, req)
 	if rr.Code != http.StatusUnauthorized {
-		t.Fatalf("no-token status = %d, want 401", rr.Code)
+		t.Fatalf("remote no-token status = %d, want 401", rr.Code)
 	}
 
 	// Valid token => served.
@@ -84,7 +104,7 @@ func TestHandleDashboard_RequiresAuthWhenConfigured(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer secret-token")
 	hs.handleDashboard(rr, req)
 	if rr.Code != http.StatusOK {
-		t.Fatalf("valid-token status = %d, want 200", rr.Code)
+		t.Fatalf("remote valid-token status = %d, want 200", rr.Code)
 	}
 	if !strings.Contains(rr.Body.String(), "trvl status") {
 		t.Error("authorized dashboard body missing title")


### PR DESCRIPTION
## Why

The dashboard (shipped in v1.14.0) was auth-gated whenever a bearer token was configured. But `trvl mcp --http` auto-generates a token even on localhost, and a browser can't send an Authorization header from the URL bar — so opening the dashboard in a browser returned 401. The web view was effectively unusable without a curl-and-header workaround.

## What

Gate dashboard auth on the **bind host** rather than "is a token configured":

- **Loopback bind** (default 127.0.0.1): served token-free. It is read-only, secret-redacted, and reachable only from the local machine — the same posture as the health route. So `trvl mcp --http` then opening the local dashboard URL just works, with live auto-refresh.
- **Non-loopback bind** (host 0.0.0.0): still requires the bearer token. requireRemoteAuth continues to guarantee a remote bind cannot start unauthenticated, so remote exposure is never token-free.

## Tests

- LoopbackServesWithoutToken — loopback with a token configured still serves without a token (the UX fix).
- RemoteBindRequiresToken — a 0.0.0.0 bind returns 401 without a token, 200 with.
- Existing render test (loopback) unchanged.

Verified live: started the HTTP server and requested the dashboard with no token on loopback — 200 with the rendered HTML page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)