### PR TITLE
Expose the npm (npx) channel in the MCP registry entry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,7 +284,8 @@ jobs:
           jq --arg v "${VERSION}" '
             .version = $v |
             .packages[0].identifier = "ghcr.io/mikkoparkkola/trvl:" + $v |
-            del(.packages[0].version)
+            del(.packages[0].version) |
+            (.packages[] | select(.registryType=="npm") | .version) = $v
           ' server.json > server.tmp
           mv server.tmp server.json
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,22 +1,51 @@
 {
   "name": "trvl-mcp",
+  "mcpName": "io.github.MikkoParkkola/trvl",
   "version": "1.10.0",
-  "description": "Travel MCP server + CLI for flights, hotels, trains, cars, and ferries — no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart MCP tool plus 66 compatibility aliases.",
+  "description": "Travel MCP server + CLI for flights, hotels, trains, cars, and ferries \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart MCP tool plus 66 compatibility aliases.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MikkoParkkola/trvl"
   },
   "homepage": "https://github.com/MikkoParkkola/trvl",
-  "keywords": ["mcp", "mcp-server", "travel", "flights", "flight-search", "hotels", "hotel-search", "trains", "rail", "ferries", "ground-transport", "no-api-key", "travel-agent", "google-flights", "google-hotels", "price-alerts", "ai", "claude", "cli", "model-context-protocol"],
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "travel",
+    "flights",
+    "flight-search",
+    "hotels",
+    "hotel-search",
+    "trains",
+    "rail",
+    "ferries",
+    "ground-transport",
+    "no-api-key",
+    "travel-agent",
+    "google-flights",
+    "google-hotels",
+    "price-alerts",
+    "ai",
+    "claude",
+    "cli",
+    "model-context-protocol"
+  ],
   "bin": {
     "trvl-mcp": "bin/trvl-mcp.js"
   },
   "scripts": {
     "postinstall": "node bin/install.js"
   },
-  "os": ["darwin", "linux", "win32"],
-  "cpu": ["x64", "arm64"],
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
   "engines": {
     "node": ">=16"
   }

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
-  "description": "Travel MCP server for flight search and hotels with no API keys required — flights, hotels, trains, rental cars, ferries, ground transport, and price alerts in a single Go binary that works with any MCP client (Claude, Cursor, Windsurf, Codex). One-command install (`trvl mcp install`) auto-configures 10 MCP clients with no JSON editing.",
+  "description": "Travel MCP server for flight search and hotels with no API keys required \u2014 flights, hotels, trains, rental cars, ferries, ground transport, and price alerts in a single Go binary that works with any MCP client (Claude, Cursor, Windsurf, Codex). One-command install (`trvl mcp install`) auto-configures 10 MCP clients with no JSON editing.",
   "version": "1.10.0",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",
@@ -13,6 +13,16 @@
     {
       "registryType": "oci",
       "identifier": "ghcr.io/mikkoparkkola/trvl:1.10.0",
+      "transport": {
+        "type": "stdio"
+      }
+    },
+    {
+      "registryType": "npm",
+      "identifier": "trvl-mcp",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "version": "1.10.0",
+      "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Why

trvl is published to the official MCP registry (`io.github.MikkoParkkola/trvl`, 19 versions), but the live entry lists **only the OCI/ghcr package** — not `trvl-mcp` on npm, which is the highest-volume install channel (2,636/mo) and the path MCP clients use by default via `npx`. Anyone discovering trvl through the registry or its downstream aggregators (PulseMCP, mcpmarket) currently sees only a Docker pull. This surfaces the npm path where discovery happens.

## What (3 coordinated edits)

1. **server.json** — add the npm package alongside OCI (`registryType: npm`, `identifier: trvl-mcp`, `runtimeHint: npx`, `registryBaseUrl: https://registry.npmjs.org`).
2. **npm/package.json** — add `"mcpName": "io.github.MikkoParkkola/trvl"`. The MCP registry validates npm-package ownership against this marker; **without it the publish would fail.** (Also bumps the stale `version` 1.10.0 → current via the existing release sed.)
3. **release.yml** — extend the `Stamp server.json` jq so the npm package version is stamped to the release tag (was OCI-only).

## Verification (local dry-run of the release stamp)

```
jq --arg v 1.14.1 '<stamp>' server.json  ->
  top version: 1.14.1
  oci -> ghcr.io/mikkoparkkola/trvl:1.14.1
  npm -> trvl-mcp  v=1.14.1
package.json: valid JSON, mcpName=io.github.MikkoParkkola/trvl
```

## ⚠️ Validate at release, not on PR CI

The mcp-publisher npm-ownership check only runs at **release time** (on tag push), not in PR CI. Recommended: merge, then cut a patch release and confirm the registry entry shows both `oci` + `npm`. Prereq the marker enables: `trvl-mcp@<version>` must be published to npm with `mcpName` present before/with the registry publish step — the existing release flow publishes npm first, so the next release satisfies this automatically.

## Notes
- [x] Local jq stamp dry-run passes
- [ ] CI green
- [ ] **Operator: merge + cut a release to validate registry publish** (do not rely on PR CI alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)