### PR TITLE
fix(multimodal): price each leg in its discovered mode, stop relabeling ferries as buses

### DIFF
--- a/cmd/trvl/multimodal_plan.go
+++ b/cmd/trvl/multimodal_plan.go
@@ -92,7 +92,11 @@ func printMultimodalPlan(plan *multimodal.Plan) {
 			if leg.Estimated {
 				label = models.Red("estimate")
 			}
-			fmt.Printf("     • %-6s %-18s %s via %s\n", leg.Mode, leg.From+"→"+leg.To, price, label)
+			line := fmt.Sprintf("     • %-6s %-18s %s via %s", leg.Mode, leg.From+"→"+leg.To, price, label)
+			if leg.Detail != "" {
+				line += " " + leg.Detail
+			}
+			fmt.Println(line)
 		}
 		if it.HackSaving != nil {
 			fmt.Printf("     %s %s: save %s %.2f (%s)\n",

--- a/cmd/trvl/multimodal_plan_detail_test.go
+++ b/cmd/trvl/multimodal_plan_detail_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/multimodal"
+)
+
+// TestPrintMultimodalPlan_DisclosesLegDetail is the same-package regression test
+// for the cmd/trvl half of the "price each leg in its discovered mode, stop
+// relabeling ferries as buses" fix. The pricing logic that *computes* a leg's
+// intermodal Detail (e.g. "via bus + ferry") is covered in
+// internal/multimodal/pricing_mode_test.go; this test guards the rendering half:
+// printMultimodalPlan must actually surface a non-empty PricedLeg.Detail so an
+// embedded ferry is disclosed to the user rather than silently hidden behind a
+// single "bus" label.
+//
+// Fail-before/pass-after: before the fix the leg line was printed without the
+// Detail suffix, so the "via bus + ferry" disclosure never reached stdout.
+func TestPrintMultimodalPlan_DisclosesLegDetail(t *testing.T) {
+	plan := &multimodal.Plan{
+		From:       "Helsinki",
+		To:         "Tallinn",
+		Date:       "2026-07-09",
+		Discovered: 1,
+		Itineraries: []multimodal.Itinerary{
+			{
+				From:       "Helsinki",
+				To:         "Tallinn",
+				Date:       "2026-07-09",
+				Currency:   "EUR",
+				TotalPrice: 42,
+				ModeChain:  "bus → ferry",
+				Legs: []multimodal.PricedLeg{
+					{
+						Mode:     "bus",
+						From:     "Helsinki",
+						To:       "Tallinn",
+						Price:    42,
+						Currency: "EUR",
+						Provider: "FlixBus",
+						Detail:   "via bus + ferry",
+					},
+					{
+						Mode:     "train",
+						From:     "Tallinn",
+						To:       "Tartu",
+						Price:    12,
+						Currency: "EUR",
+						Provider: "Elron",
+						// No Detail: a single-mode leg must render no suffix.
+					},
+				},
+			},
+		},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	printMultimodalPlan(plan)
+	_ = w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	out := buf.String()
+
+	if !strings.Contains(out, "via bus + ferry") {
+		t.Fatalf("leg Detail not disclosed: ferry crossing hidden behind bus label\n--- output ---\n%s", out)
+	}
+
+	// The single-mode train leg must not gain a spurious detail suffix. Its line
+	// should end at the provider with no trailing "via ..." chain disclosure.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Tallinn→Tartu") && strings.Contains(line, "via bus + ferry") {
+			t.Fatalf("single-mode leg leaked an unrelated Detail suffix: %q", line)
+		}
+	}
+}

--- a/internal/ground/rome2rio_dump_test.go
+++ b/internal/ground/rome2rio_dump_test.go
@@ -1,0 +1,73 @@
+package ground
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// TestDumpRome2RioAnchors is a live diagnostic (opt-in via R2R_DUMP=1). It uses
+// trvl's real fetch path and prints, per route anchor: the route= URL param and
+// the full normalized anchor text, so we can see whether ferry segments that the
+// name-only parser drops are actually present in the source.
+func TestDumpRome2RioAnchors(t *testing.T) {
+	if os.Getenv("R2R_DUMP") == "" {
+		t.Skip("set R2R_DUMP=1 to run the live Rome2Rio anchor dump")
+	}
+	from, to := "Helsinki", "Tallinn"
+	if v := os.Getenv("R2R_FROM"); v != "" {
+		from = v
+	}
+	if v := os.Getenv("R2R_TO"); v != "" {
+		to = v
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var body string
+	var err error
+	for attempt := 0; attempt < 4; attempt++ {
+		body, err = fetchRome2Rio(ctx, from, to, true)
+		if err == nil && strings.Contains(body, rome2rioMarker) {
+			break
+		}
+		t.Logf("attempt %d: err=%v marker=%v", attempt, err, strings.Contains(body, rome2rioMarker))
+		time.Sleep(3 * time.Second)
+	}
+	if err != nil {
+		t.Fatalf("fetch failed: %v", err)
+	}
+	t.Logf("body bytes=%d marker=%v", len(body), strings.Contains(body, rome2rioMarker))
+
+	doc, perr := html.Parse(strings.NewReader(body))
+	if perr != nil {
+		t.Fatal(perr)
+	}
+	n := 0
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if node.Type == html.ElementNode && node.Data == "a" {
+			href := attr(node, "href")
+			if m := r2rRouteHref.FindStringSubmatch(href); m != nil {
+				n++
+				text := normalizeWS(textOf(node))
+				fmt.Printf("\n=== ROUTE %d ===\n  route_param=%q\n  derived_modes=%v\n  anchor_text=%q\n", n, m[1], rome2rioModes(m[1]), text)
+			}
+		}
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+	fmt.Printf("\nTOTAL ROUTE ANCHORS: %d\n", n)
+
+	// Also dump any JSON-ish blobs that might carry richer segment data.
+	for _, kw := range []string{"\"segments\"", "\"hops\"", "\"vehicle\"", "ferry", "Ferry"} {
+		fmt.Printf("source contains %q: %v\n", kw, strings.Contains(body, kw))
+	}
+}

--- a/internal/multimodal/pricing.go
+++ b/internal/multimodal/pricing.go
@@ -100,17 +100,25 @@ func priceFlightLeg(ctx context.Context, spec LegSpec) (PricedLeg, bool) {
 
 // priceGroundLeg prices the cheapest ground option for the leg via the existing
 // ground search (hacks disabled to avoid a nested savings fan-out).
+//
+// The search is constrained to the discovered mode (bus/train/ferry) so a ferry
+// crossing is priced as a ferry rather than silently relabeled as the cheapest
+// bus that happens to serve the same city pair. A concrete discovered mode is
+// authoritative for the leg label; when the priced route itself decomposes into
+// several modes (e.g. a coach that boards a ferry), that chain is disclosed in
+// Detail so an embedded ferry is never hidden.
 func priceGroundLeg(ctx context.Context, spec LegSpec, allowBrowser bool) (PricedLeg, bool) {
 	if strings.TrimSpace(spec.From) == "" || strings.TrimSpace(spec.To) == "" {
 		return PricedLeg{}, false
 	}
+	disc := normalizeMode(spec.Mode)
 	opts := ground.SearchOptions{
 		NoHacks:               true,
 		AllowBrowserFallbacks: allowBrowser,
 	}
-	switch normalizeMode(spec.Mode) {
-	case "bus", "train":
-		opts.Type = normalizeMode(spec.Mode)
+	switch disc {
+	case "bus", "train", "ferry":
+		opts.Type = disc
 	}
 	res, err := ground.SearchByName(ctx, spec.From, spec.To, spec.Date, opts)
 	if err != nil || res == nil || !res.Success {
@@ -120,10 +128,7 @@ func priceGroundLeg(ctx context.Context, spec LegSpec, allowBrowser bool) (Price
 	if !ok {
 		return PricedLeg{}, false
 	}
-	mode := best.Type
-	if mode == "" {
-		mode = normalizeMode(spec.Mode)
-	}
+	mode, detail := resolveLegMode(disc, best)
 	return PricedLeg{
 		Mode:        mode,
 		From:        spec.From,
@@ -133,7 +138,48 @@ func priceGroundLeg(ctx context.Context, spec LegSpec, allowBrowser bool) (Price
 		DurationMin: best.Duration,
 		Provider:    best.Provider,
 		BookingURL:  best.BookingURL,
+		Detail:      detail,
 	}, true
+}
+
+// resolveLegMode decides a priced ground leg's display mode and any intermodal
+// disclosure. A concrete discovered mode (bus/train/ferry) is authoritative —
+// the ground search is constrained to it, so a ferry is never relabeled as a
+// bus. When the priced route decomposes into multiple modes (e.g. a coach that
+// boards a ferry), the full chain is returned as a "via ..." detail so the
+// embedded ferry is disclosed rather than hidden. Nothing is fabricated: the
+// disclosure comes only from the route's own leg breakdown.
+func resolveLegMode(disc string, best models.GroundRoute) (mode, detail string) {
+	mode = normalizeMode(disc)
+	chain := distinctLegModes(best.Legs)
+	if mode == "" || mode == "mixed" {
+		switch {
+		case len(chain) >= 1:
+			mode = chain[0]
+		case strings.TrimSpace(best.Type) != "":
+			mode = normalizeMode(best.Type)
+		}
+	}
+	if len(chain) > 1 {
+		return mode, "via " + strings.Join(chain, " + ")
+	}
+	return mode, ""
+}
+
+// distinctLegModes returns the ordered, de-duplicated normalized modes of a
+// route's leg breakdown (empty when the route carries no per-leg detail).
+func distinctLegModes(legs []models.GroundLeg) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, l := range legs {
+		m := normalizeMode(l.Type)
+		if m == "" || seen[m] {
+			continue
+		}
+		seen[m] = true
+		out = append(out, m)
+	}
+	return out
 }
 
 // resolveAirport turns a place name into a bookable IATA code: an explicit IATA

--- a/internal/multimodal/pricing_mode_test.go
+++ b/internal/multimodal/pricing_mode_test.go
@@ -1,0 +1,89 @@
+package multimodal
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func legs(modes ...string) []models.GroundLeg {
+	out := make([]models.GroundLeg, len(modes))
+	for i, m := range modes {
+		out[i] = models.GroundLeg{Type: m, Provider: "rome2rio"}
+	}
+	return out
+}
+
+func TestResolveLegMode(t *testing.T) {
+	cases := []struct {
+		name       string
+		disc       string
+		route      models.GroundRoute
+		wantMode   string
+		wantDetail string
+	}{
+		{
+			name:     "ferry stays ferry, never relabeled as a bus",
+			disc:     "ferry",
+			route:    models.GroundRoute{Type: "ferry", Legs: legs("ferry")},
+			wantMode: "ferry", wantDetail: "",
+		},
+		{
+			// A coach that boards a ferry (Helsinki–Tallinn Lux Express style):
+			// the bookable vehicle is a bus, but the ferry crossing must show.
+			name:     "coach-on-ferry discloses the ferry segment",
+			disc:     "bus",
+			route:    models.GroundRoute{Type: "bus", Legs: legs("bus", "ferry")},
+			wantMode: "bus", wantDetail: "via bus + ferry",
+		},
+		{
+			name:     "plain bus has no spurious disclosure",
+			disc:     "bus",
+			route:    models.GroundRoute{Type: "bus", Legs: legs("bus")},
+			wantMode: "bus", wantDetail: "",
+		},
+		{
+			name:     "concrete discovered mode wins over a contradictory provider type",
+			disc:     "train",
+			route:    models.GroundRoute{Type: "bus", Legs: legs("bus")},
+			wantMode: "train", wantDetail: "",
+		},
+		{
+			name:     "non-concrete mode falls back to the leg breakdown",
+			disc:     "mixed",
+			route:    models.GroundRoute{Type: "", Legs: legs("train", "fly")},
+			wantMode: "train", wantDetail: "via train + fly",
+		},
+		{
+			name:     "empty mode with no legs falls back to route type",
+			disc:     "",
+			route:    models.GroundRoute{Type: "ferry"},
+			wantMode: "ferry", wantDetail: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, detail := resolveLegMode(tc.disc, tc.route)
+			if mode != tc.wantMode || detail != tc.wantDetail {
+				t.Errorf("resolveLegMode(%q) = (%q, %q), want (%q, %q)",
+					tc.disc, mode, detail, tc.wantMode, tc.wantDetail)
+			}
+		})
+	}
+}
+
+func TestDistinctLegModes(t *testing.T) {
+	got := distinctLegModes(legs("bus", "bus", "ferry", "ferry"))
+	want := []string{"bus", "ferry"}
+	if len(got) != len(want) {
+		t.Fatalf("distinctLegModes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("distinctLegModes = %v, want %v", got, want)
+		}
+	}
+	if m := distinctLegModes(nil); len(m) != 0 {
+		t.Errorf("distinctLegModes(nil) = %v, want empty", m)
+	}
+}


### PR DESCRIPTION
## The bug

`priceGroundLeg` only constrained the ground search by Type for bus and train. A discovered ferry leg therefore searched every mode, took the single cheapest result (a 5 EUR coach serving the same city pair), and set the leg mode from that result, so a ferry crossing got relabeled as a bus.

On Helsinki to Tallinn, where every surface option crosses the Gulf of Finland by ferry, three distinct discovered chains (bus, ferry, ferry-via) all collapsed into three identical "bus 5 EUR" rows.

## The fix

- Constrain the ground search to the discovered mode for ferry as well as bus and train, so a ferry chain is priced as a ferry.
- Make a concrete discovered mode authoritative for the leg label (resolveLegMode), so a contradictory provider type can no longer relabel the leg.
- Disclose genuinely intermodal routes from the route's own leg breakdown: a coach that boards a ferry renders "via bus + ferry" rather than hiding the crossing. Nothing is fabricated; disclosure comes only from real leg data, so an opaque single-mode "Bus" from the discovery source is not given an invented ferry.

## Verification

Live, Helsinki to Tallinn:

```
1. bus    EUR 5.00   (Lux Express coach, stays a bus)
2. ferry  EUR 12.00  (was mislabeled bus, now ferry)
3. ferry  EUR 12.00  (Ferry-via-Helsinki, now ferry)
4. fly    EUR 79.00  (estimate, labeled)
```

Unit tests cover the mode-resolution matrix, including the coach-on-ferry disclosure and the concrete-mode-wins guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)