### PR TITLE
Publish to MCP registry after npm (fix mcpName validation race)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
 
   mcp-registry:
     runs-on: ubuntu-latest
-    needs: docker
+    needs: [docker, npm]
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Why

#238 added the npm channel to server.json + the `mcpName` ownership marker to npm/package.json. The MCP registry validates that marker against the **live** npm package. But `mcp-registry` (needs: docker) and `npm` (needs: goreleaser) run in parallel — so the registry publish can fire before `trvl-mcp@<version>` is on npm, and validation fails (the prior published version has no `mcpName`).

## What

`mcp-registry: needs: [docker, npm]` — the registry publish now waits for the npm job, so the freshly published package (with `mcpName`) exists before validation runs.

## Notes
- [x] YAML validated
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)