### PR TITLE
fix(multimodal): parse Rome2Rio per-segment legs so multi-leg routes actually price

### DIFF
--- a/internal/ground/rome2rio.go
+++ b/internal/ground/rome2rio.go
@@ -206,7 +206,6 @@ func parseRome2Rio(body, from, to string) ([]models.GroundRoute, error) {
 // into a discovery GroundRoute. Returns ok=false when the option has neither a
 // duration nor a price (i.e. not a real travel option).
 func buildRome2RioRoute(routeName, text, href, from, to string) (models.GroundRoute, bool) {
-	modes := rome2rioModes(routeName)
 	dur := rome2rioDuration(text)
 	lo, hi, cur := rome2rioPrice(text)
 
@@ -214,18 +213,28 @@ func buildRome2RioRoute(routeName, text, href, from, to string) (models.GroundRo
 		return models.GroundRoute{}, false
 	}
 
+	// Prefer the rich per-segment breakdown parsed from the anchor text (real
+	// modes AND endpoints). Fall back to the lossy route= name chain (modes
+	// only, no stops) when the prose carries no recognizable segments.
+	legs := parseRome2RioSegments(text)
+	var modes []string
+	if len(legs) > 0 {
+		modes = distinctSegmentModes(legs)
+	} else {
+		modes = rome2rioModes(routeName)
+		legs = make([]models.GroundLeg, 0, len(modes))
+		for _, m := range modes {
+			legs = append(legs, models.GroundLeg{Type: m, Provider: "rome2rio"})
+		}
+	}
+
 	typ := "mixed"
 	if len(modes) == 1 {
 		typ = modes[0]
 	}
 	transfers := 0
-	if len(modes) > 1 {
-		transfers = len(modes) - 1
-	}
-
-	legs := make([]models.GroundLeg, 0, len(modes))
-	for _, m := range modes {
-		legs = append(legs, models.GroundLeg{Type: m, Provider: "rome2rio"})
+	if len(legs) > 1 {
+		transfers = len(legs) - 1
 	}
 
 	return models.GroundRoute{

--- a/internal/ground/rome2rio_segments.go
+++ b/internal/ground/rome2rio_segments.go
@@ -1,0 +1,104 @@
+package ground
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// Rome2Rio's SSR anchor text spells out every segment of a route in a regular
+// prose grammar, e.g.:
+//
+//	"Take the ferry from Helsinki to Tallinn ferry ferry
+//	 Fly from Lennart Meri International Airport (TLL) to Luton Airport (LTN) plane plane TLL - LTN
+//	 Take the train from Luton Airport Parkway to London St Pancras Intl train train"
+//
+// Each segment is "<verb> from <A> to <B> <mode-token>...". Parsing this yields
+// the true per-leg modes AND endpoints — which the route= URL param alone does
+// not carry — so downstream per-leg pricing can query the real intermediate
+// stops instead of mispricing every leg as the overall origin→destination.
+var rome2rioSegmentRE = regexp.MustCompile(
+	`(?:Take the (car ferry|car train|ferry|bus|train|rideshare|subway|tram|taxi)|(Drive)|(Fly)) from (.+?) to (.+?) (?:carferry|cartrain|ferry|bus|train|plane|car|rideshare|subway|tram|taxi)\b`)
+
+// iataInParen matches an airport's IATA code in trailing parentheses, e.g.
+// "Luton Airport (LTN)" -> "LTN".
+var iataInParen = regexp.MustCompile(`\(([A-Z]{3})\)`)
+
+// segmentModeNormalize maps a Rome2Rio verb/mode to trvl's canonical leg type.
+func segmentModeNormalize(takeMode, drive, fly string) string {
+	switch {
+	case fly != "":
+		return "fly"
+	case drive != "":
+		return "drive"
+	}
+	switch strings.ToLower(strings.TrimSpace(takeMode)) {
+	case "car ferry", "ferry":
+		return "ferry"
+	case "car train", "train":
+		return "train"
+	case "bus":
+		return "bus"
+	default:
+		return strings.ToLower(strings.TrimSpace(takeMode))
+	}
+}
+
+// cleanRome2RioStop splits a raw stop string into a pricing-friendly city token
+// and the full station label. An airport keeps its IATA code as the city (so a
+// flight leg can resolve it); a "City, Terminal" string keeps the city prefix.
+func cleanRome2RioStop(raw string) (city, station string) {
+	station = strings.TrimSpace(raw)
+	if m := iataInParen.FindStringSubmatch(station); m != nil {
+		return m[1], station
+	}
+	if i := strings.IndexByte(station, ','); i > 0 {
+		return strings.TrimSpace(station[:i]), station
+	}
+	return station, station
+}
+
+// parseRome2RioSegments extracts the ordered per-leg breakdown from a route's
+// anchor text. Returns nil when the text carries no recognizable segments, so
+// callers can fall back to the route-name mode chain.
+func parseRome2RioSegments(text string) []models.GroundLeg {
+	matches := rome2rioSegmentRE.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	legs := make([]models.GroundLeg, 0, len(matches))
+	for _, m := range matches {
+		mode := segmentModeNormalize(m[1], m[2], m[3])
+		fromCity, fromStation := cleanRome2RioStop(m[4])
+		toCity, toStation := cleanRome2RioStop(m[5])
+		if mode == "" || fromCity == "" || toCity == "" {
+			continue
+		}
+		legs = append(legs, models.GroundLeg{
+			Type:      mode,
+			Provider:  "rome2rio",
+			Departure: models.GroundStop{City: fromCity, Station: fromStation},
+			Arrival:   models.GroundStop{City: toCity, Station: toStation},
+		})
+	}
+	if len(legs) == 0 {
+		return nil
+	}
+	return legs
+}
+
+// distinctSegmentModes returns the ordered, de-duplicated modes of a parsed leg
+// chain (used to type the route and detect multi-mode "mixed" itineraries).
+func distinctSegmentModes(legs []models.GroundLeg) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, l := range legs {
+		if l.Type == "" || seen[l.Type] {
+			continue
+		}
+		seen[l.Type] = true
+		out = append(out, l.Type)
+	}
+	return out
+}

--- a/internal/ground/rome2rio_segments_test.go
+++ b/internal/ground/rome2rio_segments_test.go
@@ -1,0 +1,71 @@
+package ground
+
+import "testing"
+
+// Fixtures are verbatim anchor texts captured live from Rome2Rio SSR
+// (Helsinki→Tallinn and Helsinki→London), so the parser is tested against the
+// real grammar, not an invented one.
+func TestParseRome2RioSegments(t *testing.T) {
+	t.Run("single bus leg keeps city + full station", func(t *testing.T) {
+		legs := parseRome2RioSegments("Take the bus from Helsinki, Harbour Terminal 2 to Tallinn, Harbour Terminal D bus bus 1203")
+		if len(legs) != 1 {
+			t.Fatalf("got %d legs, want 1: %+v", len(legs), legs)
+		}
+		l := legs[0]
+		if l.Type != "bus" || l.Departure.City != "Helsinki" || l.Arrival.City != "Tallinn" {
+			t.Errorf("leg = %+v", l)
+		}
+		if l.Departure.Station != "Helsinki, Harbour Terminal 2" || l.Arrival.Station != "Tallinn, Harbour Terminal D" {
+			t.Errorf("stations not preserved: %+v", l)
+		}
+	})
+
+	t.Run("ferry+fly+train resolves modes, IATA, and stops in order", func(t *testing.T) {
+		text := "Ferry to Lennart Meri International Airport, fly to Luton Airport, train " +
+			"Take the ferry from Helsinki to Tallinn ferry ferry " +
+			"Fly from Lennart Meri International Airport (TLL) to Luton Airport (LTN) plane plane TLL - LTN " +
+			"Take the train from Luton Airport Parkway to London St Pancras Intl train train"
+		legs := parseRome2RioSegments(text)
+		if len(legs) != 3 {
+			t.Fatalf("got %d legs, want 3: %+v", len(legs), legs)
+		}
+		want := []struct{ mode, from, to string }{
+			{"ferry", "Helsinki", "Tallinn"},
+			{"fly", "TLL", "LTN"},
+			{"train", "Luton Airport Parkway", "London St Pancras Intl"},
+		}
+		for i, w := range want {
+			if legs[i].Type != w.mode || legs[i].Departure.City != w.from || legs[i].Arrival.City != w.to {
+				t.Errorf("leg %d = {%s %s→%s}, want {%s %s→%s}",
+					i, legs[i].Type, legs[i].Departure.City, legs[i].Arrival.City, w.mode, w.from, w.to)
+			}
+		}
+	})
+
+	t.Run("drive + car ferry chain normalizes car ferry to ferry", func(t *testing.T) {
+		text := "Drive, car ferry Drive from Helsinki to Gothenburg car car " +
+			"Take the car ferry from Gothenburg to Port of Frederikshavn carferry car ferry " +
+			"Drive from Port Of Frederikshavn to Calais car car " +
+			"Take the car ferry from Calais to Port of Dover carferry car ferry " +
+			"Drive from Port of Dover to London car car"
+		legs := parseRome2RioSegments(text)
+		if len(legs) != 5 {
+			t.Fatalf("got %d legs, want 5: %+v", len(legs), legs)
+		}
+		wantModes := []string{"drive", "ferry", "drive", "ferry", "drive"}
+		for i, m := range wantModes {
+			if legs[i].Type != m {
+				t.Errorf("leg %d mode = %s, want %s", i, legs[i].Type, m)
+			}
+		}
+		if legs[1].Departure.City != "Gothenburg" || legs[1].Arrival.City != "Port of Frederikshavn" {
+			t.Errorf("car-ferry leg endpoints = %s→%s", legs[1].Departure.City, legs[1].Arrival.City)
+		}
+	})
+
+	t.Run("no segments yields nil for fallback", func(t *testing.T) {
+		if legs := parseRome2RioSegments("See schedules"); legs != nil {
+			t.Errorf("expected nil, got %+v", legs)
+		}
+	})
+}


### PR DESCRIPTION
Investigated against the live Rome2Rio source, not assumed. Two confirmed defects, both rooted in discarding the anchor text.

## 1. The route= param is lossy; the anchor prose is the real source

Each Rome2Rio route's anchor text spells out every segment with its real mode, endpoints and line, for example:

```
Take the ferry from Helsinki to Tallinn ...
Fly from Lennart Meri International Airport (TLL) to Luton Airport (LTN) ...
Take the train from Luton Airport Parkway to London St Pancras Intl ...
```

buildRome2RioRoute read only the route= URL param and threw all of that away.

## 2. Multi-leg routes could not price at all

Because legs carried no stops, legSpecsForRoute left every intermediate endpoint blank. A multi-leg route then priced each leg with empty origin and destination, every provider call failed, and the whole itinerary degraded to estimates. The real per-leg pricing headline was effectively dead for genuine multimodal routes. The earlier failures I attributed to rate limits were actually this.

## Fix

Parse the anchor text into ordered structured legs (mode plus from-stop plus to-stop), extracting IATA from "(LTN)" for flights and the city prefix from "City, Terminal" for ground. buildRome2RioRoute prefers these real segments and falls back to the name-derived chain only when no segments parse.

## Verification (live, Helsinki to London)

Routes now show real chains with real endpoints and real fares:

```
1. ferry -> fly -> train   ferry Helsinki->Tallinn EUR 12, fly TLL->LTN, train Luton->London St Pancras
2. fly                     HEL->STN EUR 95.65 via skiplagged   (real provider fare, not estimate)
4. fly -> train            HEL->LGW EUR 93.04 via skiplagged + train Gatwick->London Victoria
```

The parser is unit-tested against verbatim live anchor-text fixtures: ferry+fly+train with IATA extraction, a drive plus car-ferry chain, and harbour-terminal city splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)