### PR TITLE
fix(multimodal): indicative prices never shown as confirmed fares; dedupe identical itineraries

### DIFF
--- a/internal/ground/provider_filter_test.go
+++ b/internal/ground/provider_filter_test.go
@@ -1,0 +1,29 @@
+package ground
+
+import "testing"
+
+func TestProviderEnabled(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		include  []string
+		exclude  []string
+		want     bool
+	}{
+		{"no filters allows all", "flixbus", nil, nil, true},
+		{"exclude wins", "rome2rio", nil, []string{"rome2rio"}, false},
+		{"exclude is case-insensitive", "Rome2Rio", nil, []string{"rome2rio"}, false},
+		{"exclude beats include", "rome2rio", []string{"rome2rio"}, []string{"rome2rio"}, false},
+		{"include allow-list permits listed", "flixbus", []string{"flixbus"}, nil, true},
+		{"include allow-list blocks unlisted", "regiojet", []string{"flixbus"}, nil, false},
+		{"not excluded passes through", "viking line", nil, []string{"rome2rio"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := providerEnabled(tc.provider, tc.include, tc.exclude); got != tc.want {
+				t.Errorf("providerEnabled(%q, %v, %v) = %v, want %v",
+					tc.provider, tc.include, tc.exclude, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ground/search.go
+++ b/internal/ground/search.go
@@ -219,6 +219,26 @@ type SearchOptions struct {
 	NoHacks bool
 }
 
+// providerEnabled reports whether a provider should run given an optional
+// allow-list (include; empty means all) and a deny-list (exclude, which always
+// wins). Pure and case-insensitive so it is unit-tested without the network.
+func providerEnabled(name string, include, exclude []string) bool {
+	for _, p := range exclude {
+		if strings.EqualFold(p, name) {
+			return false
+		}
+	}
+	if len(include) == 0 {
+		return true
+	}
+	for _, p := range include {
+		if strings.EqualFold(p, name) {
+			return true
+		}
+	}
+	return false
+}
+
 // SearchByName searches all providers for ground transport between two cities
 // given by name. Resolves city names to provider-specific IDs automatically.
 func SearchByName(ctx context.Context, from, to, date string, opts SearchOptions) (*models.GroundSearchResult, error) {
@@ -343,20 +363,7 @@ func searchByNameCore(ctx context.Context, from, to, date string, opts SearchOpt
 	results := make(chan providerResult, searchResultBufferCapacity())
 
 	useProvider := func(name string) bool {
-		for _, p := range opts.ExcludeProviders {
-			if strings.EqualFold(p, name) {
-				return false
-			}
-		}
-		if len(opts.Providers) == 0 {
-			return true
-		}
-		for _, p := range opts.Providers {
-			if strings.EqualFold(p, name) {
-				return true
-			}
-		}
-		return false
+		return providerEnabled(name, opts.Providers, opts.ExcludeProviders)
 	}
 
 	// Distribusion — ground transport GDS covering bus, ferry, train, airport transfers.

--- a/internal/ground/search.go
+++ b/internal/ground/search.go
@@ -206,6 +206,7 @@ func launchProvider(wg *sync.WaitGroup, results chan<- providerResult, name stri
 type SearchOptions struct {
 	Currency              string   // Default: EUR
 	Providers             []string // Filter to specific providers; empty = all
+	ExcludeProviders      []string // Skip these providers even when otherwise enabled
 	MaxPrice              float64  // 0 = no limit
 	Type                  string   // "bus", "train", or empty for all
 	NoCache               bool     // bypass response cache
@@ -342,6 +343,11 @@ func searchByNameCore(ctx context.Context, from, to, date string, opts SearchOpt
 	results := make(chan providerResult, searchResultBufferCapacity())
 
 	useProvider := func(name string) bool {
+		for _, p := range opts.ExcludeProviders {
+			if strings.EqualFold(p, name) {
+				return false
+			}
+		}
 		if len(opts.Providers) == 0 {
 			return true
 		}

--- a/internal/multimodal/assemble.go
+++ b/internal/multimodal/assemble.go
@@ -2,6 +2,7 @@ package multimodal
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
@@ -222,4 +223,25 @@ func rankItineraries(its []Itinerary) {
 
 func round2(v float64) float64 {
 	return float64(int64(v*100+0.5)) / 100
+}
+
+// dedupeItineraries collapses itineraries that present identically — same mode
+// chain, total, currency and duration — keeping the first (rank order already
+// puts the cheapest, fully-priced option first). Two discovered chains that
+// resolve to the same journey at the same price would otherwise render as
+// duplicate rows. Must run after rankItineraries.
+func dedupeItineraries(its []Itinerary) []Itinerary {
+	seen := make(map[string]bool, len(its))
+	out := its[:0]
+	for _, it := range its {
+		key := it.ModeChain + "|" + it.Currency + "|" +
+			strconv.FormatFloat(it.TotalPrice, 'f', 2, 64) + "|" +
+			strconv.Itoa(it.DurationMin)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, it)
+	}
+	return out
 }

--- a/internal/multimodal/composer.go
+++ b/internal/multimodal/composer.go
@@ -199,6 +199,7 @@ func (p *Planner) Plan(ctx context.Context, from, to, date string) (*Plan, error
 	plan.Priced = len(itineraries)
 
 	rankItineraries(itineraries)
+	itineraries = dedupeItineraries(itineraries)
 	if len(itineraries) > p.maxItineraries() {
 		itineraries = itineraries[:p.maxItineraries()]
 	}

--- a/internal/multimodal/dedupe_test.go
+++ b/internal/multimodal/dedupe_test.go
@@ -1,0 +1,32 @@
+package multimodal
+
+import "testing"
+
+func TestDedupeItineraries(t *testing.T) {
+	in := []Itinerary{
+		{ModeChain: "ferry", Currency: "EUR", TotalPrice: 12, DurationMin: 120, Source: "a"},
+		{ModeChain: "ferry", Currency: "EUR", TotalPrice: 12, DurationMin: 120, Source: "b"}, // dup of first
+		{ModeChain: "ferry", Currency: "EUR", TotalPrice: 14, DurationMin: 120, Source: "c"}, // different price
+		{ModeChain: "ferry → fly", Currency: "EUR", TotalPrice: 12, DurationMin: 120, Source: "d"}, // different chain
+		{ModeChain: "ferry", Currency: "EUR", TotalPrice: 12, DurationMin: 159, Source: "e"}, // different duration
+	}
+	out := dedupeItineraries(in)
+	if len(out) != 4 {
+		t.Fatalf("got %d itineraries, want 4: %+v", len(out), out)
+	}
+	// The first of a duplicate pair is kept (rank order already preferred it).
+	if out[0].Source != "a" {
+		t.Errorf("kept %q for the ferry/12/120 row, want the first (a)", out[0].Source)
+	}
+	for _, it := range out {
+		if it.Source == "b" {
+			t.Error("duplicate itinerary (b) was not collapsed")
+		}
+	}
+}
+
+func TestDedupeItineraries_Empty(t *testing.T) {
+	if out := dedupeItineraries(nil); len(out) != 0 {
+		t.Errorf("dedupeItineraries(nil) = %v, want empty", out)
+	}
+}

--- a/internal/multimodal/pricing.go
+++ b/internal/multimodal/pricing.go
@@ -115,6 +115,12 @@ func priceGroundLeg(ctx context.Context, spec LegSpec, allowBrowser bool) (Price
 	opts := ground.SearchOptions{
 		NoHacks:               true,
 		AllowBrowserFallbacks: allowBrowser,
+		// Rome2Rio is the DISCOVERY source; its prices are indicative ranges, not
+		// confirmed fares. Excluding it from per-leg pricing keeps a "real" leg
+		// price honest (a bookable provider only) and avoids a redundant Cloudflare
+		// fetch per leg. When no bookable provider covers the leg, the composer
+		// falls back to the route's indicative range, clearly labelled as an estimate.
+		ExcludeProviders: []string{"rome2rio"},
 	}
 	switch disc {
 	case "bus", "train", "ferry":


### PR DESCRIPTION
Two further multimodal correctness issues found while investigating the real Rome2Rio source. Builds on #239 (mode truth) and #241 (segment parsing).

## 1. Honesty: Rome2Rio indicative prices were shown as confirmed fares

ground.SearchByName includes Rome2Rio in its provider fan-out, and Rome2Rio is the discovery source whose prices the code documents as indicative ranges, not bookable fares. The per-leg pricer could pick Rome2Rio's own indicative price and present it as a confirmed fare with no estimate flag (for example "ferry EUR 12 via rome2rio" shown as real). That is circular and dishonest.

Fix: add SearchOptions.ExcludeProviders and exclude rome2rio from per-leg pricing, so a leg's real price comes from a bookable provider only. When none covers the leg, the composer falls back to the route's indicative range, clearly labelled as an estimate. Bonus: removes a redundant Cloudflare fetch per leg.

## 2. Duplicate itinerary rows

Two discovered chains that resolve to the same journey at the same price rendered as identical rows. Add dedupeItineraries (after ranking), keyed on mode-chain, total, currency and duration.

## Tests

- dedupeItineraries matrix (duplicate, different price, different chain, different duration, empty).
- ground and multimodal suites green; vet and staticcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)