### PR TITLE
Fix MCP registry publish: description must be <= 100 chars

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
-  "description": "Travel MCP server for flight search and hotels with no API keys required \u2014 flights, hotels, trains, rental cars, ferries, ground transport, and price alerts in a single Go binary that works with any MCP client (Claude, Cursor, Windsurf, Codex). One-command install (`trvl mcp install`) auto-configures 10 MCP clients with no JSON editing.",
+  "description": "Travel MCP server + CLI for flights, hotels, trains, cars & ferries. No API keys, single Go binary.",
   "version": "1.10.0",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",


### PR DESCRIPTION
## Why

The v1.14.2 release's `mcp-registry` job failed with **422: body.description expected length <= 100**. The registry tightened the description limit; trvl's server.json description was 338 chars (1.13.1 predates the rule). This blocks every future registry publish — including the npm-channel addition from #238 — until shortened.

## What

Trims server.json `description` to 99 chars, keeping the core value prop. The npm + oci channels from #238 are retained. GitHub-repo and npm descriptions (which have no such limit) are unchanged.

## Notes
- [x] description = 99 chars; packages = [oci, npm]
- Next release will publish the registry entry with both channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)