### PR TITLE
Fix MCP registry publish: server.json description must be <= 100 chars

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
-  "description": "Travel MCP server for flight search and hotels with no API keys required \u2014 flights, hotels, trains, rental cars, ferries, door-to-door multimodal itineraries, ground transport, and price alerts in a single Go binary that works with any MCP client (Claude, Cursor, Windsurf, Codex). One-command install (`trvl mcp install`) auto-configures 10 MCP clients with no JSON editing.",
+  "description": "Door-to-door travel MCP + CLI: flights, hotels, trains, cars, ferries. No API keys, Go binary.",
   "version": "1.10.0",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",


### PR DESCRIPTION
## Why

The v1.14.2 `mcp-registry` job failed: **422 body.description expected length <= 100**. The registry enforces a 100-char description cap; trvl's server.json description is 375 chars (#243 expanded it). This blocks every registry publish — including the npm-channel addition (#238) — so the registry still shows oci-only at 1.13.1.

## What

Trims **server.json** `description` to <=100 chars (keeps the door-to-door multimodal framing). This is the only field with the cap — the GitHub repo description, npm description, and README keep the full rich copy. The oci+npm channels from #238 are retained.

## Notes
- [x] description <=100; packages = [oci, npm]
- The next release will publish the registry entry with both channels. (v1.14.2/v1.14.3 predate this fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)