### PR TITLE
fix(hotels): surface link durability and island fallback

### DIFF
--- a/cmd/trvl/prices.go
+++ b/cmd/trvl/prices.go
@@ -83,17 +83,37 @@ func formatPricesTable(result *models.HotelPriceResult) error {
 		fmt.Printf("Notice: %s\n\n", result.Notice)
 	}
 
-	headers := []string{"Provider", "Price", "Currency"}
+	headers := []string{"Provider", "Price", "Currency", "Link"}
 	rows := make([][]string, 0, len(result.Providers))
+	anyExpiring := false
 	for _, p := range result.Providers {
+		link := "-"
+		switch p.LinkDurability {
+		case "expiring":
+			link = "⚠ expiring"
+			anyExpiring = true
+		case "stable":
+			link = "stable"
+		}
 		rows = append(rows, []string{
 			p.Provider,
 			fmt.Sprintf("%.2f", p.Price),
 			p.Currency,
+			link,
 		})
 	}
 
 	models.FormatTable(os.Stdout, headers, rows)
+
+	if anyExpiring {
+		fmt.Printf("\n⚠ \"expiring\" links are Google ad-click redirects that work now but can die within a day or two — book promptly, or use the durable link below.\n")
+	}
+	if result.BookingFallbackURL != "" {
+		fmt.Printf("\nDurable link (lands on the right property + dates, won't 404): %s\n", result.BookingFallbackURL)
+	}
+	if result.TouristTaxNote != "" {
+		fmt.Printf("\nNote: %s\n", result.TouristTaxNote)
+	}
 	return nil
 }
 

--- a/cmd/trvl/prices_durability_test.go
+++ b/cmd/trvl/prices_durability_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestFormatPricesTable_SurfacesLinkDurability verifies that the provider price
+// table surfaces per-link stability, the durable fallback, and the tourist-tax
+// note in default CLI output — so a save-and-book-later traveller can tell which
+// links expire (Roberto Reale's link-durability feedback, blog issue #1).
+func TestFormatPricesTable_SurfacesLinkDurability(t *testing.T) {
+	result := &models.HotelPriceResult{
+		HotelID:  "0x133b6ab82c204df7:0x437369f021e5e869",
+		CheckIn:  "2026-07-30",
+		CheckOut: "2026-08-04",
+		Providers: []models.ProviderPrice{
+			{Provider: "Booking.com", Price: 980, Currency: "EUR", LinkDurability: "stable"},
+			{Provider: "Expedia", Price: 1402, Currency: "EUR", LinkDurability: "expiring"},
+		},
+		BookingFallbackURL: "https://www.booking.com/searchresults.html?ss=Hotel+Continental+Mare",
+		TouristTaxNote:     "A local tourist or city tax may be payable in cash at the property.",
+	}
+
+	out := captureStdout(t, func() {
+		if err := formatPricesTable(result); err != nil {
+			t.Fatalf("formatPricesTable: %v", err)
+		}
+	})
+
+	for _, want := range []string{
+		"stable",                    // stable link tag
+		"expiring",                  // expiring link tag
+		"book promptly",             // expiring-links warning
+		"Durable link",              // durable fallback surfaced
+		"booking.com/searchresults", // the fallback URL
+		"tourist or city tax",       // tourist-tax note
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("prices table output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/trvl/rooms.go
+++ b/cmd/trvl/rooms.go
@@ -57,7 +57,18 @@ func runRooms(cmd *cobra.Command, args []string) error {
 
 	result, err := resolveRoomAvailability(ctx, hotelQuery, checkIn, checkOut, currency, location)
 	if err != nil {
-		return fmt.Errorf("hotel rooms: %w", err)
+		// Smaller and island properties often have no Google Hotel ID in the
+		// index, so room-level lookup can't resolve them. Don't fail silently —
+		// point the traveller at the verification paths that do work there.
+		area := location
+		if area == "" {
+			area = hotelQuery
+		}
+		return fmt.Errorf("hotel rooms: %w\n\n"+
+			"No room-level data is available for %q. Smaller or island properties are often not in Google's hotel index. Try instead:\n"+
+			"  trvl serpapi %q --checkin %s --checkout %s --currency %s   (detail-verified provider prices; needs SERPAPI_KEY)\n"+
+			"  trvl hotels %q --checkin %s --checkout %s --format json    (find a Google place ID, then: trvl prices <id> ...)",
+			err, hotelQuery, area, checkIn, checkOut, currency, area, checkIn, checkOut)
 	}
 
 	if format == "json" {

--- a/cmd/trvl/serpapi.go
+++ b/cmd/trvl/serpapi.go
@@ -184,7 +184,7 @@ func runSerpapi(cmd *cobra.Command, args []string) error {
 	models.Banner(os.Stdout, "🏨", "Hotels", fmt.Sprintf("%s · %s to %s", location, checkIn, checkOut))
 	fmt.Println()
 
-	headers := []string{"Hotel", "Class", "Rating", "€/nt", "Totale", "Provider", "Status"}
+	headers := []string{"Hotel", "Class", "Rating", "€/nt", "Total", "Provider", "Status"}
 	rows := make([][]string, 0, len(allHotels))
 	unverifiedCount := 0
 	for _, h := range allHotels {


### PR DESCRIPTION
Closes the remaining rough edges from Roberto Reale's Budget Travel Pipeline review (RobertoReale/blog issue 1) that were not yet fully addressed.

## Link durability surfacing
`trvl prices` now shows per-provider link stability in the default CLI table ("stable" / "expiring"), warns that expiring Google ad-click redirects can die within a day or two, and prints the durable Booking.com fallback URL plus the tourist-tax note. The underlying data (LinkDurability, BookingFallbackURL, TouristTaxNote) already existed from earlier work but was only visible in JSON output — so a save-and-book-later traveller had no way to tell which links expire.

## Island fallback
`trvl rooms` no longer fails silently when a property has no Google Hotel ID (common for smaller and island hotels — his Ischia case). It now points the user to `trvl serpapi` (detail-verified provider prices) and `trvl hotels --format json` (to find a place ID for `trvl prices`).

## Typo
The serpapi results table header read "Totale" (Italian); now "Total".

## Test
Covers the link-durability surfacing: stable and expiring tags, the expiring warning, the durable fallback, and the tourist-tax note in default output.