### PR TITLE
feat: price-history substrate and four travel-intelligence features (MIK-6229, 6231, 6232, 6233, 6234)

### DIFF
--- a/cmd/trvl/commands_test.go
+++ b/cmd/trvl/commands_test.go
@@ -21,7 +21,8 @@ func TestRootCmd_SubcommandCount(t *testing.T) {
 	// 66 -> 67 with `multimodal` (innovation #2 multimodal composer).
 	// 67 -> 68 with `plan-all` (innovation #5 unified trip coalescer).
 	// 68 -> 69 with `status` (operational health/circuit/rate-limit snapshot).
-	const want = 69
+	// 69 -> 70 with `nudges` (MIK-6233 personal travel graph nudges).
+	const want = 70
 	got := len(rootCmd.Commands())
 	if got != want {
 		names := make([]string, 0, got)

--- a/cmd/trvl/counterfactual_render.go
+++ b/cmd/trvl/counterfactual_render.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/MikkoParkkola/trvl/internal/counterfactual"
+)
+
+// printSavings renders call-free (MIK-6234 Tier 0) counterfactual savings. The
+// heading makes the zero-cost guarantee explicit so the output never implies a
+// fresh fan-out happened.
+func printSavings(w io.Writer, savings []counterfactual.Saving) {
+	if len(savings) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "\nSavings you could capture (no extra searches):")
+	for _, s := range savings {
+		fmt.Fprintf(w, "  • %s\n", s.Description)
+	}
+}

--- a/cmd/trvl/d2d_render.go
+++ b/cmd/trvl/d2d_render.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/MikkoParkkola/trvl/internal/d2d"
+	"github.com/MikkoParkkola/trvl/internal/multimodal"
+)
+
+// printDoorToDoor renders the MIK-6231 honest door-to-door total for one
+// multimodal itinerary: a confirmed total that EXCLUDES indicative legs, the
+// indicative portion surfaced separately, and a confidence band rather than a
+// false-precise single figure.
+func printDoorToDoor(w io.Writer, it multimodal.Itinerary) {
+	total := d2d.Compute(itineraryToLegs(it))
+	if total.Counts.Confirmed == 0 && total.Counts.Indicative == 0 && total.Counts.Unverified == 0 {
+		return
+	}
+	fmt.Fprintf(w, "     Door-to-door: %s %.2f confirmed", total.Currency, total.ConfirmedTotal)
+	if sum, n := legSum(total.IndicativeLegs); n > 0 {
+		fmt.Fprintf(w, " + %s %.2f indicative across %d leg(s) — verify before booking", total.Currency, sum, n)
+	}
+	if sum, n := legSum(total.UnverifiedLegs); n > 0 {
+		fmt.Fprintf(w, " + %s %.2f unverified across %d leg(s)", total.Currency, sum, n)
+	}
+	if total.MixedCurrency {
+		fmt.Fprintf(w, " (mixed currencies: %d leg(s) excluded)", len(total.ExcludedCurrencyLegs))
+	}
+	fmt.Fprintf(w, " · band %s [%.0f–%.0f]\n", total.Band, total.BandLow, total.BandHigh)
+}
+
+func itineraryToLegs(it multimodal.Itinerary) []d2d.Leg {
+	legs := make([]d2d.Leg, len(it.Legs))
+	for i, l := range it.Legs {
+		v := d2d.Confirmed
+		if l.Estimated {
+			v = d2d.Indicative
+		}
+		legs[i] = d2d.Leg{
+			Mode:         l.Mode,
+			From:         l.From,
+			To:           l.To,
+			Price:        l.Price,
+			Currency:     l.Currency,
+			Source:       l.Provider,
+			Verification: v,
+		}
+	}
+	return legs
+}
+
+func legSum(legs []d2d.Leg) (float64, int) {
+	var sum float64
+	for _, l := range legs {
+		sum += l.Price
+	}
+	return sum, len(legs)
+}

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -17,10 +17,13 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/hacks"
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/obslog"
 	"github.com/MikkoParkkola/trvl/internal/points"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/pricesignal"
 	"github.com/MikkoParkkola/trvl/internal/scoring"
 	"github.com/MikkoParkkola/trvl/internal/travelctx"
+	"github.com/MikkoParkkola/trvl/internal/watch"
 	"github.com/spf13/cobra"
 )
 
@@ -195,6 +198,20 @@ Examples:
 				return err
 			}
 
+			// MIK-6229: log this search into price history and compute a
+			// price-position signal. Best-effort and single-O/D only — a
+			// multi-airport search has no single route key, so we skip it
+			// rather than mis-key the corpus. Never breaks a search.
+			var pricePos *pricesignal.Position
+			if len(origins) == 1 && len(destinations) == 1 && result != nil && len(result.Flights) > 0 {
+				if store, serr := watch.DefaultStore(); serr == nil && store.Load() == nil {
+					_ = obslog.FlightSearch(store, origins[0], destinations[0], date, result)
+					key := watch.RouteKey("flight", origins[0], destinations[0], date)
+					p := pricesignal.Compute(store.RoutePrices(key), result.Flights[0].Price, 0)
+					pricePos = &p
+				}
+			}
+
 			// Cache best result for `trvl share --last`.
 			if result != nil && result.Success && len(result.Flights) > 0 {
 				f := result.Flights[0]
@@ -218,12 +235,19 @@ Examples:
 			}
 
 			if format == "json" {
+				if pricePos != nil {
+					return models.FormatJSON(os.Stdout, struct {
+						*models.FlightSearchResult
+						PricePosition *pricesignal.Position `json:"price_position,omitempty"`
+					}{result, pricePos})
+				}
 				return models.FormatJSON(os.Stdout, result)
 			}
 
 			if err := printFlightsTable(cmd.Context(), strings.Join(origins, ","), strings.Join(destinations, ","), targetCurrency, result, explain); err != nil {
 				return err
 			}
+			printPricePosition(os.Stdout, pricePos)
 
 			// Auto-trigger: run applicable hack detectors and print tips
 			// below the flight results.

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/baggage"
+	"github.com/MikkoParkkola/trvl/internal/counterfactual"
 	"github.com/MikkoParkkola/trvl/internal/deals"
 	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights"
@@ -248,6 +249,21 @@ Examples:
 				return err
 			}
 			printPricePosition(os.Stdout, pricePos)
+
+			// MIK-6234 Tier 0: surface call-free counterfactual savings derived
+			// from data already fetched (same-day spread + vs-history). No new
+			// provider calls are issued.
+			if len(result.Flights) > 0 {
+				now := time.Now()
+				var savings []counterfactual.Saving
+				if s := counterfactual.SameDayAlternative(result.Flights, 10, now); s != nil {
+					savings = append(savings, *s)
+				}
+				if s := counterfactual.VsHistory(pricePos, result.Flights[0].Currency, now); s != nil {
+					savings = append(savings, *s)
+				}
+				printSavings(os.Stdout, savings)
+			}
 
 			// Auto-trigger: run applicable hack detectors and print tips
 			// below the flight results.

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -208,7 +208,7 @@ Examples:
 				if store, serr := watch.DefaultStore(); serr == nil && store.Load() == nil {
 					_ = obslog.FlightSearch(store, origins[0], destinations[0], date, result)
 					key := watch.RouteKey("flight", origins[0], destinations[0], date)
-					p := pricesignal.Compute(store.RoutePrices(key), result.Flights[0].Price, 0)
+					p := pricesignal.Compute(store.RoutePrices(key, result.Flights[0].Currency), result.Flights[0].Price, 0)
 					pricePos = &p
 				}
 			}

--- a/cmd/trvl/multimodal_plan.go
+++ b/cmd/trvl/multimodal_plan.go
@@ -98,6 +98,7 @@ func printMultimodalPlan(plan *multimodal.Plan) {
 			}
 			fmt.Println(line)
 		}
+		printDoorToDoor(os.Stdout, it)
 		if it.HackSaving != nil {
 			fmt.Printf("     %s %s: save %s %.2f (%s)\n",
 				"💡", it.HackSaving.Title, it.Currency, it.HackSaving.Savings, it.HackSaving.Type)

--- a/cmd/trvl/nudges.go
+++ b/cmd/trvl/nudges.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/travelgraph"
+	"github.com/MikkoParkkola/trvl/internal/trips"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+	"github.com/spf13/cobra"
+)
+
+// nudgesCmd surfaces grounded proactive nudges from the personal travel graph
+// (MIK-6233). It reads only local state (~/.trvl) and emits nudges ONLY when a
+// real trigger fires (a watch crossing its target, or a confident historic
+// low). It never speculates.
+func nudgesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "nudges",
+		Short: "Show grounded proactive travel nudges from your local history",
+		Long: `Join your watches, price history, preferences, and trips into a personal
+travel graph and surface proactive nudges. Every nudge is grounded in a real
+record (a watch that crossed your target price, or a route at a confident
+historic low) and cites its source. No speculation: when nothing has triggered,
+nothing is shown.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			store, err := watch.DefaultStore()
+			if err != nil {
+				return fmt.Errorf("open watch store: %w", err)
+			}
+			if err := store.Load(); err != nil {
+				return fmt.Errorf("load watches: %w", err)
+			}
+			ws := store.List()
+
+			var history []watch.PricePoint
+			for _, w := range ws {
+				history = append(history, store.History(w.ID)...)
+			}
+
+			prefs, err := preferences.Load()
+			if err != nil {
+				prefs = preferences.Default()
+			}
+
+			var ts []trips.Trip
+			if tstore, terr := trips.DefaultStore(); terr == nil && tstore.Load() == nil {
+				ts = tstore.List()
+			}
+
+			g := travelgraph.Build(ws, history, prefs, ts)
+			nudges := travelgraph.Nudges(g)
+
+			if format == "json" {
+				return models.FormatJSON(os.Stdout, nudges)
+			}
+			if len(nudges) == 0 {
+				fmt.Println("No nudges — watches quiet and no historic lows detected.")
+				return nil
+			}
+			for _, n := range nudges {
+				fmt.Printf("[%s] %s\n  sources: %s\n", n.Kind, n.Message, strings.Join(n.Sources, ", "))
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/trvl/prices.go
+++ b/cmd/trvl/prices.go
@@ -76,9 +76,9 @@ func runPrices(cmd *cobra.Command, args []string) error {
 		if store, serr := watch.DefaultStore(); serr == nil && store.Load() == nil {
 			_ = obslog.HotelPrices(store, hotelID, checkin, result)
 			key := watch.RouteKey("hotel", hotelID, "", checkin)
-			cheapest := cheapestProviderPrice(result.Providers)
-			if cheapest > 0 {
-				p := pricesignal.Compute(store.RoutePrices(key), cheapest, 0)
+			cheapest := cheapestProvider(result.Providers)
+			if cheapest.Price > 0 {
+				p := pricesignal.Compute(store.RoutePrices(key, cheapest.Currency), cheapest.Price, 0)
 				pricePos = &p
 			}
 		}
@@ -155,11 +155,6 @@ func cheapestProvider(providers []models.ProviderPrice) models.ProviderPrice {
 		}
 	}
 	return best
-}
-
-// cheapestProviderPrice returns the lowest positive provider price, or 0.
-func cheapestProviderPrice(providers []models.ProviderPrice) float64 {
-	return cheapestProvider(providers).Price
 }
 
 func formatPricesTable(result *models.HotelPriceResult) error {

--- a/cmd/trvl/prices.go
+++ b/cmd/trvl/prices.go
@@ -10,6 +10,9 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/hotelarb"
 	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/obslog"
+	"github.com/MikkoParkkola/trvl/internal/pricesignal"
+	"github.com/MikkoParkkola/trvl/internal/watch"
 	"github.com/spf13/cobra"
 )
 
@@ -65,11 +68,47 @@ func runPrices(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("hotel prices: %w", err)
 	}
 
+	// MIK-6229: log the cheapest provider price into history and compute a
+	// price-position signal for this hotel + check-in. Best-effort.
+	var pricePos *pricesignal.Position
+	if result != nil && len(result.Providers) > 0 {
+		if store, serr := watch.DefaultStore(); serr == nil && store.Load() == nil {
+			_ = obslog.HotelPrices(store, hotelID, checkin, result)
+			key := watch.RouteKey("hotel", hotelID, "", checkin)
+			cheapest := cheapestProviderPrice(result.Providers)
+			if cheapest > 0 {
+				p := pricesignal.Compute(store.RoutePrices(key), cheapest, 0)
+				pricePos = &p
+			}
+		}
+	}
+
 	if format == "json" {
+		if pricePos != nil {
+			return models.FormatJSON(os.Stdout, struct {
+				*models.HotelPriceResult
+				PricePosition *pricesignal.Position `json:"price_position,omitempty"`
+			}{result, pricePos})
+		}
 		return models.FormatJSON(os.Stdout, result)
 	}
 
-	return formatPricesTable(result)
+	if err := formatPricesTable(result); err != nil {
+		return err
+	}
+	printPricePosition(os.Stdout, pricePos)
+	return nil
+}
+
+// cheapestProviderPrice returns the lowest positive provider price, or 0.
+func cheapestProviderPrice(providers []models.ProviderPrice) float64 {
+	var best float64
+	for _, p := range providers {
+		if p.Price > 0 && (best == 0 || p.Price < best) {
+			best = p.Price
+		}
+	}
+	return best
 }
 
 func formatPricesTable(result *models.HotelPriceResult) error {

--- a/cmd/trvl/prices.go
+++ b/cmd/trvl/prices.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/booking"
 	"github.com/MikkoParkkola/trvl/internal/hotelarb"
 	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/models"
@@ -83,12 +84,28 @@ func runPrices(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// MIK-6232: compose a booking-readiness verdict from the signals this
+	// endpoint actually has. Refundability is not known here (prices lacks it),
+	// which conservatively keeps the verdict below "ready" by design.
+	var readiness *booking.Verdict
+	if result != nil && len(result.Providers) > 0 {
+		v := bookingReadinessForPrices(hotelID, result.Providers)
+		readiness = &v
+	}
+
 	if format == "json" {
-		if pricePos != nil {
-			return models.FormatJSON(os.Stdout, struct {
+		if pricePos != nil || readiness != nil {
+			out := struct {
 				*models.HotelPriceResult
-				PricePosition *pricesignal.Position `json:"price_position,omitempty"`
-			}{result, pricePos})
+				PricePosition    *pricesignal.Position `json:"price_position,omitempty"`
+				BookingReadiness string                `json:"booking_readiness,omitempty"`
+				ReadinessReasons []string              `json:"booking_readiness_reasons,omitempty"`
+			}{HotelPriceResult: result, PricePosition: pricePos}
+			if readiness != nil {
+				out.BookingReadiness = string(readiness.Readiness)
+				out.ReadinessReasons = readiness.Reasons
+			}
+			return models.FormatJSON(os.Stdout, out)
 		}
 		return models.FormatJSON(os.Stdout, result)
 	}
@@ -97,18 +114,52 @@ func runPrices(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	printPricePosition(os.Stdout, pricePos)
+	if readiness != nil {
+		fmt.Printf("\nBooking readiness: %s — %s\n", readiness.Label(), readiness.Summary())
+	}
 	return nil
+}
+
+// bookingReadinessForPrices maps the signals available on the prices endpoint
+// into a readiness verdict. A nil Signal means "not known", which the contract
+// treats conservatively. LinkStable and Verified come from the cheapest
+// provider; identity is confirmed because the caller supplied a place ID;
+// refundability is left nil here.
+func bookingReadinessForPrices(hotelID string, providers []models.ProviderPrice) booking.Verdict {
+	cheapest := cheapestProvider(providers)
+	var in booking.Input // all signals default to nil = not known
+	if hotelID != "" {
+		in.IdentityConfirmed = booking.True()
+	}
+	switch cheapest.LinkDurability {
+	case "stable":
+		in.LinkStable = booking.True()
+	case "expiring":
+		in.LinkStable = booking.False()
+	}
+	switch cheapest.PriceConfidence {
+	case models.PriceConfidenceVerified, models.PriceConfidenceRoomLevel:
+		in.Verified = booking.True()
+	case models.PriceConfidenceUnverified:
+		in.Verified = booking.False()
+	}
+	return booking.Evaluate(in)
+}
+
+// cheapestProvider returns the lowest positive-priced provider, or a zero value.
+func cheapestProvider(providers []models.ProviderPrice) models.ProviderPrice {
+	var best models.ProviderPrice
+	for _, p := range providers {
+		if p.Price > 0 && (best.Price == 0 || p.Price < best.Price) {
+			best = p
+		}
+	}
+	return best
 }
 
 // cheapestProviderPrice returns the lowest positive provider price, or 0.
 func cheapestProviderPrice(providers []models.ProviderPrice) float64 {
-	var best float64
-	for _, p := range providers {
-		if p.Price > 0 && (best == 0 || p.Price < best) {
-			best = p.Price
-		}
-	}
-	return best
+	return cheapestProvider(providers).Price
 }
 
 func formatPricesTable(result *models.HotelPriceResult) error {

--- a/cmd/trvl/pricesignal_render.go
+++ b/cmd/trvl/pricesignal_render.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/MikkoParkkola/trvl/internal/pricesignal"
+)
+
+// printPricePosition renders the MIK-6229 price-position summary line.
+//
+// Honesty contract (TRVL.PH.3): below the confidence floor it states that there
+// is not enough history and asserts NO trend or verdict. It never fabricates a
+// buy/wait recommendation from sparse data.
+func printPricePosition(w io.Writer, pos *pricesignal.Position) {
+	if pos == nil {
+		return
+	}
+	if !pos.Confident {
+		fmt.Fprintf(w, "\nPrice position: not enough history yet (%d observation(s)) — current price shown, no trend.\n", pos.Observations)
+		return
+	}
+	fmt.Fprintf(w, "\nPrice position: %s — %s of this route (low %.0f / median %.0f / high %.0f over %d obs, %s vs median).\n",
+		verdictText(pos.Verdict),
+		bandText(pos.Band),
+		pos.Low, pos.Median, pos.High, pos.Observations,
+		signedPct(pos.VsMedianPct),
+	)
+}
+
+func verdictText(v pricesignal.Verdict) string {
+	switch v {
+	case pricesignal.VerdictBuy:
+		return "BUY now"
+	case pricesignal.VerdictWait:
+		return "WAIT — historically high"
+	case pricesignal.VerdictNeutral:
+		return "typical price"
+	default:
+		return "no verdict"
+	}
+}
+
+func bandText(b pricesignal.Band) string {
+	switch b {
+	case pricesignal.BandLow:
+		return "in the cheap third"
+	case pricesignal.BandHigh:
+		return "in the expensive third"
+	case pricesignal.BandTypical:
+		return "in the middle third"
+	default:
+		return "position unknown"
+	}
+}
+
+func signedPct(p float64) string {
+	if p >= 0 {
+		return fmt.Sprintf("+%.0f%%", p)
+	}
+	return fmt.Sprintf("%.0f%%", p)
+}

--- a/cmd/trvl/pricesignal_render_test.go
+++ b/cmd/trvl/pricesignal_render_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/pricesignal"
+)
+
+func TestPrintPricePosition_NotConfident(t *testing.T) {
+	var b bytes.Buffer
+	printPricePosition(&b, &pricesignal.Position{Observations: 3, Confident: false, Band: pricesignal.BandUnknown})
+	out := b.String()
+	if !strings.Contains(out, "not enough history") {
+		t.Fatalf("sparse data must say 'not enough history', got %q", out)
+	}
+	// Must NOT assert a trend/verdict.
+	for _, banned := range []string{"BUY", "WAIT", "cheap third", "expensive third"} {
+		if strings.Contains(out, banned) {
+			t.Fatalf("sparse output must not assert %q: %q", banned, out)
+		}
+	}
+}
+
+func TestPrintPricePosition_Confident(t *testing.T) {
+	var b bytes.Buffer
+	printPricePosition(&b, &pricesignal.Position{
+		Confident: true, Band: pricesignal.BandLow, Verdict: pricesignal.VerdictBuy,
+		Low: 100, Median: 150, High: 200, Observations: 12, VsMedianPct: -20,
+	})
+	out := b.String()
+	if !strings.Contains(out, "BUY now") || !strings.Contains(out, "cheap third") {
+		t.Fatalf("confident buy must show verdict+band, got %q", out)
+	}
+	if !strings.Contains(out, "-20%") {
+		t.Fatalf("want vs-median pct, got %q", out)
+	}
+}
+
+func TestPrintPricePosition_Nil(t *testing.T) {
+	var b bytes.Buffer
+	printPricePosition(&b, nil)
+	if b.Len() != 0 {
+		t.Fatalf("nil position must print nothing, got %q", b.String())
+	}
+}

--- a/cmd/trvl/root.go
+++ b/cmd/trvl/root.go
@@ -113,6 +113,7 @@ func init() {
 	rootCmd.AddCommand(rateStatusCmd())
 	rootCmd.AddCommand(multimodalPlanCmd())
 	rootCmd.AddCommand(planAllCmd())
+	rootCmd.AddCommand(nudgesCmd())
 }
 
 // airportCompletion provides IATA code completion for cobra commands.

--- a/internal/booking/readiness.go
+++ b/internal/booking/readiness.go
@@ -1,0 +1,175 @@
+// Package booking provides a pure, network-free booking-readiness contract that
+// composes existing trust signals (price verification, link durability, identity
+// confirmation, and refundability) into a single verdict for CLI and MCP
+// consumers.
+//
+// Verdict lattice (all inputs are tri-state: true / false / unknown)
+//
+//	All four signals explicitly true              → Ready
+//	Any signal unknown, none false               → Caution
+//	Any signal false (regardless of unknowns)    → Caution
+//	All signals unknown (no information at all)  → Unverified
+//
+// The defining invariant: unknown is never treated as true. An absence of
+// evidence is never elevated to a positive assertion. The only path to Ready
+// is four explicit "yes" values.
+package booking
+
+import "strings"
+
+// Readiness is the coarse booking-readiness verdict.
+type Readiness string
+
+const (
+	// Ready means all four signals are explicitly confirmed true. The offer is
+	// verified, the link is durable, the property identity is confirmed, and
+	// the refundability status is known. Safe to surface as a primary CTA.
+	Ready Readiness = "ready"
+
+	// Caution means at least one signal is false or unknown. The offer may be
+	// bookable but the consumer should verify before committing.
+	Caution Readiness = "caution"
+
+	// Unverified means every signal is unknown — trvl has no evidence to judge
+	// any dimension of the offer. Shown only when signals are entirely absent.
+	Unverified Readiness = "unverified"
+)
+
+// Signal is a tri-state boolean: explicitly true, explicitly false, or unknown
+// (nil). Unknown is structurally distinct from false; callers must set a
+// non-nil value to make a positive or negative assertion.
+type Signal = *bool
+
+// True, False, and Unknown are convenience constructors for Signal values.
+// They eliminate the &localVar dance at every call site.
+func True() Signal  { b := true; return &b }
+func False() Signal { b := false; return &b }
+
+// Unknown returns nil, which is the zero value for Signal. It is provided for
+// documentary clarity when building an Input struct.
+func Unknown() Signal { return nil }
+
+// Input holds the four independent trust signals that feed the verdict.
+// Each field is a Signal (*bool): nil means the information is not available.
+type Input struct {
+	// Verified is true when the quoted price/offer has been independently
+	// confirmed (e.g. Confidence.Label == "high" with Rated == true). False
+	// when the price is known to be stale or unverifiable. Nil when trvl
+	// returned an unrated Confidence.
+	Verified Signal
+
+	// LinkStable is true when the booking deep-link is a direct OTA or property
+	// URL (LinkDurability == "stable"). False when it is an expiring ad-click
+	// redirect (LinkDurability == "expiring"). Nil when no link is present or
+	// durability was not assessed.
+	LinkStable Signal
+
+	// IdentityConfirmed is true when the property or fare identity has been
+	// positively matched (e.g. MatchConfidence == "high", or name-matched with
+	// a canonical Google hotel ID). False when only a fuzzy name match was
+	// possible. Nil when no identity signal is available.
+	IdentityConfirmed Signal
+
+	// RefundabilityKnown is true when the refund policy is known (regardless of
+	// whether the offer is actually refundable). False should not normally be
+	// used here — "not refundable" is still "known"; reserve false for the case
+	// where the data was available but actively contradicted. Nil when the
+	// provider did not surface any cancellation/refundability information.
+	RefundabilityKnown Signal
+}
+
+// Verdict is the output of Evaluate: a coarse Readiness level and a slice of
+// human-readable reasons explaining any downgrade.
+type Verdict struct {
+	Readiness Readiness
+	// Reasons lists the signals that caused a downgrade, e.g.
+	// ["refundability unknown → downgraded to caution"].
+	// Empty when Readiness is Ready.
+	Reasons []string
+}
+
+// named bundles a signal with its display name for uniform reason generation.
+type named struct {
+	label  string
+	signal Signal
+}
+
+// Evaluate composes the four signals into a Verdict according to the lattice
+// documented in the package comment. It is pure and allocation-minimal: only
+// the Reasons slice allocates, and only when a downgrade occurs.
+//
+// Contract:
+//   - All signals true          → Ready, no reasons.
+//   - Any signal false          → Caution, reason per false signal.
+//   - Any signal unknown        → Caution (unless all unknown → Unverified), reason per unknown signal.
+//   - All signals unknown       → Unverified, reasons for each.
+func Evaluate(in Input) Verdict {
+	signals := [4]named{
+		{"verified", in.Verified},
+		{"link_stable", in.LinkStable},
+		{"identity_confirmed", in.IdentityConfirmed},
+		{"refundability_known", in.RefundabilityKnown},
+	}
+
+	var reasons []string
+	allUnknown := true
+	anyFalseOrUnknown := false
+
+	for _, s := range signals {
+		switch {
+		case s.signal == nil:
+			reasons = append(reasons, s.label+" unknown → downgraded")
+			anyFalseOrUnknown = true
+			// allUnknown stays true
+		case !*s.signal:
+			reasons = append(reasons, s.label+" false → downgraded")
+			anyFalseOrUnknown = true
+			allUnknown = false
+		default:
+			// explicitly true
+			allUnknown = false
+		}
+	}
+
+	if !anyFalseOrUnknown {
+		return Verdict{Readiness: Ready}
+	}
+	if allUnknown {
+		return Verdict{Readiness: Unverified, Reasons: reasons}
+	}
+	return Verdict{Readiness: Caution, Reasons: reasons}
+}
+
+// Label returns a short display string for embedding in CLI table cells or
+// JSON fields, e.g. "ready", "caution (3)", "unverified".
+func (v Verdict) Label() string {
+	if len(v.Reasons) == 0 {
+		return string(v.Readiness)
+	}
+	return string(v.Readiness) + " (" + itoa(len(v.Reasons)) + ")"
+}
+
+// Summary joins all downgrade reasons into a single human-readable sentence
+// suitable for a CLI footer or MCP annotation.
+func (v Verdict) Summary() string {
+	if len(v.Reasons) == 0 {
+		return "all signals confirmed"
+	}
+	return strings.Join(v.Reasons, "; ")
+}
+
+// itoa converts a small non-negative integer to its decimal string without
+// importing strconv (keeps the package dependency-free for trivial counts).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	buf := [20]byte{}
+	pos := len(buf)
+	for n > 0 {
+		pos--
+		buf[pos] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[pos:])
+}

--- a/internal/booking/readiness_test.go
+++ b/internal/booking/readiness_test.go
@@ -1,0 +1,256 @@
+package booking_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/booking"
+)
+
+// allTrue is the canonical all-confirmed input; reused across subtests.
+var allTrue = booking.Input{
+	Verified:           booking.True(),
+	LinkStable:         booking.True(),
+	IdentityConfirmed:  booking.True(),
+	RefundabilityKnown: booking.True(),
+}
+
+func TestEvaluate_AllTrue_ReturnsReady(t *testing.T) {
+	// GIVEN all four signals explicitly true
+	// WHEN  Evaluate is called
+	// THEN  verdict is Ready with no reasons
+	v := booking.Evaluate(allTrue)
+
+	if v.Readiness != booking.Ready {
+		t.Errorf("readiness = %q, want %q", v.Readiness, booking.Ready)
+	}
+	if len(v.Reasons) != 0 {
+		t.Errorf("reasons = %v, want none", v.Reasons)
+	}
+}
+
+// unknownCases enumerates the four single-field-unknown scenarios (core AC).
+var unknownCases = []struct {
+	name  string
+	input booking.Input
+	field string // label expected in Reasons
+}{
+	{
+		name: "verified_unknown",
+		input: booking.Input{
+			Verified:           booking.Unknown(),
+			LinkStable:         booking.True(),
+			IdentityConfirmed:  booking.True(),
+			RefundabilityKnown: booking.True(),
+		},
+		field: "verified",
+	},
+	{
+		name: "link_stable_unknown",
+		input: booking.Input{
+			Verified:           booking.True(),
+			LinkStable:         booking.Unknown(),
+			IdentityConfirmed:  booking.True(),
+			RefundabilityKnown: booking.True(),
+		},
+		field: "link_stable",
+	},
+	{
+		name: "identity_confirmed_unknown",
+		input: booking.Input{
+			Verified:           booking.True(),
+			LinkStable:         booking.True(),
+			IdentityConfirmed:  booking.Unknown(),
+			RefundabilityKnown: booking.True(),
+		},
+		field: "identity_confirmed",
+	},
+	{
+		name: "refundability_known_unknown",
+		input: booking.Input{
+			Verified:           booking.True(),
+			LinkStable:         booking.True(),
+			IdentityConfirmed:  booking.True(),
+			RefundabilityKnown: booking.Unknown(),
+		},
+		field: "refundability_known",
+	},
+}
+
+// TestEvaluate_SingleUnknown_NotReady is the load-bearing AC: any unknown
+// field must prevent Ready.
+func TestEvaluate_SingleUnknown_NotReady(t *testing.T) {
+	for _, tc := range unknownCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// GIVEN one field unknown, the rest true
+			// WHEN  Evaluate is called
+			// THEN  readiness is NOT ready, and reasons mention the field
+			v := booking.Evaluate(tc.input)
+
+			if v.Readiness == booking.Ready {
+				t.Errorf("readiness = Ready, want Caution or Unverified (unknown must block Ready)")
+			}
+			if len(v.Reasons) == 0 {
+				t.Error("reasons is empty, want at least one downgrade reason")
+			}
+			if !reasonsMention(v.Reasons, tc.field) {
+				t.Errorf("reasons %v do not mention field %q", v.Reasons, tc.field)
+			}
+		})
+	}
+}
+
+// falseCases enumerates the four single-field-false scenarios.
+var falseCases = []struct {
+	name  string
+	input booking.Input
+	field string
+}{
+	{
+		name: "verified_false",
+		input: booking.Input{
+			Verified:           booking.False(),
+			LinkStable:         booking.True(),
+			IdentityConfirmed:  booking.True(),
+			RefundabilityKnown: booking.True(),
+		},
+		field: "verified",
+	},
+	{
+		name: "link_stable_false",
+		input: booking.Input{
+			Verified:           booking.True(),
+			LinkStable:         booking.False(),
+			IdentityConfirmed:  booking.True(),
+			RefundabilityKnown: booking.True(),
+		},
+		field: "link_stable",
+	},
+	{
+		name: "identity_confirmed_false",
+		input: booking.Input{
+			Verified:           booking.True(),
+			LinkStable:         booking.True(),
+			IdentityConfirmed:  booking.False(),
+			RefundabilityKnown: booking.True(),
+		},
+		field: "identity_confirmed",
+	},
+	{
+		name: "refundability_known_false",
+		input: booking.Input{
+			Verified:           booking.True(),
+			LinkStable:         booking.True(),
+			IdentityConfirmed:  booking.True(),
+			RefundabilityKnown: booking.False(),
+		},
+		field: "refundability_known",
+	},
+}
+
+// TestEvaluate_SingleFalse_NotReady verifies false signals prevent Ready.
+func TestEvaluate_SingleFalse_NotReady(t *testing.T) {
+	for _, tc := range falseCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// GIVEN one field false, the rest true
+			// WHEN  Evaluate is called
+			// THEN  readiness is Caution, and reasons name the field
+			v := booking.Evaluate(tc.input)
+
+			if v.Readiness != booking.Caution {
+				t.Errorf("readiness = %q, want %q", v.Readiness, booking.Caution)
+			}
+			if !reasonsMention(v.Reasons, tc.field) {
+				t.Errorf("reasons %v do not mention field %q", v.Reasons, tc.field)
+			}
+		})
+	}
+}
+
+func TestEvaluate_AllUnknown_ReturnsUnverified(t *testing.T) {
+	// GIVEN all signals unknown (zero-value Input)
+	// WHEN  Evaluate is called
+	// THEN  verdict is Unverified
+	v := booking.Evaluate(booking.Input{})
+
+	if v.Readiness != booking.Unverified {
+		t.Errorf("readiness = %q, want %q", v.Readiness, booking.Unverified)
+	}
+	if len(v.Reasons) != 4 {
+		t.Errorf("want 4 downgrade reasons (one per unknown field), got %d: %v", len(v.Reasons), v.Reasons)
+	}
+}
+
+func TestEvaluate_MixedFalseAndUnknown_ReturnsCaution(t *testing.T) {
+	// GIVEN one field false and one unknown (rest true)
+	// WHEN  Evaluate is called
+	// THEN  verdict is Caution (false takes precedence over all-unknown path)
+	v := booking.Evaluate(booking.Input{
+		Verified:           booking.False(),
+		LinkStable:         booking.Unknown(),
+		IdentityConfirmed:  booking.True(),
+		RefundabilityKnown: booking.True(),
+	})
+
+	if v.Readiness != booking.Caution {
+		t.Errorf("readiness = %q, want %q", v.Readiness, booking.Caution)
+	}
+	if len(v.Reasons) != 2 {
+		t.Errorf("want 2 reasons (1 false + 1 unknown), got %d: %v", len(v.Reasons), v.Reasons)
+	}
+}
+
+func TestVerdict_Label(t *testing.T) {
+	tests := []struct {
+		name  string
+		input booking.Input
+		want  string
+	}{
+		{"ready", allTrue, "ready"},
+		{"caution_one_false", booking.Input{
+			Verified:           booking.False(),
+			LinkStable:         booking.True(),
+			IdentityConfirmed:  booking.True(),
+			RefundabilityKnown: booking.True(),
+		}, "caution (1)"},
+		{"unverified", booking.Input{}, "unverified (4)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := booking.Evaluate(tc.input).Label()
+			if got != tc.want {
+				t.Errorf("Label() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVerdict_Summary_ReadyHasNoReasons(t *testing.T) {
+	v := booking.Evaluate(allTrue)
+	if v.Summary() != "all signals confirmed" {
+		t.Errorf("Summary() = %q, want %q", v.Summary(), "all signals confirmed")
+	}
+}
+
+func TestVerdict_Summary_ContainsReasons(t *testing.T) {
+	v := booking.Evaluate(booking.Input{
+		Verified:           booking.Unknown(),
+		LinkStable:         booking.True(),
+		IdentityConfirmed:  booking.True(),
+		RefundabilityKnown: booking.True(),
+	})
+	if !strings.Contains(v.Summary(), "verified") {
+		t.Errorf("Summary() = %q, want it to mention 'verified'", v.Summary())
+	}
+}
+
+// reasonsMention checks whether any element in reasons contains field as a
+// substring, covering both "field unknown → …" and "field false → …" forms.
+func reasonsMention(reasons []string, field string) bool {
+	for _, r := range reasons {
+		if strings.Contains(r, field) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/counterfactual/counterfactual.go
+++ b/internal/counterfactual/counterfactual.go
@@ -1,0 +1,159 @@
+// Package counterfactual computes "you could save X by ..." savings from data
+// trvl has ALREADY fetched — never by issuing fresh provider searches (MIK-6234
+// Tier 0). Every function here is pure: it takes already-fetched grids,
+// itinerary lists, or persisted history and returns deltas. The structural
+// guarantee is that a Tier-0 counterfactual costs ZERO marginal provider calls,
+// because nothing in this package can reach the network.
+//
+// Tiers 1 (scheduler-amortized speculative probe) and 2 (interactive cold-route
+// fan-out) live behind the probebudget two-lane firewall and are intentionally
+// out of scope here.
+package counterfactual
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/pricesignal"
+)
+
+// Kind identifies the counterfactual lever.
+type Kind string
+
+const (
+	// KindShiftDay: a different departure date in an already-fetched grid is cheaper.
+	KindShiftDay Kind = "shift_day"
+	// KindSameDay: a cheaper itinerary on the SAME date (carrier/time) than the headline.
+	KindSameDay Kind = "same_day_alternative"
+	// KindVsHistory: the current price relative to this route's own history.
+	KindVsHistory Kind = "vs_history"
+)
+
+// Saving is one call-free counterfactual finding. Amount is the money saved
+// versus the reference price, in Currency. AsOf records when the underlying data
+// was observed, so a stale finding is never presented as live (TRVL.CF.5).
+type Saving struct {
+	Kind        Kind      `json:"kind"`
+	Description string    `json:"description"`
+	Amount      float64   `json:"amount"`
+	Currency    string    `json:"currency,omitempty"`
+	AsOf        time.Time `json:"as_of"`
+	// CallFree is always true for Tier-0 findings: a guarantee, surfaced in the
+	// payload, that producing this saving issued no provider call.
+	CallFree bool `json:"call_free"`
+}
+
+// ShiftDay finds dates in an already-fetched price grid that beat the price on
+// currentDate by at least minDelta. grid is the output of a date search the user
+// already ran; asOf is when that grid was fetched. Results are the cheapest
+// alternatives first. Zero provider calls.
+func ShiftDay(grid []models.DatePriceResult, currentDate string, minDelta float64, asOf time.Time) []Saving {
+	var current float64
+	var currency string
+	for _, d := range grid {
+		if d.Date == currentDate {
+			current = d.Price
+			currency = d.Currency
+			break
+		}
+	}
+	if current <= 0 {
+		return nil
+	}
+	var out []Saving
+	for _, d := range grid {
+		if d.Date == currentDate || d.Price <= 0 {
+			continue
+		}
+		delta := current - d.Price
+		if delta < minDelta {
+			continue
+		}
+		cur := d.Currency
+		if cur == "" {
+			cur = currency
+		}
+		out = append(out, Saving{
+			Kind:        KindShiftDay,
+			Description: fmt.Sprintf("Depart %s instead of %s to save %.0f %s", d.Date, currentDate, delta, cur),
+			Amount:      delta,
+			Currency:    cur,
+			AsOf:        asOf,
+			CallFree:    true,
+		})
+	}
+	sortByAmountDesc(out)
+	return out
+}
+
+// SameDayAlternative finds itineraries in an already-returned flight list that
+// are cheaper than the headline (cheapest is the reference) by at least
+// minDelta. Because a single flight search already returns every same-day
+// carrier/time, this is pure spread analysis with zero new calls.
+//
+// In practice the cheapest is usually the headline, so this surfaces the case
+// where a non-headline option trades a small premium for a better time/carrier
+// the renderer wants to mention — here we report genuine savings vs the most
+// expensive shown option, framed honestly as the spread available on the day.
+func SameDayAlternative(flights []models.FlightResult, minDelta float64, asOf time.Time) *Saving {
+	if len(flights) < 2 {
+		return nil
+	}
+	var lo, hi float64
+	var currency string
+	for _, f := range flights {
+		if f.Price <= 0 {
+			continue
+		}
+		if lo == 0 || f.Price < lo {
+			lo = f.Price
+			currency = f.Currency
+		}
+		if f.Price > hi {
+			hi = f.Price
+		}
+	}
+	delta := hi - lo
+	if lo <= 0 || delta < minDelta {
+		return nil
+	}
+	return &Saving{
+		Kind:        KindSameDay,
+		Description: fmt.Sprintf("Same-day fares range %.0f–%.0f %s; the cheapest saves %.0f %s over the dearest shown", lo, hi, currency, delta, currency),
+		Amount:      delta,
+		Currency:    currency,
+		AsOf:        asOf,
+		CallFree:    true,
+	}
+}
+
+// VsHistory expresses a confident price-position as a counterfactual saving:
+// how far below this route's median the current price sits. Returns nil when the
+// position is not confident (honesty: no history-based claim under the floor) or
+// when the current price is at/above median.
+func VsHistory(pos *pricesignal.Position, currency string, asOf time.Time) *Saving {
+	if pos == nil || !pos.Confident || pos.Median <= 0 {
+		return nil
+	}
+	delta := pos.Median - pos.Current
+	if delta <= 0 {
+		return nil
+	}
+	return &Saving{
+		Kind:        KindVsHistory,
+		Description: fmt.Sprintf("Current price is %.0f %s below this route's typical (median %.0f over %d obs)", delta, currency, pos.Median, pos.Observations),
+		Amount:      delta,
+		Currency:    currency,
+		AsOf:        asOf,
+		CallFree:    true,
+	}
+}
+
+func sortByAmountDesc(s []Saving) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j].Amount > s[j-1].Amount; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}

--- a/internal/counterfactual/counterfactual.go
+++ b/internal/counterfactual/counterfactual.go
@@ -87,42 +87,38 @@ func ShiftDay(grid []models.DatePriceResult, currentDate string, minDelta float6
 	return out
 }
 
-// SameDayAlternative finds itineraries in an already-returned flight list that
-// are cheaper than the headline (cheapest is the reference) by at least
-// minDelta. Because a single flight search already returns every same-day
-// carrier/time, this is pure spread analysis with zero new calls.
+// SameDayAlternative finds a genuine, actionable saving within an
+// already-returned flight list: when the headline result (flights[0], i.e. what
+// the current sort puts first — by duration, departure time, etc.) is pricier
+// than the cheapest same-day fare, choosing the cheapest captures a real saving.
 //
-// In practice the cheapest is usually the headline, so this surfaces the case
-// where a non-headline option trades a small premium for a better time/carrier
-// the renderer wants to mention — here we report genuine savings vs the most
-// expensive shown option, framed honestly as the spread available on the day.
+// This is honest by construction: when the list is already sorted cheapest-first
+// the headline IS the cheapest, the delta is zero, and nil is returned — no
+// illusory "saving" is fabricated. Zero new provider calls (pure spread of data
+// the search already returned).
 func SameDayAlternative(flights []models.FlightResult, minDelta float64, asOf time.Time) *Saving {
 	if len(flights) < 2 {
 		return nil
 	}
-	var lo, hi float64
-	var currency string
-	for _, f := range flights {
-		if f.Price <= 0 {
-			continue
-		}
-		if lo == 0 || f.Price < lo {
-			lo = f.Price
-			currency = f.Currency
-		}
-		if f.Price > hi {
-			hi = f.Price
+	headline := flights[0]
+	if headline.Price <= 0 {
+		return nil
+	}
+	cheapest := headline
+	for _, f := range flights[1:] {
+		if f.Price > 0 && f.Price < cheapest.Price {
+			cheapest = f
 		}
 	}
-	delta := hi - lo
-	if lo <= 0 || delta < minDelta {
-		return nil
+	delta := headline.Price - cheapest.Price
+	if delta < minDelta {
+		return nil // headline already is (within minDelta of) the cheapest
 	}
 	return &Saving{
 		Kind:        KindSameDay,
-		Description: fmt.Sprintf("Same-day fares range %.0f–%.0f %s; the cheapest saves %.0f %s over the dearest shown", lo, hi, currency, delta, currency),
+		Description: fmt.Sprintf("The cheapest same-day fare (%.0f %s) saves %.0f %s over the top-listed result (%.0f %s)", cheapest.Price, cheapest.Currency, delta, headline.Currency, headline.Price, headline.Currency),
 		Amount:      delta,
-		Currency:    currency,
+		Currency:    cheapest.Currency,
 		AsOf:        asOf,
 		CallFree:    true,
 	}

--- a/internal/counterfactual/counterfactual_test.go
+++ b/internal/counterfactual/counterfactual_test.go
@@ -1,0 +1,81 @@
+package counterfactual
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/pricesignal"
+)
+
+var asOf = time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+
+// TRVL.CF.1: shift-day deltas computed purely from an already-fetched grid,
+// zero provider calls (the function cannot reach the network).
+func TestShiftDayFromGrid(t *testing.T) {
+	grid := []models.DatePriceResult{
+		{Date: "2026-07-14", Price: 90, Currency: "EUR"},
+		{Date: "2026-07-15", Price: 150, Currency: "EUR"}, // current
+		{Date: "2026-07-16", Price: 140, Currency: "EUR"},
+		{Date: "2026-07-17", Price: 200, Currency: "EUR"},
+	}
+	out := ShiftDay(grid, "2026-07-15", 5, asOf)
+	if len(out) != 2 {
+		t.Fatalf("want 2 cheaper dates, got %d (%+v)", len(out), out)
+	}
+	// Sorted by biggest saving first: 14th (-60) before 16th (-10).
+	if out[0].Amount != 60 || out[0].Kind != KindShiftDay {
+		t.Fatalf("first saving should be 60 shift_day, got %+v", out[0])
+	}
+	if !out[0].CallFree {
+		t.Fatalf("Tier-0 saving must be marked call-free")
+	}
+	if !out[0].AsOf.Equal(asOf) {
+		t.Fatalf("as-of must be carried for staleness")
+	}
+}
+
+func TestShiftDayNoCurrentDate(t *testing.T) {
+	grid := []models.DatePriceResult{{Date: "2026-07-14", Price: 90, Currency: "EUR"}}
+	if out := ShiftDay(grid, "2026-07-15", 5, asOf); out != nil {
+		t.Fatalf("missing current date must yield nil, got %+v", out)
+	}
+}
+
+func TestSameDayAlternative(t *testing.T) {
+	flights := []models.FlightResult{
+		{Price: 150, Currency: "EUR"},
+		{Price: 220, Currency: "EUR"},
+		{Price: 180, Currency: "EUR"},
+	}
+	s := SameDayAlternative(flights, 10, asOf)
+	if s == nil || s.Amount != 70 {
+		t.Fatalf("want spread saving 70, got %+v", s)
+	}
+	// Single flight or tiny spread -> nil.
+	if SameDayAlternative(flights[:1], 10, asOf) != nil {
+		t.Fatalf("single flight must yield nil")
+	}
+	if SameDayAlternative([]models.FlightResult{{Price: 150}, {Price: 155}}, 10, asOf) != nil {
+		t.Fatalf("spread below minDelta must yield nil")
+	}
+}
+
+func TestVsHistoryHonesty(t *testing.T) {
+	// Not confident -> no claim.
+	if VsHistory(&pricesignal.Position{Confident: false, Median: 200, Current: 150}, "EUR", asOf) != nil {
+		t.Fatalf("non-confident position must not produce a history claim")
+	}
+	// Confident and below median -> saving.
+	s := VsHistory(&pricesignal.Position{Confident: true, Median: 200, Current: 150, Observations: 12}, "EUR", asOf)
+	if s == nil || s.Amount != 50 || s.Kind != KindVsHistory {
+		t.Fatalf("want 50 vs_history saving, got %+v", s)
+	}
+	// Confident but at/above median -> nil (no fake saving).
+	if VsHistory(&pricesignal.Position{Confident: true, Median: 200, Current: 220}, "EUR", asOf) != nil {
+		t.Fatalf("price above median must not produce a saving")
+	}
+	if VsHistory(nil, "EUR", asOf) != nil {
+		t.Fatalf("nil position must yield nil")
+	}
+}

--- a/internal/counterfactual/counterfactual_test.go
+++ b/internal/counterfactual/counterfactual_test.go
@@ -43,21 +43,34 @@ func TestShiftDayNoCurrentDate(t *testing.T) {
 }
 
 func TestSameDayAlternative(t *testing.T) {
+	// Headline (first) is pricier than a later, cheaper fare -> real saving.
+	// Mimics a duration/time-sorted list where the fastest is not the cheapest.
 	flights := []models.FlightResult{
-		{Price: 150, Currency: "EUR"},
-		{Price: 220, Currency: "EUR"},
+		{Price: 220, Currency: "EUR"}, // headline (e.g. fastest)
+		{Price: 150, Currency: "EUR"}, // cheapest
 		{Price: 180, Currency: "EUR"},
 	}
 	s := SameDayAlternative(flights, 10, asOf)
 	if s == nil || s.Amount != 70 {
-		t.Fatalf("want spread saving 70, got %+v", s)
+		t.Fatalf("want headline-vs-cheapest saving 70, got %+v", s)
 	}
-	// Single flight or tiny spread -> nil.
+
+	// Already cheapest-first -> headline IS cheapest -> no illusory saving.
+	sorted := []models.FlightResult{
+		{Price: 150, Currency: "EUR"},
+		{Price: 180, Currency: "EUR"},
+		{Price: 220, Currency: "EUR"},
+	}
+	if SameDayAlternative(sorted, 10, asOf) != nil {
+		t.Fatalf("cheapest-first list must yield no saving (honesty)")
+	}
+
+	// Single flight or sub-minDelta -> nil.
 	if SameDayAlternative(flights[:1], 10, asOf) != nil {
 		t.Fatalf("single flight must yield nil")
 	}
-	if SameDayAlternative([]models.FlightResult{{Price: 150}, {Price: 155}}, 10, asOf) != nil {
-		t.Fatalf("spread below minDelta must yield nil")
+	if SameDayAlternative([]models.FlightResult{{Price: 155}, {Price: 150}}, 10, asOf) != nil {
+		t.Fatalf("delta below minDelta must yield nil")
 	}
 }
 

--- a/internal/d2d/d2d.go
+++ b/internal/d2d/d2d.go
@@ -1,0 +1,318 @@
+// Package d2d computes honest door-to-door (end-to-end) totals for multimodal
+// journeys with per-leg verification status and a confidence band.
+//
+// Honesty contract:
+//   - Indicative legs (e.g. sourced from rome2rio) are NEVER folded into the
+//     confirmed total. They are surfaced separately so the caller can render an
+//     honest "at least X confirmed + ~Y indicative" rather than a false-precise
+//     sum.
+//   - Unverified legs (no source information) are excluded from ConfirmedTotal
+//     and reported in their own bucket.
+//   - Mixed currencies are flagged: if legs disagree on currency the total is not
+//     silently summed. MixedCurrency is set and ConfirmedTotal reflects only the
+//     legs in the headline currency.
+//   - The confidence band widens whenever any non-confirmed leg exists. A single
+//     figure is only produced for all-confirmed, single-currency trips.
+//
+// This package is pure (no network I/O, no new dependencies beyond stdlib).
+package d2d
+
+import (
+	"strings"
+)
+
+// Verification classifies how trustworthy a leg's price is.
+//
+// The three levels map directly to trvl's provider semantics:
+//   - Confirmed: a live or recent bookable fare from a transactional provider.
+//   - Indicative: a range or estimate (e.g. Rome2Rio discovery prices). Never
+//     presented as a bookable fare; always surfaced separately.
+//   - Unverified: no source information is available; the price is unknown or
+//     caller-supplied without evidence.
+type Verification string
+
+const (
+	// Confirmed means the price comes from a transactional provider and is
+	// suitable for inclusion in a confirmed total.
+	Confirmed Verification = "confirmed"
+
+	// Indicative means the price is an estimate or range (e.g. Rome2Rio).
+	// It must not be summed into a confirmed total.
+	Indicative Verification = "indicative"
+
+	// Unverified means no source evidence backs the price.
+	Unverified Verification = "unverified"
+)
+
+// BandKind is a qualitative confidence band for the end-to-end total.
+type BandKind string
+
+const (
+	// BandExact: all legs confirmed in a single currency — the total is precise.
+	BandExact BandKind = "exact"
+
+	// BandNarrow: all legs confirmed but mixed currencies prevented full
+	// summation. The confirmed subtotal is still reliable.
+	BandNarrow BandKind = "narrow"
+
+	// BandWide: one or more legs are indicative. The true cost may differ
+	// materially from the confirmed subtotal.
+	BandWide BandKind = "wide"
+
+	// BandUnknown: one or more legs are unverified. The total is uncertain.
+	BandUnknown BandKind = "unknown"
+)
+
+// Leg is a single segment of a door-to-door journey.
+//
+// Callers that have already determined the verification status should set it
+// explicitly. When Verification is left empty, ResolveVerification maps the
+// Source to a default (e.g. "rome2rio" → Indicative).
+type Leg struct {
+	// Mode is the transport or accommodation type: "air", "train", "bus",
+	// "ferry", "hotel", "taxi", etc. Free-form; used for display only.
+	Mode string
+
+	// From and To are human-readable place names (city, airport, station).
+	From string
+	To   string
+
+	// Price is the fare or cost for this leg. Zero means unknown.
+	Price float64
+
+	// Currency is an ISO 4217 code (e.g. "EUR", "USD"). Must be non-empty
+	// for a leg to be summed into the confirmed total.
+	Currency string
+
+	// Source is the provider that returned this price (e.g. "google_flights",
+	// "rome2rio", "booking.com"). Used to derive Verification when the field
+	// is left empty.
+	Source string
+
+	// Verification is the caller-supplied trust level. When empty, the package
+	// derives it from Source via DefaultVerification.
+	Verification Verification
+}
+
+// effectiveVerification returns the leg's verification, falling back to the
+// source-derived default when the caller left the field empty.
+func (l Leg) effectiveVerification() Verification {
+	if l.Verification != "" {
+		return l.Verification
+	}
+	return DefaultVerification(l.Source)
+}
+
+// LegCount reports how many legs fall into each verification bucket.
+type LegCount struct {
+	Confirmed  int
+	Indicative int
+	Unverified int
+}
+
+// Total is the honest end-to-end result for a set of legs.
+type Total struct {
+	// ConfirmedTotal is the sum of all Confirmed legs in the headline currency.
+	// Legs in other currencies are excluded and appear in ExcludedCurrencyLegs.
+	ConfirmedTotal float64
+
+	// IndicativeLegs holds every leg whose Verification is Indicative. These
+	// are intentionally NOT summed into ConfirmedTotal.
+	IndicativeLegs []Leg
+
+	// UnverifiedLegs holds every leg whose Verification is Unverified.
+	UnverifiedLegs []Leg
+
+	// ExcludedCurrencyLegs holds Confirmed legs that could not be summed
+	// because they are in a different currency than the headline.
+	ExcludedCurrencyLegs []Leg
+
+	// Currency is the headline currency — the currency of the first confirmed
+	// leg with a valid price, or the most common currency among all legs.
+	Currency string
+
+	// MixedCurrency is true when legs carry more than one currency code,
+	// regardless of how many could be summed.
+	MixedCurrency bool
+
+	// Counts breaks down the total number of legs by verification status.
+	Counts LegCount
+
+	// Band is a qualitative confidence level for the end-to-end total.
+	Band BandKind
+
+	// BandLow is the lower bound of the estimated total range.
+	// Equal to ConfirmedTotal when Band == BandExact.
+	BandLow float64
+
+	// BandHigh is the upper bound of the estimated total range.
+	// Equal to ConfirmedTotal when Band == BandExact; inflated by indicative
+	// and unverified leg prices when available, else left as ConfirmedTotal.
+	BandHigh float64
+}
+
+// indicativeSources is the canonical set of sources whose prices are indicative
+// by default. Rome2Rio is the primary case: its prices are discovery ranges, not
+// confirmed fares. See internal/multimodal/pricing.go:124 ("Rome2Rio is the
+// DISCOVERY source; its prices are indicative ranges, not confirmed fares").
+var indicativeSources = map[string]bool{
+	"rome2rio": true,
+}
+
+// DefaultVerification returns the default Verification for a given source name.
+// rome2rio → Indicative; any unknown or empty source → Unverified; all other
+// known transactional providers → Confirmed.
+func DefaultVerification(source string) Verification {
+	s := strings.ToLower(strings.TrimSpace(source))
+	if s == "" {
+		return Unverified
+	}
+	if indicativeSources[s] {
+		return Indicative
+	}
+	return Confirmed
+}
+
+// Compute returns the honest door-to-door total for a slice of legs.
+//
+// The returned Total always reflects exactly what the input legs can honestly
+// support: indicative and unverified legs are never silently folded into
+// ConfirmedTotal, and the confidence band widens whenever non-confirmed legs
+// exist. An empty or nil legs slice returns a zero Total with BandUnknown.
+func Compute(legs []Leg) Total {
+	if len(legs) == 0 {
+		return Total{Band: BandUnknown}
+	}
+
+	currency := headlineCurrency(legs)
+	counts, confirmed, indicative, unverified, excluded := classifyLegs(legs, currency)
+	mixedCurrency := hasMixedCurrencies(legs)
+
+	confirmedTotal := sumPrices(confirmed)
+	band, low, high := computeBand(confirmedTotal, indicative, unverified, excluded, mixedCurrency)
+
+	return Total{
+		ConfirmedTotal:       round2(confirmedTotal),
+		IndicativeLegs:       indicative,
+		UnverifiedLegs:       unverified,
+		ExcludedCurrencyLegs: excluded,
+		Currency:             currency,
+		MixedCurrency:        mixedCurrency,
+		Counts:               counts,
+		Band:                 band,
+		BandLow:              round2(low),
+		BandHigh:             round2(high),
+	}
+}
+
+// headlineCurrency picks the currency in which the confirmed total is expressed.
+// It prefers the first confirmed leg with a non-zero price, falls back to the
+// first leg with any currency, and finally returns "EUR" as a safe default.
+func headlineCurrency(legs []Leg) string {
+	for _, l := range legs {
+		if l.effectiveVerification() == Confirmed && l.Price > 0 && l.Currency != "" {
+			return l.Currency
+		}
+	}
+	for _, l := range legs {
+		if l.Currency != "" {
+			return l.Currency
+		}
+	}
+	return "EUR"
+}
+
+// classifyLegs splits legs into confirmed (in headline currency), indicative,
+// unverified, and currency-excluded confirmed buckets.
+func classifyLegs(legs []Leg, currency string) (LegCount, []Leg, []Leg, []Leg, []Leg) {
+	var (
+		counts     LegCount
+		confirmed  []Leg
+		indicative []Leg
+		unverified []Leg
+		excluded   []Leg
+	)
+	for _, l := range legs {
+		switch l.effectiveVerification() {
+		case Confirmed:
+			counts.Confirmed++
+			if l.Currency != currency {
+				excluded = append(excluded, l)
+			} else {
+				confirmed = append(confirmed, l)
+			}
+		case Indicative:
+			counts.Indicative++
+			indicative = append(indicative, l)
+		default: // Unverified or any unknown value
+			counts.Unverified++
+			unverified = append(unverified, l)
+		}
+	}
+	return counts, confirmed, indicative, unverified, excluded
+}
+
+// hasMixedCurrencies reports whether legs carry more than one distinct currency.
+func hasMixedCurrencies(legs []Leg) bool {
+	seen := ""
+	for _, l := range legs {
+		if l.Currency == "" {
+			continue
+		}
+		if seen == "" {
+			seen = l.Currency
+			continue
+		}
+		if l.Currency != seen {
+			return true
+		}
+	}
+	return false
+}
+
+// sumPrices returns the total price of legs that carry a positive price.
+func sumPrices(legs []Leg) float64 {
+	var total float64
+	for _, l := range legs {
+		if l.Price > 0 {
+			total += l.Price
+		}
+	}
+	return total
+}
+
+// computeBand derives the confidence band and [low, high] range. The band
+// widens whenever non-confirmed legs or mixed-currency exclusions exist.
+func computeBand(confirmed float64, indicative, unverified, excluded []Leg, mixed bool) (BandKind, float64, float64) {
+	hasIndicative := len(indicative) > 0
+	hasUnverified := len(unverified) > 0
+	hasExcluded := len(excluded) > 0
+
+	switch {
+	case hasUnverified:
+		high := confirmed + sumPrices(indicative) + sumPrices(unverified) + sumPrices(excluded)
+		if high < confirmed {
+			high = confirmed
+		}
+		return BandUnknown, confirmed, high
+	case hasIndicative:
+		high := confirmed + sumPrices(indicative) + sumPrices(excluded)
+		if high < confirmed {
+			high = confirmed
+		}
+		return BandWide, confirmed, high
+	case hasExcluded || mixed:
+		high := confirmed + sumPrices(excluded)
+		if high < confirmed {
+			high = confirmed
+		}
+		return BandNarrow, confirmed, high
+	default:
+		return BandExact, confirmed, confirmed
+	}
+}
+
+// round2 rounds a float to 2 decimal places (matches multimodal/assemble.go).
+func round2(v float64) float64 {
+	return float64(int64(v*100+0.5)) / 100
+}

--- a/internal/d2d/d2d_test.go
+++ b/internal/d2d/d2d_test.go
@@ -1,0 +1,294 @@
+package d2d_test
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/d2d"
+)
+
+// --- helpers ---
+
+func confirmedLeg(from, to string, price float64, currency, source string) d2d.Leg {
+	return d2d.Leg{
+		Mode: "train", From: from, To: to,
+		Price: price, Currency: currency, Source: source,
+		Verification: d2d.Confirmed,
+	}
+}
+
+func indicativeLeg(from, to string, price float64, currency, source string) d2d.Leg {
+	return d2d.Leg{
+		Mode: "bus", From: from, To: to,
+		Price: price, Currency: currency, Source: source,
+		Verification: d2d.Indicative,
+	}
+}
+
+func unverifiedLeg(from, to string, price float64, currency string) d2d.Leg {
+	return d2d.Leg{
+		Mode: "taxi", From: from, To: to,
+		Price: price, Currency: currency,
+		Verification: d2d.Unverified,
+	}
+}
+
+// sourceLeg builds a leg with no explicit Verification — relies on DefaultVerification.
+func sourceLeg(from, to string, price float64, currency, source string) d2d.Leg {
+	return d2d.Leg{
+		Mode: "bus", From: from, To: to,
+		Price: price, Currency: currency, Source: source,
+	}
+}
+
+// --- TRVL.D2D core tests ---
+
+// TRVL.D2D.1 — mixed trip: confirmed leg + rome2rio/indicative leg.
+// The indicative leg must NOT appear in ConfirmedTotal and MUST be in IndicativeLegs.
+func TestCompute_mixedTrip_indicativeLegExcludedFromConfirmedTotal(t *testing.T) {
+	// GIVEN: one confirmed flight + one indicative rome2rio bus
+	legs := []d2d.Leg{
+		confirmedLeg("HEL", "LHR", 120.0, "EUR", "google_flights"),
+		{Mode: "bus", From: "London", To: "Paris", Price: 25.0, Currency: "EUR", Source: "rome2rio"},
+	}
+
+	// WHEN
+	got := d2d.Compute(legs)
+
+	// THEN: confirmed total = 120 only; indicative leg surfaced separately
+	if got.ConfirmedTotal != 120.0 {
+		t.Errorf("ConfirmedTotal = %.2f, want 120.00 (rome2rio leg must not be included)", got.ConfirmedTotal)
+	}
+	if len(got.IndicativeLegs) != 1 {
+		t.Errorf("IndicativeLegs len = %d, want 1", len(got.IndicativeLegs))
+	}
+	if got.IndicativeLegs[0].Source != "rome2rio" {
+		t.Errorf("IndicativeLegs[0].Source = %q, want \"rome2rio\"", got.IndicativeLegs[0].Source)
+	}
+	if len(got.UnverifiedLegs) != 0 {
+		t.Errorf("UnverifiedLegs len = %d, want 0", len(got.UnverifiedLegs))
+	}
+	if got.Band != d2d.BandWide {
+		t.Errorf("Band = %q, want %q (indicative leg present)", got.Band, d2d.BandWide)
+	}
+	if got.Counts.Confirmed != 1 || got.Counts.Indicative != 1 || got.Counts.Unverified != 0 {
+		t.Errorf("Counts = %+v, want {Confirmed:1 Indicative:1 Unverified:0}", got.Counts)
+	}
+}
+
+// TRVL.D2D.2 — all-confirmed trip: tight band, ConfirmedTotal = sum.
+func TestCompute_allConfirmed_tightBandAndExactSum(t *testing.T) {
+	// GIVEN: three confirmed legs, same currency
+	legs := []d2d.Leg{
+		confirmedLeg("HEL", "LHR", 120.0, "EUR", "google_flights"),
+		confirmedLeg("London St Pancras", "Paris Gare du Nord", 85.50, "EUR", "eurostar"),
+		confirmedLeg("Paris CDG", "Nice", 49.0, "EUR", "ouigo"),
+	}
+
+	// WHEN
+	got := d2d.Compute(legs)
+
+	// THEN
+	want := 120.0 + 85.50 + 49.0 // = 254.50
+	if got.ConfirmedTotal != want {
+		t.Errorf("ConfirmedTotal = %.2f, want %.2f", got.ConfirmedTotal, want)
+	}
+	if got.Band != d2d.BandExact {
+		t.Errorf("Band = %q, want %q", got.Band, d2d.BandExact)
+	}
+	if got.BandLow != got.ConfirmedTotal || got.BandHigh != got.ConfirmedTotal {
+		t.Errorf("Band[%f,%f] should equal ConfirmedTotal %f for exact band", got.BandLow, got.BandHigh, got.ConfirmedTotal)
+	}
+	if got.MixedCurrency {
+		t.Error("MixedCurrency should be false for single-currency trip")
+	}
+	if len(got.IndicativeLegs) != 0 || len(got.UnverifiedLegs) != 0 {
+		t.Errorf("want no indicative/unverified legs, got ind=%d unv=%d", len(got.IndicativeLegs), len(got.UnverifiedLegs))
+	}
+	if got.Counts.Confirmed != 3 {
+		t.Errorf("Counts.Confirmed = %d, want 3", got.Counts.Confirmed)
+	}
+}
+
+// TRVL.D2D.3 — trip with an unverified leg: excluded from confirmed total, band reflects uncertainty.
+func TestCompute_unverifiedLeg_excludedAndBandUnknown(t *testing.T) {
+	// GIVEN: confirmed flight + unverified last-mile
+	legs := []d2d.Leg{
+		confirmedLeg("HEL", "TLL", 60.0, "EUR", "ryanair"),
+		unverifiedLeg("Tallinn Airport", "Hotel", 15.0, "EUR"),
+	}
+
+	// WHEN
+	got := d2d.Compute(legs)
+
+	// THEN: confirmed total = 60 only
+	if got.ConfirmedTotal != 60.0 {
+		t.Errorf("ConfirmedTotal = %.2f, want 60.00", got.ConfirmedTotal)
+	}
+	if len(got.UnverifiedLegs) != 1 {
+		t.Errorf("UnverifiedLegs len = %d, want 1", len(got.UnverifiedLegs))
+	}
+	if got.Band != d2d.BandUnknown {
+		t.Errorf("Band = %q, want %q", got.Band, d2d.BandUnknown)
+	}
+	// BandHigh should include the unverified leg's price
+	if got.BandHigh < got.ConfirmedTotal+15.0 {
+		t.Errorf("BandHigh = %.2f, want >= %.2f (confirmed + unverified)", got.BandHigh, got.ConfirmedTotal+15.0)
+	}
+	if got.Counts.Unverified != 1 || got.Counts.Confirmed != 1 {
+		t.Errorf("Counts = %+v, want {Confirmed:1 Unverified:1}", got.Counts)
+	}
+}
+
+// TRVL.D2D.4 — source → verification mapping: rome2rio always maps to Indicative.
+func TestDefaultVerification_rome2rioIsIndicative(t *testing.T) {
+	cases := []struct {
+		source string
+		want   d2d.Verification
+	}{
+		{"rome2rio", d2d.Indicative},
+		{"Rome2Rio", d2d.Indicative}, // case-insensitive
+		{"ROME2RIO", d2d.Indicative},
+		{"google_flights", d2d.Confirmed},
+		{"ryanair", d2d.Confirmed},
+		{"booking.com", d2d.Confirmed},
+		{"", d2d.Unverified},
+		{"unknown_provider", d2d.Confirmed}, // unknown transactional providers default Confirmed
+	}
+	for _, tc := range cases {
+		got := d2d.DefaultVerification(tc.source)
+		if got != tc.want {
+			t.Errorf("DefaultVerification(%q) = %q, want %q", tc.source, got, tc.want)
+		}
+	}
+}
+
+// TRVL.D2D.5 — source-derived verification via Leg (no explicit Verification field).
+func TestCompute_sourceDerivesVerification_rome2rioIndicative(t *testing.T) {
+	// GIVEN: leg with no Verification set — source is "rome2rio"
+	legs := []d2d.Leg{
+		confirmedLeg("A", "B", 100.0, "EUR", "google_flights"),
+		sourceLeg("B", "C", 30.0, "EUR", "rome2rio"), // should be treated as Indicative
+	}
+
+	// WHEN
+	got := d2d.Compute(legs)
+
+	// THEN: rome2rio leg derived as indicative, not in ConfirmedTotal
+	if got.ConfirmedTotal != 100.0 {
+		t.Errorf("ConfirmedTotal = %.2f, want 100.00", got.ConfirmedTotal)
+	}
+	if len(got.IndicativeLegs) != 1 {
+		t.Errorf("IndicativeLegs len = %d, want 1", len(got.IndicativeLegs))
+	}
+}
+
+// TRVL.D2D.6 — mixed currency guard: legs in different currencies.
+func TestCompute_mixedCurrency_flaggedAndPartialTotal(t *testing.T) {
+	// GIVEN: EUR flight + USD hotel (different currencies)
+	legs := []d2d.Leg{
+		confirmedLeg("HEL", "JFK", 450.0, "EUR", "google_flights"),
+		confirmedLeg("Manhattan", "Hotel Bed", 200.0, "USD", "booking.com"),
+	}
+
+	// WHEN
+	got := d2d.Compute(legs)
+
+	// THEN: MixedCurrency flagged; only EUR leg in ConfirmedTotal
+	if !got.MixedCurrency {
+		t.Error("MixedCurrency should be true for EUR + USD trip")
+	}
+	// Headline currency is EUR (first confirmed leg)
+	if got.Currency != "EUR" {
+		t.Errorf("Currency = %q, want \"EUR\"", got.Currency)
+	}
+	if got.ConfirmedTotal != 450.0 {
+		t.Errorf("ConfirmedTotal = %.2f, want 450.00 (only EUR leg)", got.ConfirmedTotal)
+	}
+	if len(got.ExcludedCurrencyLegs) != 1 {
+		t.Errorf("ExcludedCurrencyLegs len = %d, want 1", len(got.ExcludedCurrencyLegs))
+	}
+	if got.ExcludedCurrencyLegs[0].Currency != "USD" {
+		t.Errorf("ExcludedCurrencyLegs[0].Currency = %q, want \"USD\"", got.ExcludedCurrencyLegs[0].Currency)
+	}
+	// Band is at least Narrow (currency exclusion)
+	if got.Band == d2d.BandExact {
+		t.Error("Band should not be Exact when currencies are mixed")
+	}
+}
+
+// TRVL.D2D.7 — all-indicative trip: ConfirmedTotal = 0, all legs in IndicativeLegs.
+func TestCompute_allIndicative_confirmedTotalIsZero(t *testing.T) {
+	legs := []d2d.Leg{
+		indicativeLeg("A", "B", 50.0, "EUR", "rome2rio"),
+		indicativeLeg("B", "C", 30.0, "EUR", "rome2rio"),
+	}
+	got := d2d.Compute(legs)
+	if got.ConfirmedTotal != 0 {
+		t.Errorf("ConfirmedTotal = %.2f, want 0.00", got.ConfirmedTotal)
+	}
+	if len(got.IndicativeLegs) != 2 {
+		t.Errorf("IndicativeLegs len = %d, want 2", len(got.IndicativeLegs))
+	}
+	if got.Band != d2d.BandWide {
+		t.Errorf("Band = %q, want %q", got.Band, d2d.BandWide)
+	}
+}
+
+// TRVL.D2D.8 — empty legs slice: returns zero Total with BandUnknown.
+func TestCompute_emptyLegs_zeroTotalBandUnknown(t *testing.T) {
+	got := d2d.Compute(nil)
+	if got.ConfirmedTotal != 0 {
+		t.Errorf("ConfirmedTotal = %.2f, want 0", got.ConfirmedTotal)
+	}
+	if got.Band != d2d.BandUnknown {
+		t.Errorf("Band = %q, want %q", got.Band, d2d.BandUnknown)
+	}
+}
+
+// TRVL.D2D.9 — band high >= confirmed total in all cases.
+func TestCompute_bandHighAlwaysGEConfirmedTotal(t *testing.T) {
+	cases := []struct {
+		name string
+		legs []d2d.Leg
+	}{
+		{"all confirmed", []d2d.Leg{confirmedLeg("A", "B", 100, "EUR", "src")}},
+		{"with indicative", []d2d.Leg{
+			confirmedLeg("A", "B", 100, "EUR", "src"),
+			indicativeLeg("B", "C", 50, "EUR", "rome2rio"),
+		}},
+		{"with unverified", []d2d.Leg{
+			confirmedLeg("A", "B", 100, "EUR", "src"),
+			unverifiedLeg("B", "C", 20, "EUR"),
+		}},
+		{"mixed currency", []d2d.Leg{
+			confirmedLeg("A", "B", 100, "EUR", "src"),
+			confirmedLeg("C", "D", 200, "USD", "src2"),
+		}},
+	}
+	for _, tc := range cases {
+		got := d2d.Compute(tc.legs)
+		if got.BandHigh < got.ConfirmedTotal {
+			t.Errorf("[%s] BandHigh=%.2f < ConfirmedTotal=%.2f", tc.name, got.BandHigh, got.ConfirmedTotal)
+		}
+	}
+}
+
+// TRVL.D2D.10 — explicit Verified leg takes precedence over source mapping.
+func TestCompute_explicitVerificationOverridesSource(t *testing.T) {
+	// GIVEN: leg explicitly marked Confirmed even though source is rome2rio
+	legs := []d2d.Leg{
+		{
+			Mode: "bus", From: "A", To: "B",
+			Price: 40.0, Currency: "EUR",
+			Source:       "rome2rio",
+			Verification: d2d.Confirmed, // caller explicitly confirmed it
+		},
+	}
+	got := d2d.Compute(legs)
+	if got.ConfirmedTotal != 40.0 {
+		t.Errorf("ConfirmedTotal = %.2f, want 40.00 (explicit Confirmed beats source mapping)", got.ConfirmedTotal)
+	}
+	if len(got.IndicativeLegs) != 0 {
+		t.Error("IndicativeLegs should be empty when leg is explicitly Confirmed")
+	}
+}

--- a/internal/obslog/obslog.go
+++ b/internal/obslog/obslog.go
@@ -1,0 +1,70 @@
+// Package obslog records observed prices from ad-hoc searches into the price
+// history store (MIK-6229). It is the thin seam between the search handlers
+// (CLI + MCP) and the watch.Store, so the "log every search" behaviour lives in
+// exactly one place rather than being copy-pasted into every call site.
+//
+// All functions are best-effort: a logging failure must never break a search.
+// Callers may ignore the returned error or surface it as a non-fatal warning.
+package obslog
+
+import (
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// Recorder is the subset of watch.Store that obslog needs. Defined as an
+// interface so tests can substitute a fake and so callers are not forced to
+// pass a fully-loaded store.
+type Recorder interface {
+	RecordObservation(routeKey string, price float64, currency string) error
+}
+
+// FlightSearch logs the cheapest fare from a flight search result under the
+// route key flight|ORIGIN|DEST|DATE. No-op when the result is empty or carries
+// no positive price.
+func FlightSearch(r Recorder, origin, destination, date string, res *models.FlightSearchResult) error {
+	if r == nil || res == nil || len(res.Flights) == 0 {
+		return nil
+	}
+	price, currency := cheapestFlight(res.Flights)
+	if price <= 0 {
+		return nil
+	}
+	return r.RecordObservation(watch.RouteKey("flight", origin, destination, date), price, currency)
+}
+
+// HotelPrices logs the cheapest provider price from a hotel price lookup under
+// the route key hotel|HOTELID||CHECKIN. The destination slot is left empty
+// because a hotel is identified by its own ID, not an O/D pair.
+func HotelPrices(r Recorder, hotelID, checkIn string, res *models.HotelPriceResult) error {
+	if r == nil || res == nil || len(res.Providers) == 0 {
+		return nil
+	}
+	price, currency := cheapestProvider(res.Providers)
+	if price <= 0 {
+		return nil
+	}
+	return r.RecordObservation(watch.RouteKey("hotel", hotelID, "", checkIn), price, currency)
+}
+
+func cheapestFlight(flights []models.FlightResult) (float64, string) {
+	var best float64
+	var cur string
+	for _, f := range flights {
+		if f.Price > 0 && (best == 0 || f.Price < best) {
+			best, cur = f.Price, f.Currency
+		}
+	}
+	return best, cur
+}
+
+func cheapestProvider(providers []models.ProviderPrice) (float64, string) {
+	var best float64
+	var cur string
+	for _, p := range providers {
+		if p.Price > 0 && (best == 0 || p.Price < best) {
+			best, cur = p.Price, p.Currency
+		}
+	}
+	return best, cur
+}

--- a/internal/obslog/obslog_test.go
+++ b/internal/obslog/obslog_test.go
@@ -1,0 +1,104 @@
+package obslog
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+type fakeRecorder struct {
+	calls []call
+	err   error
+}
+
+type call struct {
+	key      string
+	price    float64
+	currency string
+}
+
+func (f *fakeRecorder) RecordObservation(key string, price float64, currency string) error {
+	f.calls = append(f.calls, call{key, price, currency})
+	return f.err
+}
+
+func TestFlightSearchLogsCheapest(t *testing.T) {
+	r := &fakeRecorder{}
+	res := &models.FlightSearchResult{Flights: []models.FlightResult{
+		{Price: 200, Currency: "EUR"},
+		{Price: 150, Currency: "EUR"},
+		{Price: 175, Currency: "EUR"},
+	}}
+	if err := FlightSearch(r, "ams", "VLC", "2026-07-15", res); err != nil {
+		t.Fatalf("FlightSearch: %v", err)
+	}
+	if len(r.calls) != 1 {
+		t.Fatalf("want 1 record, got %d", len(r.calls))
+	}
+	c := r.calls[0]
+	if c.price != 150 {
+		t.Fatalf("want cheapest 150, got %v", c.price)
+	}
+	if c.key != watch.RouteKey("flight", "ams", "VLC", "2026-07-15") {
+		t.Fatalf("unexpected key %q", c.key)
+	}
+}
+
+func TestNoOpOnEmptyOrZero(t *testing.T) {
+	r := &fakeRecorder{}
+	if err := FlightSearch(r, "AMS", "VLC", "d", &models.FlightSearchResult{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := FlightSearch(r, "AMS", "VLC", "d", nil); err != nil {
+		t.Fatal(err)
+	}
+	// All zero/negative prices -> no record.
+	if err := FlightSearch(r, "AMS", "VLC", "d", &models.FlightSearchResult{
+		Flights: []models.FlightResult{{Price: 0, Currency: "EUR"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.calls) != 0 {
+		t.Fatalf("expected no records, got %d", len(r.calls))
+	}
+	// Nil recorder must not panic.
+	if err := FlightSearch(nil, "AMS", "VLC", "d", &models.FlightSearchResult{
+		Flights: []models.FlightResult{{Price: 100, Currency: "EUR"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHotelPricesLogsCheapest(t *testing.T) {
+	r := &fakeRecorder{}
+	res := &models.HotelPriceResult{Providers: []models.ProviderPrice{
+		{Provider: "a", Price: 300, Currency: "EUR"},
+		{Provider: "b", Price: 250, Currency: "EUR"},
+	}}
+	if err := HotelPrices(r, "/g/abc", "2026-07-15", res); err != nil {
+		t.Fatalf("HotelPrices: %v", err)
+	}
+	if len(r.calls) != 1 || r.calls[0].price != 250 {
+		t.Fatalf("want cheapest 250, got %+v", r.calls)
+	}
+	if r.calls[0].key != watch.RouteKey("hotel", "/g/abc", "", "2026-07-15") {
+		t.Fatalf("unexpected key %q", r.calls[0].key)
+	}
+}
+
+// Integration: obslog writes through a real Store and pricesignal can read it.
+func TestEndToEndThroughStore(t *testing.T) {
+	dir := t.TempDir()
+	s := watch.NewStore(dir)
+	for _, p := range []float64{120, 110, 130, 140, 100} {
+		res := &models.FlightSearchResult{Flights: []models.FlightResult{{Price: p, Currency: "EUR"}}}
+		if err := FlightSearch(s, "AMS", "VLC", "2026-07-15", res); err != nil {
+			t.Fatal(err)
+		}
+	}
+	prices := s.RoutePrices(watch.RouteKey("flight", "AMS", "VLC", "2026-07-15"))
+	if len(prices) != 5 {
+		t.Fatalf("want 5 logged prices, got %d", len(prices))
+	}
+}

--- a/internal/obslog/obslog_test.go
+++ b/internal/obslog/obslog_test.go
@@ -97,7 +97,7 @@ func TestEndToEndThroughStore(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	prices := s.RoutePrices(watch.RouteKey("flight", "AMS", "VLC", "2026-07-15"))
+	prices := s.RoutePrices(watch.RouteKey("flight", "AMS", "VLC", "2026-07-15"), "EUR")
 	if len(prices) != 5 {
 		t.Fatalf("want 5 logged prices, got %d", len(prices))
 	}

--- a/internal/pricesignal/pricesignal.go
+++ b/internal/pricesignal/pricesignal.go
@@ -1,0 +1,156 @@
+// Package pricesignal computes a price-position signal: where a current price
+// sits within a route's own local price history, and a buy/wait verdict.
+//
+// It is deliberately dependency-free (operates on plain float64 prices) so it
+// can be reused by the CLI, the MCP layer, the counterfactual engine, and the
+// travel graph without import cycles.
+//
+// The cardinal rule is honesty under sparse data: below a confidence floor the
+// signal reports Unknown and never asserts a trend. A wrong "wait" that costs a
+// booking burns the trust that makes the history corpus valuable, so the floor
+// is mandatory, not advisory.
+package pricesignal
+
+import "sort"
+
+// DefaultConfidenceFloor is the minimum number of historical observations
+// required before a band or verdict is emitted. Below this, Compute returns a
+// BandUnknown / VerdictUnknown position with Confident=false.
+const DefaultConfidenceFloor = 10
+
+// Band describes where a current price sits relative to a route's history,
+// using terciles of the historical distribution.
+type Band string
+
+const (
+	// BandLow means the current price is in the cheapest third of history.
+	BandLow Band = "low"
+	// BandTypical means the current price is in the middle third.
+	BandTypical Band = "typical"
+	// BandHigh means the current price is in the most expensive third.
+	BandHigh Band = "high"
+	// BandUnknown means there is not enough history to judge.
+	BandUnknown Band = "unknown"
+)
+
+// Verdict is a buy/wait recommendation derived from the band.
+type Verdict string
+
+const (
+	// VerdictBuy recommends booking now (price is in the cheap third).
+	VerdictBuy Verdict = "buy"
+	// VerdictWait suggests waiting (price is in the expensive third).
+	VerdictWait Verdict = "wait"
+	// VerdictNeutral means no strong signal either way (typical price).
+	VerdictNeutral Verdict = "neutral"
+	// VerdictUnknown means there is not enough history to judge.
+	VerdictUnknown Verdict = "unknown"
+)
+
+// Position is the computed price-position signal for a current price against a
+// route's historical observations.
+type Position struct {
+	Band         Band    `json:"band"`
+	Verdict      Verdict `json:"verdict"`
+	Current      float64 `json:"current"`
+	Low          float64 `json:"low,omitempty"`           // historical minimum
+	High         float64 `json:"high,omitempty"`          // historical maximum
+	Median       float64 `json:"median,omitempty"`        // historical median
+	VsMedianPct  float64 `json:"vs_median_pct,omitempty"` // (current-median)/median*100; negative = below median
+	Observations int     `json:"observations"`            // number of historical points used
+	// Confident reports whether Observations met the confidence floor. When
+	// false, Band and Verdict are Unknown and Low/High/Median are still filled
+	// for transparency but carry no recommendation.
+	Confident bool `json:"confident"`
+}
+
+// Compute classifies current against the historical prices using the given
+// confidence floor. A floor <= 0 falls back to DefaultConfidenceFloor.
+//
+// history may be in any order and may contain non-positive values, which are
+// ignored (a 0/negative price is never a real fare). current must be > 0 to be
+// classified; a non-positive current yields an Unknown position.
+func Compute(history []float64, current float64, floor int) Position {
+	if floor <= 0 {
+		floor = DefaultConfidenceFloor
+	}
+
+	// Filter to valid positive observations.
+	prices := make([]float64, 0, len(history))
+	for _, p := range history {
+		if p > 0 {
+			prices = append(prices, p)
+		}
+	}
+	sort.Float64s(prices)
+
+	pos := Position{
+		Current:      current,
+		Observations: len(prices),
+		Band:         BandUnknown,
+		Verdict:      VerdictUnknown,
+	}
+
+	if len(prices) == 0 || current <= 0 {
+		return pos
+	}
+
+	pos.Low = prices[0]
+	pos.High = prices[len(prices)-1]
+	pos.Median = median(prices)
+	if pos.Median > 0 {
+		pos.VsMedianPct = (current - pos.Median) / pos.Median * 100
+	}
+
+	// Below the confidence floor: report numbers, withhold the verdict.
+	if len(prices) < floor {
+		return pos
+	}
+	pos.Confident = true
+
+	loCut := quantile(prices, 1.0/3.0)
+	hiCut := quantile(prices, 2.0/3.0)
+	switch {
+	case current <= loCut:
+		pos.Band = BandLow
+		pos.Verdict = VerdictBuy
+	case current >= hiCut:
+		pos.Band = BandHigh
+		pos.Verdict = VerdictWait
+	default:
+		pos.Band = BandTypical
+		pos.Verdict = VerdictNeutral
+	}
+	return pos
+}
+
+// median returns the median of a sorted, non-empty slice.
+func median(sorted []float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if n%2 == 1 {
+		return sorted[n/2]
+	}
+	return (sorted[n/2-1] + sorted[n/2]) / 2
+}
+
+// quantile returns the value at fraction q (0..1) of a sorted, non-empty slice
+// using nearest-rank interpolation.
+func quantile(sorted []float64, q float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return sorted[0]
+	}
+	pos := q * float64(n-1)
+	lo := int(pos)
+	if lo >= n-1 {
+		return sorted[n-1]
+	}
+	frac := pos - float64(lo)
+	return sorted[lo]*(1-frac) + sorted[lo+1]*frac
+}

--- a/internal/pricesignal/pricesignal_test.go
+++ b/internal/pricesignal/pricesignal_test.go
@@ -1,0 +1,108 @@
+package pricesignal
+
+import (
+	"math"
+	"testing"
+)
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 1e-6 }
+
+// TRVL.PH.3 / TRVL.PH.4: the confidence floor is the load-bearing guard. Below
+// it, no verdict is emitted; at/above it, a verdict appears.
+func TestConfidenceFloorBoundary(t *testing.T) {
+	// 9 observations, floor 10 -> below floor -> no verdict.
+	below := make([]float64, 9)
+	for i := range below {
+		below[i] = 100
+	}
+	p := Compute(below, 100, 10)
+	if p.Confident {
+		t.Fatalf("9 obs with floor 10 must not be confident")
+	}
+	if p.Band != BandUnknown || p.Verdict != VerdictUnknown {
+		t.Fatalf("below floor must be Unknown, got band=%s verdict=%s", p.Band, p.Verdict)
+	}
+	if p.Observations != 9 {
+		t.Fatalf("want 9 observations, got %d", p.Observations)
+	}
+	// Numbers are still surfaced for transparency.
+	if p.Low != 100 || p.High != 100 || p.Median != 100 {
+		t.Fatalf("below-floor numbers should still be filled: %+v", p)
+	}
+
+	// 10 observations, floor 10 -> at floor -> verdict emitted.
+	at := make([]float64, 10)
+	for i := range at {
+		at[i] = 100
+	}
+	p = Compute(at, 100, 10)
+	if !p.Confident {
+		t.Fatalf("10 obs with floor 10 must be confident")
+	}
+	if p.Verdict == VerdictUnknown {
+		t.Fatalf("at floor a verdict must be emitted, got Unknown")
+	}
+}
+
+func TestBandClassification(t *testing.T) {
+	// Spread 100..200 in steps of ~10, 11 observations (>= floor).
+	hist := []float64{100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200}
+
+	cheap := Compute(hist, 105, 0) // default floor 10
+	if cheap.Band != BandLow || cheap.Verdict != VerdictBuy {
+		t.Fatalf("105 should be low/buy, got %s/%s", cheap.Band, cheap.Verdict)
+	}
+	if !cheap.Confident {
+		t.Fatalf("11 obs should be confident")
+	}
+
+	mid := Compute(hist, 150, 0)
+	if mid.Band != BandTypical || mid.Verdict != VerdictNeutral {
+		t.Fatalf("150 should be typical/neutral, got %s/%s", mid.Band, mid.Verdict)
+	}
+
+	dear := Compute(hist, 195, 0)
+	if dear.Band != BandHigh || dear.Verdict != VerdictWait {
+		t.Fatalf("195 should be high/wait, got %s/%s", dear.Band, dear.Verdict)
+	}
+}
+
+func TestStatsAndVsMedian(t *testing.T) {
+	hist := []float64{100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200}
+	p := Compute(hist, 120, 0)
+	if p.Low != 100 || p.High != 200 {
+		t.Fatalf("low/high wrong: %+v", p)
+	}
+	if !approx(p.Median, 150) {
+		t.Fatalf("median want 150 got %v", p.Median)
+	}
+	// (120-150)/150*100 = -20
+	if !approx(p.VsMedianPct, -20) {
+		t.Fatalf("vsMedianPct want -20 got %v", p.VsMedianPct)
+	}
+}
+
+func TestIgnoresNonPositiveAndEmpty(t *testing.T) {
+	// Empty history -> unknown.
+	p := Compute(nil, 100, 0)
+	if p.Band != BandUnknown || p.Observations != 0 {
+		t.Fatalf("empty history must be unknown/0, got %+v", p)
+	}
+	// Non-positive prices are dropped.
+	hist := []float64{0, -5, 100, 100, 100}
+	p = Compute(hist, 100, 0)
+	if p.Observations != 3 {
+		t.Fatalf("non-positive prices must be ignored, want 3 got %d", p.Observations)
+	}
+	// Non-positive current -> unknown band even with history.
+	p = Compute([]float64{100, 110, 120, 130, 140, 150, 160, 170, 180, 190}, 0, 0)
+	if p.Band != BandUnknown {
+		t.Fatalf("non-positive current must be unknown, got %s", p.Band)
+	}
+}
+
+func TestEvenMedian(t *testing.T) {
+	if m := median([]float64{10, 20, 30, 40}); !approx(m, 25) {
+		t.Fatalf("even median want 25 got %v", m)
+	}
+}

--- a/internal/probebudget/probebudget.go
+++ b/internal/probebudget/probebudget.go
@@ -1,0 +1,97 @@
+// Package probebudget implements the two-lane provider-call budget that makes
+// counterfactual fan-out (MIK-6234 Tier 1/2) safe: counterfactual probes draw
+// from a separate, slow-refilling, best-effort bucket that is strictly lower
+// priority than interactive traffic. A counterfactual probe can NEVER consume
+// the budget a user's live query needs.
+//
+// The invariant this package guarantees: interactive acquisition is unbounded
+// and unaffected by the probe lane; probe acquisition is bounded by its own
+// bucket and, when exhausted, fails fast (TryAcquire returns false) rather than
+// borrowing from or blocking interactive work. Budget exhausted means "serve
+// cache / say not-yet-computed", never a silent fresh fan-out.
+package probebudget
+
+import (
+	"sync"
+	"time"
+)
+
+// Clock returns the current time; injectable for deterministic tests.
+type Clock func() time.Time
+
+// Budget is a two-lane call budget. The probe lane is a token bucket; the
+// interactive lane is intentionally unmetered so it is never throttled by probe
+// activity.
+type Budget struct {
+	mu           sync.Mutex
+	tokens       float64
+	capacity     float64
+	refillPerSec float64
+	last         time.Time
+	now          Clock
+}
+
+// New creates a probe budget with the given bucket capacity and refill rate
+// (tokens per second). It starts full. A nil clock uses time.Now.
+func New(capacity, refillPerSec float64, clock Clock) *Budget {
+	if clock == nil {
+		clock = time.Now
+	}
+	if capacity < 0 {
+		capacity = 0
+	}
+	if refillPerSec < 0 {
+		refillPerSec = 0
+	}
+	return &Budget{
+		tokens:       capacity,
+		capacity:     capacity,
+		refillPerSec: refillPerSec,
+		last:         clock(),
+		now:          clock,
+	}
+}
+
+// TryAcquireProbe attempts to take one token from the probe lane. It returns
+// true if a token was available (probe may proceed), false if the lane is
+// exhausted (caller MUST fall back to cache, never a fresh fan-out). It never
+// blocks.
+func (b *Budget) TryAcquireProbe() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.refill()
+	if b.tokens >= 1 {
+		b.tokens--
+		return true
+	}
+	return false
+}
+
+// AcquireInteractive accounts for an interactive (user-facing) call. It always
+// succeeds and is never throttled by the probe lane — that is the safety
+// invariant. It exists so callers route every provider call through one place
+// and so the two lanes are explicit at call sites.
+func (b *Budget) AcquireInteractive() bool {
+	return true
+}
+
+// ProbeTokens reports the currently available probe tokens (after refill).
+func (b *Budget) ProbeTokens() float64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.refill()
+	return b.tokens
+}
+
+func (b *Budget) refill() {
+	now := b.now()
+	elapsed := now.Sub(b.last).Seconds()
+	if elapsed <= 0 {
+		return
+	}
+	b.last = now
+	b.tokens += elapsed * b.refillPerSec
+	if b.tokens > b.capacity {
+		b.tokens = b.capacity
+	}
+}

--- a/internal/probebudget/probebudget_test.go
+++ b/internal/probebudget/probebudget_test.go
@@ -1,0 +1,79 @@
+package probebudget
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// TRVL.CF.2: the load-bearing safety test. A SATURATED probe lane must never
+// delay or starve interactive acquisition.
+func TestInteractiveNeverStarvedBySaturatedProbeLane(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	b := New(2, 0.0, clk.now) // capacity 2, no refill
+
+	// Drain the probe lane completely.
+	if !b.TryAcquireProbe() {
+		t.Fatalf("first probe should succeed")
+	}
+	if !b.TryAcquireProbe() {
+		t.Fatalf("second probe should succeed")
+	}
+	if b.TryAcquireProbe() {
+		t.Fatalf("third probe must fail (lane exhausted)")
+	}
+
+	// Interactive must still succeed every time, lane fully drained.
+	for i := 0; i < 1000; i++ {
+		if !b.AcquireInteractive() {
+			t.Fatalf("interactive acquisition #%d was denied — invariant violated", i)
+		}
+	}
+}
+
+func TestProbeRefill(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	b := New(2, 1.0, clk.now) // 1 token/sec, cap 2
+
+	b.TryAcquireProbe()
+	b.TryAcquireProbe()
+	if b.TryAcquireProbe() {
+		t.Fatalf("lane should be empty")
+	}
+	clk.advance(1500 * time.Millisecond) // +1.5 tokens
+	if !b.TryAcquireProbe() {
+		t.Fatalf("after refill a probe should be available")
+	}
+	// Capacity cap holds.
+	clk.advance(10 * time.Second)
+	if got := b.ProbeTokens(); got > 2 {
+		t.Fatalf("tokens must not exceed capacity, got %v", got)
+	}
+}
+
+func TestExhaustedMeansFallback(t *testing.T) {
+	b := New(0, 0, nil) // no probe budget at all
+	if b.TryAcquireProbe() {
+		t.Fatalf("zero-capacity lane must always fail (forces cache fallback)")
+	}
+	if !b.AcquireInteractive() {
+		t.Fatalf("interactive must still succeed with zero probe budget")
+	}
+}

--- a/internal/travelgraph/travelgraph.go
+++ b/internal/travelgraph/travelgraph.go
@@ -1,0 +1,249 @@
+// Package travelgraph joins watches, price history, trips, and preferences into
+// a personal travel graph and emits GROUNDED proactive nudges.
+//
+// A nudge is grounded when it derives from a real data record — a watch whose
+// LastPrice has crossed below its BelowPrice threshold, or a route whose current
+// price is at or near a multi-month low confirmed by fareintel. Nudges are NEVER
+// speculative: if no grounded trigger exists, no nudge is emitted.
+//
+// All core functions are pure (no file I/O, no network) so they are trivially
+// unit-testable with constructed data.
+package travelgraph
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/fareintel"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/trips"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// routeKey returns a canonical "ORIGIN-DESTINATION" key (upper-case, trimmed).
+func routeKey(origin, destination string) string {
+	return strings.ToUpper(strings.TrimSpace(origin)) + "-" +
+		strings.ToUpper(strings.TrimSpace(destination))
+}
+
+// NudgeKind classifies the trigger that produced a nudge.
+type NudgeKind string
+
+const (
+	// KindBelowThreshold fires when a watched route's LastPrice has crossed
+	// below its configured BelowPrice target.
+	KindBelowThreshold NudgeKind = "below_threshold"
+
+	// KindHistoricLow fires when fareintel rates the current price as "buy"
+	// with high confidence — meaning it is materially below the observed median
+	// and backed by sufficient observations.
+	KindHistoricLow NudgeKind = "historic_low"
+)
+
+// Nudge is a single proactive message grounded in one or more source records.
+//
+// Every Nudge carries at least one Source identifier so the caller can trace it
+// back to the underlying watch, route key, or trip that triggered it. Nudges
+// with an empty Sources slice are not produced by this package.
+type Nudge struct {
+	Kind    NudgeKind
+	Message string
+	// Sources holds the identifiers (watch ID, route key, trip ID) that ground
+	// this nudge. len(Sources) >= 1 is an invariant for all emitted nudges.
+	Sources []string
+}
+
+// routeHistory groups price points by route key (for multi-watch aggregation).
+type routeHistory struct {
+	points  []watch.PricePoint
+	watches []watch.Watch // watches that cover this route
+}
+
+// Graph is the indexed travel graph built from the user's data.
+// Use [Build] to construct it; treat fields as read-only after construction.
+type Graph struct {
+	// byRoute maps "ORIGIN-DESTINATION" to the aggregated history and watches.
+	byRoute map[string]*routeHistory
+	// prefs holds user preferences for contextual filtering (currently stored for
+	// future extension; not used in nudge logic itself).
+	prefs *preferences.Preferences
+	// trips holds planned / booked trips indexed by ID.
+	trips map[string]trips.Trip
+}
+
+// Build constructs a Graph from the supplied data. None of the inputs are
+// required to be non-nil; missing slices are silently treated as empty.
+//
+//   - ws: active watches from watch.Store.List()
+//   - history: all price points, typically from watch.Store's full history
+//   - prefs: user preferences (pass nil to use defaults)
+//   - ts: planned or booked trips
+func Build(
+	ws []watch.Watch,
+	history []watch.PricePoint,
+	prefs *preferences.Preferences,
+	ts []trips.Trip,
+) *Graph {
+	if prefs == nil {
+		prefs = preferences.Default()
+	}
+
+	g := &Graph{
+		byRoute: make(map[string]*routeHistory),
+		prefs:   prefs,
+		trips:   make(map[string]trips.Trip, len(ts)),
+	}
+
+	// Index trips by ID.
+	for _, t := range ts {
+		g.trips[t.ID] = t
+	}
+
+	// Index watches by route key, ensuring each route entry exists.
+	for _, w := range ws {
+		key := routeKey(w.Origin, w.Destination)
+		rh := g.routeFor(key)
+		rh.watches = append(rh.watches, w)
+	}
+
+	// Index price history. Points may carry a WatchID; map them to the route key
+	// via the watch index we just built.
+	watchToRoute := make(map[string]string, len(ws))
+	for _, w := range ws {
+		watchToRoute[w.ID] = routeKey(w.Origin, w.Destination)
+	}
+
+	for _, p := range history {
+		key, ok := watchToRoute[p.WatchID]
+		if !ok {
+			continue // point belongs to a deleted or unknown watch; skip
+		}
+		rh := g.routeFor(key)
+		rh.points = append(rh.points, p)
+	}
+
+	return g
+}
+
+// routeFor returns the routeHistory for a key, creating it on first access.
+func (g *Graph) routeFor(key string) *routeHistory {
+	rh, ok := g.byRoute[key]
+	if !ok {
+		rh = &routeHistory{}
+		g.byRoute[key] = rh
+	}
+	return rh
+}
+
+// Nudges evaluates the graph and returns all grounded nudges. It emits at most
+// one nudge per watch (below-threshold check) and at most one nudge per route
+// (historic-low check). If there are no grounded triggers, the slice is empty.
+//
+// Trigger rules:
+//
+//  1. A watch whose LastPrice > 0 and LastPrice <= BelowPrice fires
+//     KindBelowThreshold. Source: watch.ID.
+//
+//  2. A route with >= 3 price-history points whose fareintel verdict is "buy"
+//     and confidence is "high" fires KindHistoricLow. Source: route key.
+//     This check is skipped if the route already fired a KindBelowThreshold to
+//     avoid duplicate nudges for the same route.
+func Nudges(g *Graph) []Nudge {
+	var out []Nudge
+	// Track which routes already produced a KindBelowThreshold nudge so the
+	// historic-low check doesn't double-fire on the same route.
+	belowRoutes := make(map[string]bool)
+
+	for key, rh := range g.byRoute {
+		belowNudges := belowThresholdNudges(rh)
+		if len(belowNudges) > 0 {
+			out = append(out, belowNudges...)
+			belowRoutes[key] = true
+		}
+	}
+
+	for key, rh := range g.byRoute {
+		if belowRoutes[key] {
+			continue // already nudged via threshold crossing
+		}
+		if n, ok := historicLowNudge(key, rh); ok {
+			out = append(out, n)
+		}
+	}
+
+	return out
+}
+
+// belowThresholdNudges emits one KindBelowThreshold nudge per watch that has
+// crossed its price target. A watch qualifies when:
+//   - LastPrice > 0 (an observation exists)
+//   - BelowPrice > 0 (a threshold is configured)
+//   - LastPrice <= BelowPrice
+func belowThresholdNudges(rh *routeHistory) []Nudge {
+	var out []Nudge
+	for _, w := range rh.watches {
+		if !isThresholdCrossed(w) {
+			continue
+		}
+		out = append(out, Nudge{
+			Kind: KindBelowThreshold,
+			Message: fmt.Sprintf(
+				"%s→%s dropped to %.0f %s — below your %.0f %s target",
+				w.Origin, w.Destination,
+				w.LastPrice, w.Currency,
+				w.BelowPrice, w.Currency,
+			),
+			Sources: []string{w.ID},
+		})
+	}
+	return out
+}
+
+// isThresholdCrossed returns true when the watch has a valid observation that
+// meets or beats its configured price target.
+func isThresholdCrossed(w watch.Watch) bool {
+	return w.LastPrice > 0 && w.BelowPrice > 0 && w.LastPrice <= w.BelowPrice
+}
+
+// historicLowNudge returns a KindHistoricLow nudge for a route when fareintel
+// rates it as a "buy" with "high" confidence. The current price is derived from
+// the most recent price point in history. Returns (Nudge, true) when a nudge
+// fires, (Nudge{}, false) otherwise.
+func historicLowNudge(key string, rh *routeHistory) (Nudge, bool) {
+	if len(rh.points) < 3 {
+		return Nudge{}, false
+	}
+
+	latest := latestPoint(rh.points)
+	if latest.Price <= 0 {
+		return Nudge{}, false
+	}
+
+	res := fareintel.Analyze(latest.Price, latest.Currency, rh.points)
+	if res.Verdict != fareintel.VerdictBuy || res.Confidence != "high" {
+		return Nudge{}, false
+	}
+
+	return Nudge{
+		Kind: KindHistoricLow,
+		Message: fmt.Sprintf(
+			"%s is at a historic low (%.0f %s, %.1f%% below median of %.0f %s) — strong buy signal",
+			key,
+			latest.Price, latest.Currency,
+			-res.PercentVsMedian, res.MedianPrice, latest.Currency,
+		),
+		Sources: []string{key},
+	}, true
+}
+
+// latestPoint returns the price point with the most recent Timestamp.
+// Callers must ensure len(points) >= 1.
+func latestPoint(points []watch.PricePoint) watch.PricePoint {
+	latest := points[0]
+	for _, p := range points[1:] {
+		if p.Timestamp.After(latest.Timestamp) {
+			latest = p
+		}
+	}
+	return latest
+}

--- a/internal/travelgraph/travelgraph_test.go
+++ b/internal/travelgraph/travelgraph_test.go
@@ -1,0 +1,297 @@
+package travelgraph_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/travelgraph"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// now is a fixed reference timestamp for test data.
+var now = time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+
+func pt(watchID string, price float64, currency string, hoursAgo float64) watch.PricePoint {
+	return watch.PricePoint{
+		WatchID:   watchID,
+		Price:     price,
+		Currency:  currency,
+		Timestamp: now.Add(-time.Duration(hoursAgo * float64(time.Hour))),
+	}
+}
+
+// historyWithSpread builds n points for a given watchID and currency, spread
+// around basePrice with ±spread, oldest first, all before now.
+func historyWithSpread(watchID, currency string, n int, basePrice, spread float64) []watch.PricePoint {
+	pts := make([]watch.PricePoint, n)
+	for i := range pts {
+		delta := spread * float64(i-n/2) / float64(n)
+		pts[i] = watch.PricePoint{
+			WatchID:   watchID,
+			Price:     basePrice + delta,
+			Currency:  currency,
+			Timestamp: now.Add(-time.Duration((n - i) * int(time.Hour))),
+		}
+	}
+	return pts
+}
+
+// --- AC.1: below-threshold watch produces exactly one grounded nudge ---
+
+func TestBelowThreshold_OneNudgeWithWatchIDInSources(t *testing.T) {
+	// GIVEN: a watch whose LastPrice has crossed below BelowPrice
+	w := watch.Watch{
+		ID:          "w1",
+		Origin:      "HEL",
+		Destination: "BER",
+		BelowPrice:  200.0,
+		LastPrice:   180.0,
+		Currency:    "EUR",
+	}
+	history := []watch.PricePoint{pt("w1", 180.0, "EUR", 1)}
+
+	// WHEN
+	g := travelgraph.Build([]watch.Watch{w}, history, nil, nil)
+	nudges := travelgraph.Nudges(g)
+
+	// THEN: exactly one nudge, cites the watch ID
+	if len(nudges) != 1 {
+		t.Fatalf("expected 1 nudge, got %d: %v", len(nudges), nudges)
+	}
+	n := nudges[0]
+	if n.Kind != travelgraph.KindBelowThreshold {
+		t.Errorf("expected KindBelowThreshold, got %q", n.Kind)
+	}
+	if !containsSource(n.Sources, "w1") {
+		t.Errorf("expected Sources to contain %q, got %v", "w1", n.Sources)
+	}
+}
+
+// --- AC.1 edge: LastPrice exactly at threshold still fires ---
+
+func TestBelowThreshold_AtExactThreshold_Fires(t *testing.T) {
+	w := watch.Watch{
+		ID:          "w-exact",
+		Origin:      "AMS",
+		Destination: "LIS",
+		BelowPrice:  150.0,
+		LastPrice:   150.0,
+		Currency:    "EUR",
+	}
+
+	g := travelgraph.Build([]watch.Watch{w}, nil, nil, nil)
+	nudges := travelgraph.Nudges(g)
+
+	if len(nudges) != 1 {
+		t.Fatalf("expected 1 nudge at exact threshold, got %d", len(nudges))
+	}
+	if nudges[0].Kind != travelgraph.KindBelowThreshold {
+		t.Errorf("expected KindBelowThreshold, got %q", nudges[0].Kind)
+	}
+}
+
+// --- AC.2: no grounded trigger → zero nudges (anti-speculation guarantee) ---
+
+func TestNoGroundedTrigger_ZeroNudges(t *testing.T) {
+	// GIVEN: a watch above its threshold, flat history → fareintel "watch" not "buy"
+	w := watch.Watch{
+		ID:          "w2",
+		Origin:      "HEL",
+		Destination: "LHR",
+		BelowPrice:  200.0,
+		LastPrice:   250.0,
+		Currency:    "EUR",
+	}
+	history := []watch.PricePoint{
+		pt("w2", 250.0, "EUR", 72),
+		pt("w2", 252.0, "EUR", 48),
+		pt("w2", 248.0, "EUR", 24),
+	}
+
+	// WHEN
+	g := travelgraph.Build([]watch.Watch{w}, history, nil, nil)
+	nudges := travelgraph.Nudges(g)
+
+	// THEN: no nudges
+	if len(nudges) != 0 {
+		t.Errorf("expected 0 nudges, got %d: %v", len(nudges), nudges)
+	}
+}
+
+// --- AC.2 variant: watch above threshold, no history → zero nudges ---
+
+func TestWatchAboveThresholdNoHistory_ZeroNudges(t *testing.T) {
+	w := watch.Watch{
+		ID:          "w3",
+		Origin:      "CPH",
+		Destination: "CDG",
+		BelowPrice:  100.0,
+		LastPrice:   130.0,
+		Currency:    "EUR",
+	}
+
+	g := travelgraph.Build([]watch.Watch{w}, nil, nil, nil)
+	nudges := travelgraph.Nudges(g)
+
+	if len(nudges) != 0 {
+		t.Errorf("expected 0 nudges, got %d", len(nudges))
+	}
+}
+
+// --- AC.3: historic-low route (confident observations, current in low band) ---
+
+func TestHistoricLow_ConfidentAndLowBand_FiresNudge(t *testing.T) {
+	// GIVEN: 11 historical points near 300 EUR median + a 220 EUR current
+	// fareintel.Analyze needs >= 10 points for confidence="high"
+	w := watch.Watch{
+		ID:          "w-hist",
+		Origin:      "HEL",
+		Destination: "NYC",
+		BelowPrice:  0,
+		LastPrice:   220.0,
+		Currency:    "EUR",
+	}
+	history := historyWithSpread("w-hist", "EUR", 11, 300.0, 40.0)
+	history = append(history, pt("w-hist", 220.0, "EUR", 0.5))
+
+	// WHEN
+	g := travelgraph.Build([]watch.Watch{w}, history, nil, nil)
+	nudges := travelgraph.Nudges(g)
+
+	// THEN: exactly one KindHistoricLow nudge citing the route key
+	lowNudges := filterKind(nudges, travelgraph.KindHistoricLow)
+	if len(lowNudges) == 0 {
+		t.Fatalf("expected a KindHistoricLow nudge, got %d nudge(s): %v", len(nudges), nudges)
+	}
+	n := lowNudges[0]
+	expectedKey := "HEL-NYC"
+	if !containsSource(n.Sources, expectedKey) {
+		t.Errorf("expected Sources to contain %q, got %v", expectedKey, n.Sources)
+	}
+}
+
+// --- AC.4: every emitted nudge has len(Sources) >= 1 ---
+
+func TestAllNudgesHaveAtLeastOneSource(t *testing.T) {
+	// GIVEN: a below-threshold watch and a historic-low route on distinct routes
+	wBelow := watch.Watch{
+		ID: "wb1", Origin: "AMS", Destination: "BCN",
+		BelowPrice: 80.0, LastPrice: 75.0, Currency: "EUR",
+	}
+	wHist := watch.Watch{
+		ID: "wh1", Origin: "HEL", Destination: "DXB",
+		BelowPrice: 0, LastPrice: 400.0, Currency: "EUR",
+	}
+	histHist := historyWithSpread("wh1", "EUR", 11, 600.0, 80.0)
+	histHist = append(histHist, pt("wh1", 400.0, "EUR", 1))
+
+	g := travelgraph.Build(
+		[]watch.Watch{wBelow, wHist},
+		append([]watch.PricePoint{pt("wb1", 75.0, "EUR", 2)}, histHist...),
+		nil, nil,
+	)
+	nudges := travelgraph.Nudges(g)
+
+	if len(nudges) == 0 {
+		t.Fatal("expected at least one nudge")
+	}
+	for i, n := range nudges {
+		if len(n.Sources) < 1 {
+			t.Errorf("nudge[%d] has empty Sources: %+v", i, n)
+		}
+	}
+}
+
+// --- AC.4 invariant: empty inputs → zero nudges, no panic ---
+
+func TestEmptyInputs_NoPanicZeroNudges(t *testing.T) {
+	g := travelgraph.Build(nil, nil, nil, nil)
+	nudges := travelgraph.Nudges(g)
+	if len(nudges) != 0 {
+		t.Errorf("expected 0 nudges on empty graph, got %d", len(nudges))
+	}
+}
+
+// --- No BelowPrice configured → threshold check never fires ---
+
+func TestNoBelowPrice_NeverFiresThreshold(t *testing.T) {
+	w := watch.Watch{
+		ID:          "w-nobp",
+		Origin:      "FRA",
+		Destination: "JFK",
+		BelowPrice:  0,
+		LastPrice:   350.0,
+		Currency:    "EUR",
+	}
+
+	g := travelgraph.Build([]watch.Watch{w}, nil, nil, nil)
+	nudges := filterKind(travelgraph.Nudges(g), travelgraph.KindBelowThreshold)
+
+	if len(nudges) != 0 {
+		t.Errorf("expected no threshold nudges when BelowPrice=0, got %d", len(nudges))
+	}
+}
+
+// --- orphan price point (unknown watch ID) is silently skipped ---
+
+func TestOrphanPricePoint_Ignored(t *testing.T) {
+	// GIVEN: a history point whose WatchID has no corresponding watch
+	orphan := watch.PricePoint{
+		WatchID:   "nonexistent-watch",
+		Price:     100.0,
+		Currency:  "EUR",
+		Timestamp: now,
+	}
+
+	// WHEN
+	g := travelgraph.Build(nil, []watch.PricePoint{orphan}, nil, nil)
+	nudges := travelgraph.Nudges(g)
+
+	// THEN: no panic, no nudges
+	if len(nudges) != 0 {
+		t.Errorf("expected 0 nudges for orphan point, got %d", len(nudges))
+	}
+}
+
+// --- historic-low: fewer than 3 history points → no nudge (guard branch) ---
+
+func TestHistoricLow_TooFewPoints_NoNudge(t *testing.T) {
+	w := watch.Watch{
+		ID: "w-few", Origin: "OSL", Destination: "MAD",
+		BelowPrice: 0, LastPrice: 120.0, Currency: "EUR",
+	}
+	history := []watch.PricePoint{
+		pt("w-few", 200.0, "EUR", 48),
+		pt("w-few", 120.0, "EUR", 1),
+	}
+	g := travelgraph.Build([]watch.Watch{w}, history, nil, nil)
+	nudges := filterKind(travelgraph.Nudges(g), travelgraph.KindHistoricLow)
+	if len(nudges) != 0 {
+		t.Errorf("expected 0 historic-low nudges with only 2 points, got %d", len(nudges))
+	}
+}
+
+// --- helpers ---
+
+func containsSource(sources []string, id string) bool {
+	for _, s := range sources {
+		if s == id {
+			return true
+		}
+	}
+	return false
+}
+
+func filterKind(nudges []travelgraph.Nudge, kind travelgraph.NudgeKind) []travelgraph.Nudge {
+	var out []travelgraph.Nudge
+	for _, n := range nudges {
+		if n.Kind == kind {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// Compile-time check: Nudge, NudgeKind, Build, Nudges are exported.
+var _ = fmt.Sprintf("%T", travelgraph.Nudge{})

--- a/internal/watch/observation_test.go
+++ b/internal/watch/observation_test.go
@@ -1,6 +1,9 @@
 package watch
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestRouteKeyCanonical(t *testing.T) {
 	got := RouteKey("flight", " ams ", "vlc", "2026-07-15")
@@ -32,7 +35,7 @@ func TestRecordObservationAndRouteHistory(t *testing.T) {
 	if len(hist) != 3 {
 		t.Fatalf("want 3 route points, got %d", len(hist))
 	}
-	prices := s.RoutePrices(key)
+	prices := s.RoutePrices(key, "EUR")
 	if len(prices) != 3 || prices[0] != 120 || prices[2] != 130 {
 		t.Fatalf("RoutePrices wrong: %v", prices)
 	}
@@ -47,7 +50,80 @@ func TestRecordObservationAndRouteHistory(t *testing.T) {
 	if err := s2.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if got := s2.RoutePrices(key); len(got) != 3 {
+	if got := s2.RoutePrices(key, "EUR"); len(got) != 3 {
 		t.Fatalf("after reload want 3, got %d", len(got))
+	}
+}
+
+// P0 fix: RoutePrices must not mix currencies, or pricesignal bands are garbage.
+func TestRoutePricesCurrencyFilter(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+	key := RouteKey("flight", "AMS", "VLC", "2026-07-15")
+	// Distinct prices so throttle never collapses them.
+	_ = s.RecordObservation(key, 120, "EUR")
+	_ = s.RecordObservation(key, 200, "USD")
+	_ = s.RecordObservation(key, 130, "EUR")
+
+	if eur := s.RoutePrices(key, "EUR"); len(eur) != 2 {
+		t.Fatalf("want 2 EUR prices, got %d (%v)", len(eur), eur)
+	}
+	if usd := s.RoutePrices(key, "usd"); len(usd) != 1 { // case-insensitive
+		t.Fatalf("want 1 USD price, got %d", len(usd))
+	}
+	if all := s.RoutePrices(key, ""); len(all) != 3 {
+		t.Fatalf("empty currency must return all, got %d", len(all))
+	}
+}
+
+// P0 fix: near-identical repeat observations within the throttle window are
+// skipped, so rapid repeat searches do not each rewrite the file.
+func TestRecordObservationThrottlesNearDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+	key := RouteKey("flight", "AMS", "VLC", "2026-07-15")
+
+	_ = s.RecordObservation(key, 100, "EUR")
+	_ = s.RecordObservation(key, 100.2, "EUR") // within 0.5% -> skipped
+	if got := s.RoutePrices(key, "EUR"); len(got) != 1 {
+		t.Fatalf("near-duplicate must be throttled, got %d points", len(got))
+	}
+	// A material move IS recorded.
+	_ = s.RecordObservation(key, 130, "EUR")
+	if got := s.RoutePrices(key, "EUR"); len(got) != 2 {
+		t.Fatalf("material price move must be recorded, got %d", len(got))
+	}
+	// A different currency is recorded even at the same price (separate series).
+	_ = s.RecordObservation(key, 130, "USD")
+	if got := s.RoutePrices(key, "USD"); len(got) != 1 {
+		t.Fatalf("different currency must record, got %d", len(got))
+	}
+}
+
+// P0 fix: per-route cap bounds the history file.
+func TestRecordObservationCapsPerRoute(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+	key := RouteKey("flight", "AMS", "VLC", "2026-07-15")
+
+	// Push well past the cap with strictly increasing prices (so throttle never
+	// collapses them) using direct history seeding to keep the test fast.
+	base := time.Now().Add(-time.Hour)
+	for i := 0; i < maxObservationsPerRoute+50; i++ {
+		s.history = append(s.history, PricePoint{
+			RouteKey:  key,
+			Price:     float64(100 + i),
+			Currency:  "EUR",
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+		})
+	}
+	s.pruneRouteLocked(key)
+	got := s.RoutePrices(key, "EUR")
+	if len(got) != maxObservationsPerRoute {
+		t.Fatalf("want cap %d, got %d", maxObservationsPerRoute, len(got))
+	}
+	// Oldest dropped: first retained price should be the (50+1)th cheapest.
+	if got[0] != float64(100+50) {
+		t.Fatalf("oldest 50 should be pruned; first kept = %v", got[0])
 	}
 }

--- a/internal/watch/observation_test.go
+++ b/internal/watch/observation_test.go
@@ -1,0 +1,53 @@
+package watch
+
+import "testing"
+
+func TestRouteKeyCanonical(t *testing.T) {
+	got := RouteKey("flight", " ams ", "vlc", "2026-07-15")
+	want := "FLIGHT|AMS|VLC|2026-07-15"
+	if got != want {
+		t.Fatalf("RouteKey = %q, want %q", got, want)
+	}
+}
+
+func TestRecordObservationAndRouteHistory(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+
+	key := RouteKey("flight", "AMS", "VLC", "2026-07-15")
+	for _, p := range []float64{120, 110, 130} {
+		if err := s.RecordObservation(key, p, "EUR"); err != nil {
+			t.Fatalf("RecordObservation: %v", err)
+		}
+	}
+	// Non-positive and empty-key observations are dropped silently.
+	if err := s.RecordObservation(key, 0, "EUR"); err != nil {
+		t.Fatalf("zero price should be a no-op, got %v", err)
+	}
+	if err := s.RecordObservation("", 100, "EUR"); err != nil {
+		t.Fatalf("empty key should be a no-op, got %v", err)
+	}
+
+	hist := s.RouteHistory(key)
+	if len(hist) != 3 {
+		t.Fatalf("want 3 route points, got %d", len(hist))
+	}
+	prices := s.RoutePrices(key)
+	if len(prices) != 3 || prices[0] != 120 || prices[2] != 130 {
+		t.Fatalf("RoutePrices wrong: %v", prices)
+	}
+
+	// Route observations must not leak into the watch-ID corpus and vice versa.
+	if got := s.History("some-watch-id"); len(got) != 0 {
+		t.Fatalf("route obs leaked into watch history: %d", len(got))
+	}
+
+	// Round-trips through disk.
+	s2 := NewStore(dir)
+	if err := s2.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := s2.RoutePrices(key); len(got) != 3 {
+		t.Fatalf("after reload want 3, got %d", len(got))
+	}
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -184,12 +184,31 @@ func validateWatchDate(label, value string) error {
 	return nil
 }
 
-// PricePoint records a single price observation for a watch.
+// PricePoint records a single price observation.
+//
+// Observations come from two sources, distinguished by which key is set:
+//   - Watch scheduler checks set WatchID (the original, watch-scoped corpus).
+//   - Ad-hoc searches set RouteKey (MIK-6229), so the history corpus compounds
+//     across every searched route, not only the watched ones.
+//
+// Exactly one of WatchID / RouteKey is expected to be set on a given point;
+// older records carry only WatchID and remain valid.
 type PricePoint struct {
-	WatchID   string    `json:"watch_id"`
+	WatchID   string    `json:"watch_id,omitempty"`
+	RouteKey  string    `json:"route_key,omitempty"`
 	Price     float64   `json:"price"`
 	Currency  string    `json:"currency"`
 	Timestamp time.Time `json:"timestamp"`
+}
+
+// RouteKey builds the canonical history key for an ad-hoc observation. The key
+// is provider-agnostic and date-scoped so that a "flight AMS->VLC on
+// 2026-07-15" search accrues to the same series regardless of which provider
+// returned the cheapest fare. Inputs are upper-cased and trimmed; an empty
+// date is allowed (route-level series).
+func RouteKey(kind, origin, destination, date string) string {
+	norm := func(s string) string { return strings.ToUpper(strings.TrimSpace(s)) }
+	return strings.Join([]string{norm(kind), norm(origin), norm(destination), strings.TrimSpace(date)}, "|")
 }
 
 // Sparkline renders a compact Unicode sparkline from price history.
@@ -424,6 +443,56 @@ func (s *Store) History(watchID string) []PricePoint {
 	for _, p := range s.history {
 		if p.WatchID == watchID {
 			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// RecordObservation appends an ad-hoc (route-keyed) price observation and
+// persists. This is the MIK-6229 enabler: every flight/hotel search can log its
+// observed price so the history corpus compounds across all searched routes,
+// not only watched ones. A non-positive price is ignored (never a real fare).
+func (s *Store) RecordObservation(routeKey string, price float64, currency string) error {
+	if routeKey == "" || price <= 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.history = append(s.history, PricePoint{
+		RouteKey:  routeKey,
+		Price:     price,
+		Currency:  currency,
+		Timestamp: time.Now(),
+	})
+	return s.saveLocked()
+}
+
+// RouteHistory returns all price points recorded for a given route key, ordered
+// by insertion (chronological) time.
+func (s *Store) RouteHistory(routeKey string) []PricePoint {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var out []PricePoint
+	for _, p := range s.history {
+		if p.RouteKey == routeKey {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// RoutePrices returns just the price values for a route key, for direct use
+// with the pricesignal package.
+func (s *Store) RoutePrices(routeKey string) []float64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var out []float64
+	for _, p := range s.history {
+		if p.RouteKey == routeKey {
+			out = append(out, p.Price)
 		}
 	}
 	return out

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -8,12 +8,26 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
+)
+
+// Scaling guards for ad-hoc route observations (MIK-6229 improve pass).
+const (
+	// maxObservationsPerRoute caps retained points per route key, bounding the
+	// price-history file to cap x number-of-routes.
+	maxObservationsPerRoute = 1000
+	// observationThrottle suppresses near-identical repeat observations for the
+	// same route+currency within this window.
+	observationThrottle = 15 * time.Minute
+	// observationEpsilonPct is the relative price delta below which a throttled
+	// observation is treated as a duplicate.
+	observationEpsilonPct = 0.005
 )
 
 // Watch represents a price tracking rule for a flight or hotel route.
@@ -452,6 +466,14 @@ func (s *Store) History(watchID string) []PricePoint {
 // persists. This is the MIK-6229 enabler: every flight/hotel search can log its
 // observed price so the history corpus compounds across all searched routes,
 // not only watched ones. A non-positive price is ignored (never a real fare).
+//
+// Two scaling guards (added in the MIK-6229 improve pass) keep the corpus
+// bounded and the per-search write cheap:
+//   - Throttle: a near-identical observation for the same route+currency within
+//     observationThrottle is skipped entirely (no write), so rapid repeat
+//     searches of the same route do not each rewrite the history file.
+//   - Cap: at most maxObservationsPerRoute points are retained per route key;
+//     the oldest are pruned, bounding file growth to cap x number-of-routes.
 func (s *Store) RecordObservation(routeKey string, price float64, currency string) error {
 	if routeKey == "" || price <= 0 {
 		return nil
@@ -459,13 +481,63 @@ func (s *Store) RecordObservation(routeKey string, price float64, currency strin
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	cur := strings.ToUpper(strings.TrimSpace(currency))
+	if last, ok := s.lastObservationLocked(routeKey, cur); ok && last.Price > 0 {
+		if time.Since(last.Timestamp) < observationThrottle &&
+			math.Abs(price-last.Price)/last.Price <= observationEpsilonPct {
+			return nil // redundant near-duplicate; skip the write entirely
+		}
+	}
+
 	s.history = append(s.history, PricePoint{
 		RouteKey:  routeKey,
 		Price:     price,
-		Currency:  currency,
+		Currency:  cur,
 		Timestamp: time.Now(),
 	})
+	s.pruneRouteLocked(routeKey)
 	return s.saveLocked()
+}
+
+// lastObservationLocked returns the most recent price point for a route key,
+// optionally filtered to a currency (empty currency matches any). Caller holds s.mu.
+func (s *Store) lastObservationLocked(routeKey, currency string) (PricePoint, bool) {
+	for i := len(s.history) - 1; i >= 0; i-- {
+		p := s.history[i]
+		if p.RouteKey != routeKey {
+			continue
+		}
+		if currency != "" && strings.ToUpper(p.Currency) != currency {
+			continue
+		}
+		return p, true
+	}
+	return PricePoint{}, false
+}
+
+// pruneRouteLocked drops the oldest observations for routeKey beyond the cap,
+// preserving order. Caller holds s.mu.
+func (s *Store) pruneRouteLocked(routeKey string) {
+	var idx []int
+	for i, p := range s.history {
+		if p.RouteKey == routeKey {
+			idx = append(idx, i)
+		}
+	}
+	if len(idx) <= maxObservationsPerRoute {
+		return
+	}
+	drop := make(map[int]bool, len(idx)-maxObservationsPerRoute)
+	for _, i := range idx[:len(idx)-maxObservationsPerRoute] {
+		drop[i] = true
+	}
+	kept := s.history[:0:0]
+	for i, p := range s.history {
+		if !drop[i] {
+			kept = append(kept, p)
+		}
+	}
+	s.history = kept
 }
 
 // RouteHistory returns all price points recorded for a given route key, ordered
@@ -483,17 +555,23 @@ func (s *Store) RouteHistory(routeKey string) []PricePoint {
 	return out
 }
 
-// RoutePrices returns just the price values for a route key, for direct use
-// with the pricesignal package.
-func (s *Store) RoutePrices(routeKey string) []float64 {
+// RoutePrices returns the price values for a route key, filtered to a currency
+// so callers never mix currencies into a single price-position computation.
+// An empty currency returns every recorded price for the key.
+func (s *Store) RoutePrices(routeKey, currency string) []float64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	cur := strings.ToUpper(strings.TrimSpace(currency))
 	var out []float64
 	for _, p := range s.history {
-		if p.RouteKey == routeKey {
-			out = append(out, p.Price)
+		if p.RouteKey != routeKey {
+			continue
 		}
+		if cur != "" && strings.ToUpper(p.Currency) != cur {
+			continue
+		}
+		out = append(out, p.Price)
 	}
 	return out
 }


### PR DESCRIPTION
# Five travel-intelligence features on one price-history substrate

Implements MIK-6229, MIK-6231, MIK-6232, MIK-6233, MIK-6234. All five read from one shared, per-user-local data substrate.

## What changed

- **MIK-6229 price substrate** (`internal/pricesignal`, `internal/obslog`, `internal/watch`): every ad-hoc flight and hotel search now logs its observed price into price-history keyed by route and date (not just watched routes). Results surface a `price_position` signal (low, typical, high band plus a buy or wait verdict) gated on a strict confidence floor. Below the floor it reports unknown and asserts no trend.
- **MIK-6234 counterfactual savings, Tier 0** (`internal/counterfactual`, `internal/probebudget`): call-free savings derived from data already fetched (same-day headline-vs-cheapest, vs-history). Plus the two-lane probe budget: counterfactual probes draw from a separate best-effort bucket that can never starve interactive traffic. Tiers 1 and 2 are deferred (default off).
- **MIK-6231 door-to-door total** (`internal/d2d`): honest end-to-end total where indicative legs (Rome2Rio) are excluded from the confirmed total and surfaced separately, with a confidence band instead of a single false-precise figure.
- **MIK-6232 booking-readiness contract** (`internal/booking`): composes verified, link-stable, identity-confirmed, and refundability-known into one verdict (ready, caution, or unverified). Any unknown input forces a conservative downgrade.
- **MIK-6233 personal travel graph** (`internal/travelgraph`, new `trvl nudges` command): joins watches, history, preferences, and trips, and emits grounded nudges only on real triggers, each citing its source record.

## Honesty and safety guarantees (tested, not promised)

- Price verdicts are withheld below the confidence floor (`pricesignal`).
- Same-day savings return nil when the list is already cheapest-first, so no illusory saving is shown.
- The probe budget has a test proving interactive acquisition is never starved by a saturated counterfactual lane.
- Route price history is currency-filtered so a price-position computation never mixes currencies.
- Price-history writes are bounded: a per-route cap plus a near-duplicate write-throttle.

## Validation

- go build, go vet, staticcheck: clean across the repo.
- go test with the race detector: all packages pass.
- Coverage on new packages: 89 to 97 percent (repo floor is 50).
- govulncheck: no vulnerabilities (no new dependencies).

## Notes for follow-up

- `internal/pricesignal` overlaps the older `internal/fareintel`; consolidation onto one engine is a sensible follow-up (this PR narrows the gap by making both currency-aware).
- `internal/travelgraph` reads watch-keyed history; wiring it to also read the new route-keyed corpus is a small follow-up.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
