### PR TITLE
feat: backlog drain — Tier-1 scheduler probe, livecheck test, tripcoalesce flake fix, docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,11 @@ Optional parameters:
 - `exclude_basic`: true/false — exclude basic economy fares — server-side
 - `airlines`: comma-separated IATA codes to restrict results (e.g. "AY,LH")
 - `provider`: empty (default) merges Google Flights + Kiwi + Skiplagged into one sorted list; `"skiplagged"` queries Skiplagged solo for hidden-city / virtual-interlining cross-validation
+- `deep`: true/false — opt-in budget-gated counterfactual fan-out. Probes nearby departure airports, split-ticket options, and hidden-city routes via extra provider calls. Capped by a best-effort budget; never delays the primary result. When the budget is spent the tool returns what it has and notes the shortfall.
+
+Response extras (single-airport, single-destination searches only):
+- `price_position`: where the current fare sits in the route's observed history (low / typical / high) with a buy-or-wait verdict. Omitted when there is not enough history or below the data floor.
+- `savings`: call-free savings opportunities read from the persisted price calendar — same-day cheaper fares, vs-history comparison, shift-day options. Each entry carries an `as_of` age when the data is not live.
 
 ### search_dates — Find the cheapest day to fly
 ```json
@@ -374,6 +379,13 @@ Use `hotel_prices` as a provider comparison when Google exposes booking partners
 not as a standalone guarantee. For final hotel recommendations, prefer
 `search_hotels_with_details` or `hotel_rooms` totals because they can include
 room-level cancellation, board, and tax/fee fields.
+
+Response extras:
+- `price_position`: where the current rate sits in the property's observed price history (low / typical / high). Omitted when there is not enough data.
+- `booking_readiness`: a verdict string — `"ready"`, `"caution"`, or `"unverified"` — composed from verified price, stable link, confirmed property identity, and known refundability. Any unknown signal downgrades the verdict conservatively.
+- `booking_readiness_reasons`: list of strings explaining what contributed to the verdict.
+
+`hotel_rooms` returns the same `booking_readiness` and `booking_readiness_reasons` fields.
 
 CLI re-book flow for existing refundable reservations:
 ```bash
@@ -538,6 +550,17 @@ Searches 20+ providers in parallel including FlixBus, RegioJet, Eurostar, DB, NS
 {"type": "flight", "origin": "HEL", "destination": "BCN", "date": "2026-07-01", "target_price": 89, "currency": "EUR"}
 ```
 Stores watch in `~/.trvl/watches.json`. Use `check_watches` to re-check prices, `list_watches` to see all active watches. Hotel watches can set `last_minute: true` and `last_minute_drop_pct` (default 25) to alert when sub-48h availability drops materially below the last seen price.
+
+### nudges — Grounded proactive travel nudges (CLI)
+
+`trvl nudges` reads watches, price history, preferences, and trips from `~/.trvl` and surfaces nudges when a real trigger fires. Triggers are: a watch crossing its target price, or a route sitting at a confident historic low. When nothing has triggered, the command outputs nothing. Each nudge cites its source record. No network calls are made.
+
+```bash
+trvl nudges                   # Show grounded nudges (silent when nothing triggered)
+trvl nudges --format json     # Machine-readable
+```
+
+This command has no MCP equivalent — use `watch_price` + `check_watches` for watch management and `search_flights` for on-demand price signals.
 
 ### provider_health — Provider status dashboard
 ```json

--- a/README.md
+++ b/README.md
@@ -501,7 +501,14 @@ trvl flights JFK LHR 2026-07-01 --cabin business --stops nonstop
 trvl flights AMS,EIN,ANR HEL,TKU,TLL 2026-06-15     # Multi-airport search
 trvl flights HEL BCN 2026-07-01 --return 2026-07-08
 trvl flights HEL NRT 2026-06-15 --format json       # JSON output
+trvl flights HEL BCN 2026-07-01 --deep              # Budget-gated counterfactual fan-out
 ```
+
+**`--deep` flag:** runs a budget-gated counterfactual fan-out after the primary search. It probes nearby departure airports, split-ticket options, and hidden-city routes via extra provider calls. The budget is best-effort and caps the total call count; if the budget runs out before all probes complete, the primary result is returned with a note. The flag never delays the primary search output.
+
+**Price position:** when a route has enough price history, each result includes where the current fare sits in that route's observed range (low / typical / high) and a buy-or-wait verdict. Below the data floor the output says so and makes no trend claim. Available in `--format json` as `price_position` and in the MCP `search_flights` response.
+
+**Call-free savings:** results include a "Savings you could capture" panel showing same-day cheaper fares, a vs-history comparison, and a shift-day option (departing a nearby date). These read from the persisted price calendar — no extra provider calls. Each carries an age label when the data is not live.
 
 ### Cheapest Dates
 
@@ -530,6 +537,10 @@ trvl prices hold "<hotel_id>" --name "Hotel Lutetia Paris" --checkin 2026-06-15 
 trvl prices rebook <hold_id> --min-savings 25
 trvl rooms "Hotel Lutetia Paris" --checkin 2026-06-15 --checkout 2026-06-18
 ```
+
+**Price position:** `trvl prices` shows where the current rate sits in that property's observed price history (low / typical / high). Available in `--format json` as `price_position`.
+
+**Booking readiness:** `trvl prices` and `trvl rooms` show a readiness verdict (ready / caution / unverified) composed from verified price, stable link, confirmed property identity, and known refundability. Any unknown signal downgrades the verdict conservatively. In `--format json` the fields are `booking_readiness` and `booking_readiness_reasons`.
 
 ### Explore Destinations
 
@@ -645,6 +656,15 @@ trvl deals                                            # All recent deals
 trvl deals --from HEL,AMS --max-price 400             # From my airports, under €400
 trvl deals --from Helsinki,Amsterdam,Prague            # City names also accepted
 trvl deals --type error_fare                           # Error fares only
+```
+
+### Proactive Nudges
+
+`trvl nudges` reads your watches, price history, preferences, and trips and surfaces a list of grounded nudges. A nudge fires only when a real trigger exists: a price watch crossing its target, or a route sitting at a confident historic low. When nothing has triggered, the command prints nothing. Every nudge cites the record it came from. The command reads only `~/.trvl` and makes no network calls.
+
+```bash
+trvl nudges                   # Show grounded nudges (quiet when nothing triggered)
+trvl nudges --format json     # Machine-readable output
 ```
 
 ### Travel Hacks

--- a/cmd/trvl/counterfactual_render.go
+++ b/cmd/trvl/counterfactual_render.go
@@ -8,7 +8,12 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/counterfactual"
 	"github.com/MikkoParkkola/trvl/internal/dategrid"
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/probecache"
 )
+
+// probeCacheFreshness bounds how recent a Tier-1 cached probe must be to be
+// served. Beyond it the cached fan-out result is treated as stale and skipped.
+const probeCacheFreshness = 12 * time.Hour
 
 // gridFreshness is how recent a persisted price grid must be to drive a
 // call-free shift-day counterfactual. Beyond this it is treated as stale and
@@ -38,6 +43,21 @@ func shiftDaySavings(origin, destination, date string, now time.Time) []counterf
 		})
 	}
 	return counterfactual.ShiftDay(grid, date, 10, g.UpdatedAt)
+}
+
+// tier1CachedSavings returns Tier-1 counterfactual savings pre-computed by the
+// watch scheduler for this route (MIK-6234). Served call-free from the probe
+// cache; nothing is returned when no fresh entry exists. No provider calls.
+func tier1CachedSavings(origin, destination string, now time.Time) []counterfactual.Saving {
+	store, err := probecache.DefaultStore()
+	if err != nil || store.Load() != nil {
+		return nil
+	}
+	e, ok := store.Get(probecache.RouteKey(origin, destination))
+	if !ok || !e.Fresh(now, probeCacheFreshness) {
+		return nil
+	}
+	return e.Savings
 }
 
 // printSavings renders counterfactual savings, split by whether they were free.

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -225,6 +225,9 @@ Examples:
 					savings = append(savings, *s)
 				}
 				savings = append(savings, shiftDaySavings(origins[0], destinations[0], date, now)...)
+				// MIK-6234 Tier 1: serve scheduler-precomputed probe savings for
+				// this route, call-free from the cache (no provider calls now).
+				savings = append(savings, tier1CachedSavings(origins[0], destinations[0], now)...)
 
 				// MIK-6234 Tier 2: opt-in, budget-gated cold-route fan-out. The
 				// probe lane is separate from interactive traffic; if exhausted

--- a/internal/livecheck/livecheck.go
+++ b/internal/livecheck/livecheck.go
@@ -108,6 +108,14 @@ func persistDateGrid(origin, destination string, dates []models.DatePriceResult)
 	if err := store.Load(); err != nil {
 		return
 	}
+	persistDateGridTo(store, origin, destination, dates, time.Now())
+}
+
+// persistDateGridTo is the testable core of persistDateGrid. It builds the
+// points slice from dates (skipping non-positive prices), picks the currency
+// from the first positive entry, and writes to store. Errors are silently
+// discarded: grid persistence is best-effort.
+func persistDateGridTo(store *dategrid.Store, origin, destination string, dates []models.DatePriceResult, now time.Time) {
 	pts := make([]dategrid.Point, 0, len(dates))
 	currency := ""
 	for _, d := range dates {
@@ -124,7 +132,7 @@ func persistDateGrid(origin, destination string, dates []models.DatePriceResult)
 			Currency:   d.Currency,
 		})
 	}
-	_ = store.Put(dategrid.RouteKey(origin, destination), currency, pts, time.Now())
+	_ = store.Put(dategrid.RouteKey(origin, destination), currency, pts, now)
 }
 
 func checkHotel(ctx context.Context, w watch.Watch) (float64, string, string, error) {

--- a/internal/livecheck/persist_dategrid_test.go
+++ b/internal/livecheck/persist_dategrid_test.go
@@ -1,0 +1,164 @@
+package livecheck
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/dategrid"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// fixedNow is a deterministic timestamp used across grid tests.
+var fixedNow = time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+
+// newTempStore returns a fresh Store backed by t.TempDir() and panics if Load
+// fails. Every test gets an isolated directory; no ~/.trvl access.
+func newTempStore(t *testing.T) *dategrid.Store {
+	t.Helper()
+	s := dategrid.NewStore(t.TempDir())
+	if err := s.Load(); err != nil {
+		t.Fatalf("Store.Load: %v", err)
+	}
+	return s
+}
+
+// TestPersistDateGridTo_WritesPositivePricesOnly asserts that non-positive
+// prices are skipped and valid points are persisted under the correct key.
+func TestPersistDateGridTo_WritesPositivePricesOnly(t *testing.T) {
+	t.Parallel()
+
+	// GIVEN: a store, a route, and a mix of positive, zero, and negative prices.
+	store := newTempStore(t)
+	origin, destination := "HEL", "BCN"
+	dates := []models.DatePriceResult{
+		{Date: "2026-08-01", Price: 0, Currency: "EUR"},    // zero — must be skipped
+		{Date: "2026-08-02", Price: -5.0, Currency: "EUR"}, // negative — must be skipped
+		{Date: "2026-08-03", Price: 120.50, Currency: "EUR"},
+		{Date: "2026-08-04", Price: 98.00, Currency: "EUR", ReturnDate: "2026-08-11"},
+	}
+
+	// WHEN: the grid is persisted.
+	persistDateGridTo(store, origin, destination, dates, fixedNow)
+
+	// THEN: the grid exists and contains exactly the two positive-price points.
+	grid, ok := store.Get(dategrid.RouteKey(origin, destination))
+	if !ok {
+		t.Fatal("expected grid to be stored, got nothing")
+	}
+	if got, want := len(grid.Points), 2; got != want {
+		t.Errorf("len(Points) = %d, want %d", got, want)
+	}
+}
+
+// TestPersistDateGridTo_CurrencyFromFirstPositive asserts that the grid
+// currency is taken from the first entry with a positive price.
+func TestPersistDateGridTo_CurrencyFromFirstPositive(t *testing.T) {
+	t.Parallel()
+
+	// GIVEN: the first two entries are non-positive; the first positive one uses EUR.
+	store := newTempStore(t)
+	dates := []models.DatePriceResult{
+		{Date: "2026-08-01", Price: 0, Currency: "USD"},
+		{Date: "2026-08-02", Price: 89.0, Currency: "EUR"},
+		{Date: "2026-08-03", Price: 75.0, Currency: "GBP"},
+	}
+
+	// WHEN
+	persistDateGridTo(store, "ARN", "LHR", dates, fixedNow)
+
+	// THEN: grid currency = EUR (first positive entry), not USD or GBP.
+	grid, ok := store.Get(dategrid.RouteKey("ARN", "LHR"))
+	if !ok {
+		t.Fatal("expected grid to be stored")
+	}
+	if got, want := grid.Currency, "EUR"; got != want {
+		t.Errorf("Currency = %q, want %q", got, want)
+	}
+}
+
+// TestPersistDateGridTo_PointFieldsRoundTrip asserts that Date, ReturnDate,
+// Price, and Currency are preserved verbatim through Store.Put / Store.Get.
+func TestPersistDateGridTo_PointFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// GIVEN: a single positive entry with a return date.
+	store := newTempStore(t)
+	want := models.DatePriceResult{
+		Date:       "2026-09-10",
+		ReturnDate: "2026-09-17",
+		Price:      210.99,
+		Currency:   "EUR",
+	}
+
+	// WHEN
+	persistDateGridTo(store, "HEL", "JFK", []models.DatePriceResult{want}, fixedNow)
+
+	// THEN: the persisted point matches the input exactly.
+	grid, ok := store.Get(dategrid.RouteKey("HEL", "JFK"))
+	if !ok {
+		t.Fatal("expected grid to be stored")
+	}
+	if len(grid.Points) != 1 {
+		t.Fatalf("len(Points) = %d, want 1", len(grid.Points))
+	}
+	p := grid.Points[0]
+	if p.Date != want.Date {
+		t.Errorf("Date = %q, want %q", p.Date, want.Date)
+	}
+	if p.ReturnDate != want.ReturnDate {
+		t.Errorf("ReturnDate = %q, want %q", p.ReturnDate, want.ReturnDate)
+	}
+	if p.Price != want.Price {
+		t.Errorf("Price = %f, want %f", p.Price, want.Price)
+	}
+	if p.Currency != want.Currency {
+		t.Errorf("Currency = %q, want %q", p.Currency, want.Currency)
+	}
+}
+
+// TestPersistDateGridTo_AllNonPositive asserts that when every price is
+// non-positive, Put receives an empty slice and the grid is absent (Store.Put
+// is a no-op for empty slices).
+func TestPersistDateGridTo_AllNonPositive(t *testing.T) {
+	t.Parallel()
+
+	// GIVEN: only zero and negative prices.
+	store := newTempStore(t)
+	dates := []models.DatePriceResult{
+		{Date: "2026-08-01", Price: 0, Currency: "EUR"},
+		{Date: "2026-08-02", Price: -1, Currency: "EUR"},
+	}
+
+	// WHEN
+	persistDateGridTo(store, "TLL", "VIE", dates, fixedNow)
+
+	// THEN: no grid is stored.
+	_, ok := store.Get(dategrid.RouteKey("TLL", "VIE"))
+	if ok {
+		t.Error("expected no grid for all-non-positive prices, but found one")
+	}
+}
+
+// TestPersistDateGridTo_UpdatedAtMatchesNow asserts that the UpdatedAt
+// timestamp matches the explicit `now` argument passed by the caller.
+func TestPersistDateGridTo_UpdatedAtMatchesNow(t *testing.T) {
+	t.Parallel()
+
+	// GIVEN
+	store := newTempStore(t)
+	dates := []models.DatePriceResult{
+		{Date: "2026-10-01", Price: 55.0, Currency: "EUR"},
+	}
+
+	// WHEN
+	persistDateGridTo(store, "RIX", "MAD", dates, fixedNow)
+
+	// THEN: UpdatedAt is the explicit now, not a real wall-clock time.
+	grid, ok := store.Get(dategrid.RouteKey("RIX", "MAD"))
+	if !ok {
+		t.Fatal("expected grid to be stored")
+	}
+	if !grid.UpdatedAt.Equal(fixedNow) {
+		t.Errorf("UpdatedAt = %v, want %v", grid.UpdatedAt, fixedNow)
+	}
+}

--- a/internal/probecache/probecache.go
+++ b/internal/probecache/probecache.go
@@ -1,0 +1,185 @@
+// Package probecache stores counterfactual savings that the watch scheduler
+// pre-computes for a route (MIK-6234 Tier-1, scheduler-amortized fan-out). A
+// later flight search reads them back with zero new provider calls.
+//
+// Like internal/dategrid it is independent of the watch store (own file, mutex,
+// path) so it composes without touching the hot watch-persistence path.
+package probecache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/counterfactual"
+)
+
+// maxRoutes caps how many routes are retained, bounding the file. The oldest
+// (by UpdatedAt) are dropped first.
+const maxRoutes = 200
+
+// Entry is the cached probe result for one route.
+type Entry struct {
+	RouteKey  string                  `json:"route_key"`
+	Savings   []counterfactual.Saving `json:"savings"`
+	UpdatedAt time.Time               `json:"updated_at"`
+}
+
+// Fresh reports whether the entry was updated within maxAge of now.
+func (e Entry) Fresh(now time.Time, maxAge time.Duration) bool {
+	return !e.UpdatedAt.IsZero() && now.Sub(e.UpdatedAt) <= maxAge
+}
+
+// RouteKey builds the canonical cache key for a route (origin-destination).
+func RouteKey(origin, destination string) string {
+	norm := func(s string) string { return strings.ToUpper(strings.TrimSpace(s)) }
+	return norm(origin) + "|" + norm(destination)
+}
+
+// Store persists probe entries to ~/.trvl/probe-cache.json. Safe for concurrent use.
+type Store struct {
+	mu      sync.Mutex
+	dir     string
+	entries map[string]Entry
+}
+
+// NewStore creates a store rooted at dir (typically ~/.trvl).
+func NewStore(dir string) *Store { return &Store{dir: dir, entries: make(map[string]Entry)} }
+
+// DefaultStore returns a store at ~/.trvl.
+func DefaultStore() (*Store, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	return NewStore(filepath.Join(home, ".trvl")), nil
+}
+
+func (s *Store) path() string { return filepath.Join(s.dir, "probe-cache.json") }
+
+// Load reads entries from disk. A missing file starts the store empty.
+func (s *Store) Load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.entries = make(map[string]Entry)
+	data, err := os.ReadFile(s.path())
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	var list []Entry
+	if err := json.Unmarshal(data, &list); err != nil {
+		return err
+	}
+	for _, e := range list {
+		s.entries[e.RouteKey] = e
+	}
+	return nil
+}
+
+// Put stores (replacing) the savings for routeKey and persists. An empty
+// savings slice still records an entry (a probe that found nothing is a valid,
+// cacheable outcome that suppresses redundant re-probing).
+func (s *Store) Put(routeKey string, savings []counterfactual.Saving, now time.Time) error {
+	if routeKey == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.entries[routeKey] = Entry{RouteKey: routeKey, Savings: savings, UpdatedAt: now}
+	s.evictLocked()
+	return s.saveLocked()
+}
+
+// Get returns the entry for routeKey, or false if absent.
+func (s *Store) Get(routeKey string) (Entry, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[routeKey]
+	return e, ok
+}
+
+// evictLocked drops the oldest entries beyond maxRoutes. Caller holds s.mu.
+func (s *Store) evictLocked() {
+	if len(s.entries) <= maxRoutes {
+		return
+	}
+	type kv struct {
+		k string
+		t time.Time
+	}
+	all := make([]kv, 0, len(s.entries))
+	for k, e := range s.entries {
+		all = append(all, kv{k, e.UpdatedAt})
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].t.Before(all[j].t) })
+	for _, x := range all[:len(all)-maxRoutes] {
+		delete(s.entries, x.k)
+	}
+}
+
+func (s *Store) saveLocked() error {
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(s.entries))
+	for k := range s.entries {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	list := make([]Entry, 0, len(keys))
+	for _, k := range keys {
+		list = append(list, s.entries[k])
+	}
+	b, err := json.MarshalIndent(list, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(s.dir, "probe-cache.json.tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, s.path()); err != nil {
+		if runtime.GOOS == "windows" {
+			_ = os.Remove(s.path())
+			if err2 := os.Rename(tmpPath, s.path()); err2 == nil {
+				cleanup = false
+				return nil
+			}
+		}
+		return err
+	}
+	cleanup = false
+	return nil
+}

--- a/internal/probecache/probecache_test.go
+++ b/internal/probecache/probecache_test.go
@@ -1,0 +1,78 @@
+package probecache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/counterfactual"
+)
+
+func TestPutGetRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	key := RouteKey("ams", "VLC")
+
+	sav := []counterfactual.Saving{
+		{Kind: counterfactual.KindProbe, Description: "Fly from BGY", Amount: 40, Currency: "EUR", AsOf: now},
+	}
+	if err := s.Put(key, sav, now); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	s2 := NewStore(dir)
+	if err := s2.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	e, ok := s2.Get(key)
+	if !ok || len(e.Savings) != 1 || e.Savings[0].Amount != 40 {
+		t.Fatalf("round-trip failed: %+v ok=%v", e, ok)
+	}
+	if !e.UpdatedAt.Equal(now) {
+		t.Fatalf("UpdatedAt mismatch")
+	}
+}
+
+func TestFresh(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	e := Entry{UpdatedAt: now.Add(-2 * time.Hour)}
+	if !e.Fresh(now, 6*time.Hour) {
+		t.Fatalf("2h entry should be fresh under 6h")
+	}
+	if e.Fresh(now, time.Hour) {
+		t.Fatalf("2h entry should be stale under 1h")
+	}
+	if (Entry{}).Fresh(now, time.Hour) {
+		t.Fatalf("zero entry must never be fresh")
+	}
+}
+
+// An empty-savings probe result is a valid cacheable outcome (suppresses
+// redundant re-probing of a route that yielded nothing).
+func TestEmptySavingsStillCached(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+	now := time.Now()
+	if err := s.Put("K", nil, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.Get("K"); !ok {
+		t.Fatalf("empty-savings entry must still be cached")
+	}
+}
+
+func TestEviction(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < maxRoutes+10; i++ {
+		key := RouteKey("A", string(rune('A'+i%26))+string(rune('0'+i/26)))
+		_ = s.Put(key, nil, base.Add(time.Duration(i)*time.Minute))
+	}
+	s.mu.Lock()
+	n := len(s.entries)
+	s.mu.Unlock()
+	if n > maxRoutes {
+		t.Fatalf("eviction failed: %d entries > cap %d", n, maxRoutes)
+	}
+}

--- a/internal/tier1/tier1.go
+++ b/internal/tier1/tier1.go
@@ -1,0 +1,71 @@
+// Package tier1 runs the MIK-6234 scheduler-amortized counterfactual probe: at
+// most one budget-gated fan-out per scheduler tick, rotated across active flight
+// watches, with results cached for later call-free reads by a flight search.
+//
+// It is the glue that lets the watch daemon pre-compute cold-route
+// counterfactuals (nearby-airport, split, hidden-city) on its idle cycles
+// without ever fanning out at a user's query time. The detect function is
+// injected so the package is testable without the network and so the watch
+// package never depends on the hacks engine.
+package tier1
+
+import (
+	"context"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/cfprobe"
+	"github.com/MikkoParkkola/trvl/internal/hacks"
+	"github.com/MikkoParkkola/trvl/internal/probecache"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// DetectFunc is the fan-out producer (hacks.DetectAll in production).
+type DetectFunc func(ctx context.Context, in hacks.DetectorInput) []hacks.Hack
+
+// ProbeOne runs at most one budget-gated probe for a single active flight watch,
+// selected by tick rotation, and caches the savings for later call-free reads.
+// It is best-effort: when the probe budget is exhausted it caches nothing and
+// returns, so the daemon never fans out unbounded. Returns true when a probe ran.
+func ProbeOne(ctx context.Context, active []watch.Watch, tick int, engine *cfprobe.Engine, cache *probecache.Store, now time.Time, detect DetectFunc) bool {
+	if engine == nil || cache == nil || detect == nil {
+		return false
+	}
+	candidates := flightCandidates(active)
+	if len(candidates) == 0 {
+		return false
+	}
+	w := candidates[((tick%len(candidates))+len(candidates))%len(candidates)]
+
+	in := hacks.DetectorInput{
+		Origin:      w.Origin,
+		Destination: w.Destination,
+		Date:        w.DepartDate,
+		ReturnDate:  w.ReturnDate,
+		Currency:    w.Currency,
+		NaivePrice:  w.LastPrice,
+		Passengers:  1,
+	}
+	savings, status := engine.Probe(now, func() []hacks.Hack { return detect(ctx, in) })
+	if status != cfprobe.StatusRan {
+		return false // budget exhausted: cache nothing, never a silent unbounded fan-out
+	}
+	// Served call-free from the cache at read time; stamp accordingly so the
+	// flight renderer shows them under "no extra searches (as of N ago)".
+	for i := range savings {
+		savings[i].CallFree = true
+		savings[i].AsOf = now
+	}
+	_ = cache.Put(probecache.RouteKey(w.Origin, w.Destination), savings, now)
+	return true
+}
+
+// flightCandidates selects flight watches with enough information to probe.
+func flightCandidates(active []watch.Watch) []watch.Watch {
+	var out []watch.Watch
+	for _, w := range active {
+		if w.Type == "flight" && w.Origin != "" && w.Destination != "" && w.LastPrice > 0 {
+			out = append(out, w)
+		}
+	}
+	return out
+}

--- a/internal/tier1/tier1_test.go
+++ b/internal/tier1/tier1_test.go
@@ -1,0 +1,91 @@
+package tier1
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/cfprobe"
+	"github.com/MikkoParkkola/trvl/internal/hacks"
+	"github.com/MikkoParkkola/trvl/internal/probecache"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+var now = time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+
+func newCache(t *testing.T) *probecache.Store {
+	t.Helper()
+	return probecache.NewStore(t.TempDir())
+}
+
+func TestProbeOneCachesSavings(t *testing.T) {
+	cache := newCache(t)
+	engine := cfprobe.NewEngine(5, 0, nil)
+	active := []watch.Watch{
+		{Type: "flight", Origin: "AMS", Destination: "VLC", Currency: "EUR", LastPrice: 200},
+	}
+	detect := func(_ context.Context, in hacks.DetectorInput) []hacks.Hack {
+		return []hacks.Hack{{Type: "positioning", Title: "Fly from BGY", Savings: 40, Currency: "EUR"}}
+	}
+	if !ProbeOne(context.Background(), active, 0, engine, cache, now, detect) {
+		t.Fatalf("probe should have run")
+	}
+	e, ok := cache.Get(probecache.RouteKey("AMS", "VLC"))
+	if !ok || len(e.Savings) != 1 || e.Savings[0].Amount != 40 {
+		t.Fatalf("savings not cached: %+v ok=%v", e, ok)
+	}
+	if !e.Savings[0].CallFree {
+		t.Fatalf("cached savings must be stamped call-free for read-time serving")
+	}
+}
+
+// Budget exhausted -> no probe, nothing cached (no silent unbounded fan-out).
+func TestProbeOneBudgetExhaustedCachesNothing(t *testing.T) {
+	cache := newCache(t)
+	engine := cfprobe.NewEngine(1, 0, nil) // one token
+	active := []watch.Watch{{Type: "flight", Origin: "AMS", Destination: "VLC", Currency: "EUR", LastPrice: 200}}
+	calls := 0
+	detect := func(_ context.Context, _ hacks.DetectorInput) []hacks.Hack { calls++; return nil }
+
+	ProbeOne(context.Background(), active, 0, engine, cache, now, detect) // spends the token
+	ran := ProbeOne(context.Background(), active, 1, engine, cache, now, detect)
+	if ran {
+		t.Fatalf("second probe must be refused (budget exhausted)")
+	}
+	if calls != 1 {
+		t.Fatalf("detect should run exactly once (first probe), got %d", calls)
+	}
+}
+
+func TestProbeOneSkipsNonFlightAndZeroPrice(t *testing.T) {
+	cache := newCache(t)
+	engine := cfprobe.NewEngine(5, 0, nil)
+	active := []watch.Watch{
+		{Type: "hotel", Origin: "AMS", Destination: "VLC", LastPrice: 200},
+		{Type: "flight", Origin: "AMS", Destination: "VLC", LastPrice: 0}, // no price
+	}
+	detect := func(_ context.Context, _ hacks.DetectorInput) []hacks.Hack { return nil }
+	if ProbeOne(context.Background(), active, 0, engine, cache, now, detect) {
+		t.Fatalf("no eligible flight candidate -> must not run")
+	}
+}
+
+func TestProbeOneRotates(t *testing.T) {
+	cache := newCache(t)
+	engine := cfprobe.NewEngine(10, 0, nil)
+	active := []watch.Watch{
+		{Type: "flight", Origin: "AMS", Destination: "VLC", Currency: "EUR", LastPrice: 200},
+		{Type: "flight", Origin: "HEL", Destination: "BCN", Currency: "EUR", LastPrice: 300},
+	}
+	detect := func(_ context.Context, in hacks.DetectorInput) []hacks.Hack {
+		return []hacks.Hack{{Title: "x", Savings: 10, Currency: in.Currency}}
+	}
+	ProbeOne(context.Background(), active, 0, engine, cache, now, detect)
+	ProbeOne(context.Background(), active, 1, engine, cache, now, detect)
+	if _, ok := cache.Get(probecache.RouteKey("AMS", "VLC")); !ok {
+		t.Fatalf("tick 0 should probe AMS-VLC")
+	}
+	if _, ok := cache.Get(probecache.RouteKey("HEL", "BCN")); !ok {
+		t.Fatalf("tick 1 should probe HEL-BCN")
+	}
+}

--- a/internal/tripcoalesce/coalesce_test.go
+++ b/internal/tripcoalesce/coalesce_test.go
@@ -87,7 +87,12 @@ func TestPlanConcurrentFanOut(t *testing.T) {
 	var current int64
 
 	enter := func() {
-		started.Done()
+		// Increment current BEFORE signalling the barrier so the release
+		// goroutine can only close the channel once all three domains are
+		// provably counted in current. Under -race the scheduler overhead is
+		// large enough that calling started.Done() first lets the barrier fire
+		// and other goroutines drain through <-release before this one even
+		// reaches atomic.AddInt64, making maxConcurrent never reach 3.
 		n := atomic.AddInt64(&current, 1)
 		for {
 			old := atomic.LoadInt64(&maxConcurrent)
@@ -95,6 +100,7 @@ func TestPlanConcurrentFanOut(t *testing.T) {
 				break
 			}
 		}
+		started.Done()
 		<-release
 		atomic.AddInt64(&current, -1)
 	}

--- a/internal/watch/scheduler.go
+++ b/internal/watch/scheduler.go
@@ -23,6 +23,21 @@ type Scheduler struct {
 	stopped   bool
 	cancel    context.CancelFunc
 	done      chan struct{}
+
+	// probeHook, when set, runs after each check round with the active watches.
+	// It is the injection seam for the MIK-6234 Tier-1 scheduler-amortized
+	// counterfactual probe: the daemon wires a budget-gated probe here (the
+	// watch package never imports the hacks/probe engines, avoiding a cycle).
+	// Nil by default, so standard scheduler behaviour is unchanged.
+	probeHook func(ctx context.Context, active []Watch)
+}
+
+// SetProbeHook installs an optional per-round hook invoked with the active
+// watches after each check. Safe to call before Start. Pass nil to disable.
+func (s *Scheduler) SetProbeHook(hook func(ctx context.Context, active []Watch)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.probeHook = hook
 }
 
 // NoopChecker is a PriceChecker that always returns zero price.
@@ -177,6 +192,19 @@ func (s *Scheduler) runOnce(ctx context.Context) {
 		"checked", len(results),
 		"triggered", triggered,
 	)
+
+	// MIK-6234 Tier-1: run the optional, budget-gated counterfactual probe over
+	// the active routes. Best-effort and panic-isolated — it must never affect
+	// the check round.
+	s.mu.Lock()
+	hook := s.probeHook
+	s.mu.Unlock()
+	if hook != nil {
+		func() {
+			defer func() { _ = recover() }()
+			hook(ctx, active)
+		}()
+	}
 }
 
 func (s *Scheduler) closeDone() {

--- a/internal/watch/scheduler_probe_test.go
+++ b/internal/watch/scheduler_probe_test.go
@@ -1,0 +1,61 @@
+package watch
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSchedulerProbeHookInvoked verifies the Tier-1 probe hook fires with the
+// active watches after a check round, and that a panicking hook does not crash
+// the scheduler.
+func TestSchedulerProbeHookInvoked(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	if _, err := store.Add(Watch{Type: "flight", Origin: "AMS", Destination: "VLC", Currency: "EUR"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	s := NewScheduler(dir, time.Hour, NoopChecker{})
+
+	var mu sync.Mutex
+	var gotActive int
+	called := make(chan struct{}, 1)
+	s.SetProbeHook(func(_ context.Context, active []Watch) {
+		mu.Lock()
+		gotActive = len(active)
+		mu.Unlock()
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+		panic("hook panics must be isolated") // must not crash the scheduler
+	})
+
+	s.Start()
+	select {
+	case <-called:
+	case <-time.After(5 * time.Second):
+		t.Fatal("probe hook was never invoked")
+	}
+	s.Stop() // must return cleanly despite the panicking hook
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotActive != 1 {
+		t.Fatalf("hook should see 1 active watch, got %d", gotActive)
+	}
+}
+
+// TestSchedulerNilProbeHookNoop verifies a scheduler with no hook runs normally.
+func TestSchedulerNilProbeHookNoop(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	_, _ = store.Add(Watch{Type: "flight", Origin: "AMS", Destination: "VLC", Currency: "EUR"})
+
+	s := NewScheduler(dir, time.Hour, NoopChecker{})
+	s.Start()
+	time.Sleep(50 * time.Millisecond)
+	s.Stop() // clean shutdown with nil hook
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -158,6 +158,13 @@ func NewServer() *Server {
 		// actually re-prices watches; NoopChecker here meant the scheduler ran
 		// every 30 minutes but never updated any price.
 		s.scheduler = watch.NewScheduler(watchDir, 30*time.Minute, livecheck.Checker{})
+		// MIK-6234 Tier-1 (env-gated, default OFF): the scheduler pre-computes
+		// counterfactual probes for one watched route per tick, budget-gated, so
+		// a later flight search serves them call-free. Off by default to keep the
+		// daemon's provider-call footprint unchanged unless explicitly enabled.
+		if os.Getenv("TRVL_TIER1_PROBE") == "1" {
+			installTier1Probe(s.scheduler, watchDir)
+		}
 	}
 
 	// Initialize provider registry (best-effort; nil registry is handled gracefully).

--- a/mcp/tier1_probe.go
+++ b/mcp/tier1_probe.go
@@ -1,0 +1,27 @@
+package mcp
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/cfprobe"
+	"github.com/MikkoParkkola/trvl/internal/hacks"
+	"github.com/MikkoParkkola/trvl/internal/probecache"
+	"github.com/MikkoParkkola/trvl/internal/tier1"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// installTier1Probe wires the MIK-6234 Tier-1 scheduler-amortized probe onto the
+// watch scheduler. Each tick it runs at most one budget-gated counterfactual
+// probe for one active flight watch (rotating), caching the result for later
+// call-free reads by `trvl flights`. Gated by TRVL_TIER1_PROBE at the call site.
+func installTier1Probe(sched *watch.Scheduler, dir string) {
+	cache := probecache.NewStore(dir)
+	_ = cache.Load()
+	var tick int64
+	sched.SetProbeHook(func(ctx context.Context, active []watch.Watch) {
+		n := int(atomic.AddInt64(&tick, 1) - 1)
+		tier1.ProbeOne(ctx, active, n, cfprobe.Default(), cache, time.Now(), hacks.DetectAll)
+	})
+}


### PR DESCRIPTION
# Backlog drain: Tier-1 probe, livecheck test, flake fix, docs

Completes the deferred items from the feature work.

## Tier-1 scheduler-amortized probe (MIK-6234 CF.3), env-gated default OFF
- `internal/probecache` persists pre-computed counterfactual savings per route.
- `internal/tier1` runs at most one budget-gated fan-out per scheduler tick, rotated across active flight watches, caching the result. The fan-out producer is injected so the package is unit-tested without the network and the watch package never depends on the hacks engine.
- The watch scheduler gains an optional probe hook (default nil, behaviour unchanged); a panicking hook is isolated and never affects a check round.
- The MCP server installs the hook only when TRVL_TIER1_PROBE=1, so the daemon's provider-call footprint is unchanged unless explicitly enabled.
- `trvl flights` reads the probe cache and serves those savings call-free (no provider calls at query time), with an "as of" age.

## Flaky test fixed: internal/tripcoalesce TestPlanConcurrentFanOut
Root cause was a barrier-ordering bug in the test harness, not the production code: the test signalled its WaitGroup barrier before incrementing the concurrency counter, so under race-detector scheduling the barrier could fire before all three domains were counted. Production plan.go was correct. Fix increments the counter and records the peak before signalling the barrier. Verified green at `-race -count=100`.

## livecheck grid persistence now tested
`persistDateGrid` was refactored into a thin wrapper plus an injectable `persistDateGridTo(store, ...)` seam and covered with tests (skips non-positive prices, currency from first positive, field round-trip, explicit clock). Package coverage 3.1 percent to 16.7 percent.

## Documentation
README.md and AGENTS.md now document `trvl nudges`, `trvl flights --deep`, price_position, the call-free savings panel, and booking readiness on prices and rooms. The public-docs count test passes.

## Validation
- go build, go vet, staticcheck (whole repo): clean.
- go test with the race detector: passes (the tripcoalesce flake is fixed).
- Total coverage: 77.9 percent (floor 50).
- govulncheck: no vulnerabilities (no new dependencies).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
