### PR TITLE
fix(savings): distinct honest bucket for pre-computed Tier-1 savings

### DIFF
--- a/cmd/trvl/counterfactual_render.go
+++ b/cmd/trvl/counterfactual_render.go
@@ -60,35 +60,45 @@ func tier1CachedSavings(origin, destination string, now time.Time) []counterfact
 	return e.Savings
 }
 
-// printSavings renders counterfactual savings, split by whether they were free.
-// Call-free savings (MIK-6234 Tier 0) carry the explicit "no extra searches"
-// guarantee; probed savings (Tier 2) are labelled as found by a deeper search so
-// the output never implies a fan-out that did not happen, or hides one that did.
+// printSavings renders counterfactual savings in three honest buckets:
+//   - Tier 0 (call-free, not probe-derived): genuine by-products of data already
+//     in hand — "no extra searches".
+//   - Tier 1 (call-free but probe-derived): pre-computed by the background watch
+//     monitor — free to read now, but they DID cost provider calls earlier, so
+//     they are labelled as such rather than hidden among the true by-products.
+//   - Tier 2 (not call-free): a deeper search that issued extra provider calls
+//     just now.
+//
 // Each line carries an "as of" age when its data is not from this moment
-// (TRVL.CF.5 honesty).
+// (TRVL.CF.5 honesty). The point is to never imply a fan-out that did not happen
+// nor hide one that did — including one that happened in the background.
 func printSavings(w io.Writer, savings []counterfactual.Saving, now time.Time) {
 	if len(savings) == 0 {
 		return
 	}
-	var free, probed []counterfactual.Saving
+	var free, precomputed, probed []counterfactual.Saving
 	for _, s := range savings {
-		if s.CallFree {
+		switch {
+		case s.CallFree && s.Kind == counterfactual.KindProbe:
+			precomputed = append(precomputed, s)
+		case s.CallFree:
 			free = append(free, s)
-		} else {
+		default:
 			probed = append(probed, s)
 		}
 	}
-	if len(free) > 0 {
-		fmt.Fprintln(w, "\nSavings you could capture (no extra searches):")
-		for _, s := range free {
-			fmt.Fprintf(w, "  • %s%s\n", s.Description, asOfSuffix(s.AsOf, now))
-		}
+	printSavingsSection(w, "\nSavings you could capture (no extra searches):", free, now)
+	printSavingsSection(w, "\nPre-computed by your watch monitor (no extra searches now):", precomputed, now)
+	printSavingsSection(w, "\nFound by a deeper search (extra provider calls):", probed, now)
+}
+
+func printSavingsSection(w io.Writer, header string, savings []counterfactual.Saving, now time.Time) {
+	if len(savings) == 0 {
+		return
 	}
-	if len(probed) > 0 {
-		fmt.Fprintln(w, "\nFound by a deeper search (extra provider calls):")
-		for _, s := range probed {
-			fmt.Fprintf(w, "  • %s%s\n", s.Description, asOfSuffix(s.AsOf, now))
-		}
+	fmt.Fprintln(w, header)
+	for _, s := range savings {
+		fmt.Fprintf(w, "  • %s%s\n", s.Description, asOfSuffix(s.AsOf, now))
 	}
 }
 

--- a/cmd/trvl/counterfactual_render_test.go
+++ b/cmd/trvl/counterfactual_render_test.go
@@ -14,6 +14,7 @@ func TestPrintSavings_SplitsCallFreeFromProbed(t *testing.T) {
 	savings := []counterfactual.Saving{
 		{Kind: counterfactual.KindSameDay, Description: "cheapest saves 70", Amount: 70, CallFree: true, AsOf: now},
 		{Kind: counterfactual.KindProbe, Description: "nearby airport saves 40", Amount: 40, CallFree: false, AsOf: now},
+		{Kind: counterfactual.KindProbe, Description: "split ticket saves 25 precomputed", Amount: 25, CallFree: true, AsOf: now},
 	}
 	var b bytes.Buffer
 	printSavings(&b, savings, now)
@@ -24,23 +25,29 @@ func TestPrintSavings_SplitsCallFreeFromProbed(t *testing.T) {
 	if !strings.Contains(out, "deeper search") {
 		t.Fatalf("probed section header missing: %q", out)
 	}
-	// Honesty: the probed saving must appear under the deeper-search header, not
-	// the call-free one.
-	free, probed := splitSections(out)
-	if !strings.Contains(free, "cheapest saves 70") {
-		t.Fatalf("call-free saving misplaced: %q", free)
+	if !strings.Contains(out, "watch monitor") {
+		t.Fatalf("precomputed section header missing: %q", out)
 	}
-	if !strings.Contains(probed, "nearby airport saves 40") {
-		t.Fatalf("probed saving misplaced: %q", probed)
+	// Honesty: a probe-derived saving (even when free to read now) must NOT sit
+	// under the pure by-product "no extra searches" Tier-0 header.
+	tier0, rest := cut(out, "Pre-computed")
+	if strings.Contains(tier0, "nearby airport") || strings.Contains(tier0, "precomputed") {
+		t.Fatalf("probe-derived saving leaked into the Tier-0 by-product section: %q", tier0)
+	}
+	if !strings.Contains(rest, "split ticket saves 25 precomputed") {
+		t.Fatalf("precomputed saving misplaced: %q", rest)
+	}
+	if !strings.Contains(tier0, "cheapest saves 70") {
+		t.Fatalf("genuine by-product saving misplaced: %q", tier0)
 	}
 }
 
-func splitSections(out string) (free, probed string) {
-	idx := strings.Index(out, "deeper search")
+func cut(s, sep string) (before, after string) {
+	idx := strings.Index(s, sep)
 	if idx < 0 {
-		return out, ""
+		return s, ""
 	}
-	return out[:idx], out[idx:]
+	return s[:idx], s[idx:]
 }
 
 func TestPrintSavings_Empty(t *testing.T) {


### PR DESCRIPTION
Improve-pass finding: Tier-1 savings are pre-computed by the background watch monitor and read call-free, but they DID cost provider calls earlier. Lumping them under the Tier-0 'no extra searches' header conflated a free by-product with work that spent calls. The render now uses three buckets: genuine call-free by-products, pre-computed-by-monitor (free to read now, labelled), and live deeper-search probes. Test asserts a probe-derived saving never leaks into the Tier-0 by-product section.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)