### PR TITLE
feat(mcp): enable Tier-1 by default + make price signals clear on the MCP path

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -158,11 +158,12 @@ func NewServer() *Server {
 		// actually re-prices watches; NoopChecker here meant the scheduler ran
 		// every 30 minutes but never updated any price.
 		s.scheduler = watch.NewScheduler(watchDir, 30*time.Minute, livecheck.Checker{})
-		// MIK-6234 Tier-1 (env-gated, default OFF): the scheduler pre-computes
-		// counterfactual probes for one watched route per tick, budget-gated, so
-		// a later flight search serves them call-free. Off by default to keep the
-		// daemon's provider-call footprint unchanged unless explicitly enabled.
-		if os.Getenv("TRVL_TIER1_PROBE") == "1" {
+		// MIK-6234 Tier-1: the scheduler pre-computes counterfactual probes for
+		// one watched route per tick, budget-gated, so a later flight search
+		// serves them call-free. ON by default; set TRVL_TIER1_PROBE=0 to disable.
+		// The probe lane is a separate best-effort budget that can never starve
+		// interactive traffic, so default-on is safe.
+		if os.Getenv("TRVL_TIER1_PROBE") != "0" {
 			installTier1Probe(s.scheduler, watchDir)
 		}
 	}

--- a/mcp/tools_flights.go
+++ b/mcp/tools_flights.go
@@ -109,6 +109,32 @@ func flightSearchOutputSchema() interface{} {
 					"fix_hint_code": schemaString(),
 				},
 			}),
+			"price_position": map[string]interface{}{
+				"type":        "object",
+				"description": "Where today's cheapest fare sits in this route's own price history (MIK-6229). Only assert a verdict when confident=true; otherwise tell the user there is not enough history yet.",
+				"properties": map[string]interface{}{
+					"band":          schemaStringDesc("low, typical, or high (a not-confident marker when history is too sparse)"),
+					"verdict":       schemaStringDesc("buy, wait, or neutral (a not-confident marker when history is too sparse)"),
+					"current":       schemaNum(),
+					"low":           schemaNum(),
+					"high":          schemaNum(),
+					"median":        schemaNum(),
+					"vs_median_pct": schemaNum(),
+					"observations":  schemaInt(),
+					"confident":     schemaBool(),
+				},
+			},
+			"savings": schemaArrayDesc("Call-free money-saving options (MIK-6234): cheaper same-day fare, vs-history, depart-a-nearby-date shift-day, and routes pre-computed by the watch monitor. No extra searches were made to produce these. Surface them; respect as_of staleness and never present stale data as a live quote.", map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"kind":        schemaStringDesc("shift_day, same_day_alternative, vs_history, or probe"),
+					"description": schemaString(),
+					"amount":      schemaNum(),
+					"currency":    schemaString(),
+					"as_of":       schemaStringDesc("RFC3339 time the underlying data was observed"),
+					"call_free":   schemaBool(),
+				},
+			}),
 			"error": schemaString(),
 		},
 		"required": []string{"success", "count"},
@@ -146,7 +172,7 @@ func searchFlightsTool() ToolDef {
 	return ToolDef{
 		Name:        "search_flights",
 		Title:       "Search Flights",
-		Description: "Search flights via Google Flights, and on compatible one-way searches also include Kiwi virtual-interlining results with explicit self-connect warnings. Returns real-time pricing, durations, stops, and leg details for a given route and date. IMPORTANT: call get_preferences before your first search in a conversation to load the user's home airport and flight preferences. If the profile is empty, interview the user first — get_preferences returns instructions. Use home_airports as default origin when the user doesn't specify where from.",
+		Description: "Search flights via Google Flights, and on compatible one-way searches also include Kiwi virtual-interlining results with explicit self-connect warnings. Returns real-time pricing, durations, stops, and leg details for a given route and date. IMPORTANT: call get_preferences before your first search in a conversation to load the user's home airport and flight preferences. If the profile is empty, interview the user first — get_preferences returns instructions. Use home_airports as default origin when the user doesn't specify where from. EXTRA SIGNALS (use them when present): the response may include `price_position` — where today's fare sits in this route's own history (band low/typical/high + a buy/wait verdict, only when `confident` is true; otherwise say there is not enough history and do not assert a trend); and `savings` — call-free money-saving options (cheaper same-day fares, vs-history, depart-a-nearby-date shift-day, and routes pre-computed by the user's watch monitor). Each saving has `call_free` and an `as_of` time; surface them to the user but never present a stale `as_of` as a live quote. These cost no extra searches; you do not need to (and cannot) request a deeper fan-out from this tool.",
 		InputSchema: InputSchema{
 			Type: "object",
 			Properties: map[string]Property{

--- a/mcp/tools_hotels.go
+++ b/mcp/tools_hotels.go
@@ -132,8 +132,25 @@ func hotelPricesOutputSchema() interface{} {
 			}),
 			"booking_fallback_url": schemaStringDesc("Durable Booking.com property+date deep-link that never 404s, used when a provider link expires."),
 			"tourist_tax_note":     schemaStringDesc("Descriptive caveat that a local tourist or city tax may be payable in cash at the property and is not in any online total. Never a numeric estimate; never affects ranking."),
-			"notice":               schemaString(),
-			"error":                schemaString(),
+			"price_position": map[string]interface{}{
+				"type":        "object",
+				"description": "Where this stay's cheapest price sits in its own history (MIK-6229). Only assert a verdict when confident=true.",
+				"properties": map[string]interface{}{
+					"band":          schemaStringDesc("one of: low, typical, high (plus a not-confident marker when history is too sparse)"),
+					"verdict":       schemaStringDesc("one of: buy, wait, neutral (plus a not-confident marker when history is too sparse)"),
+					"current":       schemaNum(),
+					"low":           schemaNum(),
+					"high":          schemaNum(),
+					"median":        schemaNum(),
+					"vs_median_pct": schemaNum(),
+					"observations":  schemaInt(),
+					"confident":     schemaBool(),
+				},
+			},
+			"booking_readiness":         schemaStringDesc("Composite booking-readiness verdict (MIK-6232), one of: ready, caution, unverified. 'ready' requires verified price AND stable link AND confirmed identity AND known refundability; any missing signal downgrades it. Treat anything below ready as 'verify before booking' and tell the user why via booking_readiness_reasons."),
+			"booking_readiness_reasons": schemaStringArrayDesc("Which signals drove the readiness verdict down (e.g. 'refundability not known')."),
+			"notice":                    schemaString(),
+			"error":                     schemaString(),
 		},
 		"required": []string{"success"},
 	}
@@ -203,7 +220,7 @@ func hotelPricesTool() ToolDef {
 	return ToolDef{
 		Name:        "hotel_prices",
 		Title:       "Hotel Prices Comparison",
-		Description: "Get exposed booking-provider prices for a specific Google Hotels property. Use as a provider comparison, not a rate guarantee; for booking decisions prefer room-level totals from hotel_rooms or search_hotels_with_details when available.",
+		Description: "Get exposed booking-provider prices for a specific Google Hotels property. Use as a provider comparison, not a rate guarantee; for booking decisions prefer room-level totals from hotel_rooms or search_hotels_with_details when available. EXTRA SIGNALS (use them when present): `price_position` shows where this price sits in the property's own history (only trust the verdict when `confident` is true); `booking_readiness` is a composite verdict (ready, caution, unverified) — anything below `ready` means verify before booking, and `booking_readiness_reasons` explains why. Note: from this endpoint readiness usually stays at caution because refundability is not known here; call hotel_rooms for a property where 'ready' can be reached.",
 		InputSchema: InputSchema{
 			Type: "object",
 			Properties: map[string]Property{
@@ -655,13 +672,15 @@ func hotelRoomsOutputSchema() interface{} {
 	return map[string]interface{}{
 		"type": "object",
 		"properties": map[string]interface{}{
-			"success":   schemaBool(),
-			"hotel_id":  schemaString(),
-			"name":      schemaString(),
-			"check_in":  schemaString(),
-			"check_out": schemaString(),
-			"rooms":     schemaArray(hotelRoomTypeSchema()),
-			"error":     schemaString(),
+			"success":                   schemaBool(),
+			"hotel_id":                  schemaString(),
+			"name":                      schemaString(),
+			"check_in":                  schemaString(),
+			"check_out":                 schemaString(),
+			"rooms":                     schemaArray(hotelRoomTypeSchema()),
+			"booking_readiness":         schemaStringDesc("Composite booking-readiness verdict (MIK-6232), one of: ready, caution, unverified. Reachable to 'ready' here because rooms carry refundability and a classifiable link. Anything below ready means verify before booking."),
+			"booking_readiness_reasons": schemaStringArrayDesc("Which signals drove the readiness verdict down."),
+			"error":                     schemaString(),
 		},
 		"required": []string{"success"},
 	}
@@ -759,5 +778,18 @@ func handleHotelRooms(ctx context.Context, args map[string]any, elicit ElicitFun
 		return nil, nil, err
 	}
 
-	return content, availability, nil
+	// MIK-6232: attach a booking-readiness verdict. Rooms carry refundability +
+	// a classifiable link, so "ready" is reachable here (unlike hotel_prices).
+	readiness := roomsBookingReadiness(availability)
+	enriched := struct {
+		*hotels.RoomAvailability
+		BookingReadiness        string   `json:"booking_readiness,omitempty"`
+		BookingReadinessReasons []string `json:"booking_readiness_reasons,omitempty"`
+	}{
+		RoomAvailability:        availability,
+		BookingReadiness:        string(readiness.Readiness),
+		BookingReadinessReasons: readiness.Reasons,
+	}
+
+	return content, enriched, nil
 }

--- a/mcp/tools_price_signals.go
+++ b/mcp/tools_price_signals.go
@@ -10,10 +10,19 @@ import (
 
 	"github.com/MikkoParkkola/trvl/internal/booking"
 	"github.com/MikkoParkkola/trvl/internal/counterfactual"
+	"github.com/MikkoParkkola/trvl/internal/dategrid"
+	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/obslog"
 	"github.com/MikkoParkkola/trvl/internal/pricesignal"
+	"github.com/MikkoParkkola/trvl/internal/probecache"
 	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// Freshness windows for cached, call-free savings served on the MCP path.
+const (
+	mcpGridFreshness  = 24 * time.Hour
+	mcpProbeFreshness = 12 * time.Hour
 )
 
 // flightPriceSignals logs the cheapest fare from a flight search into the
@@ -71,7 +80,44 @@ func flightPriceSignals(
 	if s := counterfactual.VsHistory(pos, cheapestCurrency, now); s != nil {
 		savings = append(savings, *s)
 	}
+	// Shift-day from the persisted price grid + Tier-1 probes pre-computed by the
+	// watch monitor — both served call-free from cache (no provider calls here).
+	savings = append(savings, shiftDaySavingsMCP(origin, dest, date, now)...)
+	savings = append(savings, tier1CachedSavingsMCP(origin, dest, now)...)
 	return pos, savings
+}
+
+// shiftDaySavingsMCP reads the persisted price grid for a route and returns
+// call-free shift-day counterfactuals. No provider calls; nothing when no fresh
+// grid covers the route.
+func shiftDaySavingsMCP(origin, destination, date string, now time.Time) []counterfactual.Saving {
+	store, err := dategrid.DefaultStore()
+	if err != nil || store.Load() != nil {
+		return nil
+	}
+	g, ok := store.Get(dategrid.RouteKey(origin, destination))
+	if !ok || !g.Fresh(now, mcpGridFreshness) {
+		return nil
+	}
+	grid := make([]models.DatePriceResult, 0, len(g.Points))
+	for _, p := range g.Points {
+		grid = append(grid, models.DatePriceResult{Date: p.Date, ReturnDate: p.ReturnDate, Price: p.Price, Currency: p.Currency})
+	}
+	return counterfactual.ShiftDay(grid, date, 10, g.UpdatedAt)
+}
+
+// tier1CachedSavingsMCP returns Tier-1 savings the watch monitor pre-computed
+// for this route, served call-free from the probe cache.
+func tier1CachedSavingsMCP(origin, destination string, now time.Time) []counterfactual.Saving {
+	store, err := probecache.DefaultStore()
+	if err != nil || store.Load() != nil {
+		return nil
+	}
+	e, ok := store.Get(probecache.RouteKey(origin, destination))
+	if !ok || !e.Fresh(now, mcpProbeFreshness) {
+		return nil
+	}
+	return e.Savings
 }
 
 // hotelPriceSignals logs the cheapest provider price from a hotel price lookup
@@ -157,4 +203,62 @@ func cheapestProviderPrice(providers []models.ProviderPrice) models.ProviderPric
 		}
 	}
 	return best
+}
+
+// roomsBookingReadiness maps the richer signals on the hotel_rooms endpoint into
+// a booking.Verdict. Unlike hotel_prices, rooms carry refundability and a
+// classifiable link, so "ready" is reachable here. Mirrors the CLI
+// bookingReadinessForRooms without importing package main.
+func roomsBookingReadiness(result *hotels.RoomAvailability) booking.Verdict {
+	var in booking.Input
+	if result.HotelID != "" {
+		in.IdentityConfirmed = booking.True()
+	}
+	// Refundability: known when any room exposes a refund/cancellation signal.
+	for _, r := range result.Rooms {
+		if r.Refundable != nil || r.FreeCancellation != nil || r.CancellationPolicy != "" {
+			in.RefundabilityKnown = booking.True()
+			break
+		}
+	}
+	// Verified: any room inventory option with verified/room-level confidence.
+	for _, r := range result.Rooms {
+		done := false
+		for _, opt := range r.InventoryOptions {
+			switch opt.PriceConfidence {
+			case models.PriceConfidenceVerified, models.PriceConfidenceRoomLevel:
+				in.Verified = booking.True()
+				done = true
+			}
+			if done {
+				break
+			}
+		}
+		if done {
+			break
+		}
+	}
+	// LinkStable: classify any room booking URL; a stable link unlocks "ready".
+	sawExpiring := false
+	for _, r := range result.Rooms {
+		urls := []string{r.ProviderURL}
+		for _, opt := range r.InventoryOptions {
+			urls = append(urls, opt.ProviderURL)
+		}
+		for _, u := range urls {
+			switch hotels.ClassifyLinkDurability(u) {
+			case "stable":
+				in.LinkStable = booking.True()
+			case "expiring":
+				sawExpiring = true
+			}
+		}
+		if in.LinkStable != nil {
+			break
+		}
+	}
+	if in.LinkStable == nil && sawExpiring {
+		in.LinkStable = booking.False()
+	}
+	return booking.Evaluate(in)
 }

--- a/mcp/tools_price_signals_test.go
+++ b/mcp/tools_price_signals_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/booking"
+	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/pricesignal"
 )
@@ -466,3 +467,43 @@ func TestErrors_NewCompiles(t *testing.T) {
 
 // Ensure time import is used.
 var _ = time.Now
+
+// --- roomsBookingReadiness (MCP hotel_rooms readiness, MIK-6232) ---
+
+func TestRoomsBookingReadiness_ReadyReachable(t *testing.T) {
+	refundable := true
+	avail := &hotels.RoomAvailability{
+		HotelID: "/g/abc",
+		Rooms: []hotels.RoomType{
+			{
+				Refundable:  &refundable,
+				ProviderURL: "https://www.booking.com/hotel/x.html",
+				InventoryOptions: []models.RoomInventoryQuote{
+					{PriceConfidence: models.PriceConfidenceVerified},
+				},
+			},
+		},
+	}
+	if v := roomsBookingReadiness(avail); v.Readiness != booking.Ready {
+		t.Fatalf("want ready, got %s (reasons %v)", v.Readiness, v.Reasons)
+	}
+}
+
+func TestRoomsBookingReadiness_ExpiringLinkDowngrades(t *testing.T) {
+	refundable := true
+	avail := &hotels.RoomAvailability{
+		HotelID: "/g/abc",
+		Rooms: []hotels.RoomType{
+			{
+				Refundable:  &refundable,
+				ProviderURL: "https://www.google.com/aclk?adurl=x",
+				InventoryOptions: []models.RoomInventoryQuote{
+					{PriceConfidence: models.PriceConfidenceVerified},
+				},
+			},
+		},
+	}
+	if v := roomsBookingReadiness(avail); v.Readiness == booking.Ready {
+		t.Fatalf("expiring link must downgrade below ready")
+	}
+}


### PR DESCRIPTION
Turns on the safe background features and makes them legible to an LLM over MCP.

## Enabled
- Tier-1 scheduler probe is now ON by default (set TRVL_TIER1_PROBE=0 to disable). Its two-lane budget means it can never starve interactive traffic, so default-on is safe.
- Skiplagged is already part of the default flight merge (no change needed). Transavia / easyJet / Travelpayouts / AFKLM are not toggles — they require API keys or reachable endpoints and are documented as such.
- --deep stays opt-in (not enabled), as requested.

## MCP clarity (the main ask)
- search_flights and hotel_prices descriptions now explain price_position and savings, including how to act on them (only trust the verdict when confident; respect as_of staleness; these cost no extra searches).
- Output schemas declare price_position, savings, booking_readiness, and booking_readiness_reasons so an LLM knows the response shape.
- The MCP flight handler now also serves shift-day and Tier-1 pre-computed savings (previously CLI-only), so the MCP path has parity.
- hotel_rooms now returns booking_readiness, so 'ready' is reachable over MCP (hotel_prices stays at caution by design and now says so, pointing the model to hotel_rooms).

## Validation
build / vet / staticcheck / gofmt clean; race suite passes; MCP tests green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)