### PR TITLE
perf(watch): bound total ad-hoc route observations (never evict watch history)

### DIFF
--- a/internal/watch/observation_test.go
+++ b/internal/watch/observation_test.go
@@ -127,3 +127,38 @@ func TestRecordObservationCapsPerRoute(t *testing.T) {
 		t.Fatalf("oldest 50 should be pruned; first kept = %v", got[0])
 	}
 }
+
+// improve pass: the global route-keyed cap bounds total ad-hoc points across
+// many routes while never evicting watch-keyed history.
+func TestGlobalRouteCapPreservesWatchHistory(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+	// Watch-keyed history that must survive eviction.
+	for i := 0; i < 5; i++ {
+		_ = s.RecordPrice("watch-1", float64(100+i), "EUR")
+	}
+	// Route-keyed points seeded well past the global cap.
+	base := time.Now().Add(-time.Hour)
+	for i := 0; i < maxRouteObservations+100; i++ {
+		s.history = append(s.history, PricePoint{
+			RouteKey:  "FLIGHT|AMS|VLC|2026-07-15",
+			Price:     float64(100 + i),
+			Currency:  "EUR",
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+		})
+	}
+	s.pruneGlobalRouteLocked()
+
+	routeCount := 0
+	for _, p := range s.history {
+		if p.RouteKey != "" && p.WatchID == "" {
+			routeCount++
+		}
+	}
+	if routeCount != maxRouteObservations {
+		t.Fatalf("route-keyed points = %d, want cap %d", routeCount, maxRouteObservations)
+	}
+	if got := len(s.History("watch-1")); got != 5 {
+		t.Fatalf("watch history must be preserved, got %d want 5", got)
+	}
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -22,6 +22,11 @@ const (
 	// maxObservationsPerRoute caps retained points per route key, bounding the
 	// price-history file to cap x number-of-routes.
 	maxObservationsPerRoute = 1000
+	// maxRouteObservations caps the TOTAL number of ad-hoc route-keyed points
+	// across all routes, evicting the oldest first. Watch-keyed points (which
+	// back the existing sparkline/fareintel features) are NEVER evicted here, so
+	// this bounds the new ad-hoc corpus without touching the watch corpus.
+	maxRouteObservations = 20000
 	// observationThrottle suppresses near-identical repeat observations for the
 	// same route+currency within this window.
 	observationThrottle = 15 * time.Minute
@@ -496,7 +501,35 @@ func (s *Store) RecordObservation(routeKey string, price float64, currency strin
 		Timestamp: time.Now(),
 	})
 	s.pruneRouteLocked(routeKey)
+	s.pruneGlobalRouteLocked()
 	return s.saveLocked()
+}
+
+// pruneGlobalRouteLocked evicts the oldest ad-hoc route-keyed observations once
+// their total exceeds maxRouteObservations, bounding the file regardless of how
+// many distinct routes are searched. Watch-keyed points (WatchID set) are never
+// touched. Caller holds s.mu.
+func (s *Store) pruneGlobalRouteLocked() {
+	var routeIdx []int
+	for i, p := range s.history {
+		if p.RouteKey != "" && p.WatchID == "" {
+			routeIdx = append(routeIdx, i)
+		}
+	}
+	if len(routeIdx) <= maxRouteObservations {
+		return
+	}
+	drop := make(map[int]bool, len(routeIdx)-maxRouteObservations)
+	for _, i := range routeIdx[:len(routeIdx)-maxRouteObservations] {
+		drop[i] = true
+	}
+	kept := s.history[:0:0]
+	for i, p := range s.history {
+		if !drop[i] {
+			kept = append(kept, p)
+		}
+	}
+	s.history = kept
 }
 
 // lastObservationLocked returns the most recent price point for a route key,


### PR DESCRIPTION
## improve finding
The per-route cap (1000 per route) and the route-count caps on the grid and probe caches left one unbounded tail: the watch price-history has no cap on the NUMBER of distinct route keys. A heavy user who searches many routes grows the file without bound, and every search does a whole-file load+save, so per-search latency creeps up forever. The two new caches are bounded; this one was not.

## Fix
A global cap (maxRouteObservations = 20000) evicts the oldest ad-hoc route-keyed points once the total is exceeded. Watch-keyed points (which back the existing sparkline and fareintel features) are NEVER evicted, so this bounds only the new corpus without touching the shipped watch feature. A test proves both: route-keyed points capped, watch history preserved.

## Validation
build, vet, staticcheck, gofmt clean; watch tests pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)