### PR TITLE
fix(d2d): single-currency confidence band (no fabricated cross-currency sums)

### DIFF
--- a/internal/d2d/d2d.go
+++ b/internal/d2d/d2d.go
@@ -11,8 +11,10 @@
 //   - Mixed currencies are flagged: if legs disagree on currency the total is not
 //     silently summed. MixedCurrency is set and ConfirmedTotal reflects only the
 //     legs in the headline currency.
-//   - The confidence band widens whenever any non-confirmed leg exists. A single
-//     figure is only produced for all-confirmed, single-currency trips.
+//   - The confidence band widens whenever any non-confirmed leg exists, and is
+//     always expressed in the headline currency — magnitudes in other currencies
+//     are never summed into it. A single figure is only produced for
+//     all-confirmed, single-currency trips.
 //
 // This package is pure (no network I/O, no new dependencies beyond stdlib).
 package d2d
@@ -66,8 +68,8 @@ const (
 // Leg is a single segment of a door-to-door journey.
 //
 // Callers that have already determined the verification status should set it
-// explicitly. When Verification is left empty, ResolveVerification maps the
-// Source to a default (e.g. "rome2rio" → Indicative).
+// explicitly. When Verification is left empty, DefaultVerification maps the
+// Source to a default (e.g. "rome2rio" -> Indicative).
 type Leg struct {
 	// Mode is the transport or accommodation type: "air", "train", "bus",
 	// "ferry", "hotel", "taxi", etc. Free-form; used for display only.
@@ -145,9 +147,9 @@ type Total struct {
 	// Equal to ConfirmedTotal when Band == BandExact.
 	BandLow float64
 
-	// BandHigh is the upper bound of the estimated total range.
-	// Equal to ConfirmedTotal when Band == BandExact; inflated by indicative
-	// and unverified leg prices when available, else left as ConfirmedTotal.
+	// BandHigh is the upper bound of the estimated total range, in the headline
+	// currency. Equal to ConfirmedTotal when Band == BandExact; inflated by
+	// indicative and unverified legs that are in the headline currency.
 	BandHigh float64
 }
 
@@ -160,8 +162,8 @@ var indicativeSources = map[string]bool{
 }
 
 // DefaultVerification returns the default Verification for a given source name.
-// rome2rio → Indicative; any unknown or empty source → Unverified; all other
-// known transactional providers → Confirmed.
+// rome2rio -> Indicative; any unknown or empty source -> Unverified; all other
+// known transactional providers -> Confirmed.
 func DefaultVerification(source string) Verification {
 	s := strings.ToLower(strings.TrimSpace(source))
 	if s == "" {
@@ -189,7 +191,7 @@ func Compute(legs []Leg) Total {
 	mixedCurrency := hasMixedCurrencies(legs)
 
 	confirmedTotal := sumPrices(confirmed)
-	band, low, high := computeBand(confirmedTotal, indicative, unverified, excluded, mixedCurrency)
+	band, low, high := computeBand(confirmedTotal, currency, indicative, unverified, len(excluded) > 0, mixedCurrency)
 
 	return Total{
 		ConfirmedTotal:       round2(confirmedTotal),
@@ -281,38 +283,47 @@ func sumPrices(legs []Leg) float64 {
 	return total
 }
 
-// computeBand derives the confidence band and [low, high] range. The band
-// widens whenever non-confirmed legs or mixed-currency exclusions exist.
-func computeBand(confirmed float64, indicative, unverified, excluded []Leg, mixed bool) (BandKind, float64, float64) {
+// sumPricesInCurrency totals only legs priced in the given currency, so a
+// confidence band never adds magnitudes from a different currency (which would
+// be a fabricated, meaningless number).
+func sumPricesInCurrency(legs []Leg, currency string) float64 {
+	var total float64
+	for _, l := range legs {
+		if l.Price > 0 && l.Currency == currency {
+			total += l.Price
+		}
+	}
+	return total
+}
+
+// computeBand derives the confidence band and [low, high] range, all in the
+// headline currency. The band widens whenever non-confirmed legs exist.
+// Indicative and unverified legs inflate the upper bound ONLY when priced in the
+// headline currency; foreign-currency legs (including all excluded legs) are
+// never summed into the band — they are surfaced via the MixedCurrency flag and
+// the ExcludedCurrencyLegs bucket instead.
+func computeBand(confirmed float64, currency string, indicative, unverified []Leg, hasExcluded, mixed bool) (BandKind, float64, float64) {
 	hasIndicative := len(indicative) > 0
 	hasUnverified := len(unverified) > 0
-	hasExcluded := len(excluded) > 0
 
 	switch {
 	case hasUnverified:
-		high := confirmed + sumPrices(indicative) + sumPrices(unverified) + sumPrices(excluded)
-		if high < confirmed {
-			high = confirmed
-		}
+		high := confirmed + sumPricesInCurrency(indicative, currency) + sumPricesInCurrency(unverified, currency)
 		return BandUnknown, confirmed, high
 	case hasIndicative:
-		high := confirmed + sumPrices(indicative) + sumPrices(excluded)
-		if high < confirmed {
-			high = confirmed
-		}
+		high := confirmed + sumPricesInCurrency(indicative, currency)
 		return BandWide, confirmed, high
 	case hasExcluded || mixed:
-		high := confirmed + sumPrices(excluded)
-		if high < confirmed {
-			high = confirmed
-		}
-		return BandNarrow, confirmed, high
+		// Confirmed subtotal is reliable; foreign-currency legs exist but cannot
+		// be summed into a single-currency bound, so the band stays at the subtotal.
+		return BandNarrow, confirmed, confirmed
 	default:
 		return BandExact, confirmed, confirmed
 	}
 }
 
-// round2 rounds a float to 2 decimal places (matches multimodal/assemble.go).
+// round2 rounds a non-negative float to 2 decimal places (matches
+// multimodal/assemble.go). Prices in this package are never negative.
 func round2(v float64) float64 {
 	return float64(int64(v*100+0.5)) / 100
 }

--- a/internal/d2d/d2d_test.go
+++ b/internal/d2d/d2d_test.go
@@ -292,3 +292,30 @@ func TestCompute_explicitVerificationOverridesSource(t *testing.T) {
 		t.Error("IndicativeLegs should be empty when leg is explicitly Confirmed")
 	}
 }
+
+// improve pass: the confidence band must never add a foreign-currency magnitude
+// into its upper bound (that would be a fabricated cross-currency number).
+func TestComputeBandExcludesForeignCurrency(t *testing.T) {
+	// Confirmed EUR 100 + indicative in USD: band-high must stay at 100, NOT
+	// 100+50 (EUR and USD cannot be summed).
+	foreign := d2d.Compute([]d2d.Leg{
+		{Mode: "air", Price: 100, Currency: "EUR", Verification: d2d.Confirmed},
+		{Mode: "train", Price: 50, Currency: "USD", Verification: d2d.Indicative},
+	})
+	if foreign.BandHigh != 100 {
+		t.Fatalf("foreign-currency indicative leg must not inflate band-high; got %.2f want 100", foreign.BandHigh)
+	}
+
+	// Confirmed EUR 100 + indicative EUR 50: same-currency indicative DOES
+	// inflate the band to 150.
+	same := d2d.Compute([]d2d.Leg{
+		{Mode: "air", Price: 100, Currency: "EUR", Verification: d2d.Confirmed},
+		{Mode: "train", Price: 50, Currency: "EUR", Verification: d2d.Indicative},
+	})
+	if same.BandHigh != 150 {
+		t.Fatalf("same-currency indicative leg must inflate band-high; got %.2f want 150", same.BandHigh)
+	}
+	if same.BandLow != 100 {
+		t.Fatalf("band-low must equal the confirmed subtotal; got %.2f want 100", same.BandLow)
+	}
+}


### PR DESCRIPTION
Closes #257.

## What changed

- Add NAB_KEYCHAIN_INTERACTION=never for background callers.
- Disable macOS Keychain UI around native cookie-password reads and serialize every process-global Keychain interaction-policy transition.
- Skip prompt-capable Python fallback in non-interactive mode.
- Avoid Keychain and schema reads for plaintext-only or empty result sets.
- Fail closed on non-UTF-8 policy values, native key failures, SQLite nonzero exits, and malformed schema versions.
- Preserve recoverable plaintext cookies in normal interactive mode when encrypted rows cannot be decoded.
- Apply the contract to ordinary and rich-cookie extraction and document it in README and the man page.

Default direct CLI behavior remains interactive when the variable is unset.

## Root cause and impact

Automated callers could launch multiple Nab processes. Native macOS cookie decryption could open a Keychain authorization dialog, then Python fallback could prompt again. The new mode provides a zero-dialog contract: no Keychain UI and no prompt-capable fallback.

## Validation

- cargo fmt --all -- --check: passed.
- cargo clippy --all-targets -- -D warnings: passed.
- Cookie extraction suite: 65 passed.
- Full library suite: 1,402 passed, 7 ignored.
- Final independent review: no Critical, Important, or Minor findings.
- New-head CI: all required checks passed, including formatting, Clippy, Ubuntu and macOS tests, feature tests, security, packaging, every build matrix, and the CI Gate.

Repository-wide cargo test still has three live httpbin.org HTTP 503 failures reproduced on untouched origin/main; tracked separately in #259. The unchanged optional-PDF all-features compile failure is tracked in #260. Neither is introduced by this PR.
