### PR TITLE
fix: flatio fetcher data race + gate live tripwindow tests + d2d currency band

### DIFF
--- a/internal/d2d/d2d.go
+++ b/internal/d2d/d2d.go
@@ -11,8 +11,10 @@
 //   - Mixed currencies are flagged: if legs disagree on currency the total is not
 //     silently summed. MixedCurrency is set and ConfirmedTotal reflects only the
 //     legs in the headline currency.
-//   - The confidence band widens whenever any non-confirmed leg exists. A single
-//     figure is only produced for all-confirmed, single-currency trips.
+//   - The confidence band widens whenever any non-confirmed leg exists, and is
+//     always expressed in the headline currency — magnitudes in other currencies
+//     are never summed into it. A single figure is only produced for
+//     all-confirmed, single-currency trips.
 //
 // This package is pure (no network I/O, no new dependencies beyond stdlib).
 package d2d
@@ -66,8 +68,8 @@ const (
 // Leg is a single segment of a door-to-door journey.
 //
 // Callers that have already determined the verification status should set it
-// explicitly. When Verification is left empty, ResolveVerification maps the
-// Source to a default (e.g. "rome2rio" → Indicative).
+// explicitly. When Verification is left empty, DefaultVerification maps the
+// Source to a default (e.g. "rome2rio" -> Indicative).
 type Leg struct {
 	// Mode is the transport or accommodation type: "air", "train", "bus",
 	// "ferry", "hotel", "taxi", etc. Free-form; used for display only.
@@ -145,9 +147,9 @@ type Total struct {
 	// Equal to ConfirmedTotal when Band == BandExact.
 	BandLow float64
 
-	// BandHigh is the upper bound of the estimated total range.
-	// Equal to ConfirmedTotal when Band == BandExact; inflated by indicative
-	// and unverified leg prices when available, else left as ConfirmedTotal.
+	// BandHigh is the upper bound of the estimated total range, in the headline
+	// currency. Equal to ConfirmedTotal when Band == BandExact; inflated by
+	// indicative and unverified legs that are in the headline currency.
 	BandHigh float64
 }
 
@@ -160,8 +162,8 @@ var indicativeSources = map[string]bool{
 }
 
 // DefaultVerification returns the default Verification for a given source name.
-// rome2rio → Indicative; any unknown or empty source → Unverified; all other
-// known transactional providers → Confirmed.
+// rome2rio -> Indicative; any unknown or empty source -> Unverified; all other
+// known transactional providers -> Confirmed.
 func DefaultVerification(source string) Verification {
 	s := strings.ToLower(strings.TrimSpace(source))
 	if s == "" {
@@ -189,7 +191,7 @@ func Compute(legs []Leg) Total {
 	mixedCurrency := hasMixedCurrencies(legs)
 
 	confirmedTotal := sumPrices(confirmed)
-	band, low, high := computeBand(confirmedTotal, indicative, unverified, excluded, mixedCurrency)
+	band, low, high := computeBand(confirmedTotal, currency, indicative, unverified, len(excluded) > 0, mixedCurrency)
 
 	return Total{
 		ConfirmedTotal:       round2(confirmedTotal),
@@ -281,38 +283,47 @@ func sumPrices(legs []Leg) float64 {
 	return total
 }
 
-// computeBand derives the confidence band and [low, high] range. The band
-// widens whenever non-confirmed legs or mixed-currency exclusions exist.
-func computeBand(confirmed float64, indicative, unverified, excluded []Leg, mixed bool) (BandKind, float64, float64) {
+// sumPricesInCurrency totals only legs priced in the given currency, so a
+// confidence band never adds magnitudes from a different currency (which would
+// be a fabricated, meaningless number).
+func sumPricesInCurrency(legs []Leg, currency string) float64 {
+	var total float64
+	for _, l := range legs {
+		if l.Price > 0 && l.Currency == currency {
+			total += l.Price
+		}
+	}
+	return total
+}
+
+// computeBand derives the confidence band and [low, high] range, all in the
+// headline currency. The band widens whenever non-confirmed legs exist.
+// Indicative and unverified legs inflate the upper bound ONLY when priced in the
+// headline currency; foreign-currency legs (including all excluded legs) are
+// never summed into the band — they are surfaced via the MixedCurrency flag and
+// the ExcludedCurrencyLegs bucket instead.
+func computeBand(confirmed float64, currency string, indicative, unverified []Leg, hasExcluded, mixed bool) (BandKind, float64, float64) {
 	hasIndicative := len(indicative) > 0
 	hasUnverified := len(unverified) > 0
-	hasExcluded := len(excluded) > 0
 
 	switch {
 	case hasUnverified:
-		high := confirmed + sumPrices(indicative) + sumPrices(unverified) + sumPrices(excluded)
-		if high < confirmed {
-			high = confirmed
-		}
+		high := confirmed + sumPricesInCurrency(indicative, currency) + sumPricesInCurrency(unverified, currency)
 		return BandUnknown, confirmed, high
 	case hasIndicative:
-		high := confirmed + sumPrices(indicative) + sumPrices(excluded)
-		if high < confirmed {
-			high = confirmed
-		}
+		high := confirmed + sumPricesInCurrency(indicative, currency)
 		return BandWide, confirmed, high
 	case hasExcluded || mixed:
-		high := confirmed + sumPrices(excluded)
-		if high < confirmed {
-			high = confirmed
-		}
-		return BandNarrow, confirmed, high
+		// Confirmed subtotal is reliable; foreign-currency legs exist but cannot
+		// be summed into a single-currency bound, so the band stays at the subtotal.
+		return BandNarrow, confirmed, confirmed
 	default:
 		return BandExact, confirmed, confirmed
 	}
 }
 
-// round2 rounds a float to 2 decimal places (matches multimodal/assemble.go).
+// round2 rounds a non-negative float to 2 decimal places (matches
+// multimodal/assemble.go). Prices in this package are never negative.
 func round2(v float64) float64 {
 	return float64(int64(v*100+0.5)) / 100
 }

--- a/internal/d2d/d2d_test.go
+++ b/internal/d2d/d2d_test.go
@@ -292,3 +292,30 @@ func TestCompute_explicitVerificationOverridesSource(t *testing.T) {
 		t.Error("IndicativeLegs should be empty when leg is explicitly Confirmed")
 	}
 }
+
+// improve pass: the confidence band must never add a foreign-currency magnitude
+// into its upper bound (that would be a fabricated cross-currency number).
+func TestComputeBandExcludesForeignCurrency(t *testing.T) {
+	// Confirmed EUR 100 + indicative in USD: band-high must stay at 100, NOT
+	// 100+50 (EUR and USD cannot be summed).
+	foreign := d2d.Compute([]d2d.Leg{
+		{Mode: "air", Price: 100, Currency: "EUR", Verification: d2d.Confirmed},
+		{Mode: "train", Price: 50, Currency: "USD", Verification: d2d.Indicative},
+	})
+	if foreign.BandHigh != 100 {
+		t.Fatalf("foreign-currency indicative leg must not inflate band-high; got %.2f want 100", foreign.BandHigh)
+	}
+
+	// Confirmed EUR 100 + indicative EUR 50: same-currency indicative DOES
+	// inflate the band to 150.
+	same := d2d.Compute([]d2d.Leg{
+		{Mode: "air", Price: 100, Currency: "EUR", Verification: d2d.Confirmed},
+		{Mode: "train", Price: 50, Currency: "EUR", Verification: d2d.Indicative},
+	})
+	if same.BandHigh != 150 {
+		t.Fatalf("same-currency indicative leg must inflate band-high; got %.2f want 150", same.BandHigh)
+	}
+	if same.BandLow != 100 {
+		t.Fatalf("band-low must equal the confirmed subtotal; got %.2f want 100", same.BandLow)
+	}
+}

--- a/internal/hotels/flatio.go
+++ b/internal/hotels/flatio.go
@@ -57,11 +57,16 @@ var flatioLimiter = rate.NewLimiter(rate.Every(500*time.Millisecond), 2)
 var flatioClient providers.Fetcher
 var flatioClientOnce sync.Once
 
+// flatioFetcher returns the Fetcher for Flatio requests, building a Tier1Client
+// once on first use. All access goes through flatioClientOnce so concurrent
+// callers (e.g. via singleflight) never race on the flatioClient interface
+// value — an earlier unsynchronized fast-path read could tear the interface and
+// crash. Tests inject a client by setting flatioClient before the first call.
 func flatioFetcher() providers.Fetcher {
-	if flatioClient != nil {
-		return flatioClient
-	}
 	flatioClientOnce.Do(func() {
+		if flatioClient != nil {
+			return // already injected (typically by a test)
+		}
 		if c, err := providers.NewTier1Client(); err == nil {
 			flatioClient = c
 		}

--- a/internal/hotels/flatio_race_test.go
+++ b/internal/hotels/flatio_race_test.go
@@ -1,0 +1,35 @@
+package hotels
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestFlatioFetcher_ConcurrentNoRace hammers flatioFetcher from many goroutines.
+// Before the fix, flatioFetcher read the package-global flatioClient interface on
+// an unsynchronized fast path while sync.Once.Do wrote it, racing on the
+// interface value (caught here under `go test -race`; it crashed Windows CI).
+// All access now flows through the Once, so this is race-free.
+func TestFlatioFetcher_ConcurrentNoRace(t *testing.T) {
+	// Reset the lazy-init state so this test exercises the build path, not a
+	// value a prior test injected. Save and restore to avoid cross-test leakage.
+	prevClient := flatioClient
+	prevOnce := flatioClientOnce
+	flatioClient = nil
+	flatioClientOnce = sync.Once{}
+	t.Cleanup(func() {
+		flatioClient = prevClient
+		flatioClientOnce = prevOnce
+	})
+
+	const n = 64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_ = flatioFetcher() // concurrent read/build; -race flags any tear
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/hotels/flatio_race_test.go
+++ b/internal/hotels/flatio_race_test.go
@@ -10,17 +10,15 @@ import (
 // an unsynchronized fast path while sync.Once.Do wrote it, racing on the
 // interface value (caught here under `go test -race`; it crashed Windows CI).
 // All access now flows through the Once, so this is race-free.
+//
+// The Once is intentionally not reset (copying a sync.Once is a vet error and a
+// bug). Nulling flatioClient exercises the cold build path when this test runs
+// before any other caller warms the Once; otherwise it exercises concurrent
+// reads. Both are race-free under the fix.
 func TestFlatioFetcher_ConcurrentNoRace(t *testing.T) {
-	// Reset the lazy-init state so this test exercises the build path, not a
-	// value a prior test injected. Save and restore to avoid cross-test leakage.
 	prevClient := flatioClient
-	prevOnce := flatioClientOnce
+	t.Cleanup(func() { flatioClient = prevClient })
 	flatioClient = nil
-	flatioClientOnce = sync.Once{}
-	t.Cleanup(func() {
-		flatioClient = prevClient
-		flatioClientOnce = prevOnce
-	})
 
 	const n = 64
 	var wg sync.WaitGroup

--- a/internal/tripwindow/tripwindow_extra_test.go
+++ b/internal/tripwindow/tripwindow_extra_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/testutil"
 )
 
 // ============================================================
@@ -12,6 +14,7 @@ import (
 // ============================================================
 
 func TestFind_BudgetFilter(t *testing.T) {
+	testutil.RequireLiveIntegration(t)
 	t.Parallel()
 	// With an impossibly low budget, all candidates should be filtered out
 	// (or returned with 0 cost since the searches will fail for fake cities).
@@ -40,6 +43,7 @@ func TestFind_BudgetFilter(t *testing.T) {
 // ============================================================
 
 func TestFind_SingleNightWindow(t *testing.T) {
+	testutil.RequireLiveIntegration(t)
 	t.Parallel()
 	candidates, err := Find(context.Background(), Input{
 		Origin:      "HEL",


### PR DESCRIPTION
Three fixes; the first is a real crash caught under the 0-bug stop-the-line policy.

## 1. Data race in internal/hotels flatio fetcher (the bug)
flatioFetcher() read the package-global flatioClient interface on an unsynchronized fast path while a concurrent goroutine wrote it inside sync.Once.Do. Multiple callers via singleflight raced on the interface value, tearing it and crashing on Windows CI (SIGSEGV). All access now goes through the Once, so every read happens-after the write; test injection still works. Verified with go test -race on the hotels package.

## 2. Repo hygiene: live tests in the default suite
TestFind_BudgetFilter and TestFind_SingleNightWindow performed live flight and hotel searches in the default suite (slow, provider-dependent, and what tripped the flatio race on Windows). They now use the existing testutil.RequireLiveIntegration gate, matching the rest of the package. Default suite is deterministic and offline again.

## 3. d2d single-currency confidence band (carried from #258)
The door-to-door band summed magnitudes across currencies into its upper bound. Now strictly single-currency. Supersedes #258.

## Validation
build, vet, staticcheck, gofmt clean; full race suite passes; tripwindow suite deterministic offline.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)