### PR TITLE
refactor: shared atomicjson helper + migrate probecache and dealquality

### DIFF
--- a/internal/atomicjson/atomicjson.go
+++ b/internal/atomicjson/atomicjson.go
@@ -1,0 +1,76 @@
+// Package atomicjson writes JSON to disk atomically with restrictive
+// permissions. It is the single implementation of the temp-file + fsync + rename
+// pattern that was previously copy-pasted across every ~/.trvl store (watch,
+// trips, dategrid, probecache, dealquality, providers, ...). Centralising it
+// means the security-sensitive bits — 0600 file perms, 0700 dir, atomic rename,
+// the Windows rename-over-existing fallback — are written correctly once.
+package atomicjson
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// Write marshals v as indented JSON and writes it to path atomically: it is
+// rendered to a temp file in the same directory (0600), fsynced, then renamed
+// over path so a reader never observes a partial file. The parent directory is
+// created (0700) if absent.
+func Write(path string, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	return WriteBytes(path, b)
+}
+
+// WriteBytes writes raw bytes to path atomically (same guarantees as Write).
+func WriteBytes(path string, b []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		// Windows cannot rename over an existing file; remove then retry.
+		if runtime.GOOS == "windows" {
+			_ = os.Remove(path)
+			if err2 := os.Rename(tmpPath, path); err2 == nil {
+				cleanup = false
+				return nil
+			}
+		}
+		return err
+	}
+	cleanup = false
+	return nil
+}

--- a/internal/atomicjson/atomicjson_test.go
+++ b/internal/atomicjson/atomicjson_test.go
@@ -1,0 +1,97 @@
+package atomicjson
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+type sample struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+}
+
+func TestWriteRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "x.json")
+	in := sample{Name: "a", Value: 7}
+	if err := Write(path, in); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var out sample
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: %+v != %+v", out, in)
+	}
+}
+
+func TestWritePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits not meaningful on windows")
+	}
+	path := filepath.Join(t.TempDir(), "secret.json")
+	if err := Write(path, sample{Name: "s"}); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("file perm = %o, want 600", perm)
+	}
+}
+
+func TestWriteOverwrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "x.json")
+	if err := Write(path, sample{Value: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Write(path, sample{Value: 2}); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	b, _ := os.ReadFile(path)
+	var out sample
+	_ = json.Unmarshal(b, &out)
+	if out.Value != 2 {
+		t.Fatalf("overwrite failed: got %d want 2", out.Value)
+	}
+}
+
+func TestWriteCreatesParentDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "deep", "x.json")
+	if err := Write(path, sample{Name: "n"}); err != nil {
+		t.Fatalf("Write into missing dir: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+}
+
+func TestWriteBytes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "raw.json")
+	if err := WriteBytes(path, []byte(`{"k":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(path)
+	if string(b) != `{"k":1}` {
+		t.Fatalf("got %q", b)
+	}
+}
+
+func TestWriteMarshalError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := Write(path, make(chan int)); err == nil {
+		t.Fatal("expected marshal error for non-serializable value")
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("no file should be written on marshal error")
+	}
+}

--- a/internal/dealquality/dealquality.go
+++ b/internal/dealquality/dealquality.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/atomicjson"
 )
 
 const historyLayout = "2006-01-02"
@@ -214,10 +215,6 @@ func (s *Store) historyPath() string {
 	return filepath.Join(s.dir, "deal-history.json")
 }
 
-func (s *Store) ensureDir() error {
-	return os.MkdirAll(s.dir, 0o700)
-}
-
 // Load reads samples from disk. If the file does not exist, the store starts empty.
 func (s *Store) Load() error {
 	s.mu.Lock()
@@ -241,56 +238,7 @@ func (s *Store) loadLocked() error {
 }
 
 func (s *Store) saveLocked() error {
-	if err := s.ensureDir(); err != nil {
-		return fmt.Errorf("create storage dir: %w", err)
-	}
-	b, err := json.MarshalIndent(s.samples, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal deal history: %w", err)
-	}
-
-	dir := filepath.Dir(s.historyPath())
-	tmp, err := os.CreateTemp(dir, "deal-history.json.tmp-*")
-	if err != nil {
-		return fmt.Errorf("create temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(tmpPath)
-		}
-	}()
-
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(b); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-
-	if err := os.Rename(tmpPath, s.historyPath()); err != nil {
-		if runtime.GOOS == "windows" {
-			_ = os.Remove(s.historyPath())
-			if err2 := os.Rename(tmpPath, s.historyPath()); err2 == nil {
-				cleanup = false
-				return nil
-			}
-		}
-		return err
-	}
-
-	cleanup = false
-	return nil
+	return atomicjson.Write(s.historyPath(), s.samples)
 }
 
 // Append adds a sample, deduplicating exact (Route,Kind,Date,Price) matches

--- a/internal/probecache/probecache.go
+++ b/internal/probecache/probecache.go
@@ -10,12 +10,12 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/atomicjson"
 	"github.com/MikkoParkkola/trvl/internal/counterfactual"
 )
 
@@ -131,9 +131,6 @@ func (s *Store) evictLocked() {
 }
 
 func (s *Store) saveLocked() error {
-	if err := os.MkdirAll(s.dir, 0o700); err != nil {
-		return err
-	}
 	keys := make([]string, 0, len(s.entries))
 	for k := range s.entries {
 		keys = append(keys, k)
@@ -143,43 +140,5 @@ func (s *Store) saveLocked() error {
 	for _, k := range keys {
 		list = append(list, s.entries[k])
 	}
-	b, err := json.MarshalIndent(list, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	tmp, err := os.CreateTemp(s.dir, "probe-cache.json.tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(tmpPath)
-		}
-	}()
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(b); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, s.path()); err != nil {
-		if runtime.GOOS == "windows" {
-			_ = os.Remove(s.path())
-			if err2 := os.Rename(tmpPath, s.path()); err2 == nil {
-				cleanup = false
-				return nil
-			}
-		}
-		return err
-	}
-	cleanup = false
-	return nil
+	return atomicjson.Write(s.path(), list)
 }


### PR DESCRIPTION
First progressive slice of the atomic-JSON dedup (the temp-file plus fsync plus rename plus 0600 pattern copy-pasted across about 8 stores).

## This slice
- New internal atomicjson package: one tested implementation of atomic JSON persistence (0600 file, 0700 dir, fsync, atomic rename, Windows rename-over fallback). Six unit tests cover round-trip, perms, overwrite, parent-dir creation, raw bytes, and marshal-error.
- Migrated probecache and dealquality to use it; each drops about 40 lines of duplicated persistence logic with no behaviour change (package tests pass).

## Remaining (future slices)
trips, watch, the providers registry, and hotelarb still carry their own copy; dategrid too. Each migrates to a one-line atomicjson.Write call, done incrementally so every change stays small and individually verifiable.

## Validation
build, vet, staticcheck, gofmt clean; race tests pass on all three packages.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)