### PR TITLE
refactor(trips): use atomicjson helper for trip+alert persistence

### DIFF
--- a/internal/trips/trips.go
+++ b/internal/trips/trips.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/atomicjson"
 )
 
 // Trip represents a planned or booked travel itinerary.
@@ -415,51 +416,5 @@ func loadJSON(path string, dst interface{}) error {
 
 // saveJSON writes data as pretty-printed JSON to path using an atomic rename.
 func saveJSON(path string, data interface{}) error {
-	b, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(tmpPath)
-		}
-	}()
-
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(b); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-
-	if err := os.Rename(tmpPath, path); err != nil {
-		if runtime.GOOS == "windows" {
-			_ = os.Remove(path)
-			if err2 := os.Rename(tmpPath, path); err2 == nil {
-				cleanup = false
-				return nil
-			}
-		}
-		return err
-	}
-
-	cleanup = false
-	return nil
+	return atomicjson.Write(path, data)
 }


### PR DESCRIPTION
## What

`saveJSON` in `internal/trips` duplicated the temp-file + chmod 0600 + fsync + atomic-rename pattern (including the Windows rename-over-existing fallback). That pattern now lives in `internal/atomicjson`. This collapses the body to a one-line `atomicjson.Write` call and drops the now-unused `runtime` import.

Part of the progressive consolidation onto the shared atomicjson helper (after probecache, dealquality, hotelarb, providers registry).

## Why

One correctly-written atomic-write implementation instead of seven copies. The security-sensitive bits (0600 perms, 0700 dir, fsync, atomic rename) live in one tested place.

## Safety

- `saveJSON` wrapper kept, so both call sites and the existing `saveJSON`/`loadJSON` test are unchanged.
- Behaviour identical: same 0600 file perms, same atomic-rename semantics, same Windows fallback (now inside the helper).
- gofmt clean, build ok, vet ok, staticcheck ok, `-race` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)