### PR TITLE
refactor(watch): use atomicjson helper for watch+history persistence

### DIFF
--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -11,10 +11,11 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/atomicjson"
 )
 
 // Scaling guards for ad-hoc route observations (MIK-6229 improve pass).
@@ -652,51 +653,5 @@ func loadJSON(path string, dst interface{}) error {
 
 // saveJSON writes data as pretty-printed JSON.
 func saveJSON(path string, data interface{}) error {
-	b, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(tmpPath)
-		}
-	}()
-
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(b); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-
-	if err := os.Rename(tmpPath, path); err != nil {
-		if runtime.GOOS == "windows" {
-			_ = os.Remove(path)
-			if err2 := os.Rename(tmpPath, path); err2 == nil {
-				cleanup = false
-				return nil
-			}
-		}
-		return err
-	}
-
-	cleanup = false
-	return nil
+	return atomicjson.Write(path, data)
 }


### PR DESCRIPTION
## What

`saveJSON` in `internal/watch` duplicated the temp-file + chmod 0600 + fsync + atomic-rename pattern (including the Windows rename-over-existing fallback). That pattern now lives in `internal/atomicjson`. This collapses the body to a one-line `atomicjson.Write` call and drops the now-unused `runtime` import.

Part of the progressive consolidation onto the shared atomicjson helper (after probecache, dealquality, hotelarb, providers registry, trips).

## Why

One correctly-written atomic-write implementation instead of many copies. The security-sensitive bits (0600 perms, 0700 dir, fsync, atomic rename) live in one tested place.

## Safety

- `saveJSON` wrapper kept, so both `saveLocked` call sites are unchanged.
- Behaviour identical: same 0600 file perms, same atomic-rename semantics, same Windows fallback (now inside the helper).
- gofmt clean, build ok, vet ok, staticcheck ok, `-race` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)