### PR TITLE
refactor(nudge): use atomicjson helper for nudge-state persistence

### DIFF
--- a/cmd/trvl/nudge.go
+++ b/cmd/trvl/nudge.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"golang.org/x/term"
+
+	"github.com/MikkoParkkola/trvl/internal/atomicjson"
 )
 
 // nudgeState tracks star-nudge state across sessions.
@@ -57,24 +59,9 @@ func loadNudgeState(path string) nudgeState {
 	return s
 }
 
-// saveNudgeState writes the nudge state to disk atomically.
+// saveNudgeState writes the nudge state to disk atomically (best-effort).
 func saveNudgeState(path string, s nudgeState) {
-	dir := filepath.Dir(path)
-	_ = os.MkdirAll(dir, 0o700)
-
-	data, err := json.Marshal(s)
-	if err != nil {
-		return
-	}
-
-	tmp, err := os.CreateTemp(dir, "nudge-*.tmp")
-	if err != nil {
-		return
-	}
-	tmpName := tmp.Name()
-	_, _ = tmp.Write(data)
-	_ = tmp.Close()
-	_ = os.Rename(tmpName, path)
+	_ = atomicjson.Write(path, s)
 }
 
 // shouldShowNudge decides whether to display the star nudge.


### PR DESCRIPTION
## What

`saveNudgeState` in `cmd/trvl/nudge.go` hand-rolled a temp-file + rename. Collapse it to a one-line `atomicjson.Write` (best-effort; the caller never inspected the error and still does not).

Part of the progressive consolidation onto the shared `internal/atomicjson` helper.

## Why

Removes another copy of the atomic-write dance, and hardens the write at no behavioural cost.

## Safety

The previous code:
- created the temp file with the process umask (typically world- or group-readable) and never chmod'd it
- never fsynced
- had no Windows rename-over-existing fallback

`atomicjson.Write` gives 0600 perms, fsync, and the Windows fallback — all strict improvements. The nudge-state file is not sensitive, so the tighter 0600 is free hardening. The on-disk JSON switches from compact to indented; the loader reads it identically.

gofmt clean, build ok, vet ok, staticcheck ok, nudge tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)