### PR TITLE
harden(atomicjson): create temp file with O_EXCL at 0600 to close TOCTOU window

### DIFF
--- a/internal/atomicjson/atomicjson.go
+++ b/internal/atomicjson/atomicjson.go
@@ -7,7 +7,10 @@
 package atomicjson
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,11 +35,23 @@ func WriteBytes(path string, b []byte) error {
 		return err
 	}
 
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	// Open the temp file with O_CREATE|O_EXCL at mode 0600 directly, rather than
+	// os.CreateTemp followed by Chmod. CreateTemp inherits the process umask, so
+	// the file can be momentarily group/world-readable between creation and the
+	// Chmod — a TOCTOU window. With a crypto-random name and O_EXCL the file is
+	// owner-only from the instant it exists, which is what lets even secret
+	// stores (API keys, preferences) rely on this single implementation.
+	rnd := make([]byte, 8)
+	if _, err := rand.Read(rnd); err != nil {
+		return fmt.Errorf("atomicjson: generate temp name: %w", err)
+	}
+	tmpPath := filepath.Join(dir, filepath.Base(path)+".tmp-"+hex.EncodeToString(rnd))
+	//nolint:gosec // mode 0600 is intentional — store files must be owner-only
+	tmp, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return err
 	}
-	tmpPath := tmp.Name()
+	tmpPath = tmp.Name()
 	cleanup := true
 	defer func() {
 		if cleanup {
@@ -44,10 +59,6 @@ func WriteBytes(path string, b []byte) error {
 		}
 	}()
 
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
 	if _, err := tmp.Write(b); err != nil {
 		_ = tmp.Close()
 		return err

--- a/internal/atomicjson/atomicjson_test.go
+++ b/internal/atomicjson/atomicjson_test.go
@@ -95,3 +95,27 @@ func TestWriteMarshalError(t *testing.T) {
 		t.Fatal("no file should be written on marshal error")
 	}
 }
+
+// TestWriteNoTempLeftover verifies that a successful write leaves exactly the
+// target file behind — no ".tmp-*" artifacts from the O_EXCL temp file.
+func TestWriteNoTempLeftover(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.json")
+	if err := Write(path, sample{Name: "a", Value: 1}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := Write(path, sample{Name: "b", Value: 2}); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "x.json" {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Fatalf("expected only x.json, got %v", names)
+	}
+}


### PR DESCRIPTION
## What

`WriteBytes` previously used `os.CreateTemp` followed by `Chmod(0600)`. `CreateTemp` inherits the process umask, so the temp file can be momentarily group- or world-readable between creation and the `Chmod` — a TOCTOU window.

This switches to a crypto-random temp name opened with `O_WRONLY | O_CREATE | O_EXCL` at mode 0600, so the file is owner-only from the instant it exists.

## Why

This mirrors the hardened pattern already used in `cmd/trvl/setup.go` (keys.json) and `internal/preferences` (preferences.json). Those two stores deliberately avoided `atomicjson` precisely because it had the TOCTOU window; closing it here means `atomicjson` becomes the single atomic-write primitive that even secret stores can rely on — a prerequisite for folding them in later.

## Safety

Behaviour for the final file is unchanged:
- same 0600 perms
- same fsync
- same atomic rename
- same Windows rename-over-existing fallback

The only change is *when* the perms are guaranteed (at creation vs. after a follow-up chmod). Adds a test asserting no temp-file artifacts leak after writes.

All six current callers (probecache, dealquality, hotelarb, providers, trips, watch) plus the atomicjson package itself pass with the race detector. Whole-repo build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)