### PR TITLE
docs: add brew trust step for Homebrew 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ That's it. Your AI will install the binary, wire the MCP server, install the ski
 **Or install manually:**
 
 ```bash
+brew trust --tap MikkoParkkola/tap   # Homebrew 6.0+
 brew install MikkoParkkola/tap/trvl   # install
 trvl mcp install                       # wire to Claude Desktop (default)
 ```


### PR DESCRIPTION
Adds the `brew trust --tap MikkoParkkola/tap` step (Homebrew 6.0 tap-trust). Required when HOMEBREW_REQUIRE_TAP_TRUST is set, harmless otherwise. Matches the canonical homebrew-tap README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)