### PR TITLE
docs(readme): user-first hero — value, who-it-is-for, differentiators

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Asciinema source: [`demo.cast`](demo.cast) · Demo script and claims: [`docs/DEM
 
 **▶ Try it live in your browser** — run trvl as a hosted MCP demo, no install (sign in to run): **[socialistic.ai/trvl-travel-mcp](https://socialistic.ai/en/skill/trvl-travel-mcp-4f7aa7)** (community-hosted by [@shesl-tinkerland](https://github.com/shesl-tinkerland)).
 
-**Ask your AI assistant to plan a real trip, and it actually can.** trvl gives Claude, Cursor, Windsurf, Codex, or any MCP-compatible assistant live access to flights, hotels, rental cars, trains, buses, ferries, price alerts, award sweet spots, weather, baggage rules, lounges, and destination intel. Free, no API keys, no signup. One binary.
+**Ask your AI assistant to plan a real trip, and it actually can.** trvl hands Claude, Cursor, Windsurf, Codex, or any MCP-compatible client 1 smart MCP tool for your AI assistant — the `travel` router — with live access to flights, hotels, rental cars, trains, buses, ferries, price alerts, award sweet spots, weather, baggage rules, lounges, and destination intel. Free, no API keys, no signup. One binary.
 
 Just ask in plain language. "Find me a cheap weekend somewhere warm." "Cheapest return flight Helsinki to Tokyo in March." "Train from Paris to Amsterdam next Friday, plus a hotel near the station." trvl searches 22 real providers across flights, hotels, trains, buses, ferries, and rental cars and hands your assistant live options with real prices, so it can compare, optimise across airlines and dates, and tee them up for booking. Prefer a terminal? The same engine runs as a standalone CLI with 56 commands.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ Asciinema source: [`demo.cast`](demo.cast) · Demo script and claims: [`docs/DEM
 
 → Full positioning: [`docs/POSITIONING.md`](docs/POSITIONING.md) · Comparison: [`docs/COMPARISON.md`](docs/COMPARISON.md) · Architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) · Traveller Workspace: [`docs/traveller-workspace.md`](docs/traveller-workspace.md) · Tools: [`AGENTS.md`](AGENTS.md)
 
+## Is this for you?
+
+**Yes, if** you already plan trips with an AI assistant (Claude, Cursor, Windsurf, Codex, any MCP client) and want it to search real flights, hotels, trains, buses, ferries, and transfers instead of guessing. Also yes if you are building an app that needs travel intent without signing up for a paid travel API.
+
+**Probably not, if** you just want to book on a website — use Google Flights. And not if you want a hosted travel product with an account and a dashboard; trvl is a tool you run, not a service you log into.
+
+## Why trvl, not the alternatives
+
+- **Whole-journey, door to door.** trvl plans the entire trip across modes (home to the airport, the flight, the arrival transfer, the hotel, the onward train) and prices each leg in its real mode. Most tools stop at one flight, one hotel.
+- **No API keys, no signup, no bill.** It works the moment you install it. There is no Amadeus key to apply for, no hosted subscription, no per-call cost.
+- **Your assistant, your machine.** One binary that runs locally and plugs into any MCP client, so you are not locked to one vendor and your trips and preferences never leave your computer.
+- **It optimises, it does not just list.** Shift-day pricing, split-airline routing, hidden-city checks, award sweet spots, return and round-trip fares. It hands back the cheaper option and shows what it saved.
+- **It is honest when a source fails.** Typed statuses and labelled estimates instead of an empty result dressed up as "nothing found" (see [Why trust it](#why-trust-it) below).
+
 ## Available on
 
 Listed across the MCP ecosystem: [Glama](https://glama.ai/mcp/servers/MikkoParkkola/trvl) · [LobeHub](https://lobehub.com/mcp/mikkoparkkola-trvl) · [Smithery](https://smithery.ai/server/@MikkoParkkola/trvl) · [MCPHub](https://www.mcphub.com/mcp-servers/MikkoParkkola/trvl) · [Cursor Directory](https://cursor.directory/mcp/trvl) · [PulseMCP](https://www.pulsemcp.com/servers/mikkoparkkola-trvl) · [Agent Index](https://agentindex.app/en/tool/mikkoparkkola-trvl) · [MCP Market](https://mcpmarket.com/server/trvl) · [Fleur](https://fleurmcp.com/mcp/trvl) · [MagicSlides](https://www.magicslides.app/mcps/mikkoparkkola-trvl) · [pkg.go.dev](https://pkg.go.dev/github.com/MikkoParkkola/trvl)

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Asciinema source: [`demo.cast`](demo.cast) · Demo script and claims: [`docs/DEM
 
 **▶ Try it live in your browser** — run trvl as a hosted MCP demo, no install (sign in to run): **[socialistic.ai/trvl-travel-mcp](https://socialistic.ai/en/skill/trvl-travel-mcp-4f7aa7)** (community-hosted by [@shesl-tinkerland](https://github.com/shesl-tinkerland)).
 
-> **Ask your AI assistant to plan a real trip, and it actually can.** trvl gives Claude, Cursor, Windsurf, Codex, or any MCP-compatible assistant live access to flights, hotels, rental cars, trains, buses, ferries, price alerts, award sweet spots, weather, baggage rules, lounges, and destination intel. Free, no API keys, no signup. One binary.
->
-> Just ask in plain language. "Find me a cheap weekend somewhere warm." "Cheapest return flight Helsinki to Tokyo in March." "Train from Paris to Amsterdam next Friday, plus a hotel near the station." trvl searches 22 real providers across flights, hotels, trains, buses, ferries, and rental cars and hands your assistant live options with real prices, so it can compare, optimise across airlines and dates, and tee them up for booking. Prefer a terminal? The same engine runs as a standalone CLI with 56 commands.
->
-> **Token-efficient by design:** advertising 1 smart tool instead of 66 keeps the `tools/list` payload at ~378 tokens instead of ~33,500 — a **98.9% smaller context footprint**, ~33K tokens handed back to your assistant. The 66 aliases stay callable via the `intent` field (set `TRVL_MCP_TOOL_MODE=legacy` to advertise all 66).
+**Ask your AI assistant to plan a real trip, and it actually can.** trvl gives Claude, Cursor, Windsurf, Codex, or any MCP-compatible assistant live access to flights, hotels, rental cars, trains, buses, ferries, price alerts, award sweet spots, weather, baggage rules, lounges, and destination intel. Free, no API keys, no signup. One binary.
+
+Just ask in plain language. "Find me a cheap weekend somewhere warm." "Cheapest return flight Helsinki to Tokyo in March." "Train from Paris to Amsterdam next Friday, plus a hotel near the station." trvl searches 22 real providers across flights, hotels, trains, buses, ferries, and rental cars and hands your assistant live options with real prices, so it can compare, optimise across airlines and dates, and tee them up for booking. Prefer a terminal? The same engine runs as a standalone CLI with 56 commands.
+
+**Token-efficient by design:** advertising 1 smart tool instead of 66 keeps the `tools/list` payload at ~378 tokens instead of ~33,500 — a **98.9% smaller context footprint**, ~33K tokens handed back to your assistant. The 66 aliases stay callable via the `intent` field (set `TRVL_MCP_TOOL_MODE=legacy` to advertise all 66).
 
 **For**: AI-assistant users who book ≥4 trips/yr · AI-app builders integrating travel intent · devs shopping MCP registries.
 **Not for**: humans booking via a website (use Google Flights) · travel-agency SaaS shoppers (we are not a hosted product).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Install in Cursor](https://img.shields.io/badge/Cursor-Install_MCP-black?logo=cursor)](cursor://anysphere.cursor-deeplink/mcp/install?name=trvl&config=%7B%22command%22%3A%22trvl%22%2C%22args%22%3A%5B%22mcp%22%5D%7D)
 [![Live Demo](https://img.shields.io/badge/Live_Demo-Try_in_browser-14b8a6?logo=googlechrome&logoColor=white)](https://socialistic.ai/en/skill/trvl-travel-mcp-4f7aa7)
 
-# trvl — The Travel MCP Server
+# trvl — Real travel search for your AI assistant
 
 ![trvl demo](https://raw.githubusercontent.com/MikkoParkkola/trvl/main/demo.gif?v=1.10.0)
 
@@ -19,9 +19,9 @@ Asciinema source: [`demo.cast`](demo.cast) · Demo script and claims: [`docs/DEM
 
 **▶ Try it live in your browser** — run trvl as a hosted MCP demo, no install (sign in to run): **[socialistic.ai/trvl-travel-mcp](https://socialistic.ai/en/skill/trvl-travel-mcp-4f7aa7)** (community-hosted by [@shesl-tinkerland](https://github.com/shesl-tinkerland)).
 
-> **The canonical travel MCP for AI assistants. 1 smart tool. 66 compatibility aliases. 22 providers. Zero API keys. One binary.**
+> **Ask your AI assistant to plan a real trip, and it actually can.** trvl gives Claude, Cursor, Windsurf, Codex, or any MCP-compatible assistant live access to flights, hotels, rental cars, trains, buses, ferries, price alerts, award sweet spots, weather, baggage rules, lounges, and destination intel. Free, no API keys, no signup. One binary.
 >
-> Gives Claude, Cursor, Windsurf, Codex, and any MCP-compatible AI 1 smart MCP tool for your AI assistant — the `travel` router — with 66 compatibility aliases for flights, hotels, rental cars, trains, buses, ferries, price alerts, award sweet spots, weather, baggage, lounges, and destination intel. Free. API-first. Also works as a standalone CLI with 56 commands.
+> Just ask in plain language. "Find me a cheap weekend somewhere warm." "Cheapest return flight Helsinki to Tokyo in March." "Train from Paris to Amsterdam next Friday, plus a hotel near the station." trvl searches 22 real providers across flights, hotels, trains, buses, ferries, and rental cars and hands your assistant live options with real prices, so it can compare, optimise across airlines and dates, and tee them up for booking. Prefer a terminal? The same engine runs as a standalone CLI with 56 commands.
 >
 > **Token-efficient by design:** advertising 1 smart tool instead of 66 keeps the `tools/list` payload at ~378 tokens instead of ~33,500 — a **98.9% smaller context footprint**, ~33K tokens handed back to your assistant. The 66 aliases stay callable via the `intent` field (set `TRVL_MCP_TOOL_MODE=legacy` to advertise all 66).
 


### PR DESCRIPTION
## What

Reworks the README hero so a reader knows in seconds what trvl does, whether it is for them, and why they would pick it over alternatives. Previously the opening read like a developer spec sheet (canonical travel MCP, 66 compatibility aliases, a token-count payload claim) and was wrapped in a blockquote that de-emphasized it.

Three changes:
1. **Lead with user value.** New title and opening paragraphs answer what trvl does (your AI assistant plans and prices real trips), how you use it (plain-language asks across flights, hotels, trains, buses, ferries), and the value (free, no keys, no signup). The token-efficiency note moves to third.
2. **"Is this for you?"** A Yes-if / Probably-not-if pair so AI-assistant trip planners and app builders self-identify, and website bookers and hosted-SaaS shoppers are told plainly it is not for them.
3. **"Why trvl, not the alternatives."** The five real differentiators: whole-journey door-to-door multimodal pricing (each leg in its real mode), no API keys, runs locally on any MCP client, optimises rather than just lists (shift-day, split-airline, hidden-city, award, return and round-trip fares), and honest typed failures.
4. **Unquoted** the hero so it renders as the headline, not an aside.

## Why

The hero is the screen most readers judge the project on. It buried the benefit, skewed the audience to developers, and never surfaced the door-to-door multimodal and round-trip capabilities that are the strongest selling points. This addresses the not-only-flights, not-only-hotels gap directly.

## Scope

Hero section of README.md only. No functional, link, or code changes.

## Test

Documentation-only. No code paths touched; CI build, vet, and tests unaffected.