### PR TITLE
refactor: migrate dategrid + share stores to internal/atomicjson

### DIFF
--- a/cmd/trvl/share.go
+++ b/cmd/trvl/share.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/atomicjson"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/trips"
 	"github.com/spf13/cobra"
@@ -342,6 +343,9 @@ func lastSearchPath() string {
 }
 
 // saveLastSearch marshals the search result and writes to the cache file.
+// Best-effort: persistence failures are intentionally ignored. The atomic
+// temp-file + fsync + 0600 + rename mechanics live once in internal/atomicjson,
+// which also creates the parent dir (0700) if absent.
 func saveLastSearch(ls *LastSearch) {
 	ls.Timestamp = time.Now()
 
@@ -349,28 +353,7 @@ func saveLastSearch(ls *LastSearch) {
 	if err != nil {
 		return // best-effort
 	}
-
-	path := lastSearchPath()
-	dir := filepath.Dir(path)
-	_ = os.MkdirAll(dir, 0o700)
-
-	// Write atomically via temp file.
-	tmp, err := os.CreateTemp(dir, "last_search.json.tmp-*")
-	if err != nil {
-		return
-	}
-	tmpPath := tmp.Name()
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpPath)
-		return
-	}
-	_ = tmp.Close()
-
-	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath)
-	}
+	_ = atomicjson.WriteBytes(lastSearchPath(), data)
 }
 
 func loadLastSearch() (*LastSearch, error) {

--- a/internal/dategrid/dategrid.go
+++ b/internal/dategrid/dategrid.go
@@ -13,11 +13,12 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/atomicjson"
 )
 
 // maxGridPoints caps the points retained per route, bounding the file.
@@ -131,10 +132,10 @@ func (s *Store) Get(routeKey string) (Grid, bool) {
 	return g, ok
 }
 
+// saveLocked persists the grids deterministically (sorted by route key) via the
+// shared atomicjson helper, which centralises MkdirAll(0700), the O_EXCL temp
+// file (0600), fsync, and the atomic rename (with the Windows fallback).
 func (s *Store) saveLocked() error {
-	if err := os.MkdirAll(s.dir, 0o700); err != nil {
-		return err
-	}
 	keys := make([]string, 0, len(s.grids))
 	for k := range s.grids {
 		keys = append(keys, k)
@@ -144,43 +145,5 @@ func (s *Store) saveLocked() error {
 	for _, k := range keys {
 		list = append(list, s.grids[k])
 	}
-	b, err := json.MarshalIndent(list, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	tmp, err := os.CreateTemp(s.dir, "date-grids.json.tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(tmpPath)
-		}
-	}()
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(b); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, s.path()); err != nil {
-		if runtime.GOOS == "windows" {
-			_ = os.Remove(s.path())
-			if err2 := os.Rename(tmpPath, s.path()); err2 == nil {
-				cleanup = false
-				return nil
-			}
-		}
-		return err
-	}
-	cleanup = false
-	return nil
+	return atomicjson.Write(s.path(), list)
 }


### PR DESCRIPTION
## What

Migrates the last two hand-rolled JSON stores to the shared internal/atomicjson helper:

- internal/dategrid/dategrid.go — Store.saveLocked
- cmd/trvl/share.go — saveLastSearch

## Why

Both functions reimplemented the same temp-file plus rename dance. atomicjson centralises MkdirAll(0700), an O_EXCL temp file (0600), fsync, and the atomic rename (with the existing Windows fallback) in one tested place. The migration is a strict superset of the prior behaviour and additionally:

- adds the missing fsync before rename (durability on crash), and
- closes a TOCTOU window on the temp file.

## Scope and safety

- Helper signatures are unchanged, so the existing callers of these stores are unaffected.
- dategrid drops the now-unused runtime import.
- share.saveLastSearch keeps its best-effort semantics (write errors stay ignored).

## Validation

- go build all clean
- go vet on internal/dategrid and cmd/trvl clean
- go test on internal/dategrid, internal/atomicjson, cmd/trvl all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)