### PR TITLE
Tag round-trip leg direction so return-ticket data is legible

### DIFF
--- a/cmd/trvl/cmd_extra_test.go
+++ b/cmd/trvl/cmd_extra_test.go
@@ -584,6 +584,37 @@ func TestFlightRoute_AnnotatesLayover(t *testing.T) {
 	}
 }
 
+func TestFlightRoute_RoundTripSplitsByDirection(t *testing.T) {
+	// A composed round-trip carries inbound-tagged legs; the route must render
+	// each direction separately so the return is visible and the turnaround is
+	// never disguised as a connection.
+	f := models.FlightResult{
+		Legs: []models.FlightLeg{
+			{DepartureAirport: models.AirportInfo{Code: "HEL"}, ArrivalAirport: models.AirportInfo{Code: "BCN"}, Direction: "outbound"},
+			{DepartureAirport: models.AirportInfo{Code: "BCN"}, ArrivalAirport: models.AirportInfo{Code: "HEL"}, Direction: "inbound"},
+		},
+	}
+	want := "HEL -> BCN  ||  BCN -> HEL"
+	if got := flightRoute(f); got != want {
+		t.Errorf("flightRoute() = %q, want %q", got, want)
+	}
+}
+
+func TestFlightRoute_RoundTripWithConnections(t *testing.T) {
+	// Each direction keeps its own layover annotation independently.
+	f := models.FlightResult{
+		Legs: []models.FlightLeg{
+			{DepartureAirport: models.AirportInfo{Code: "HEL"}, ArrivalAirport: models.AirportInfo{Code: "FRA"}, Direction: "outbound"},
+			{DepartureAirport: models.AirportInfo{Code: "FRA"}, ArrivalAirport: models.AirportInfo{Code: "BCN"}, Direction: "outbound", LayoverMinutes: 90},
+			{DepartureAirport: models.AirportInfo{Code: "BCN"}, ArrivalAirport: models.AirportInfo{Code: "HEL"}, Direction: "inbound"},
+		},
+	}
+	want := "HEL -> FRA (1h 30m) -> BCN  ||  BCN -> HEL"
+	if got := flightRoute(f); got != want {
+		t.Errorf("flightRoute() = %q, want %q", got, want)
+	}
+}
+
 func TestFlightAirlinesDisplay(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -579,18 +579,49 @@ func flightWarnings(f models.FlightResult) string {
 
 // flightRoute builds a route string like "HEL -> FRA -> NRT", annotating
 // connection airports with their layover duration, e.g.
-// "HEL -> FRA (2h00) -> NRT". Nonstop flights render as "AMS -> HEL".
+// "HEL -> FRA (2h00) -> NRT". Nonstop flights render as "AMS -> HEL". A composed
+// round-trip (legs tagged outbound/inbound) renders each direction separately
+// joined by "  ||  " so the return is visible, e.g. "HEL -> BCN  ||  BCN -> HEL"
+// — never a single chain that disguises the turnaround as a connection.
 func flightRoute(f models.FlightResult) string {
 	if len(f.Legs) == 0 {
 		return ""
 	}
+	if out, in := splitLegsByDirection(f.Legs); in != nil {
+		return legRoute(out) + "  ||  " + legRoute(in)
+	}
+	return legRoute(f.Legs)
+}
 
-	parts := []string{f.Legs[0].DepartureAirport.Code}
-	for i, leg := range f.Legs {
+// splitLegsByDirection partitions legs into outbound and inbound when the result
+// is a composed round-trip (legs carry a "inbound" Direction tag). For a one-way
+// result (no inbound legs) it returns (legs, nil) so callers render a single
+// chain unchanged.
+func splitLegsByDirection(legs []models.FlightLeg) (outbound, inbound []models.FlightLeg) {
+	for _, leg := range legs {
+		if leg.Direction == "inbound" {
+			inbound = append(inbound, leg)
+		} else {
+			outbound = append(outbound, leg)
+		}
+	}
+	if len(inbound) == 0 {
+		return legs, nil
+	}
+	return outbound, inbound
+}
+
+// legRoute renders one contiguous set of legs as "A -> B (layover) -> C".
+func legRoute(legs []models.FlightLeg) string {
+	if len(legs) == 0 {
+		return ""
+	}
+	parts := []string{legs[0].DepartureAirport.Code}
+	for i, leg := range legs {
 		// Annotate the connection airport (arrival of a non-final leg) with the
 		// layover before the next leg, when the model carries it.
-		if i < len(f.Legs)-1 {
-			lo := f.Legs[i+1].LayoverMinutes
+		if i < len(legs)-1 {
+			lo := legs[i+1].LayoverMinutes
 			if lo > 0 {
 				parts = append(parts, fmt.Sprintf("%s (%s)", leg.ArrivalAirport.Code, formatDuration(lo)))
 				continue

--- a/internal/flights/roundtrip.go
+++ b/internal/flights/roundtrip.go
@@ -160,11 +160,13 @@ func composeRoundTrips(outbound, inbound []models.FlightResult, opts SearchOptio
 // composeItinerary combines one outbound and one inbound one-way option into a
 // single round-trip FlightResult: legs concatenated outbound-then-inbound, price
 // and duration summed, stops summed. The result is flagged as two separate
-// tickets via a warning and a composed provider label.
+// tickets via a warning and a composed provider label. Each leg is tagged with
+// its Direction ("outbound"/"inbound") so consumers can tell the return legs
+// apart in the otherwise-flat Legs slice (return-ticket data, not just one-way).
 func composeItinerary(out, in models.FlightResult) models.FlightResult {
 	legs := make([]models.FlightLeg, 0, len(out.Legs)+len(in.Legs))
-	legs = append(legs, out.Legs...)
-	legs = append(legs, in.Legs...)
+	legs = append(legs, taggedLegs(out.Legs, "outbound")...)
+	legs = append(legs, taggedLegs(in.Legs, "inbound")...)
 
 	warnings := []string{"composed round-trip: outbound and inbound are two separate one-way tickets, booked independently"}
 	warnings = append(warnings, out.Warnings...)
@@ -179,6 +181,18 @@ func composeItinerary(out, in models.FlightResult) models.FlightResult {
 		Legs:     legs,
 		Warnings: warnings,
 	}
+}
+
+// taggedLegs returns a copy of legs with each leg's Direction set, leaving the
+// source slice untouched (the one-way leg results are cached/shared upstream, so
+// mutating them in place would leak the round-trip tag into a one-way response).
+func taggedLegs(legs []models.FlightLeg, direction string) []models.FlightLeg {
+	out := make([]models.FlightLeg, len(legs))
+	for i, leg := range legs {
+		leg.Direction = direction
+		out[i] = leg
+	}
+	return out
 }
 
 // composedProviderLabel builds a transparent provider label for a composed

--- a/internal/flights/roundtrip_test.go
+++ b/internal/flights/roundtrip_test.go
@@ -94,6 +94,35 @@ func TestComposeRoundTrips_ExcludesUnpriced(t *testing.T) {
 	}
 }
 
+func TestComposeRoundTrips_TagsLegDirection(t *testing.T) {
+	out := []models.FlightResult{owFlight("Google Flights", "EUR", 100, "HEL", "BCN")}
+	in := []models.FlightResult{owFlight("Ryanair", "EUR", 60, "BCN", "HEL")}
+
+	composed, _ := composeRoundTrips(out, in, SearchOptions{})
+	if len(composed) != 1 {
+		t.Fatalf("composed count: got %d, want 1", len(composed))
+	}
+	legs := composed[0].Legs
+	if len(legs) != 2 {
+		t.Fatalf("legs: got %d, want 2", len(legs))
+	}
+	if legs[0].Direction != "outbound" {
+		t.Errorf("first leg Direction: got %q, want outbound", legs[0].Direction)
+	}
+	if legs[1].Direction != "inbound" {
+		t.Errorf("second leg Direction: got %q, want inbound", legs[1].Direction)
+	}
+
+	// The source one-way leg slices must stay untagged — they are cached/shared
+	// upstream and a leaked round-trip tag would corrupt a later one-way response.
+	if out[0].Legs[0].Direction != "" {
+		t.Errorf("source outbound leg was mutated: Direction=%q", out[0].Legs[0].Direction)
+	}
+	if in[0].Legs[0].Direction != "" {
+		t.Errorf("source inbound leg was mutated: Direction=%q", in[0].Legs[0].Direction)
+	}
+}
+
 func TestComposeRoundTrips_SkipsCurrencyMismatch(t *testing.T) {
 	out := []models.FlightResult{owFlight("A", "USD", 100, "HEL", "BCN")}
 	in := []models.FlightResult{owFlight("C", "EUR", 50, "BCN", "HEL")}

--- a/internal/models/flight.go
+++ b/internal/models/flight.go
@@ -23,6 +23,12 @@ type FlightLeg struct {
 	FlightNumber     string      `json:"flight_number"`
 	Aircraft         string      `json:"aircraft,omitempty"`        // e.g. "Airbus A350"
 	LayoverMinutes   int         `json:"layover_minutes,omitempty"` // time between arrival of previous leg and this departure (0 for first leg)
+	// Direction marks which half of a round-trip this leg belongs to:
+	// "outbound" (origin->destination) or "inbound" (the return leg). Empty for
+	// a one-way search, so single-direction results are byte-unchanged. Set by
+	// the round-trip composer so consumers can distinguish the return legs from
+	// the outbound legs in the otherwise-flat Legs slice.
+	Direction string `json:"direction,omitempty"`
 }
 
 // FlightResult represents a single flight option with price and routing.


### PR DESCRIPTION
## What

Round-trip flight search already composes an outbound and an inbound one-way option into one `FlightResult` (price summed, legs concatenated). The legs landed in a flat slice with no marker, so two things were lost:

1. A consumer reading the result could not tell which legs were the return.
2. The CLI route string flattened the whole trip into one chain, which made the turnaround airport look like a connection: `HEL -> BCN -> HEL`.

## Change

- Add `FlightLeg.Direction` (`"outbound"` or `"inbound"`, `omitempty` so one-way results are byte-unchanged).
- Set it in `composeItinerary` through a non-mutating `taggedLegs` copy. The one-way leg results are cached and shared upstream, so tagging them in place would leak a round-trip marker into a later one-way response.
- Split `flightRoute` on the direction boundary so each direction renders on its own and keeps its own layover annotations: `HEL -> BCN  ||  BCN -> HEL`.

The field carries a JSON tag, so MCP clients that receive the structured `FlightResult` get the return-ticket data without any further wiring.

## Tests

- `TestComposeRoundTrips_TagsLegDirection` — legs are tagged outbound then inbound, and the shared source slices are not mutated.
- `TestFlightRoute_RoundTripSplitsByDirection` and `TestFlightRoute_RoundTripWithConnections` — the route renders each direction independently, with per-direction layovers preserved.

Full `internal/flights`, `internal/models`, and `cmd/trvl` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)