### PR TITLE
Fetch native round-trip fares and prefer them when cheaper

### DIFF
--- a/internal/flights/providers_concurrent.go
+++ b/internal/flights/providers_concurrent.go
@@ -46,6 +46,19 @@ func runKiwiProvider(ctx context.Context, client *batchexec.Client, origin, dest
 }
 
 func runSkiplaggedProvider(ctx context.Context, client *batchexec.Client, origin, destination, date string, opts SearchOptions) providerOutcome {
+	// The round-trip composer suppresses the one-way Skiplagged leg searches
+	// because it queries Skiplagged once as a native round-trip instead (see
+	// disableSkiplaggedOneWay). Report a transparent skip rather than a silent
+	// no-op so the provider-status list explains the absence.
+	if skiplaggedOneWayDisabled(ctx) {
+		return providerOutcome{status: models.ProviderStatus{
+			ID:      "skiplagged",
+			Name:    "Skiplagged",
+			Status:  "skipped",
+			Error:   "one-way Skiplagged skipped; queried once as a native round-trip instead",
+			FixHint: "search one-way for the per-direction Skiplagged list",
+		}}
+	}
 	if !skiplaggedSearchEligible(client, opts) {
 		return providerOutcome{status: models.ProviderStatus{
 			ID:      "skiplagged",

--- a/internal/flights/roundtrip.go
+++ b/internal/flights/roundtrip.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -49,10 +50,12 @@ func searchRoundTripComposed(ctx context.Context, client *batchexec.Client, orig
 	legOpts.ReturnDate = ""
 	legOpts.FirstResult = false
 
-	// Leg sub-searches run with auto-compose disabled: a single round-trip-level
-	// savings pass is attached to the composed result below, so the two one-way
-	// legs do not each spawn their own (discarded) hack fan-out.
-	legCtx := disableHacksCompose(ctx)
+	// Leg sub-searches run with auto-compose disabled (a single round-trip-level
+	// savings pass is attached below) and with the one-way Skiplagged provider
+	// suppressed: Skiplagged is queried once as a native round-trip instead (see
+	// searchNativeRoundTrip), so two redundant one-way Skiplagged calls would
+	// only waste its rate budget.
+	legCtx := disableSkiplaggedOneWay(disableHacksCompose(ctx))
 	outbound, outErr := SearchFlightsWithClient(legCtx, client, origin, destination, date, legOpts)
 	inbound, inErr := SearchFlightsWithClient(legCtx, client, destination, origin, returnDate, legOpts)
 
@@ -68,6 +71,27 @@ func searchRoundTripComposed(ctx context.Context, client *batchexec.Client, orig
 	}
 
 	composed, truncated := composeRoundTrips(outFlights, inFlights, opts)
+
+	// Native round-trip pass: providers that price a return as a single fare can
+	// beat the sum of two one-ways (a real return discount) and are one bookable
+	// ticket. Query them WITH ReturnDate intact (the legs above clear it) and
+	// merge their genuine round-trip itineraries into the candidate pool. The
+	// cheapest sorts first, so a discounted native fare naturally outranks a more
+	// expensive composed pair; FareType keeps the two honestly distinguishable.
+	nativeRT, nativeStatuses := searchNativeRoundTrip(legCtx, client, origin, destination, date, returnDate, opts, nativeRoundTripCurrency(opts, composed, outFlights))
+	statuses = append(statuses, nativeStatuses...)
+
+	if len(nativeRT) > 0 {
+		merged := make([]models.FlightResult, 0, len(nativeRT)+len(composed))
+		merged = append(merged, nativeRT...)
+		merged = append(merged, composed...)
+		sortFlightResults(merged, opts.SortBy)
+		if len(merged) > roundTripMaxResults {
+			merged = merged[:roundTripMaxResults]
+			truncated = true
+		}
+		composed = merged
+	}
 
 	statuses = append(statuses, roundTripComposerStatus(len(outFlights), len(inFlights), len(composed), truncated))
 
@@ -206,6 +230,73 @@ func composedProviderLabel(outbound, inbound string) string {
 		inbound = "unknown"
 	}
 	return fmt.Sprintf("composed (%s + %s)", outbound, inbound)
+}
+
+// searchNativeRoundTrip queries providers that price a return trip as a single
+// native fare (Skiplagged today) and returns only genuine round-trip itineraries
+// (FareRoundTrip, both legs present). It is rate-conscious: the composer has
+// already suppressed the one-way Skiplagged leg searches via the passed-in ctx,
+// so this is the *only* Skiplagged call for the whole round-trip search. Prices
+// are normalised to target so they sort against the composed pairs like-for-like.
+// A disabled or ineligible provider yields no results and no status, leaving the
+// composition-only behaviour byte-unchanged.
+func searchNativeRoundTrip(ctx context.Context, client *batchexec.Client, origin, destination, date, returnDate string, opts SearchOptions, target string) ([]models.FlightResult, []models.ProviderStatus) {
+	if !skiplaggedSearchEligible(client, opts) {
+		return nil, nil
+	}
+
+	rtOpts := opts
+	rtOpts.ReturnDate = returnDate // request the native return fare (legs cleared it)
+
+	result, err := SearchSkiplagged(ctx, origin, destination, date, rtOpts)
+	if err != nil {
+		return nil, []models.ProviderStatus{{
+			ID:     "native_roundtrip:skiplagged",
+			Name:   "Skiplagged (native round-trip)",
+			Status: models.ClassifyProviderError(err),
+			Error:  err.Error(),
+		}}
+	}
+
+	var native []models.FlightResult
+	if result != nil {
+		for _, f := range result.Flights {
+			// Keep only true round-trips. A one-way result here would duplicate
+			// the outbound leg already covered by composition.
+			if f.FareType == models.FareRoundTrip {
+				native = append(native, f)
+			}
+		}
+	}
+	normalizeFlightCurrencies(ctx, native, target, destinations.ConvertCurrency)
+
+	status := models.ProviderStatus{
+		ID:      "native_roundtrip:skiplagged",
+		Name:    "Skiplagged (native round-trip)",
+		Status:  okOrNoHit(len(native)),
+		Results: len(native),
+	}
+	if len(native) == 0 {
+		status.FixHint = "no native round-trip fare returned; composed pairs used instead"
+	}
+	return native, []models.ProviderStatus{status}
+}
+
+// nativeRoundTripCurrency picks the currency to normalise native round-trip fares
+// to, so they rank against the composed pairs in one currency: the caller's
+// explicit currency if set, else the currency the composed pairs are already in,
+// else the outbound legs' currency. Empty (no signal) lets normalisation no-op.
+func nativeRoundTripCurrency(opts SearchOptions, composed, outbound []models.FlightResult) string {
+	if opts.Currency != "" {
+		return opts.Currency
+	}
+	if len(composed) > 0 && composed[0].Currency != "" {
+		return composed[0].Currency
+	}
+	if len(outbound) > 0 {
+		return outbound[0].Currency
+	}
+	return ""
 }
 
 // topPricedFlights returns up to n cheapest flights that carry a usable price

--- a/internal/flights/roundtrip.go
+++ b/internal/flights/roundtrip.go
@@ -178,6 +178,7 @@ func composeItinerary(out, in models.FlightResult) models.FlightResult {
 		Duration: out.Duration + in.Duration,
 		Stops:    out.Stops + in.Stops,
 		Provider: composedProviderLabel(out.Provider, in.Provider),
+		FareType: models.FareSplitTickets,
 		Legs:     legs,
 		Warnings: warnings,
 	}

--- a/internal/flights/roundtrip_test.go
+++ b/internal/flights/roundtrip_test.go
@@ -94,6 +94,28 @@ func TestComposeRoundTrips_ExcludesUnpriced(t *testing.T) {
 	}
 }
 
+func TestNativeRoundTripCurrency_Priority(t *testing.T) {
+	eur := []models.FlightResult{{Currency: "EUR"}}
+	usd := []models.FlightResult{{Currency: "USD"}}
+
+	// Explicit opts.Currency wins over everything.
+	if got := nativeRoundTripCurrency(SearchOptions{Currency: "GBP"}, eur, usd); got != "GBP" {
+		t.Errorf("explicit currency: got %q want GBP", got)
+	}
+	// Else fall back to the composed pairs' currency.
+	if got := nativeRoundTripCurrency(SearchOptions{}, eur, usd); got != "EUR" {
+		t.Errorf("composed currency: got %q want EUR", got)
+	}
+	// Else fall back to the outbound legs' currency.
+	if got := nativeRoundTripCurrency(SearchOptions{}, nil, usd); got != "USD" {
+		t.Errorf("outbound currency: got %q want USD", got)
+	}
+	// No signal at all -> empty (normalisation no-ops).
+	if got := nativeRoundTripCurrency(SearchOptions{}, nil, nil); got != "" {
+		t.Errorf("no signal: got %q want empty", got)
+	}
+}
+
 func TestComposeRoundTrips_MarksSplitTicketsFareType(t *testing.T) {
 	out := []models.FlightResult{owFlight("Google Flights", "EUR", 100, "HEL", "BCN")}
 	in := []models.FlightResult{owFlight("Ryanair", "EUR", 60, "BCN", "HEL")}

--- a/internal/flights/roundtrip_test.go
+++ b/internal/flights/roundtrip_test.go
@@ -94,6 +94,20 @@ func TestComposeRoundTrips_ExcludesUnpriced(t *testing.T) {
 	}
 }
 
+func TestComposeRoundTrips_MarksSplitTicketsFareType(t *testing.T) {
+	out := []models.FlightResult{owFlight("Google Flights", "EUR", 100, "HEL", "BCN")}
+	in := []models.FlightResult{owFlight("Ryanair", "EUR", 60, "BCN", "HEL")}
+
+	composed, _ := composeRoundTrips(out, in, SearchOptions{})
+	if len(composed) != 1 {
+		t.Fatalf("composed count: got %d, want 1", len(composed))
+	}
+	// A composed pair is two separate tickets — never a native round-trip fare.
+	if composed[0].FareType != models.FareSplitTickets {
+		t.Errorf("FareType: got %q, want %q", composed[0].FareType, models.FareSplitTickets)
+	}
+}
+
 func TestComposeRoundTrips_TagsLegDirection(t *testing.T) {
 	out := []models.FlightResult{owFlight("Google Flights", "EUR", 100, "HEL", "BCN")}
 	in := []models.FlightResult{owFlight("Ryanair", "EUR", 60, "BCN", "HEL")}

--- a/internal/flights/skiplagged.go
+++ b/internal/flights/skiplagged.go
@@ -48,6 +48,23 @@ const skiplaggedMCPProtocolVersion = "2025-06-18"
 // unintended real-network calls.
 var skiplaggedEnabled = true
 
+// skiplaggedDisabledKey marks a context in which the one-way Skiplagged
+// provider should be skipped. The round-trip composer sets it on its
+// per-leg searches so Skiplagged is queried exactly once — as a native
+// round-trip (both legs, single discounted fare) — instead of twice as
+// two redundant one-way legs. This nets *fewer* Skiplagged calls per
+// round-trip search, not more, keeping the rate-limited origin happy.
+type skiplaggedDisabledKey struct{}
+
+func disableSkiplaggedOneWay(ctx context.Context) context.Context {
+	return context.WithValue(ctx, skiplaggedDisabledKey{}, true)
+}
+
+func skiplaggedOneWayDisabled(ctx context.Context) bool {
+	v, _ := ctx.Value(skiplaggedDisabledKey{}).(bool)
+	return v
+}
+
 // skiplaggedEndpoint is the resolved endpoint URL. Tests can override
 // it via skiplaggedSetEndpointForTest to point at a httptest server.
 var skiplaggedEndpoint = skiplaggedMCPEndpointDefault
@@ -531,6 +548,26 @@ func parseSkiplaggedFlights(raw json.RawMessage) ([]models.FlightResult, error) 
 				ArrivalTime:      f.Arrival.DateTime,
 				Airline:          f.Airlines,
 			}},
+		}
+		// When Skiplagged priced a round-trip, f.Return carries the inbound
+		// flight and f.Price.Amount is the single native round-trip fare, which
+		// can be discounted below the sum of two one-ways. Materialise the
+		// inbound leg, tag both directions, and flag the result as a native
+		// round-trip fare so a consumer never mistakes it for two separate
+		// tickets. A one-way result (f.Return == nil) is byte-unchanged.
+		if f.Return != nil {
+			fr.FareType = models.FareRoundTrip
+			fr.Legs[0].Direction = "outbound"
+			fr.Legs = append(fr.Legs, models.FlightLeg{
+				Direction:        "inbound",
+				DepartureAirport: models.AirportInfo{Code: f.Return.Departure.Airport},
+				ArrivalAirport:   models.AirportInfo{Code: f.Return.Arrival.Airport},
+				DepartureTime:    f.Return.Departure.DateTime,
+				ArrivalTime:      f.Return.Arrival.DateTime,
+				Airline:          f.Airlines,
+			})
+			fr.Stops += int(f.Return.Layovers)
+			fr.Duration += parseSkiplaggedDuration(f.Return.Duration)
 		}
 		// Map Skiplagged's attribute flags into Warnings so the
 		// caller can detect "this is a hidden-city ticket; the

--- a/internal/flights/skiplagged_test.go
+++ b/internal/flights/skiplagged_test.go
@@ -126,6 +126,99 @@ func newSkiplaggedTestServer(t *testing.T, sessionID string, body string) (*http
 	return srv, closer
 }
 
+// fixedSkiplaggedRoundTripBody is a single native round-trip fare: one
+// FlightCard carrying a returnFlight (the inbound) and a single total price.
+const fixedSkiplaggedRoundTripBody = `{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "structuredContent": {
+      "searchUrl": "https://example.test/search?from=AMS&to=HEL&rt=1",
+      "flights": [
+        {
+          "type": "FlightCard",
+          "id": "rt1",
+          "airlines": "AY",
+          "departure": {"airport": "AMS", "dateTime": "2026-05-15T07:30"},
+          "arrival": {"airport": "HEL", "dateTime": "2026-05-15T11:15"},
+          "duration": "2h 45m",
+          "layovers": 0,
+          "price": {"amount": 210.00, "currency": "EUR"},
+          "deepLink": "https://example.test/book/rt1",
+          "attributes": [],
+          "returnFlight": {
+            "departure": {"airport": "HEL", "dateTime": "2026-05-22T18:00"},
+            "arrival": {"airport": "AMS", "dateTime": "2026-05-22T21:00"},
+            "duration": "3h 00m",
+            "layovers": 1
+          }
+        }
+      ]
+    },
+    "content": [{"type": "text", "text": "{\"flights\":[]}"}]
+  }
+}`
+
+func TestSearchSkiplagged_NativeRoundTrip(t *testing.T) {
+	srv, closer := newSkiplaggedTestServer(t, "test-sess-rt", fixedSkiplaggedRoundTripBody)
+	defer closer()
+	defer skiplaggedSetEndpointForTest(srv.URL)()
+
+	skiplaggedEnabled = true
+	defer func() { skiplaggedEnabled = true }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := SearchSkiplagged(ctx, "AMS", "HEL", "2026-05-15", SearchOptions{ReturnDate: "2026-05-22"})
+	if err != nil {
+		t.Fatalf("SearchSkiplagged: %v", err)
+	}
+	if res == nil || len(res.Flights) != 1 {
+		t.Fatalf("expected 1 round-trip itinerary, got %+v", res)
+	}
+	f := res.Flights[0]
+	if f.FareType != models.FareRoundTrip {
+		t.Errorf("FareType=%q want %q (native round-trip)", f.FareType, models.FareRoundTrip)
+	}
+	if len(f.Legs) != 2 {
+		t.Fatalf("legs=%d want 2 (outbound + inbound)", len(f.Legs))
+	}
+	if f.Legs[0].Direction != "outbound" || f.Legs[1].Direction != "inbound" {
+		t.Errorf("leg directions: %q then %q want outbound then inbound", f.Legs[0].Direction, f.Legs[1].Direction)
+	}
+	if f.Legs[0].DepartureAirport.Code != "AMS" || f.Legs[1].DepartureAirport.Code != "HEL" {
+		t.Errorf("leg routing: %q then %q want AMS then HEL", f.Legs[0].DepartureAirport.Code, f.Legs[1].DepartureAirport.Code)
+	}
+	// Single native fare for the whole trip — not a sum of two one-ways.
+	if f.Price != 210.00 {
+		t.Errorf("price=%v want 210.00 (single native fare)", f.Price)
+	}
+	if f.Stops != 1 {
+		t.Errorf("stops=%d want 1 (0 outbound + 1 inbound)", f.Stops)
+	}
+	if f.Duration != 165+180 {
+		t.Errorf("duration=%d want 345 (165 + 180)", f.Duration)
+	}
+}
+
+func TestRunSkiplaggedProvider_OneWaySuppressed(t *testing.T) {
+	// When the round-trip composer suppresses the one-way Skiplagged legs, the
+	// provider must report a transparent skip and make NO HTTP call (no endpoint
+	// is configured here, so a call would error rather than skip).
+	ctx := disableSkiplaggedOneWay(context.Background())
+	out := runSkiplaggedProvider(ctx, nil, "AMS", "HEL", "2026-05-15", SearchOptions{})
+	if out.err != nil {
+		t.Fatalf("expected no error (call suppressed), got %v", out.err)
+	}
+	if out.status.Status != "skipped" {
+		t.Errorf("status=%q want skipped", out.status.Status)
+	}
+	if len(out.flights) != 0 {
+		t.Errorf("flights=%d want 0 (no call made)", len(out.flights))
+	}
+}
+
 func TestSearchSkiplagged_Success(t *testing.T) {
 	srv, closer := newSkiplaggedTestServer(t, "test-sess-001", fixedSkiplaggedFlightsBody)
 	defer closer()

--- a/internal/models/flight.go
+++ b/internal/models/flight.go
@@ -31,6 +31,16 @@ type FlightLeg struct {
 	Direction string `json:"direction,omitempty"`
 }
 
+// FareType classifies how a round-trip price was assembled. See FlightResult.FareType.
+type FareType string
+
+const (
+	// FareRoundTrip is a single native round-trip fare from one provider.
+	FareRoundTrip FareType = "round_trip"
+	// FareSplitTickets is two independent one-way tickets paired by the composer.
+	FareSplitTickets FareType = "split_tickets"
+)
+
 // FlightResult represents a single flight option with price and routing.
 type FlightResult struct {
 	Price               float64     `json:"price"`
@@ -39,6 +49,16 @@ type FlightResult struct {
 	Stops               int         `json:"stops"`
 	Provider            string      `json:"provider,omitempty"`
 	SelfConnect         bool        `json:"self_connect,omitempty"`
+	// FareType distinguishes how a round-trip Price was obtained, so a consumer
+	// never mistakes the expensive case for the cheap one:
+	//   FareRoundTrip   — a single native round-trip fare from one provider; may
+	//                     carry a return discount and round-trip-only fare rules.
+	//   FareSplitTickets — two independent one-way tickets paired by trvl's
+	//                     composer; the sum of two fares, booked separately, with
+	//                     no return discount and no through-protection.
+	// Empty for a one-way result. A composed itinerary is always FareSplitTickets;
+	// it is NOT a substitute for a native round-trip fare, which can be cheaper.
+	FareType            FareType    `json:"fare_type,omitempty"`
 	Warnings            []string    `json:"warnings,omitempty"`
 	Legs                []FlightLeg `json:"legs"`
 	BookingURL          string      `json:"booking_url,omitempty"`


### PR DESCRIPTION
## Why

A composed round-trip is two independent one-way tickets summed together. It carries no return discount and no through-protection, and it can cost more than a single native round-trip fare from one provider. trvl never even requested the native fare, and could not represent it if it arrived.

## What changed

**Data model**
- Add `FlightResult.FareType` (`round_trip` or `split_tickets`, `omitempty` so one-way results are byte-unchanged). JSON-tagged, so MCP clients can branch on it.
- Every composed itinerary is marked `split_tickets`.

**Native round-trip fares (Skiplagged)**
- `parseSkiplaggedFlights` now materialises the inbound leg from the `returnFlight` field it previously discarded, tags both legs by direction, sums stops and duration, and marks the result `round_trip` — the single native fare, return discount included.
- `searchRoundTripComposed` runs a native round-trip pass with `ReturnDate` intact (the composition legs clear it) and merges genuine round-trip itineraries into the candidate pool. Cheapest sorts first, so a discounted native fare outranks a pricier composed pair, while `FareType` keeps single-ticket and split-ticket honestly distinguishable.

**Rate-conscious by design**
- A round-trip search previously fired Skiplagged twice, once per one-way leg. The composer now suppresses those redundant one-way calls (`disableSkiplaggedOneWay`, a context flag mirroring the existing `disableHacksCompose`) and makes exactly one native round-trip call instead. Net fewer calls on the rate-limited origin, not more.

## Scope and limits

- Skiplagged is the native provider wired here (and it is opt-in, so default users are unaffected). The seam generalises: any provider returning a genuine multi-leg round-trip with `FareRoundTrip` merges the same way.
- Google's main flight search still rejects native round-trip encoding (issue #198), so it stays composition-only. Only providers that accept a return request contribute native fares.

## Tests

Native round-trip parse (both legs, fare type, summed stops and duration), one-way suppression, currency-target selection, plus the existing round-trip suite. `internal/flights`, `internal/models`, `cmd/trvl`, and `mcp` suites pass; `internal/flights` passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)