### PR TITLE
feat(flights): true round-trip ticket data across all providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ trvl ships with **Google Flights** (hand-rolled protobuf) on the default code pa
 |----------|----------|----------|------------|------|
 | **Google Flights** | hand-rolled protobuf | Broadest coverage, server-side filters | default | None |
 | **Kiwi** | REST | Virtual-interlining + self-connect candidates | default (one-way merge) | None |
-| **AFKLM Flying Blue** | Offers API v3 + Award API | Cash + miles cabin search on KL/AF metal | `--award` (CLI) / built-in opt-in | KLM/Flying Blue session cookie |
+| **AFKLM Flying Blue** | Offers API v3 + Award API | Cash + miles cabin search on KL/AF metal; native round-trip fares (both legs, one ticket) | `--provider afklm` (cash) / `--award` (miles), both opt-in | API credential (cash) / Flying Blue session cookie (award) |
 | **Skiplagged** | Streamable HTTP MCP (`@skiplagged/mcp` v0.0.4, protocol 2025-06-18) | Genre-defining hidden-city + virtual-interlining defaults | default (one-way merge) / `--provider skiplagged` for solo | None |
 
 The default flight search merges results from Google Flights, Kiwi, and Skiplagged into a single sorted list, so plain `trvl flights HEL BCN 2026-07-01` already includes hidden-city / virtual-interlining options. Use `--provider skiplagged` to query Skiplagged on its own when you want to cross-validate or see only the hidden-city candidates.
@@ -392,6 +392,9 @@ trvl flights HEL BCN 2026-07-01 --provider skiplagged
 
 # AFKLM Flying Blue award availability:
 trvl flights AMS NRT 2026-09-15 --award
+
+# AFKLM cash fares only, with native round-trip tickets (both legs, one fare):
+trvl flights AMS BCN 2026-07-01 --return 2026-07-08 --provider afklm
 ```
 
 ## Ground Transport Providers

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -187,6 +187,11 @@ Examples:
 					return fmt.Errorf("--provider skiplagged supports exactly one origin and one destination")
 				}
 				result, err = flights.SearchSkiplagged(cmd.Context(), origins[0], destinations[0], date, opts)
+			case "afklm", "af-klm", "airfranceklm":
+				if len(origins) != 1 || len(destinations) != 1 {
+					return fmt.Errorf("--provider afklm supports exactly one origin and one destination")
+				}
+				result, err = flights.SearchAFKLM(cmd.Context(), origins[0], destinations[0], date, opts)
 			case "", "default", "google", "google_flights", "kiwi":
 				if len(origins) > 1 || len(destinations) > 1 {
 					result, err = flights.SearchMultiAirport(cmd.Context(), origins, destinations, date, opts)
@@ -194,7 +199,7 @@ Examples:
 					result, err = flights.SearchFlights(cmd.Context(), origins[0], destinations[0], date, opts)
 				}
 			default:
-				return fmt.Errorf("unsupported --provider %q (valid: skiplagged, or empty for default Google+Kiwi+Skiplagged merge)", provider)
+				return fmt.Errorf("unsupported --provider %q (valid: skiplagged, afklm, or empty for default Google+Kiwi+Skiplagged merge)", provider)
 			}
 			if err != nil {
 				return err
@@ -298,7 +303,7 @@ Examples:
 	cmd.Flags().BoolVar(&explain, "explain", false, "Show per-factor profile match breakdown for each result")
 	cmd.Flags().BoolVar(&award, "award", false, "Search Flying Blue award availability instead of cash fares")
 	cmd.Flags().StringVar(&awardCookies, "award-cookies", "", "KLM/Flying Blue Cookie header for --award (or set AFKL_KLM_COOKIES)")
-	cmd.Flags().StringVar(&provider, "provider", "", "Flight provider: empty = default (Google Flights + Kiwi + Skiplagged merge), skiplagged = Skiplagged MCP only (hidden-city + virtual-interlining defaults)")
+	cmd.Flags().StringVar(&provider, "provider", "", "Flight provider: empty = default (Google Flights + Kiwi + Skiplagged merge), skiplagged = Skiplagged MCP only (hidden-city + virtual-interlining defaults), afklm = Air France-KLM Offers API only (opt-in, native round-trip fares; requires credential)")
 	cmd.Flags().BoolVar(&flightRailFly, "rail-fly", false, "Expand the search to rail-connected origins (KL/AF Air&Rail), surfacing cheaper rail+fly bundles even when the origin is outside the default hub list")
 	cmd.Flags().BoolVar(&deep, "deep", false, "Run a budget-gated counterfactual fan-out (nearby airports, split tickets, hidden city). Issues extra provider calls, capped by a best-effort budget that never delays the primary search")
 	cmd.Flags().BoolVar(&noGeo, "no-geo", false, "Disable geo-IP origin detection (also honored via TRVL_NO_GEO=1). Origin then resolves only from an explicit code or your saved home airport.")

--- a/internal/flights/afklm/provider.go
+++ b/internal/flights/afklm/provider.go
@@ -176,6 +176,7 @@ func mapRecommendations(resp *AvailableOffersResponse, origin, dest string) []mo
 			var legs []models.FlightLeg
 			totalDuration := 0
 			outboundStops := 0
+			bounds := 0
 
 			for boundIdx, pc := range fp.Connections {
 				if boundIdx >= len(lookup) {
@@ -185,12 +186,15 @@ func mapRecommendations(resp *AvailableOffersResponse, origin, dest string) []mo
 				if !ok {
 					continue
 				}
+				bounds++
 				totalDuration += bc.Duration
 				if boundIdx == 0 && len(bc.Segments) > 1 {
 					outboundStops = len(bc.Segments) - 1
 				}
+				direction := boundDirection(boundIdx)
 				for i, s := range bc.Segments {
 					leg := mapSegment(s)
+					leg.Direction = direction
 					// Layover = gap between prev arrival and this departure within the same bound.
 					if i > 0 {
 						if prev, cur, ok := parseLayover(bc.Segments[i-1].ArrivalDateTime, s.DepartureDateTime); ok {
@@ -209,6 +213,16 @@ func mapRecommendations(resp *AvailableOffersResponse, origin, dest string) []mo
 				currency = fp.Price.Currency
 			}
 
+			// A real return offer (outbound + inbound bound) is a genuine
+			// round-trip ticket — both legs are materialised above, so unlike
+			// the Google/Kiwi native fares this needs no "return at booking"
+			// caveat. Tag it FareRoundTrip so it ranks honestly against split
+			// pairs; a single-bound (one-way) offer keeps the default type.
+			var fareType models.FareType
+			if bounds > 1 {
+				fareType = models.FareRoundTrip
+			}
+
 			results = append(results, models.FlightResult{
 				Price:    price,
 				Currency: currency,
@@ -216,10 +230,25 @@ func mapRecommendations(resp *AvailableOffersResponse, origin, dest string) []mo
 				Stops:    outboundStops,
 				Provider: "afklm",
 				Legs:     legs,
+				FareType: fareType,
 			})
 		}
 	}
 	return results
+}
+
+// boundDirection maps an AF-KLM bound index to a leg direction tag. Bound 0 is
+// always the outbound; bound 1 (present only on round-trip requests) is the
+// inbound/return. Any further bounds (open-jaw multi-city) are left untagged.
+func boundDirection(boundIdx int) string {
+	switch boundIdx {
+	case 0:
+		return "outbound"
+	case 1:
+		return "inbound"
+	default:
+		return ""
+	}
 }
 
 // mapSegment converts a top-level BoundConnection Segment to a FlightLeg.

--- a/internal/flights/afklm/roundtrip_live_probe_test.go
+++ b/internal/flights/afklm/roundtrip_live_probe_test.go
@@ -1,0 +1,85 @@
+package afklm
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestProbeAFKLMRoundTrip hits the live AF-KLM Offers API with a real
+// round-trip request and asserts the provider returns genuine both-bound
+// return-ticket data: FareType=FareRoundTrip plus outbound/inbound Direction
+// tags on the legs. Credential is resolved through the provider's normal chain
+// (AFKLM_KEY env, macOS Keychain, then 1Password
+// op://Personal/Air France-KLM Developer API/credential).
+//
+// Opt-in (default suite stays deterministic + offline):
+//
+//	TRVL_TEST_LIVE_PROBES=1 go test ./internal/flights/afklm -run TestProbeAFKLMRoundTrip -v
+func TestProbeAFKLMRoundTrip(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("set TRVL_TEST_LIVE_PROBES=1 to run live AF-KLM round-trip probe")
+	}
+
+	p, err := NewProvider()
+	if err == ErrNoCredential {
+		t.Skip("no AF-KLM credential configured (set AFKLM_KEY or sign in to 1Password)")
+	}
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+
+	origin, dest := "AMS", "BCN"
+	dep := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
+	ret := time.Now().AddDate(0, 1, 7).Format("2006-01-02")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	opts := models.FlightSearchOptions{
+		ReturnDate: ret,
+		CabinClass: models.Economy,
+		Adults:     1,
+		Currency:   "EUR",
+	}
+	res, err := p.SearchFlights(ctx, origin, dest, dep, opts)
+	if err != nil {
+		t.Fatalf("SearchFlights: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("search not successful: %s", res.Error)
+	}
+	t.Logf("AFKLM %s->%s round-trip: %d results", origin, dest, len(res.Flights))
+	if len(res.Flights) == 0 {
+		t.Fatal("expected at least one round-trip result")
+	}
+
+	var rtCount, outboundLegs, inboundLegs int
+	for i, f := range res.Flights {
+		if f.FareType == models.FareRoundTrip {
+			rtCount++
+		}
+		for _, leg := range f.Legs {
+			switch leg.Direction {
+			case "outbound":
+				outboundLegs++
+			case "inbound":
+				inboundLegs++
+			}
+		}
+		if i < 3 {
+			t.Logf("  [%d] %.2f %s fare=%q legs=%d", i, f.Price, f.Currency, f.FareType, len(f.Legs))
+		}
+	}
+	t.Logf("FareRoundTrip results=%d outboundLegs=%d inboundLegs=%d", rtCount, outboundLegs, inboundLegs)
+
+	if rtCount == 0 {
+		t.Errorf("expected at least one FareRoundTrip result from a live round-trip request")
+	}
+	if outboundLegs == 0 || inboundLegs == 0 {
+		t.Errorf("expected both outbound and inbound legs to be Direction-tagged (got out=%d in=%d)", outboundLegs, inboundLegs)
+	}
+}

--- a/internal/flights/afklm/search_test.go
+++ b/internal/flights/afklm/search_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
 func TestAvailableOffersHappyPath(t *testing.T) {
@@ -223,6 +225,18 @@ func TestMapRecommendationsSynthetic(t *testing.T) {
 	}
 	if r.Duration != 185 {
 		t.Errorf("expected total duration 185, got %d", r.Duration)
+	}
+	// A two-bound offer is a genuine return ticket: tag it FareRoundTrip and
+	// mark each leg's direction so downstream ranking and rendering can tell
+	// the outbound from the inbound.
+	if r.FareType != models.FareRoundTrip {
+		t.Errorf("expected FareType=%q for two-bound offer, got %q", models.FareRoundTrip, r.FareType)
+	}
+	if r.Legs[0].Direction != "outbound" {
+		t.Errorf("leg 0 direction: want outbound, got %q", r.Legs[0].Direction)
+	}
+	if r.Legs[1].Direction != "inbound" {
+		t.Errorf("leg 1 direction: want inbound, got %q", r.Legs[1].Direction)
 	}
 }
 

--- a/internal/flights/afklm_search.go
+++ b/internal/flights/afklm_search.go
@@ -1,0 +1,39 @@
+package flights
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/MikkoParkkola/trvl/internal/flights/afklm"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// SearchAFKLM queries the Air France-KLM Offers API for the given route and
+// date, returning canonical FlightResults tagged provider "afklm". When a
+// ReturnDate is set the provider returns genuine both-bound round-trip tickets
+// (FareType=FareRoundTrip, legs Direction-tagged outbound/inbound).
+//
+// AF-KLM is opt-in: it requires a credential (AFKLM_KEY env, macOS Keychain, or
+// 1Password). Unlike the silently-skipped composition sources, an explicit
+// `--provider afklm` request surfaces a clear, actionable error when no
+// credential is configured rather than returning an empty result.
+func SearchAFKLM(ctx context.Context, origin, destination, date string, opts SearchOptions) (*models.FlightSearchResult, error) {
+	p, err := afklm.NewProvider()
+	if errors.Is(err, afklm.ErrNoCredential) {
+		return nil, fmt.Errorf("afklm: no API key configured — set AFKLM_KEY, add it to the macOS Keychain, or sign in to 1Password (op://Personal/Air France-KLM Developer API/credential)")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("afklm: %w", err)
+	}
+
+	return p.SearchFlights(ctx, origin, destination, date, models.FlightSearchOptions{
+		ReturnDate: opts.ReturnDate,
+		CabinClass: opts.CabinClass,
+		MaxStops:   opts.MaxStops,
+		SortBy:     opts.SortBy,
+		Airlines:   opts.Airlines,
+		Adults:     opts.Adults,
+		Currency:   opts.Currency,
+	})
+}

--- a/internal/flights/afklm_search_test.go
+++ b/internal/flights/afklm_search_test.go
@@ -1,0 +1,35 @@
+package flights
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/flights/afklm"
+)
+
+// TestSearchAFKLM_UnconfiguredReturnsClearError proves that an explicit
+// `--provider afklm` request surfaces an actionable error (not an empty result)
+// when no credential is configured. Unlike the silently-skipped composition
+// sources, an explicit provider request must tell the user how to fix it.
+//
+// The credential chain (env, Keychain, 1Password) is environment-dependent, so
+// this skips when a credential happens to be resolvable (e.g. a dev machine
+// signed in to 1Password). It is deterministic, never flaky: it asserts only
+// when the environment is genuinely unconfigured (the CI default).
+func TestSearchAFKLM_UnconfiguredReturnsClearError(t *testing.T) {
+	t.Setenv("AFKLM_KEY", "")
+	if afklm.Configured(context.Background()) {
+		t.Skip("an AF-KLM credential is resolvable in this environment; unconfigured-path test is CI-only")
+	}
+
+	_, err := SearchAFKLM(context.Background(), "AMS", "BCN", "2026-05-15", SearchOptions{ReturnDate: "2026-05-22"})
+	if err == nil {
+		t.Fatal("expected an error when AF-KLM is unconfigured, got nil")
+	}
+	for _, want := range []string{"afklm", "AFKLM_KEY"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message should mention %q to be actionable; got: %v", want, err)
+		}
+	}
+}

--- a/internal/flights/kiwi_oneway_probe_test.go
+++ b/internal/flights/kiwi_oneway_probe_test.go
@@ -1,0 +1,30 @@
+package flights
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestProbeKiwiOneWayPrice fetches a one-way HEL->BCN Kiwi price for comparison
+// against the round-trip probe, to confirm the round-trip request's price is the
+// full return total (not a one-way). Opt-in via TRVL_TEST_LIVE_PROBES=1.
+func TestProbeKiwiOneWayPrice(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("set TRVL_TEST_LIVE_PROBES=1 to run live Kiwi one-way probe")
+	}
+	dep := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	opts := SearchOptions{Adults: 1}
+	opts.defaults()
+	results, err := SearchKiwiFlights(ctx, "HEL", "BCN", dep, "EUR", opts)
+	t.Logf("ONE-WAY HEL->BCN -> %d results err=%v", len(results), err)
+	for i, f := range results {
+		if i >= 3 {
+			break
+		}
+		t.Logf("  [%d] %.2f %s legs=%d", i, f.Price, f.Currency, len(f.Legs))
+	}
+}

--- a/internal/flights/kiwi_roundtrip_probe_test.go
+++ b/internal/flights/kiwi_roundtrip_probe_test.go
@@ -1,0 +1,48 @@
+package flights
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestProbeKiwiRoundTrip hits live Kiwi with a round-trip request (returnDate
+// set) and dumps the shape of each returned itinerary so we can decide whether
+// Kiwi's MCP surface materializes the return leg or flattens A->B->A into a
+// single bogus layover chain. Opt-in:
+//
+//	TRVL_TEST_LIVE_PROBES=1 go test ./internal/flights -run TestProbeKiwiRoundTrip -v
+func TestProbeKiwiRoundTrip(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("set TRVL_TEST_LIVE_PROBES=1 to run live Kiwi round-trip probe")
+	}
+
+	origin, destination := "HEL", "BCN"
+	dep := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
+	ret := time.Now().AddDate(0, 1, 7).Format("2006-01-02")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	opts := SearchOptions{ReturnDate: ret, Adults: 1}
+	opts.defaults()
+	opts.ReturnDate = ret
+
+	results, err := SearchKiwiFlights(ctx, origin, destination, dep, "EUR", opts)
+	t.Logf("SearchKiwiFlights(returnDate=%s) -> %d results, err=%v", ret, len(results), err)
+	if err != nil {
+		t.Fatalf("kiwi round-trip request failed: %v", err)
+	}
+	for i, f := range results {
+		if i >= 6 {
+			break
+		}
+		t.Logf("  [%d] %.2f %s legs=%d stops=%d self=%v", i, f.Price, f.Currency, len(f.Legs), f.Stops, f.SelfConnect)
+		for j, leg := range f.Legs {
+			t.Logf("      leg[%d] %s -> %s dep=%s arr=%s dir=%q", j,
+				leg.DepartureAirport.Code, leg.ArrivalAirport.Code,
+				leg.DepartureTime, leg.ArrivalTime, leg.Direction)
+		}
+	}
+}

--- a/internal/flights/roundtrip.go
+++ b/internal/flights/roundtrip.go
@@ -96,6 +96,14 @@ func searchRoundTripComposed(ctx context.Context, client *batchexec.Client, orig
 	statuses = append(statuses, googleStatuses...)
 	nativeRT = append(nativeRT, googleRT...)
 
+	// Kiwi likewise prices a round-trip as one native fare (outbound leg at the
+	// full return total, return chosen at booking). kiwiEligibleOptions wrongly
+	// excluded ReturnDate as unsupported — verified live it is supported — so
+	// query it natively too; its discounted returns then compete in the merge.
+	kiwiRT, kiwiStatuses := searchKiwiNativeRoundTrip(ctx, client, origin, destination, date, returnDate, opts, nativeRoundTripCurrency(opts, composed, outFlights))
+	statuses = append(statuses, kiwiStatuses...)
+	nativeRT = append(nativeRT, kiwiRT...)
+
 	if len(nativeRT) > 0 {
 		merged := make([]models.FlightResult, 0, len(nativeRT)+len(composed))
 		merged = append(merged, nativeRT...)
@@ -355,6 +363,24 @@ func searchGoogleNativeRoundTrip(ctx context.Context, client *batchexec.Client, 
 // mutates the source legs (taggedLegs copies) so cached one-way responses stay
 // untouched. Pure and deterministic so it can be unit-tested without the network.
 func tagGoogleNativeRoundTrip(flights []models.FlightResult, origin, destination, date, returnDate, currency string) []models.FlightResult {
+	return tagNativeRoundTrip(flights, googleNativeRoundTripWarning, buildFlightBookingURL(origin, destination, date, returnDate, currency))
+}
+
+const (
+	googleNativeRoundTripWarning = "native Google round-trip fare: the price is the full round-trip total; the matching return flight is selected at booking"
+	kiwiNativeRoundTripWarning   = "native Kiwi round-trip fare: the price is the full round-trip total; the matching return flight is selected at booking (open the booking link)"
+)
+
+// tagNativeRoundTrip converts raw outbound itineraries from a provider's native
+// round-trip request into honest FareRoundTrip results. Each flight keeps its
+// price (the full round-trip total the provider quoted), gets its leg(s) tagged
+// "outbound" — the matching return flight is chosen at booking, since these
+// providers expose only the outbound itinerary plus the return total — the given
+// warning prepended, and, when bookingURL is non-empty, that round-trip booking
+// URL (empty keeps the provider's own deep link). It never mutates the source
+// legs (taggedLegs copies) so cached one-way responses stay untouched. Pure and
+// deterministic so it can be unit-tested without the network.
+func tagNativeRoundTrip(flights []models.FlightResult, warning, bookingURL string) []models.FlightResult {
 	if len(flights) == 0 {
 		return nil
 	}
@@ -362,13 +388,64 @@ func tagGoogleNativeRoundTrip(flights []models.FlightResult, origin, destination
 	for _, f := range flights {
 		f.FareType = models.FareRoundTrip
 		f.Legs = taggedLegs(f.Legs, "outbound")
-		f.BookingURL = buildFlightBookingURL(origin, destination, date, returnDate, currency)
-		f.Warnings = append([]string{
-			"native Google round-trip fare: the price is the full round-trip total; the matching return flight is selected at booking",
-		}, f.Warnings...)
+		if bookingURL != "" {
+			f.BookingURL = bookingURL
+		}
+		f.Warnings = append([]string{warning}, f.Warnings...)
 		out = append(out, f)
 	}
 	return out
+}
+
+// searchKiwiNativeRoundTrip queries Kiwi for a native round-trip fare (returnDate
+// set) and returns honest FareRoundTrip itineraries. Verified live
+// (TestProbeKiwiRoundTrip / TestProbeKiwiOneWayPrice): Kiwi returns the outbound
+// leg priced at the full round-trip total — HEL->BCN one-way is ~102 EUR, the
+// round-trip request's cheapest is ~296 EUR — with the matching return chosen at
+// booking via the Kiwi deep link. kiwiEligibleOptions wrongly rejects ReturnDate
+// as "unsupported" (the same false premise that hid Google's native round-trip),
+// so this bypasses that one check while still honouring Kiwi's real option limits
+// (airline/alliance/baggage filters) and the production shared-client guard.
+func searchKiwiNativeRoundTrip(ctx context.Context, client *batchexec.Client, origin, destination, date, returnDate string, opts SearchOptions, target string) ([]models.FlightResult, []models.ProviderStatus) {
+	// Eligibility minus the (incorrect) ReturnDate exclusion: respect Kiwi's
+	// genuine filter limits and the shared-client guard, but allow round-trips.
+	probe := opts
+	probe.ReturnDate = ""
+	if !kiwiSearchEligible(client, probe) {
+		return nil, nil // unsupported filters / non-shared client — composition covers it
+	}
+
+	rtOpts := opts
+	rtOpts.ReturnDate = returnDate
+	currency := opts.Currency
+	if currency == "" {
+		currency = "EUR"
+	}
+
+	flights, err := SearchKiwiFlights(ctx, origin, destination, date, currency, rtOpts)
+	if err != nil {
+		return nil, []models.ProviderStatus{{
+			ID:     "native_roundtrip:kiwi",
+			Name:   "Kiwi (native round-trip)",
+			Status: models.ClassifyProviderError(err),
+			Error:  err.Error(),
+		}}
+	}
+
+	// Keep Kiwi's own deep link (bookingURL=="") — it already encodes the return.
+	native := tagNativeRoundTrip(flights, kiwiNativeRoundTripWarning, "")
+	normalizeFlightCurrencies(ctx, native, target, destinations.ConvertCurrency)
+
+	status := models.ProviderStatus{
+		ID:      "native_roundtrip:kiwi",
+		Name:    "Kiwi (native round-trip)",
+		Status:  okOrNoHit(len(native)),
+		Results: len(native),
+	}
+	if len(native) == 0 {
+		status.FixHint = "no native round-trip fare returned; composed pairs used instead"
+	}
+	return native, []models.ProviderStatus{status}
 }
 
 // nativeRoundTripCurrency picks the currency to normalise native round-trip fares

--- a/internal/flights/roundtrip.go
+++ b/internal/flights/roundtrip.go
@@ -11,19 +11,26 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
-// Round-trip support is delivered by COMPOSITION: trvl runs two independent
-// one-way searches (outbound origin->destination on the departure date, inbound
-// destination->origin on the return date) and pairs the cheapest priced options
-// into combined itineraries. This sidesteps the native Google Flights round-trip
-// request encoding (tripType=1 + two segments), which Google rejects with a
-// travel.frontend.flights.ErrorResponse — the true root cause of issue #198,
-// where the misleading "unexpected flight data format" surfaced on every
-// --return_date search. Composition reuses the full one-way provider fan-out
-// (Google, Kiwi, Ryanair, Wizz, …) for each direction, so a round-trip benefits
-// from every working provider instead of a single broken code path.
+// Round-trip support combines two complementary sources:
 //
-// Composed itineraries are explicitly two separate one-way tickets: each carries
-// a warning so callers never mistake the summed price for a single bookable fare.
+//  1. NATIVE round-trip fares — Google Flights (tripType=1 with both segments in
+//     one request) and Skiplagged both price a return trip as a single, often
+//     discounted fare. These are true round-trip tickets and are preferred when
+//     cheaper. (Google's native path was wrongly disabled after #198, which was a
+//     transient rate-limit, not a structural rejection — verified live, the
+//     native request returns a parseable flight array. See
+//     searchGoogleNativeRoundTrip / searchNativeRoundTrip.)
+//  2. COMPOSITION — two independent one-way searches (outbound origin->destination,
+//     inbound destination->origin) paired into combined itineraries. This reuses
+//     the full one-way provider fan-out (Google, Kiwi, Ryanair, Wizz, …) and
+//     uniquely covers cross-carrier combinations (e.g. Google out + Ryanair back)
+//     that no single native fare offers.
+//
+// All candidates are merged and sorted cheapest-first, so a discounted native
+// round-trip naturally outranks a pricier composed pair. FareType keeps the two
+// honestly distinguishable: composed itineraries are explicitly two separate
+// one-way tickets (FareSplitTickets) and carry a warning so callers never mistake
+// the summed price for a single bookable fare; native fares are FareRoundTrip.
 
 const (
 	// roundTripLegCandidates bounds how many of the cheapest priced one-way
@@ -80,6 +87,14 @@ func searchRoundTripComposed(ctx context.Context, client *batchexec.Client, orig
 	// expensive composed pair; FareType keeps the two honestly distinguishable.
 	nativeRT, nativeStatuses := searchNativeRoundTrip(legCtx, client, origin, destination, date, returnDate, opts, nativeRoundTripCurrency(opts, composed, outFlights))
 	statuses = append(statuses, nativeStatuses...)
+
+	// Google Flights prices a round-trip as a single native fare too (tripType=1,
+	// both segments in one request). It was wrongly routed to composition-only
+	// since #198 (a transient rate-limit misread as a structural rejection); query
+	// it natively so its genuine — often discounted — round-trip total competes.
+	googleRT, googleStatuses := searchGoogleNativeRoundTrip(ctx, client, origin, destination, date, returnDate, opts, nativeRoundTripCurrency(opts, composed, outFlights))
+	statuses = append(statuses, googleStatuses...)
+	nativeRT = append(nativeRT, googleRT...)
 
 	if len(nativeRT) > 0 {
 		merged := make([]models.FlightResult, 0, len(nativeRT)+len(composed))
@@ -280,6 +295,80 @@ func searchNativeRoundTrip(ctx context.Context, client *batchexec.Client, origin
 		status.FixHint = "no native round-trip fare returned; composed pairs used instead"
 	}
 	return native, []models.ProviderStatus{status}
+}
+
+// searchGoogleNativeRoundTrip queries Google Flights with a NATIVE round-trip
+// request (tripType=1 with the outbound AND return segments in one call) and
+// returns genuine round-trip itineraries. Google prices each option at the FULL
+// round-trip total — a real return fare, frequently discounted versus two
+// one-ways — so these outrank composed split-ticket pairs whenever cheaper.
+//
+// Google's round-trip flow is two-stage: stage 1 returns the outbound itinerary
+// carrying the round-trip total; the specific matched return flight is chosen at
+// booking (Google's stage-2 return-leg RPC is undocumented and even mature
+// reverse-engineered clients punt on it). So each result is tagged FareRoundTrip
+// with the outbound leg and a clarifying note, never a fabricated inbound leg —
+// honest data: the genuine round-trip FARE, with the return selected at booking.
+//
+// Verified live (TestProbeNativeRoundTrip): the native request returns HTTP 200
+// with a parseable flight array (74 itineraries on HEL->BCN). Issue #198 was a
+// transient rate-limit, not a structural round-trip rejection; routing every
+// round-trip to composition-only discarded these real fares.
+func searchGoogleNativeRoundTrip(ctx context.Context, client *batchexec.Client, origin, destination, date, returnDate string, opts SearchOptions, target string) ([]models.FlightResult, []models.ProviderStatus) {
+	rtOpts := opts
+	rtOpts.ReturnDate = returnDate // request the native round-trip fare in one call
+	rtOpts.FirstResult = false     // keep the full list so the cheapest can win
+
+	result, err := searchGoogleFlightsWithClient(ctx, client, origin, destination, date, rtOpts)
+	if err != nil {
+		return nil, []models.ProviderStatus{{
+			ID:     "native_roundtrip:google_flights",
+			Name:   "Google Flights (native round-trip)",
+			Status: models.ClassifyProviderError(err),
+			Error:  err.Error(),
+		}}
+	}
+
+	var native []models.FlightResult
+	if result != nil {
+		native = tagGoogleNativeRoundTrip(result.Flights, origin, destination, date, returnDate, opts.Currency)
+	}
+	normalizeFlightCurrencies(ctx, native, target, destinations.ConvertCurrency)
+
+	status := models.ProviderStatus{
+		ID:      "native_roundtrip:google_flights",
+		Name:    "Google Flights (native round-trip)",
+		Status:  okOrNoHit(len(native)),
+		Results: len(native),
+	}
+	if len(native) == 0 {
+		status.FixHint = "no native round-trip fare returned; composed pairs used instead"
+	}
+	return native, []models.ProviderStatus{status}
+}
+
+// tagGoogleNativeRoundTrip converts raw Google Flights itineraries from a native
+// round-trip request into honest FareRoundTrip results: each carries the
+// round-trip total as its price, its leg(s) tagged "outbound" (the matching
+// return flight is selected at booking — Google's stage-2 return-leg RPC is
+// undocumented), a round-trip booking URL, and a clarifying warning. It never
+// mutates the source legs (taggedLegs copies) so cached one-way responses stay
+// untouched. Pure and deterministic so it can be unit-tested without the network.
+func tagGoogleNativeRoundTrip(flights []models.FlightResult, origin, destination, date, returnDate, currency string) []models.FlightResult {
+	if len(flights) == 0 {
+		return nil
+	}
+	out := make([]models.FlightResult, 0, len(flights))
+	for _, f := range flights {
+		f.FareType = models.FareRoundTrip
+		f.Legs = taggedLegs(f.Legs, "outbound")
+		f.BookingURL = buildFlightBookingURL(origin, destination, date, returnDate, currency)
+		f.Warnings = append([]string{
+			"native Google round-trip fare: the price is the full round-trip total; the matching return flight is selected at booking",
+		}, f.Warnings...)
+		out = append(out, f)
+	}
+	return out
 }
 
 // nativeRoundTripCurrency picks the currency to normalise native round-trip fares

--- a/internal/flights/roundtrip_native_probe_test.go
+++ b/internal/flights/roundtrip_native_probe_test.go
@@ -1,0 +1,151 @@
+package flights
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/batchexec"
+)
+
+// TestProbeNativeRoundTrip hits live Google Flights with a NATIVE round-trip
+// request (tripType=1, two segments) and reports the real response shape so we
+// can decide whether the existing parser handles it. Opt-in:
+//
+//	TRVL_TEST_LIVE_PROBES=1 go test ./internal/flights -run TestProbeNativeRoundTrip -v
+func TestProbeNativeRoundTrip(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("set TRVL_TEST_LIVE_PROBES=1 to run live native round-trip probe")
+	}
+
+	origin, destination := "HEL", "BCN"
+	dep := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
+	ret := time.Now().AddDate(0, 1, 7).Format("2006-01-02")
+
+	client := batchexec.NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	opts := SearchOptions{ReturnDate: ret, Adults: 1}
+	opts.defaults()
+	opts.ReturnDate = ret
+
+	filters := buildFilters(origin, destination, dep, opts)
+	encoded, err := batchexec.EncodeFlightFilters(filters)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	status, body, err := client.SearchFlightsGL(ctx, encoded, CurrencyToGL("EUR"))
+	t.Logf("HTTP status=%d bodyLen=%d err=%v", status, len(body), err)
+	if err != nil || status != 200 {
+		t.Fatalf("request failed: status=%d err=%v", status, err)
+	}
+
+	inner, derr := batchexec.DecodeFlightResponse(body)
+	if derr != nil {
+		t.Fatalf("decode: %v (first 400 bytes: %s)", derr, truncBytes(body, 400))
+	}
+
+	t.Logf("isFlightPayload=%v", isFlightPayload(inner))
+	if arr, ok := inner.([]any); ok {
+		t.Logf("inner is []any len=%d", len(arr))
+		for i, v := range arr {
+			t.Logf("  inner[%d]: %s", i, kindOf(v))
+		}
+	} else {
+		t.Logf("inner is NOT []any, kind=%s; dump=%s", kindOf(inner), jsonShort(inner, 600))
+	}
+
+	rawFlights, eerr := batchexec.ExtractFlightData(inner)
+	if eerr != nil {
+		t.Logf("ExtractFlightData ERROR: %v", eerr)
+	} else {
+		t.Logf("ExtractFlightData -> %d raw entries", len(rawFlights))
+		flights := parseFlights(rawFlights)
+		t.Logf("parseFlights -> %d flights", len(flights))
+		for i, f := range flights {
+			if i >= 5 {
+				break
+			}
+			t.Logf("  flight[%d]: price=%.2f %s legs=%d stops=%d dur=%d",
+				i, f.Price, f.Currency, len(f.Legs), f.Stops, f.Duration)
+		}
+	}
+}
+
+func truncBytes(b []byte, n int) string {
+	if len(b) > n {
+		return string(b[:n])
+	}
+	return string(b)
+}
+
+func kindOf(v any) string {
+	switch x := v.(type) {
+	case []any:
+		return fmt.Sprintf("array(len=%d)", len(x))
+	case map[string]any:
+		return fmt.Sprintf("object(keys=%d)", len(x))
+	case string:
+		if len(x) > 40 {
+			return fmt.Sprintf("string(len=%d)", len(x))
+		}
+		return fmt.Sprintf("string(%q)", x)
+	case float64:
+		return fmt.Sprintf("number(%v)", x)
+	case nil:
+		return "null"
+	default:
+		return fmt.Sprintf("%T", v)
+	}
+}
+
+func jsonShort(v any, n int) string {
+	b, _ := json.Marshal(v)
+	return truncBytes(b, n)
+}
+
+// TestProbeRoundTripOrchestrator runs the full round-trip orchestrator live and
+// confirms native Google round-trip fares (FareRoundTrip) appear in the merged
+// results. Opt-in via TRVL_TEST_LIVE_PROBES=1.
+func TestProbeRoundTripOrchestrator(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("set TRVL_TEST_LIVE_PROBES=1 to run live orchestrator probe")
+	}
+	dep := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
+	ret := time.Now().AddDate(0, 1, 7).Format("2006-01-02")
+	client := batchexec.NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	res, err := searchRoundTripComposed(ctx, client, "HEL", "BCN", dep, SearchOptions{ReturnDate: ret, Adults: 1, Currency: "EUR"})
+	if err != nil {
+		t.Logf("orchestrator err: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	var native, split int
+	for _, f := range res.Flights {
+		switch f.FareType {
+		case "round_trip":
+			native++
+		case "split_tickets":
+			split++
+		}
+	}
+	t.Logf("tripType=%s count=%d native_round_trip=%d split_tickets=%d", res.TripType, len(res.Flights), native, split)
+	for i, f := range res.Flights {
+		if i >= 4 {
+			break
+		}
+		t.Logf("  [%d] %.2f %s fare=%s provider=%q legs=%d", i, f.Price, f.Currency, f.FareType, f.Provider, len(f.Legs))
+	}
+	if native == 0 {
+		t.Errorf("expected at least one native Google round-trip fare in merged results")
+	}
+}

--- a/internal/flights/roundtrip_native_probe_test.go
+++ b/internal/flights/roundtrip_native_probe_test.go
@@ -145,7 +145,10 @@ func TestProbeRoundTripOrchestrator(t *testing.T) {
 		}
 		t.Logf("  [%d] %.2f %s fare=%s provider=%q legs=%d", i, f.Price, f.Currency, f.FareType, f.Provider, len(f.Legs))
 	}
+	for _, s := range res.ProviderStatuses {
+		t.Logf("  status %s: %s results=%d", s.ID, s.Status, s.Results)
+	}
 	if native == 0 {
-		t.Errorf("expected at least one native Google round-trip fare in merged results")
+		t.Errorf("expected at least one native round-trip fare (Google/Kiwi) in merged results")
 	}
 }

--- a/internal/flights/roundtrip_test.go
+++ b/internal/flights/roundtrip_test.go
@@ -69,6 +69,34 @@ func TestTagGoogleNativeRoundTrip_Empty(t *testing.T) {
 	}
 }
 
+func TestTagNativeRoundTrip_KeepsProviderDeepLink(t *testing.T) {
+	src := owFlight("kiwi", "EUR", 296, "HEL", "BCN")
+	src.BookingURL = "https://kiwi.com/deep/link?return=2026-07-08"
+
+	got := tagNativeRoundTrip([]models.FlightResult{src}, kiwiNativeRoundTripWarning, "")
+	if len(got) != 1 {
+		t.Fatalf("count: got %d, want 1", len(got))
+	}
+	f := got[0]
+	if f.FareType != models.FareRoundTrip {
+		t.Errorf("FareType: got %q, want %q", f.FareType, models.FareRoundTrip)
+	}
+	// Empty bookingURL must preserve the provider's own deep link (it encodes the return).
+	if f.BookingURL != "https://kiwi.com/deep/link?return=2026-07-08" {
+		t.Errorf("BookingURL overwritten: got %q, want the Kiwi deep link kept", f.BookingURL)
+	}
+	if f.Legs[0].Direction != "outbound" {
+		t.Errorf("leg Direction: got %q, want outbound", f.Legs[0].Direction)
+	}
+	if len(f.Warnings) == 0 || f.Warnings[0] != kiwiNativeRoundTripWarning {
+		t.Errorf("Warnings: got %v, want kiwi round-trip warning first", f.Warnings)
+	}
+	// Source must stay untouched (cached/shared upstream).
+	if src.Legs[0].Direction != "" || src.FareType != "" {
+		t.Errorf("source mutated: dir=%q fare=%q", src.Legs[0].Direction, src.FareType)
+	}
+}
+
 func TestComposeRoundTrips_SumsAndConcatenates(t *testing.T) {
 	out := []models.FlightResult{owFlight("Google Flights", "EUR", 100, "HEL", "BCN")}
 	in := []models.FlightResult{owFlight("Ryanair", "EUR", 60, "BCN", "HEL")}

--- a/internal/flights/roundtrip_test.go
+++ b/internal/flights/roundtrip_test.go
@@ -23,6 +23,52 @@ func owFlight(provider, currency string, price float64, dep, arr string) models.
 	}
 }
 
+func TestTagGoogleNativeRoundTrip(t *testing.T) {
+	src := []models.FlightResult{owFlight("Google Flights", "EUR", 314, "HEL", "BCN")}
+
+	got := tagGoogleNativeRoundTrip(src, "HEL", "BCN", "2026-07-01", "2026-07-08", "EUR")
+	if len(got) != 1 {
+		t.Fatalf("count: got %d, want 1", len(got))
+	}
+	f := got[0]
+
+	// A native Google fare is a true round-trip ticket, not a split pair.
+	if f.FareType != models.FareRoundTrip {
+		t.Errorf("FareType: got %q, want %q", f.FareType, models.FareRoundTrip)
+	}
+	// Price is the full round-trip total (never summed legs) — carried verbatim.
+	if f.Price != 314 {
+		t.Errorf("Price: got %.2f, want 314 (round-trip total preserved)", f.Price)
+	}
+	// Stage 1 returns the outbound itinerary; the return leg is chosen at booking.
+	if len(f.Legs) != 1 || f.Legs[0].Direction != "outbound" {
+		t.Errorf("legs: got %+v, want one outbound-tagged leg", f.Legs)
+	}
+	// A warning must make the booking-time return selection explicit.
+	if len(f.Warnings) == 0 || !strings.Contains(f.Warnings[0], "round-trip") {
+		t.Errorf("Warnings: got %v, want a round-trip clarification first", f.Warnings)
+	}
+	// Booking URL must encode the return date so the user lands on the round-trip.
+	if !strings.Contains(f.BookingURL, "2026-07-08") {
+		t.Errorf("BookingURL: got %q, want it to include the return date", f.BookingURL)
+	}
+
+	// The source flight's legs must stay untagged — Google one-way responses are
+	// cached/shared, and a leaked round-trip tag would corrupt a later one-way.
+	if src[0].Legs[0].Direction != "" {
+		t.Errorf("source leg mutated: Direction=%q", src[0].Legs[0].Direction)
+	}
+	if src[0].FareType != "" {
+		t.Errorf("source FareType mutated: %q", src[0].FareType)
+	}
+}
+
+func TestTagGoogleNativeRoundTrip_Empty(t *testing.T) {
+	if got := tagGoogleNativeRoundTrip(nil, "HEL", "BCN", "2026-07-01", "2026-07-08", "EUR"); got != nil {
+		t.Errorf("empty input should yield nil, got %v", got)
+	}
+}
+
 func TestComposeRoundTrips_SumsAndConcatenates(t *testing.T) {
 	out := []models.FlightResult{owFlight("Google Flights", "EUR", 100, "HEL", "BCN")}
 	in := []models.FlightResult{owFlight("Ryanair", "EUR", 60, "BCN", "HEL")}

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -138,10 +138,11 @@ func SearchFlightsWithClient(ctx context.Context, client *batchexec.Client, orig
 		}, fmt.Errorf("client is required")
 	}
 
-	// Round-trip is served by composition (two one-way searches paired) rather
-	// than the native Google round-trip request, which Google rejects (issue
-	// #198). The leg sub-searches re-enter this function with ReturnDate cleared,
-	// so they take the one-way path below.
+	// Round-trip fans out to native round-trip fares (Google, Skiplagged — priced
+	// as a single, often discounted return) AND composition (two one-way searches
+	// paired, covering cross-carrier combos), merged cheapest-first. The native
+	// Google path is queried inside searchRoundTripComposed; the composition leg
+	// sub-searches re-enter this function with ReturnDate cleared (one-way path).
 	if opts.ReturnDate != "" {
 		return searchRoundTripComposed(ctx, client, origin, destination, date, opts)
 	}


### PR DESCRIPTION
## What

Re-enables **native round-trip fares from Google Flights and Kiwi**, merging them with the existing Skiplagged native fares and composed cross-carrier pairs — all sorted cheapest-first.

Both providers price a round-trip as a single, often discounted fare, but both were routed to composition-only on a **false premise**:

- **Google** — disabled after #198, which was a transient rate-limit (429-then-200 retry), not the structural "Google rejects native round-trip" rejection it was misread as.
- **Kiwi** — `kiwiEligibleOptions` rejected `ReturnDate` as "unsupported", so the one-way fan-out skipped Kiwi for any return search.

The result either way: every `--return_date` search silently discarded real, frequently-discounted return fares.

## How

- `searchGoogleNativeRoundTrip` / `searchKiwiNativeRoundTrip` issue the native round-trip request and tag each itinerary `FareRoundTrip` via a shared, pure `tagNativeRoundTrip` helper.
- Both are wired into `searchRoundTripComposed` alongside Skiplagged native + composition; the cheapest-first merge means a discounted native round-trip outranks a pricier composed split-ticket pair.
- Both providers return a **two-stage** round-trip: the response carries the **outbound itinerary priced at the full round-trip total**; the matched return flight is selected at booking. So each result carries its outbound leg + a clarifying warning — **never a fabricated inbound leg**. Google gets a synthesized round-trip booking URL; Kiwi keeps its own deep link (it already encodes the return). Kiwi's real option limits (airline/alliance/baggage filters) and the production shared-client guard are still honoured.

## Honesty model

| Source | FareType | Meaning |
|---|---|---|
| Google / Kiwi / Skiplagged native | `round_trip` | One bookable return fare (full round-trip total, return at booking) |
| Composition | `split_tickets` | Two separate one-way tickets, warned |

## Verification (live, opt-in `TRVL_TEST_LIVE_PROBES=1`)

- **Google:** `TestProbeNativeRoundTrip` — native request returns HTTP 200 with **74 parseable itineraries** (HEL→BCN); existing parser handles native round-trip responses unchanged.
- **Kiwi:** `TestProbeKiwiRoundTrip` returns outbound-only legs at **~296 EUR**, while `TestProbeKiwiOneWayPrice` shows a one-way HEL→BCN is **~102 EUR** — proving the round-trip price is the genuine return total, not a one-way.
- **Deterministic:** `TestTagGoogleNativeRoundTrip` (+`_Empty`) and `TestTagNativeRoundTrip_KeepsProviderDeepLink` cover FareType, round-trip-total price preservation, outbound leg tagging, warnings, booking-URL handling (synthesized vs provider deep link), and no-mutation of shared upstream legs.
- `go build`, `go vet`, `gofmt`, full `go test -short ./internal/flights` all green.
- The live orchestrator probe is opt-in and CI-skipped (Google currently rate-limits repeated probes; the component-level native probes are the load-bearing evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
