### PR TITLE
feat(flights): selectable single low-cost carrier with composed round-trips

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,11 @@ trvl flights AMS NRT 2026-09-15 --award
 
 # AFKLM cash fares only, with native round-trip tickets (both legs, one fare):
 trvl flights AMS BCN 2026-07-01 --return 2026-07-08 --provider afklm
+
+# A single low-cost carrier only (Ryanair, Wizz Air, Transavia, or easyJet).
+# Low-cost carriers have no discounted return fare, so a --return request is
+# composed honestly as two one-way tickets (both legs, booked separately):
+trvl flights STN DUB 2026-07-01 --return 2026-07-08 --provider ryanair
 ```
 
 ## Ground Transport Providers

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -192,6 +192,11 @@ Examples:
 					return fmt.Errorf("--provider afklm supports exactly one origin and one destination")
 				}
 				result, err = flights.SearchAFKLM(cmd.Context(), origins[0], destinations[0], date, opts)
+			case "ryanair", "wizzair", "wizz", "transavia", "easyjet":
+				if len(origins) != 1 || len(destinations) != 1 {
+					return fmt.Errorf("--provider %s supports exactly one origin and one destination", provider)
+				}
+				result, err = flights.SearchLowCostCarrier(cmd.Context(), strings.ToLower(strings.TrimSpace(provider)), origins[0], destinations[0], date, opts)
 			case "", "default", "google", "google_flights", "kiwi":
 				if len(origins) > 1 || len(destinations) > 1 {
 					result, err = flights.SearchMultiAirport(cmd.Context(), origins, destinations, date, opts)
@@ -199,7 +204,7 @@ Examples:
 					result, err = flights.SearchFlights(cmd.Context(), origins[0], destinations[0], date, opts)
 				}
 			default:
-				return fmt.Errorf("unsupported --provider %q (valid: skiplagged, afklm, or empty for default Google+Kiwi+Skiplagged merge)", provider)
+				return fmt.Errorf("unsupported --provider %q (valid: skiplagged, afklm, ryanair, wizzair, transavia, easyjet, or empty for default Google+Kiwi+Skiplagged merge)", provider)
 			}
 			if err != nil {
 				return err
@@ -303,7 +308,7 @@ Examples:
 	cmd.Flags().BoolVar(&explain, "explain", false, "Show per-factor profile match breakdown for each result")
 	cmd.Flags().BoolVar(&award, "award", false, "Search Flying Blue award availability instead of cash fares")
 	cmd.Flags().StringVar(&awardCookies, "award-cookies", "", "KLM/Flying Blue Cookie header for --award (or set AFKL_KLM_COOKIES)")
-	cmd.Flags().StringVar(&provider, "provider", "", "Flight provider: empty = default (Google Flights + Kiwi + Skiplagged merge), skiplagged = Skiplagged MCP only (hidden-city + virtual-interlining defaults), afklm = Air France-KLM Offers API only (opt-in, native round-trip fares; requires credential)")
+	cmd.Flags().StringVar(&provider, "provider", "", "Flight provider: empty = default (Google Flights + Kiwi + Skiplagged merge), skiplagged = Skiplagged MCP only (hidden-city + virtual-interlining defaults), afklm = Air France-KLM Offers API only (opt-in, native round-trip fares; requires credential), ryanair|wizzair|transavia|easyjet = a single low-cost carrier only (round-trips composed as two one-way tickets; transavia/easyjet are opt-in and require a key)")
 	cmd.Flags().BoolVar(&flightRailFly, "rail-fly", false, "Expand the search to rail-connected origins (KL/AF Air&Rail), surfacing cheaper rail+fly bundles even when the origin is outside the default hub list")
 	cmd.Flags().BoolVar(&deep, "deep", false, "Run a budget-gated counterfactual fan-out (nearby airports, split tickets, hidden city). Issues extra provider calls, capped by a best-effort budget that never delays the primary search")
 	cmd.Flags().BoolVar(&noGeo, "no-geo", false, "Disable geo-IP origin detection (also honored via TRVL_NO_GEO=1). Origin then resolves only from an explicit code or your saved home airport.")

--- a/internal/flights/lcc_search.go
+++ b/internal/flights/lcc_search.go
@@ -1,0 +1,103 @@
+package flights
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// lccSearcher is the shared signature of the direct low-cost-carrier one-way
+// search functions (Ryanair, Wizz Air, Transavia, easyJet). Each returns a flat
+// slice of one-way FlightResults for a single date.
+type lccSearcher func(ctx context.Context, origin, destination, date, currency string, opts SearchOptions) ([]models.FlightResult, error)
+
+// lccRegistry maps an accepted `--provider` name to its display label and
+// one-way search function. Aliases (e.g. "wizz") point at the same entry.
+var lccRegistry = map[string]struct {
+	name   string
+	search lccSearcher
+}{
+	"ryanair":   {"Ryanair", SearchRyanair},
+	"wizzair":   {"Wizz Air", SearchWizzair},
+	"wizz":      {"Wizz Air", SearchWizzair},
+	"transavia": {"Transavia", SearchTransavia},
+	"easyjet":   {"easyJet", SearchEasyjet},
+}
+
+// SearchLowCostCarrier runs a single low-cost carrier as an explicitly
+// selectable provider, composing a genuine return ticket (two one-way legs)
+// when opts.ReturnDate is set. The provider name must be one of the keys in
+// lccRegistry; an unrecognised name is rejected with a clear error.
+func SearchLowCostCarrier(ctx context.Context, provider, origin, destination, date string, opts SearchOptions) (*models.FlightSearchResult, error) {
+	entry, ok := lccRegistry[provider]
+	if !ok {
+		return nil, fmt.Errorf("unrecognised low-cost carrier provider %q", provider)
+	}
+	return searchSingleLCC(ctx, entry.name, entry.search, origin, destination, date, opts)
+}
+
+// searchSingleLCC exposes one low-cost carrier as an explicitly selectable
+// provider (`--provider ryanair`, etc.).
+//
+// Low-cost carriers publish no discounted round-trip fare — a return is simply
+// two independent one-way tickets — so a round-trip request (opts.ReturnDate
+// set) is composed honestly from an outbound and an inbound one-way search into
+// FareSplitTickets itineraries with both legs Direction-tagged and a warning
+// that the two are booked separately. This is genuine return-ticket data, never
+// a bare one-way silently returned for a round-trip request. A one-way request
+// wraps the single-leg results directly.
+//
+// Unlike the silently-skipped fan-out path, an explicit provider request
+// surfaces the carrier's own error (e.g. an unconfigured opt-in key) rather than
+// an empty result, so the user always learns why nothing came back.
+func searchSingleLCC(ctx context.Context, name string, search lccSearcher, origin, destination, date string, opts SearchOptions) (*models.FlightSearchResult, error) {
+	currency := opts.Currency
+	if currency == "" {
+		// LCC endpoints require an explicit currency; EUR matches the default
+		// the optimizer normalises every candidate to.
+		currency = "EUR"
+	}
+
+	// Per-leg searches are one-way: clear ReturnDate (the carriers reject a
+	// round-trip request directly) and FirstResult (we must keep enough cheapest
+	// options from each direction to pair before collapsing to one).
+	legOpts := opts
+	legOpts.ReturnDate = ""
+	legOpts.FirstResult = false
+
+	outbound, err := search(ctx, origin, destination, date, currency, legOpts)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", name, err)
+	}
+
+	flights := outbound
+	tripType := "one_way"
+	if opts.ReturnDate != "" {
+		tripType = "round_trip"
+		inbound, inErr := search(ctx, destination, origin, opts.ReturnDate, currency, legOpts)
+		if inErr != nil {
+			return nil, fmt.Errorf("%s inbound %s->%s: %w", name, destination, origin, inErr)
+		}
+		composed, _ := composeRoundTrips(outbound, inbound, opts)
+		flights = composed
+	} else {
+		// One-way: honour the caller's requested sort over the provider's order.
+		sortFlightResults(flights, opts.SortBy)
+	}
+
+	status := models.ProviderStatus{
+		ID:      name,
+		Name:    name,
+		Status:  okOrNoHit(len(flights)),
+		Results: len(flights),
+	}
+
+	return &models.FlightSearchResult{
+		Success:          true,
+		Count:            len(flights),
+		TripType:         tripType,
+		Flights:          flights,
+		ProviderStatuses: []models.ProviderStatus{status},
+	}, nil
+}

--- a/internal/flights/lcc_search_test.go
+++ b/internal/flights/lcc_search_test.go
@@ -1,0 +1,137 @@
+package flights
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// fakeLeg builds a minimal one-way FlightResult for the given route and price.
+func fakeLeg(origin, dest string, price float64) models.FlightResult {
+	return models.FlightResult{
+		Price:    price,
+		Currency: "EUR",
+		Duration: 120,
+		Stops:    0,
+		Provider: "FakeLCC",
+		Legs: []models.FlightLeg{{
+			DepartureAirport: models.AirportInfo{Code: origin},
+			ArrivalAirport:   models.AirportInfo{Code: dest},
+		}},
+	}
+}
+
+// TestSearchSingleLCC_OneWay verifies a one-way request wraps the single-leg
+// results directly with trip type one_way and no composition.
+func TestSearchSingleLCC_OneWay(t *testing.T) {
+	search := func(_ context.Context, origin, dest, _, _ string, _ SearchOptions) ([]models.FlightResult, error) {
+		return []models.FlightResult{fakeLeg(origin, dest, 50)}, nil
+	}
+
+	res, err := searchSingleLCC(context.Background(), "Ryanair", search, "STN", "DUB", "2026-07-01", SearchOptions{})
+	if err != nil {
+		t.Fatalf("searchSingleLCC one-way: %v", err)
+	}
+	if res.TripType != "one_way" {
+		t.Errorf("trip type: want one_way, got %q", res.TripType)
+	}
+	if len(res.Flights) != 1 {
+		t.Fatalf("expected 1 one-way flight, got %d", len(res.Flights))
+	}
+	if res.Flights[0].FareType != "" {
+		t.Errorf("one-way fare type should be the empty default, got %q", res.Flights[0].FareType)
+	}
+}
+
+// TestSearchSingleLCC_RoundTripComposesSplitTickets is the core guarantee: a
+// round-trip request to a single low-cost carrier returns genuine return-ticket
+// data — an outbound + inbound pair composed into a FareSplitTickets itinerary
+// with both legs Direction-tagged — never a bare one-way.
+func TestSearchSingleLCC_RoundTripComposesSplitTickets(t *testing.T) {
+	// Return distinct prices per direction so we can assert the summed total.
+	search := func(_ context.Context, origin, dest, _, _ string, _ SearchOptions) ([]models.FlightResult, error) {
+		if origin == "STN" {
+			return []models.FlightResult{fakeLeg(origin, dest, 40)}, nil // outbound
+		}
+		return []models.FlightResult{fakeLeg(origin, dest, 35)}, nil // inbound
+	}
+
+	opts := SearchOptions{ReturnDate: "2026-07-08"}
+	res, err := searchSingleLCC(context.Background(), "Ryanair", search, "STN", "DUB", "2026-07-01", opts)
+	if err != nil {
+		t.Fatalf("searchSingleLCC round-trip: %v", err)
+	}
+	if res.TripType != "round_trip" {
+		t.Errorf("trip type: want round_trip, got %q", res.TripType)
+	}
+	if len(res.Flights) == 0 {
+		t.Fatal("expected at least one composed round-trip itinerary")
+	}
+
+	rt := res.Flights[0]
+	if rt.FareType != models.FareSplitTickets {
+		t.Errorf("composed fare type: want %q, got %q", models.FareSplitTickets, rt.FareType)
+	}
+	if rt.Price != 75 {
+		t.Errorf("composed price: want 40+35=75, got %v", rt.Price)
+	}
+	if len(rt.Legs) != 2 {
+		t.Fatalf("expected 2 legs (outbound + inbound), got %d", len(rt.Legs))
+	}
+	if rt.Legs[0].Direction != "outbound" {
+		t.Errorf("leg 0 direction: want outbound, got %q", rt.Legs[0].Direction)
+	}
+	if rt.Legs[1].Direction != "inbound" {
+		t.Errorf("leg 1 direction: want inbound, got %q", rt.Legs[1].Direction)
+	}
+	// The split-ticket warning must be present so the summed price is never
+	// mistaken for a single bookable fare.
+	var warned bool
+	for _, w := range rt.Warnings {
+		if strings.Contains(w, "two separate one-way tickets") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("composed round-trip missing split-ticket warning; got %v", rt.Warnings)
+	}
+}
+
+// TestSearchSingleLCC_ErrorSurfacesProviderName verifies an explicit provider
+// request surfaces the carrier's error (with its name) rather than swallowing it
+// into an empty result — the honesty contract for explicit selection.
+func TestSearchSingleLCC_ErrorSurfacesProviderName(t *testing.T) {
+	search := func(_ context.Context, _, _, _, _ string, _ SearchOptions) ([]models.FlightResult, error) {
+		return nil, errors.New("API key not configured")
+	}
+
+	_, err := searchSingleLCC(context.Background(), "Transavia", search, "AMS", "BCN", "2026-07-01", SearchOptions{})
+	if err == nil {
+		t.Fatal("expected an error to surface from the carrier search")
+	}
+	if !strings.Contains(err.Error(), "Transavia") {
+		t.Errorf("error should name the provider; got: %v", err)
+	}
+}
+
+// TestSearchLowCostCarrier_UnrecognisedProvider guards the public dispatcher.
+func TestSearchLowCostCarrier_UnrecognisedProvider(t *testing.T) {
+	_, err := SearchLowCostCarrier(context.Background(), "spirit", "JFK", "LAX", "2026-07-01", SearchOptions{})
+	if err == nil {
+		t.Fatal("expected an error for an unrecognised provider")
+	}
+}
+
+// TestLCCRegistryCoversCLIProviders ensures every low-cost carrier the CLI
+// dispatches is registered, so a new CLI case can never reference a missing
+// searcher.
+func TestLCCRegistryCoversCLIProviders(t *testing.T) {
+	for _, name := range []string{"ryanair", "wizzair", "wizz", "transavia", "easyjet"} {
+		if _, ok := lccRegistry[name]; !ok {
+			t.Errorf("lccRegistry missing CLI provider %q", name)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `--provider ryanair|wizzair|transavia|easyjet` so a single low-cost carrier can be queried on its own, matching the existing `skiplagged` / `afklm` selectable-provider pattern.

## Why this honors the round-trip guarantee

Low-cost carriers publish **no discounted return fare** — a return is two independent one-way tickets. So a `--return` request to one of these carriers is composed honestly from two one-way searches (outbound + inbound) into a `FareSplitTickets` itinerary:

- both legs `Direction`-tagged (`outbound` / `inbound`)
- a warning that the two are booked separately, so the summed price is never mistaken for a single bookable fare

This is genuine return-ticket data — never a bare one-way silently returned for a round-trip request. One-way requests wrap the single-leg results directly.

Like the other explicit providers, a selected carrier surfaces its **own error** (e.g. an unconfigured opt-in key for Transavia/easyJet) rather than an empty result, so the user always learns why nothing came back.

## Changes

- `internal/flights/lcc_search.go` — `searchSingleLCC` + `SearchLowCostCarrier` dispatcher with a name→searcher registry.
- `cmd/trvl/flights.go` — dispatch cases, unsupported-provider message, `--provider` flag help.
- `README.md` — documents the new selectable carriers and the composed split-ticket return.
- `internal/flights/lcc_search_test.go` — one-way wrap, round-trip composition to `FareSplitTickets` with Direction tags + warning, error surfacing, registry/CLI parity.

## Tests

5 new deterministic tests, all green. `go build`, `go vet`, `gofmt`, doc-count test, and the full `internal/flights` short suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)