### PR TITLE
ci: pin staticcheck and govulncheck versions instead of @latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,15 +29,21 @@ jobs:
         run: go build ./...
       - name: Vet
         run: go vet ./...
+      # Pin lint/vuln tool versions instead of @latest: every GitHub Action in
+      # this workflow is SHA-pinned, so an unpinned `go install ...@latest` was
+      # the one remaining non-reproducible, supply-chain-exposed step — a new
+      # upstream release could silently change findings or pull a compromised
+      # version into CI. These pins match the latest release at time of writing;
+      # bump them deliberately (Dependabot tracks the Go modules separately).
       - name: Install staticcheck
         if: runner.os != 'Windows'
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
       - name: Staticcheck
         if: runner.os != 'Windows'
         run: staticcheck ./...
       - name: Install govulncheck
         if: runner.os != 'Windows'
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.4.0
       - name: Vulnerability check
         if: runner.os != 'Windows'
         run: govulncheck ./...


### PR DESCRIPTION
## What

Pins the two CI lint/vuln tools to explicit versions:

- `staticcheck@latest` → `staticcheck@v0.7.0`
- `govulncheck@latest` → `govulncheck@v1.4.0`

## Why

Every GitHub Action in `ci.yaml` is already SHA-pinned. The two `go install ...@latest` steps were the one remaining non-reproducible, supply-chain-exposed link in the pipeline — a new upstream release could silently change lint findings (breaking an unrelated PR) or pull a compromised tool version into CI.

The pinned versions are exactly what `@latest` resolves to today, so this is **behavior-identical but reproducible**. Bumps become deliberate, reviewable changes.

## Verification

Local run on go1.26.4 (matches the CI toolchain):

- `staticcheck@v0.7.0 ./...` → no findings
- `govulncheck@v1.4.0 ./...` → no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)