### PR TITLE
fix(accommodations): normalize offer currency and enforce min_stars (#277)

### DIFF
--- a/internal/models/accommodation.go
+++ b/internal/models/accommodation.go
@@ -49,6 +49,7 @@ type AccommodationNeed struct {
 	MinBedrooms              int      `json:"min_bedrooms,omitempty"`
 	MinBathrooms             int      `json:"min_bathrooms,omitempty"`
 	MinBeds                  int      `json:"min_beds,omitempty"`
+	MinStars                 int      `json:"min_stars,omitempty"`
 	RequiredAmenities        []string `json:"required_amenities,omitempty"`
 	PreferredAmenities       []string `json:"preferred_amenities,omitempty"`
 	MaxDistanceKm            float64  `json:"max_distance_km,omitempty"`

--- a/internal/models/accommodation_minstars_test.go
+++ b/internal/models/accommodation_minstars_test.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"testing"
+	"time"
+)
+
+// TestEvaluateAccommodationOfferMinStarsNotOfferLevel guards issue #277 defect
+// 3: min_stars is a property-level filter enforced during candidate selection,
+// NOT an offer-level criterion. Offers carry no star rating, so adding MinStars
+// to the need must never reject an otherwise-matching offer (that would zero out
+// results, the very bug we are fixing). It also confirms the room-level gate
+// (defect 2) passes cleanly when room inventory and a room-level price exist.
+func TestEvaluateAccommodationOfferMinStarsNotOfferLevel(t *testing.T) {
+	need := AccommodationNeed{Adults: 1, Currency: "EUR", MinStars: 5}
+	offer := AccommodationOffer{
+		Currency:              "EUR",
+		NightlyPrice:          100,
+		TotalPrice:            200,
+		OccupancyAdults:       1,
+		PriceBasis:            PriceBasisRoomTotal,
+		PriceConfidence:       PriceConfidenceRoomLevel,
+		InventoryCompleteness: RoomInventoryCompletenessSingleProvider,
+		CheckedAt:             time.Now(),
+	}
+	got := EvaluateAccommodationOffer(need, offer, time.Now())
+	for _, c := range append(append([]string{}, got.MissingCriteria...), got.UnknownCriteria...) {
+		if c == "stars" || c == "min_stars" {
+			t.Fatalf("stars must not be an offer-level criterion: missing=%v unknown=%v",
+				got.MissingCriteria, got.UnknownCriteria)
+		}
+	}
+	if !got.CriteriaMatched {
+		t.Fatalf("room-level offer with matching currency/occupancy should match: missing=%v unknown=%v",
+			got.MissingCriteria, got.UnknownCriteria)
+	}
+}

--- a/internal/providers/fx.go
+++ b/internal/providers/fx.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -38,6 +39,28 @@ var fallbackRates = map[string]map[string]float64{
 
 // defaultFXCache is the package-level singleton used by normalizePrice.
 var defaultFXCache = newFXCache()
+
+// ConvertRate returns the FX conversion rate from→to and whether a rate is
+// available. Callers that need to convert several price fields with the same
+// pair (and want to know whether conversion actually happened, so they can
+// rewrite the currency label only on success) should use this instead of
+// normalizePrice. from/to are matched case-insensitively against ISO codes.
+// Identical currencies return (1, true); a pair with no known rate returns
+// (0, false) so the caller can leave the price — and its currency — untouched.
+func ConvertRate(from, to string) (float64, bool) {
+	from = strings.ToUpper(strings.TrimSpace(from))
+	to = strings.ToUpper(strings.TrimSpace(to))
+	if from == "" || to == "" {
+		return 0, false
+	}
+	if from == to {
+		return 1, true
+	}
+	if r := defaultFXCache.getRate(from, to); r > 0 {
+		return r, true
+	}
+	return 0, false
+}
 
 func newFXCache() *fxCache {
 	return &fxCache{

--- a/internal/providers/fx_convertrate_test.go
+++ b/internal/providers/fx_convertrate_test.go
@@ -1,0 +1,26 @@
+package providers
+
+import "testing"
+
+// TestConvertRate covers the exported FX helper wired into accommodation
+// currency normalization (issue #277, defect 1). USD/EUR/GBP always resolve
+// because fx.go ships hardcoded fallback rates, so this stays deterministic
+// whether or not the live Frankfurter endpoint is reachable from CI.
+func TestConvertRate(t *testing.T) {
+	if r, ok := ConvertRate("EUR", "EUR"); !ok || r != 1 {
+		t.Fatalf("identity: got (%v,%v), want (1,true)", r, ok)
+	}
+	if r, ok := ConvertRate("eur", "EUR"); !ok || r != 1 {
+		t.Fatalf("identity is case-insensitive: got (%v,%v), want (1,true)", r, ok)
+	}
+	if r, ok := ConvertRate("", "USD"); ok || r != 0 {
+		t.Fatalf("empty from: got (%v,%v), want (0,false)", r, ok)
+	}
+	if r, ok := ConvertRate("USD", ""); ok || r != 0 {
+		t.Fatalf("empty to: got (%v,%v), want (0,false)", r, ok)
+	}
+	// USD->EUR resolves to a positive rate (live ECB or hardcoded fallback).
+	if r, ok := ConvertRate("USD", "EUR"); !ok || r <= 0 {
+		t.Fatalf("USD->EUR: got (%v,%v), want a positive rate", r, ok)
+	}
+}

--- a/mcp/tools_accommodations_277_test.go
+++ b/mcp/tools_accommodations_277_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestNormalizeOfferCurrency covers issue #277 defect 1: a provider offer in a
+// foreign currency (e.g. HousingAnywhere returning USD when EUR was requested)
+// must be FX-normalized to the requested currency before criteria evaluation
+// rather than rejected for missing_criteria:["currency"].
+func TestNormalizeOfferCurrency(t *testing.T) {
+	// Same currency: untouched.
+	in := models.AccommodationOffer{Currency: "EUR", NightlyPrice: 100, TotalPrice: 200}
+	if out := normalizeOfferCurrency(in, "EUR"); out.Currency != "EUR" || out.NightlyPrice != 100 || out.TotalPrice != 200 {
+		t.Fatalf("same currency must be untouched: %+v", out)
+	}
+	// Empty target: untouched.
+	if out := normalizeOfferCurrency(in, ""); out.Currency != "EUR" || out.NightlyPrice != 100 {
+		t.Fatalf("empty want must be untouched: %+v", out)
+	}
+	// USD -> EUR: converted, relabeled, warned. USD/EUR always resolves via
+	// fx.go fallback rates, so this is deterministic offline.
+	usd := models.AccommodationOffer{Currency: "USD", NightlyPrice: 109, TotalPrice: 218, TaxesAndFees: 20}
+	out := normalizeOfferCurrency(usd, "EUR")
+	if out.Currency != "EUR" {
+		t.Fatalf("currency should be relabeled to EUR, got %q", out.Currency)
+	}
+	if out.NightlyPrice <= 0 || out.NightlyPrice >= 109 {
+		t.Fatalf("USD->EUR nightly should be positive and below the USD nominal, got %v", out.NightlyPrice)
+	}
+	if out.TotalPrice <= 0 || out.TotalPrice >= 218 {
+		t.Fatalf("USD->EUR total should be positive and below the USD nominal, got %v", out.TotalPrice)
+	}
+	found := false
+	for _, w := range out.Warnings {
+		if w == "currency_normalized" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected currency_normalized warning, got %v", out.Warnings)
+	}
+}
+
+// TestSelectAccommodationCandidateHotelsMinStars covers issue #277 defect 3:
+// min_stars must be enforced during stage-2 candidate selection. Properties
+// with a known star rating below the minimum are dropped; unrated (stars==0)
+// properties are kept because we cannot prove they fail the filter.
+func TestSelectAccommodationCandidateHotelsMinStars(t *testing.T) {
+	hotels := []models.HotelResult{
+		{Name: "Four", Stars: 4},
+		{Name: "Five", Stars: 5},
+		{Name: "Unrated", Stars: 0},
+	}
+	got := selectAccommodationCandidateHotels(hotels, 10, models.AccommodationNeed{MinStars: 5})
+	names := map[string]bool{}
+	for _, h := range got {
+		names[h.Name] = true
+	}
+	if names["Four"] {
+		t.Fatalf("4-star property must be excluded for min_stars=5, got %v", names)
+	}
+	if !names["Five"] {
+		t.Fatalf("5-star property must be kept for min_stars=5, got %v", names)
+	}
+	if !names["Unrated"] {
+		t.Fatalf("unrated property must be kept (cannot prove failure), got %v", names)
+	}
+	// No min_stars: every candidate is kept.
+	if all := selectAccommodationCandidateHotels(hotels, 10, models.AccommodationNeed{}); len(all) != 3 {
+		t.Fatalf("no min_stars filter should keep all 3, got %d", len(all))
+	}
+}

--- a/mcp/tools_accommodations_evidence.go
+++ b/mcp/tools_accommodations_evidence.go
@@ -294,6 +294,9 @@ func enrichAccommodationNeedFromArgs(need models.AccommodationNeed, args map[str
 	if maxTotal := argFloat(args, "max_total_price", 0); maxTotal > 0 {
 		need.MaxTotalPrice = maxTotal
 	}
+	if stars := argInt(args, "min_stars", argInt(args, "stars", 0)); stars > 0 {
+		need.MinStars = stars
+	}
 	if argBool(args, "must_have_washing_machine", false) {
 		need.RequiredAmenities = appendUniqueStringMCP(need.RequiredAmenities, "washing machine")
 	}
@@ -383,7 +386,21 @@ func selectAccommodationCandidateHotels(hotels []models.HotelResult, limit int, 
 	if limit <= 0 || len(hotels) == 0 {
 		return nil
 	}
-	candidates := append([]models.HotelResult(nil), hotels...)
+	candidates := make([]models.HotelResult, 0, len(hotels))
+	for _, hotel := range hotels {
+		// Enforce min_stars in stage-2 selection. Only drop properties whose
+		// star rating is known AND below the minimum; properties with an
+		// unrated stars value (0) are kept because we cannot prove they fail
+		// the filter — over-pruning would silently hide valid candidates such
+		// as apartments that legitimately carry no star rating.
+		if need.MinStars > 0 && hotel.Stars > 0 && hotel.Stars < need.MinStars {
+			continue
+		}
+		candidates = append(candidates, hotel)
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
 	sort.SliceStable(candidates, func(i, j int) bool {
 		leftScore := accommodationVerificationCandidateScore(candidates[i], need)
 		rightScore := accommodationVerificationCandidateScore(candidates[j], need)

--- a/mcp/tools_hotels_details.go
+++ b/mcp/tools_hotels_details.go
@@ -416,6 +416,7 @@ func accommodationNeedFromHotelSearchRequest(req hotelSearchRequest) models.Acco
 		MinBedrooms:              opts.MinBedrooms,
 		MinBathrooms:             opts.MinBathrooms,
 		MinBeds:                  opts.MinBeds,
+		MinStars:                 opts.Stars,
 		RequiredAmenities:        append([]string(nil), opts.Amenities...),
 		MaxDistanceKm:            opts.MaxDistanceKm,
 		MustHaveKitchen:          opts.MustHaveKitchen,

--- a/mcp/tools_hotels_details_inventory.go
+++ b/mcp/tools_hotels_details_inventory.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/providers"
 )
 
 func accommodationOffersFromRooms(hotel models.HotelResult, rooms []hotels.RoomType, need models.AccommodationNeed, checkedAt time.Time) []models.AccommodationOffer {
@@ -55,9 +56,36 @@ func accommodationOffersFromRooms(hotel models.HotelResult, rooms []hotels.RoomT
 			InventoryCompleteness: inventoryCompleteness(group.quotes),
 			InventoryOptions:      group.quotes,
 		}
+		offer = normalizeOfferCurrency(offer, need.Currency)
 		offers = append(offers, models.EvaluateAccommodationOffer(need, offer, checkedAt))
 	}
 	return offers
+}
+
+// normalizeOfferCurrency converts an offer's price fields into the requested
+// currency using live FX rates (ECB via Frankfurter, with hardcoded
+// fallbacks). Providers such as HousingAnywhere occasionally return a foreign
+// currency (USD) even when the request asked for EUR; without this the
+// criteria evaluator rejects the offer for missing_criteria:["currency"] even
+// though the price is otherwise usable. Conversion only happens when a rate is
+// available — if none is, the offer keeps its original currency and the
+// evaluator still flags it, so we never relabel a price we could not convert.
+func normalizeOfferCurrency(offer models.AccommodationOffer, want string) models.AccommodationOffer {
+	want = strings.ToUpper(strings.TrimSpace(want))
+	have := strings.ToUpper(strings.TrimSpace(offer.Currency))
+	if want == "" || have == "" || have == want {
+		return offer
+	}
+	rate, ok := providers.ConvertRate(have, want)
+	if !ok {
+		return offer
+	}
+	offer.NightlyPrice *= rate
+	offer.TotalPrice *= rate
+	offer.TaxesAndFees *= rate
+	offer.Currency = want
+	offer.Warnings = appendUniqueStringMCP(offer.Warnings, "currency_normalized")
+	return offer
 }
 
 type roomInventoryGroup struct {


### PR DESCRIPTION
## Summary

Fixes #277 — `search_accommodations` returned **0 criteria-matched offers** for well-formed queries on 1.14.3. Two of the four reported defects are fixed with tests; two are honestly deferred because they need live-provider response data to fix safely.

## Defects fixed

**Defect 1 — currency leak (`missing_criteria:["currency"]`).** Providers such as HousingAnywhere quote in USD even when EUR is requested, so `EvaluateAccommodationOffer` rejected every offer. Offers are now FX-normalized to the requested currency at the evaluation chokepoint (`mcp/tools_hotels_details_inventory.go`) via a new exported `providers.ConvertRate`, backed by the existing Frankfurter/ECB cache (`internal/providers/fx.go`) with hardcoded EUR/USD/GBP fallbacks so it works offline. Normalized offers carry a `currency_normalized` warning — no silent rewriting.

**Defect 3 — `min_stars` ignored.** `min_stars` now flows from tool args → `AccommodationNeed.MinStars` → stage-2 candidate selection (`selectAccommodationCandidateHotels`), which drops properties whose **known** star rating is below the minimum. Unrated (`stars == 0`) properties are **kept** — we can't prove they fail, and over-pruning would silently hide valid candidates (e.g. apartments with no star rating). Stars are filtered at the property level, never at the offer level (offers carry no star field), so a `min_stars` request can never zero out results.

## Defects deferred (honest, not fixed blind)

- **Defect 1b — HA price-string parser** ("11.33 USD/night Standard Room" leaking monthly/area rates): needs captured live HA responses to parse safely.
- **Defect 2 — `room_inventory` never resolving to room-level completeness**: the criteria honesty gate (`accommodation.go:293-297`) is deliberately **left intact** rather than loosened — loosening it would emit fake `booking_ready`, an honesty violation. Resolving it correctly requires live room-level inventory data.

Both are called out as follow-ups on the issue rather than papered over.

## Tests

- `internal/providers`: `TestConvertRate` — identity, empty-arg, and USD→EUR resolution.
- `mcp`: `TestNormalizeOfferCurrency` (same-currency no-op, empty-target no-op, USD→EUR convert+relabel+warn) and `TestSelectAccommodationCandidateHotelsMinStars` (4★ dropped, 5★ + unrated kept, no-filter keeps all).
- `internal/models`: `TestEvaluateAccommodationOfferMinStarsNotOfferLevel` — proves stars is never an offer-level criterion and a room-level offer matches cleanly.

All three package suites pass with `-race`; `go build`, `go vet`, and `gofmt` are clean.

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)
