### PR TITLE
fix(flights): tag native round-trip inbound legs by date

### DIFF
--- a/internal/flights/roundtrip.go
+++ b/internal/flights/roundtrip.go
@@ -363,7 +363,7 @@ func searchGoogleNativeRoundTrip(ctx context.Context, client *batchexec.Client, 
 // mutates the source legs (taggedLegs copies) so cached one-way responses stay
 // untouched. Pure and deterministic so it can be unit-tested without the network.
 func tagGoogleNativeRoundTrip(flights []models.FlightResult, origin, destination, date, returnDate, currency string) []models.FlightResult {
-	return tagNativeRoundTrip(flights, googleNativeRoundTripWarning, buildFlightBookingURL(origin, destination, date, returnDate, currency))
+	return tagNativeRoundTrip(flights, googleNativeRoundTripWarning, buildFlightBookingURL(origin, destination, date, returnDate, currency), date, returnDate)
 }
 
 const (
@@ -371,30 +371,74 @@ const (
 	kiwiNativeRoundTripWarning   = "native Kiwi round-trip fare: the price is the full round-trip total; the matching return flight is selected at booking (open the booking link)"
 )
 
-// tagNativeRoundTrip converts raw outbound itineraries from a provider's native
+// tagNativeRoundTrip converts raw itineraries from a provider's native
 // round-trip request into honest FareRoundTrip results. Each flight keeps its
-// price (the full round-trip total the provider quoted), gets its leg(s) tagged
-// "outbound" — the matching return flight is chosen at booking, since these
-// providers expose only the outbound itinerary plus the return total — the given
-// warning prepended, and, when bookingURL is non-empty, that round-trip booking
-// URL (empty keeps the provider's own deep link). It never mutates the source
-// legs (taggedLegs copies) so cached one-way responses stay untouched. Pure and
-// deterministic so it can be unit-tested without the network.
-func tagNativeRoundTrip(flights []models.FlightResult, warning, bookingURL string) []models.FlightResult {
+// price (the full round-trip total the provider quoted) and gets that
+// round-trip booking URL (empty keeps the provider's own deep link).
+//
+// Leg directions are tagged by date: a native round-trip response is
+// inconsistent — sometimes it carries the full round-trip (both halves),
+// sometimes only the outbound itinerary with the return chosen at booking.
+// directionTaggedLegs labels legs departing on/after returnDate as "inbound"
+// using the real data the provider returned, never a fabricated leg. Only when
+// no inbound leg is present do we prepend the "return selected at booking"
+// warning — when the inbound legs ARE present, the tagged legs speak for
+// themselves and that warning would be false. Never mutates the source legs
+// (directionTaggedLegs copies) so cached one-way responses stay untouched.
+// Pure and deterministic so it can be unit-tested without the network.
+func tagNativeRoundTrip(flights []models.FlightResult, warning, bookingURL, departDate, returnDate string) []models.FlightResult {
 	if len(flights) == 0 {
 		return nil
 	}
 	out := make([]models.FlightResult, 0, len(flights))
 	for _, f := range flights {
 		f.FareType = models.FareRoundTrip
-		f.Legs = taggedLegs(f.Legs, "outbound")
+		legs, hasInbound := directionTaggedLegs(f.Legs, departDate, returnDate)
+		f.Legs = legs
 		if bookingURL != "" {
 			f.BookingURL = bookingURL
 		}
-		f.Warnings = append([]string{warning}, f.Warnings...)
+		if !hasInbound && warning != "" {
+			f.Warnings = append([]string{warning}, f.Warnings...)
+		}
 		out = append(out, f)
 	}
 	return out
+}
+
+// directionTaggedLegs returns a copy of legs with each leg's Direction set to
+// "outbound" or "inbound" by comparing its departure date to returnDate: a leg
+// departing on or after returnDate is the return half. When returnDate is empty
+// or equals departDate (a same-day turn we cannot split by date), or a leg's
+// departure time is unparseable, the leg stays "outbound" — the safe,
+// non-fabricating default. hasInbound reports whether any inbound leg was found.
+func directionTaggedLegs(legs []models.FlightLeg, departDate, returnDate string) (tagged []models.FlightLeg, hasInbound bool) {
+	out := make([]models.FlightLeg, len(legs))
+	copy(out, legs)
+	splittable := returnDate != "" && returnDate != departDate
+	for i := range out {
+		dir := "outbound"
+		if splittable {
+			// ISO calendar dates compare correctly as plain strings.
+			if d, ok := legDepartDate(out[i]); ok && d >= returnDate {
+				dir = "inbound"
+				hasInbound = true
+			}
+		}
+		out[i].Direction = dir
+	}
+	return out, hasInbound
+}
+
+// legDepartDate extracts the date prefix of a leg's departure time
+// ("2026-07-22T18:40" -> "2026-07-22"), reporting false when the value is too
+// short or not date-shaped so the caller falls back to the safe default.
+func legDepartDate(leg models.FlightLeg) (string, bool) {
+	t := leg.DepartureTime
+	if len(t) < 10 || t[4] != '-' || t[7] != '-' {
+		return "", false
+	}
+	return t[:10], true
 }
 
 // searchKiwiNativeRoundTrip queries Kiwi for a native round-trip fare (returnDate
@@ -433,7 +477,7 @@ func searchKiwiNativeRoundTrip(ctx context.Context, client *batchexec.Client, or
 	}
 
 	// Keep Kiwi's own deep link (bookingURL=="") — it already encodes the return.
-	native := tagNativeRoundTrip(flights, kiwiNativeRoundTripWarning, "")
+	native := tagNativeRoundTrip(flights, kiwiNativeRoundTripWarning, "", date, returnDate)
 	normalizeFlightCurrencies(ctx, native, target, destinations.ConvertCurrency)
 
 	status := models.ProviderStatus{

--- a/internal/flights/roundtrip_test.go
+++ b/internal/flights/roundtrip_test.go
@@ -73,7 +73,7 @@ func TestTagNativeRoundTrip_KeepsProviderDeepLink(t *testing.T) {
 	src := owFlight("kiwi", "EUR", 296, "HEL", "BCN")
 	src.BookingURL = "https://kiwi.com/deep/link?return=2026-07-08"
 
-	got := tagNativeRoundTrip([]models.FlightResult{src}, kiwiNativeRoundTripWarning, "")
+	got := tagNativeRoundTrip([]models.FlightResult{src}, kiwiNativeRoundTripWarning, "", "2026-07-01", "2026-07-08")
 	if len(got) != 1 {
 		t.Fatalf("count: got %d, want 1", len(got))
 	}
@@ -94,6 +94,41 @@ func TestTagNativeRoundTrip_KeepsProviderDeepLink(t *testing.T) {
 	// Source must stay untouched (cached/shared upstream).
 	if src.Legs[0].Direction != "" || src.FareType != "" {
 		t.Errorf("source mutated: dir=%q fare=%q", src.Legs[0].Direction, src.FareType)
+	}
+}
+
+func TestTagNativeRoundTrip_TagsInboundByDate(t *testing.T) {
+	// A native round-trip fare whose payload carries BOTH halves: outbound on
+	// the departure date, the return leg on returnDate. Verified live: Google
+	// returns inbound legs for some itineraries (HEL->LON 2026-07-15/07-22), so
+	// they must be tagged "inbound" and the booking-time warning suppressed.
+	src := models.FlightResult{
+		Price: 280, Currency: "EUR", Provider: "Google Flights",
+		Legs: []models.FlightLeg{
+			{DepartureAirport: models.AirportInfo{Code: "HEL"}, ArrivalAirport: models.AirportInfo{Code: "LON"}, DepartureTime: "2026-07-15T08:05"},
+			{DepartureAirport: models.AirportInfo{Code: "LON"}, ArrivalAirport: models.AirportInfo{Code: "HEL"}, DepartureTime: "2026-07-22T18:40"},
+		},
+	}
+	got := tagNativeRoundTrip([]models.FlightResult{src}, googleNativeRoundTripWarning, "https://book", "2026-07-15", "2026-07-22")
+	if len(got) != 1 {
+		t.Fatalf("count: got %d, want 1", len(got))
+	}
+	f := got[0]
+	if f.Legs[0].Direction != "outbound" {
+		t.Errorf("leg 0 direction: got %q, want outbound", f.Legs[0].Direction)
+	}
+	if f.Legs[1].Direction != "inbound" {
+		t.Errorf("leg 1 (07-22) direction: got %q, want inbound", f.Legs[1].Direction)
+	}
+	// Inbound legs present -> the "return selected at booking" warning is false and must NOT appear.
+	for _, w := range f.Warnings {
+		if w == googleNativeRoundTripWarning {
+			t.Errorf("booking-time warning must be suppressed when inbound legs are present: %v", f.Warnings)
+		}
+	}
+	// Source must stay untouched.
+	if src.Legs[1].Direction != "" {
+		t.Errorf("source leg mutated: %q", src.Legs[1].Direction)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the round-trip complaint: *"we get departure data, not return."* A native round-trip request to Google Flights (and Kiwi) returns an **inconsistent** payload — some itineraries carry the full round-trip (both halves), others only the outbound leg with the return chosen at booking. `tagNativeRoundTrip` blanket-tagged **every** leg `outbound`, so the return legs that providers *do* return were mislabeled. A consumer filtering on `Direction:"inbound"` saw nothing for native fares.

## Live evidence

Real query `HEL→LON 2026-07-15 --return 2026-07-22 --no-cache`:

**Before** — 4 native fares, all legs `outbound` despite 07-22 (return-date) legs in the payload; overall **24 outbound / 16 inbound** (the 16 inbound came only from composed split-tickets):

```
price=280  2026-07-15:outbound  2026-07-22:outbound  2026-07-22:outbound   <- 07-22 is the RETURN
```

**After** — legs tagged by departure date (on/after `returnDate` = inbound); overall a correct **20 / 20**:

```
price=280  2026-07-15:outbound  2026-07-22:inbound   2026-07-22:inbound
price=290  2026-07-15:outbound  2026-07-15:outbound                       <- outbound-only payload, honestly all outbound
```

## What changed

- `tagNativeRoundTrip` now takes `departDate, returnDate` and delegates leg tagging to a new `directionTaggedLegs`, which labels a leg `inbound` when its departure date is on/after `returnDate` (ISO dates compare as strings). Both native callers (Google, Kiwi) updated.
- The *"return selected at booking"* warning is **suppressed when inbound legs are actually present** — it would be false.
- **No fabricated legs.** Only the real data the provider returned is tagged; outbound-only payloads stay all-outbound. `directionTaggedLegs` copies legs, so cached one-way responses are untouched. Same-day turns and unparseable times fall back to `outbound`.

## Tests

`TestTagNativeRoundTrip_TagsInboundByDate` (both halves → outbound/inbound, warning suppressed, source unmutated) plus the existing native/compose/Kiwi tests updated to the new signature. Full `internal/flights` suite passes with `-race`; `go vet` clean; re-verified against live Google traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
