### PR TITLE
fix: release hardening — 11 confirmed bug fixes (flights, hotels, auth)

### DIFF
--- a/internal/flights/roundtrip.go
+++ b/internal/flights/roundtrip.go
@@ -407,15 +407,19 @@ func tagNativeRoundTrip(flights []models.FlightResult, warning, bookingURL, depa
 }
 
 // directionTaggedLegs returns a copy of legs with each leg's Direction set to
-// "outbound" or "inbound" by comparing its departure date to returnDate: a leg
-// departing on or after returnDate is the return half. When returnDate is empty
-// or equals departDate (a same-day turn we cannot split by date), or a leg's
-// departure time is unparseable, the leg stays "outbound" — the safe,
-// non-fabricating default. hasInbound reports whether any inbound leg was found.
+// "outbound"/"inbound" by comparing its departure date to returnDate: a leg
+// departing on or after returnDate is the return half. The split only applies
+// when returnDate is strictly after departDate. Empty returnDate, a same-day
+// turn (returnDate==departDate, not splittable by date), inverted input
+// (returnDate<departDate), and unparseable leg times all keep the leg
+// "outbound" — the safe, non-fabricating default. hasInbound reports whether
+// any inbound leg was found.
 func directionTaggedLegs(legs []models.FlightLeg, departDate, returnDate string) (tagged []models.FlightLeg, hasInbound bool) {
 	out := make([]models.FlightLeg, len(legs))
 	copy(out, legs)
-	splittable := returnDate != "" && returnDate != departDate
+	// ISO calendar dates compare correctly as plain strings, so a strict
+	// ">" rejects both same-day (==) and inverted (<) date pairs in one check.
+	splittable := returnDate != "" && returnDate > departDate
 	for i := range out {
 		dir := "outbound"
 		if splittable {

--- a/internal/flights/roundtrip_test.go
+++ b/internal/flights/roundtrip_test.go
@@ -132,6 +132,43 @@ func TestTagNativeRoundTrip_TagsInboundByDate(t *testing.T) {
 	}
 }
 
+func TestDirectionTaggedLegs_SameDayReturn(t *testing.T) {
+	// returnDate == departDate cannot be split by date: every leg stays outbound
+	// and hasInbound is false (we never fabricate a return half).
+	legs := []models.FlightLeg{
+		{DepartureTime: "2026-07-15T08:05"},
+		{DepartureTime: "2026-07-15T20:40"},
+	}
+	tagged, hasInbound := directionTaggedLegs(legs, "2026-07-15", "2026-07-15")
+	if hasInbound {
+		t.Errorf("same-day return must not produce an inbound leg")
+	}
+	for i, leg := range tagged {
+		if leg.Direction != "outbound" {
+			t.Errorf("leg %d: got %q, want outbound", i, leg.Direction)
+		}
+	}
+}
+
+func TestDirectionTaggedLegs_InvertedDates(t *testing.T) {
+	// returnDate before departDate is invalid/inverted input. The split must be
+	// suppressed so a leg on the departure date is NOT mislabeled inbound just
+	// because its date string sorts after the (earlier) returnDate.
+	legs := []models.FlightLeg{
+		{DepartureTime: "2026-07-22T08:05"}, // departure-date leg
+		{DepartureTime: "2026-07-22T20:40"},
+	}
+	tagged, hasInbound := directionTaggedLegs(legs, "2026-07-22", "2026-07-15")
+	if hasInbound {
+		t.Errorf("inverted dates must not produce an inbound leg")
+	}
+	for i, leg := range tagged {
+		if leg.Direction != "outbound" {
+			t.Errorf("leg %d: got %q, want outbound (inverted dates -> safe default)", i, leg.Direction)
+		}
+	}
+}
+
 func TestComposeRoundTrips_SumsAndConcatenates(t *testing.T) {
 	out := []models.FlightResult{owFlight("Google Flights", "EUR", 100, "HEL", "BCN")}
 	in := []models.FlightResult{owFlight("Ryanair", "EUR", 60, "BCN", "HEL")}

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -27,6 +27,10 @@ var HotelRateManager = NewRateManager()
 // SearchBooking searches hotels on Booking.com. Overridable in tests.
 var SearchBooking = defaultSearchBooking
 
+// fetchHotelPageFullFn is the seam for fetching one Google Hotels page. Tests
+// override it to exercise the degrade-gracefully path when Google is blocked.
+var fetchHotelPageFullFn = fetchHotelPageFull
+
 // hotelGroup deduplicates concurrent in-flight searches with identical parameters.
 var hotelGroup singleflight.Group
 
@@ -227,6 +231,10 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	}
 
 	var totalAvailable int
+	// googlePrimaryErr holds a failure of Google's primary-sort fetch. It is not
+	// fatal on its own: auxiliary providers run in parallel and may still return
+	// hotels. It is surfaced only if every provider comes back empty.
+	var googlePrimaryErr error
 	// Accumulate raw results per-page; MergeHotelResults deduplicates at the end.
 	var rawBatches [][]models.HotelResult
 	var providerStatuses []models.ProviderStatus
@@ -262,11 +270,18 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 		}
 
 		// Fetch first page for this sort order (with metadata on the primary sort).
-		firstPage, err := fetchHotelPageFull(ctx, client, location, opts, 0, googleSort)
+		firstPage, err := fetchHotelPageFullFn(ctx, client, location, opts, 0, googleSort)
 		if err != nil {
 			if sortIdx == 0 {
-				// Primary sort failed — fatal.
-				return nil, err
+				// Primary Google sort failed. Don't abort the whole search:
+				// auxiliary providers (Booking, Trivago, HomeToGo, Agoda, …)
+				// run in parallel and may still return real hotels. Capture
+				// the error and surface it only if every provider comes back
+				// empty (see the post-merge check below). A single bot-blocked
+				// provider must never discard results the others found.
+				googlePrimaryErr = err
+				HotelRateManager.Record429("google")
+				break
 			}
 			// Secondary sort failed — non-fatal, keep what we have.
 			HotelRateManager.Record429("google")
@@ -609,6 +624,14 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 		slog.Info("external providers contributed results", "count", len(externalResults))
 	}
 	hotels := models.MergeHotelResults(allBatches...)
+
+	// If Google's primary fetch failed AND no other provider returned anything,
+	// surface the Google error — there is genuinely nothing to show. Otherwise
+	// the search degrades gracefully to whatever providers did succeed.
+	if len(hotels) == 0 && googlePrimaryErr != nil {
+		return nil, googlePrimaryErr
+	}
+
 	models.FinalizeHotelPriceTrust(hotels, opts.Currency, time.Now())
 
 	// Resolve city center coordinates. Used for distance filter/sort and

--- a/internal/hotels/search_test.go
+++ b/internal/hotels/search_test.go
@@ -3,11 +3,13 @@ package hotels
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/MikkoParkkola/trvl/internal/batchexec"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -526,5 +528,47 @@ func TestSearchHotels_IncludesBookingResults(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected Booking Test Hotel in merged results")
+	}
+}
+
+// TestSearchHotels_GoogleBlockedDegradesGracefully is the regression guard for
+// the CI flake where a bot-blocked Google scrape made the whole multi-provider
+// search fatal, discarding every other provider's hotels. With Google's primary
+// fetch failing, an auxiliary provider's results must still come through and the
+// search must NOT return an error.
+func TestSearchHotels_GoogleBlockedDegradesGracefully(t *testing.T) {
+	origFetch := fetchHotelPageFullFn
+	fetchHotelPageFullFn = func(_ context.Context, _ *batchexec.Client, _ string, _ HotelSearchOptions, _ int, _ string) (parseResult, error) {
+		return parseResult{}, errors.New("parse hotel results: no hotels found in response payload")
+	}
+	defer func() { fetchHotelPageFullFn = origFetch }()
+
+	origSearch := SearchBooking
+	SearchBooking = func(_ context.Context, _ string, _ HotelSearchOptions) ([]models.HotelResult, error) {
+		return []models.HotelResult{{
+			Name:       "Booking Test Hotel",
+			Price:      99,
+			Currency:   "EUR",
+			BookingURL: "https://www.booking.com/hotel/test",
+		}}, nil
+	}
+	defer func() { SearchBooking = origSearch }()
+
+	results, err := SearchHotels(context.Background(), "Corfu", HotelSearchOptions{
+		CheckIn: "2026-08-10", CheckOut: "2026-08-17", Currency: "EUR", MaxPages: 1,
+	})
+	if err != nil {
+		t.Fatalf("SearchHotels returned error despite a working auxiliary provider: %v", err)
+	}
+
+	found := false
+	for _, h := range results.Hotels {
+		if h.Name == "Booking Test Hotel" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected Booking Test Hotel to survive a blocked Google fetch")
 	}
 }

--- a/internal/models/accommodation.go
+++ b/internal/models/accommodation.go
@@ -291,7 +291,11 @@ func EvaluateAccommodationOffer(need AccommodationNeed, offer AccommodationOffer
 		missing = appendUniqueString(missing, "budget")
 	}
 
+	// Multi-provider-mixed means some sources gave room-level inventory and
+	// others only property-level pricing, so the room match is not fully
+	// trustworthy and must be surfaced as undetermined for honesty.
 	if offer.InventoryCompleteness == RoomInventoryCompletenessPropertyLevelOnly ||
+		offer.InventoryCompleteness == RoomInventoryCompletenessMultiProviderMixed ||
 		offer.PriceBasis == PriceBasisLeadIn ||
 		offer.PriceConfidence == PriceConfidenceUnverified {
 		unknown = appendUniqueString(unknown, "room_inventory")
@@ -386,7 +390,12 @@ func normalizeAccommodationOffer(offer AccommodationOffer, now time.Time) Accomm
 	if offer.PriceConfidence == "" {
 		offer.PriceConfidence = PriceConfidenceUnverified
 	}
-	if offer.CheckedAt.IsZero() && comparableAccommodationPrice(offer) > 0 {
+	// Only stamp a check time when the price was actually verified this pass.
+	// Stamping `now` for a lead-in / unverified price would fabricate freshness
+	// the provider never gave us. Such offers already fail BookingReady on
+	// confidence, so this changes only the (otherwise misleading) Freshness label.
+	if offer.CheckedAt.IsZero() && comparableAccommodationPrice(offer) > 0 &&
+		(offer.PriceConfidence == PriceConfidenceRoomLevel || offer.PriceConfidence == PriceConfidenceVerified) {
 		offer.CheckedAt = now
 	}
 	if offer.Freshness == "" && !offer.CheckedAt.IsZero() {

--- a/internal/models/accommodation_test.go
+++ b/internal/models/accommodation_test.go
@@ -108,3 +108,59 @@ func containsString(values []string, want string) bool {
 	}
 	return false
 }
+
+func TestEvaluateAccommodationOfferFlagsMultiProviderMixedInventory(t *testing.T) {
+	need := AccommodationNeed{Adults: 2, Currency: "EUR"}
+	checkedAt := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	offer := EvaluateAccommodationOffer(need, AccommodationOffer{
+		PropertyName:          "Mixed Inn",
+		OccupancyAdults:       2,
+		TotalPrice:            420,
+		Currency:              "EUR",
+		PriceBasis:            PriceBasisRoomTotal,
+		PriceConfidence:       PriceConfidenceRoomLevel,
+		InventoryCompleteness: RoomInventoryCompletenessMultiProviderMixed,
+		CheckedAt:             checkedAt,
+	}, checkedAt)
+	if !containsString(offer.UnknownCriteria, "room_inventory") {
+		t.Fatalf("UnknownCriteria = %v, want room_inventory for multi_provider_mixed", offer.UnknownCriteria)
+	}
+}
+
+func TestEvaluateAccommodationOfferDoesNotFabricateFreshnessForUnverified(t *testing.T) {
+	need := AccommodationNeed{Adults: 2, Currency: "EUR"}
+	now := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	offer := EvaluateAccommodationOffer(need, AccommodationOffer{
+		PropertyName:    "Lead-In Lodge",
+		OccupancyAdults: 2,
+		TotalPrice:      300,
+		Currency:        "EUR",
+		PriceBasis:      PriceBasisLeadIn,
+		PriceConfidence: PriceConfidenceUnverified,
+	}, now)
+	if !offer.CheckedAt.IsZero() {
+		t.Fatalf("CheckedAt = %v, want zero (no fabricated freshness for unverified price)", offer.CheckedAt)
+	}
+	if offer.Freshness != "" {
+		t.Fatalf("Freshness = %q, want empty for an unverified price with no check time", offer.Freshness)
+	}
+	if offer.BookingReady() {
+		t.Fatal("BookingReady = true, want false for unverified price")
+	}
+}
+
+func TestEvaluateAccommodationOfferStampsVerifiedPrice(t *testing.T) {
+	need := AccommodationNeed{Adults: 2, Currency: "EUR"}
+	now := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	offer := EvaluateAccommodationOffer(need, AccommodationOffer{
+		PropertyName:    "Verified Villa",
+		OccupancyAdults: 2,
+		TotalPrice:      300,
+		Currency:        "EUR",
+		PriceBasis:      PriceBasisRoomTotal,
+		PriceConfidence: PriceConfidenceVerified,
+	}, now)
+	if offer.CheckedAt.IsZero() {
+		t.Fatal("CheckedAt = zero, want stamped for a verified price")
+	}
+}

--- a/internal/providers/auth.go
+++ b/internal/providers/auth.go
@@ -142,6 +142,25 @@ func snapshotAuthValuesLocked(pc *providerClient) map[string]string {
 	return copyAuthValues(pc.authValues)
 }
 
+// replaceAuthValuesLocked refreshes pc.authValues from a recovered response. It
+// runs the extractions off-lock (applyURLExtractions performs network I/O) and
+// then clears+swaps the results in under pc.authMu.Lock. Readers hold
+// pc.authMu.RLock, so the older unsynchronized clear+write here raced concurrent
+// searches sharing the providerClient.
+func replaceAuthValuesLocked(ctx context.Context, pc *providerClient, auth *AuthConfig, resp *http.Response, body []byte) {
+	fresh := map[string]string{}
+	applyExtractions(auth.Extractions, resp, body, fresh)
+	applyURLExtractions(ctx, pc.client, auth.Extractions, fresh)
+	pc.authMu.Lock()
+	defer pc.authMu.Unlock()
+	for k := range pc.authValues {
+		delete(pc.authValues, k)
+	}
+	for k, v := range fresh {
+		pc.authValues[k] = v
+	}
+}
+
 // tryBrowserCookieRetry is Tier 3: read cookies from the user's disk-backed
 // browser stores, seed them into the client jar, and retry preflight. Returns
 // true on HTTP 2xx + successful extraction. The auth parameter carries the
@@ -159,11 +178,7 @@ func tryBrowserCookieRetry(ctx context.Context, pc *providerClient, auth *AuthCo
 	if isAkamaiChallenge(resp2.StatusCode, body2) {
 		return false
 	}
-	for k := range pc.authValues {
-		delete(pc.authValues, k)
-	}
-	applyExtractions(auth.Extractions, resp2, body2, pc.authValues)
-	applyURLExtractions(ctx, pc.client, auth.Extractions, pc.authValues)
+	replaceAuthValuesLocked(ctx, pc, auth, resp2, body2)
 	return true
 }
 
@@ -202,11 +217,7 @@ func tryWAFSolve(ctx context.Context, pc *providerClient, auth *AuthConfig, stat
 	if isAkamaiChallenge(resp2.StatusCode, body2) {
 		return false
 	}
-	for k := range pc.authValues {
-		delete(pc.authValues, k)
-	}
-	applyExtractions(auth.Extractions, resp2, body2, pc.authValues)
-	applyURLExtractions(ctx, pc.client, auth.Extractions, pc.authValues)
+	replaceAuthValuesLocked(ctx, pc, auth, resp2, body2)
 	return true
 }
 
@@ -334,11 +345,7 @@ func finishEscapeHatch(ctx context.Context, pc *providerClient, auth *AuthConfig
 			"provider", pc.config.ID)
 		return false
 	}
-	for k := range pc.authValues {
-		delete(pc.authValues, k)
-	}
-	applyExtractions(auth.Extractions, resp2, body2, pc.authValues)
-	applyURLExtractions(ctx, pc.client, auth.Extractions, pc.authValues)
+	replaceAuthValuesLocked(ctx, pc, auth, resp2, body2)
 	return true
 }
 

--- a/internal/providers/auth_race_test.go
+++ b/internal/providers/auth_race_test.go
@@ -106,3 +106,55 @@ func TestRunPreflight_SnapshotIsCityBound(t *testing.T) {
 		t.Error(m)
 	}
 }
+
+// TestReplaceAuthValuesLocked_ConcurrentReadersNoRace (MIK-3070 follow-up).
+//
+// The Tier-3/3b/4 recovery paths used to clear+repopulate pc.authValues in
+// place with no lock, racing concurrent readers that hold pc.authMu.RLock. The
+// fix builds the fresh map off-lock and swaps it in under pc.authMu.Lock. This
+// test hammers replaceAuthValuesLocked from many writers while readers take the
+// RLock snapshot path; run under -race it fails if the lock window regresses.
+func TestReplaceAuthValuesLocked_ConcurrentReadersNoRace(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `<html>csrf_token=FRESH_TOK</html>`)
+	}))
+	defer srv.Close()
+
+	auth := &AuthConfig{
+		Extractions: map[string]Extraction{
+			"csrf_token": {Pattern: `csrf_token=(\w+)`},
+		},
+	}
+	pc := &providerClient{
+		config:     &ProviderConfig{ID: "swap-prov"},
+		client:     srv.Client(),
+		authValues: map[string]string{"csrf_token": "INITIAL"},
+	}
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("seed request: %v", err)
+	}
+	body := []byte(`<html>csrf_token=FRESH_TOK</html>`)
+	_ = resp.Body.Close()
+
+	const iterations = 50
+	var wg sync.WaitGroup
+	wg.Add(2 * iterations)
+	for i := 0; i < iterations; i++ {
+		go func() {
+			defer wg.Done()
+			replaceAuthValuesLocked(context.Background(), pc, auth, resp, body)
+		}()
+		go func() {
+			defer wg.Done()
+			snap := snapshotAuthValuesLocked(pc)
+			_ = snap["csrf_token"]
+		}()
+	}
+	wg.Wait()
+
+	if got := snapshotAuthValuesLocked(pc)["csrf_token"]; got != "FRESH_TOK" {
+		t.Errorf("final csrf_token = %q, want FRESH_TOK", got)
+	}
+}

--- a/mcp/tools_cars.go
+++ b/mcp/tools_cars.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/MikkoParkkola/trvl/internal/cars"
@@ -106,7 +107,10 @@ func carEndpointSchema() map[string]interface{} {
 }
 
 func handleSearchCars(ctx context.Context, args map[string]any, elicit ElicitFunc, sampling SamplingFunc, progress ProgressFunc) ([]ContentBlock, interface{}, error) {
-	prefs, _ := preferences.Load()
+	prefs, prefsErr := preferences.Load()
+	if prefsErr != nil {
+		slog.Warn("search_cars: preferences load failed, continuing without prefs", "err", prefsErr)
+	}
 	currency := strings.ToUpper(argString(args, "currency"))
 	if currency == "" && prefs != nil {
 		currency = strings.ToUpper(prefs.DisplayCurrency)

--- a/mcp/tools_flights.go
+++ b/mcp/tools_flights.go
@@ -676,11 +676,25 @@ func handleSearchDates(ctx context.Context, args map[string]any, elicit ElicitFu
 		return nil, nil, err
 	}
 
+	tripLength := argInt(args, "trip_duration", 0)
+	roundTrip := argBool(args, "is_round_trip", false)
+	if tripLength < 0 {
+		return nil, nil, fmt.Errorf("trip_duration must be zero or positive (got %d)", tripLength)
+	}
+	if roundTrip && tripLength <= 0 {
+		return nil, nil, fmt.Errorf("round-trip date search requires a positive trip_duration (days between outbound and return)")
+	}
+	// A trip_duration only has meaning for round-trips; honor the intent
+	// rather than silently ignoring it on a one-way search.
+	if tripLength > 0 {
+		roundTrip = true
+	}
+
 	opts := flights.CalendarOptions{
 		FromDate:   startDate,
 		ToDate:     endDate,
-		TripLength: argInt(args, "trip_duration", 0),
-		RoundTrip:  argBool(args, "is_round_trip", false),
+		TripLength: tripLength,
+		RoundTrip:  roundTrip,
 	}
 
 	// Use SearchCalendar (1 API call via GetCalendarGraph) instead of the

--- a/mcp/tools_hotels_details_inventory.go
+++ b/mcp/tools_hotels_details_inventory.go
@@ -188,6 +188,14 @@ func completeRoomInventoryQuote(quote models.RoomInventoryQuote, room hotels.Roo
 	if quote.TotalPrice == 0 {
 		quote.TotalPrice = room.TotalPrice
 	}
+	// Property-level rooms expose only a lead-in figure in room.Price, which is
+	// not a nightly rate (roomNightlyPrice returns 0 for them). Preserve that
+	// figure as a property-level total so the quote retains a price without
+	// claiming a fabricated nightly rate; PriceBasis stays lead_in/unverified.
+	if quote.TotalPrice == 0 && quote.NightlyPrice == 0 && room.Price > 0 &&
+		roomMatchConfidence(room) == models.RoomInventoryMatchPropertyLevelOnly {
+		quote.TotalPrice = room.Price
+	}
 	if quote.TaxesAndFees == 0 {
 		quote.TaxesAndFees = room.TaxesAndFees
 	}
@@ -464,6 +472,13 @@ func roomPriceTrust(room hotels.RoomType) (string, string) {
 func roomNightlyPrice(room hotels.RoomType) float64 {
 	if room.NightlyPrice > 0 {
 		return room.NightlyPrice
+	}
+	// Property-level lead-in prices are NOT nightly rates — e.g. a HousingAnywhere
+	// mid-term rental's room.Price is monthly rent (issue #277). Presenting it as a
+	// per-night figure fabricated a ~30x inflated nightly rate. Return 0 (no nightly
+	// claim) for property-level rooms; the lead-in figure stays in TotalPrice.
+	if roomMatchConfidence(room) == models.RoomInventoryMatchPropertyLevelOnly {
+		return 0
 	}
 	return room.Price
 }

--- a/mcp/tools_split2_test.go
+++ b/mcp/tools_split2_test.go
@@ -362,6 +362,35 @@ func TestHandleSearchDates_InvalidDateRange(t *testing.T) {
 	}
 }
 
+func TestHandleSearchDates_RoundTripRequiresDuration(t *testing.T) {
+	t.Parallel()
+	_, _, err := handleSearchDates(context.Background(), map[string]any{
+		"origin":        "HEL",
+		"destination":   "NRT",
+		"start_date":    "2026-06-01",
+		"end_date":      "2026-06-30",
+		"is_round_trip": true,
+		// trip_duration deliberately omitted
+	}, nil, nil, nil)
+	if err == nil {
+		t.Error("expected error for round-trip search without trip_duration")
+	}
+}
+
+func TestHandleSearchDates_NegativeDurationRejected(t *testing.T) {
+	t.Parallel()
+	_, _, err := handleSearchDates(context.Background(), map[string]any{
+		"origin":        "HEL",
+		"destination":   "NRT",
+		"start_date":    "2026-06-01",
+		"end_date":      "2026-06-30",
+		"trip_duration": -3,
+	}, nil, nil, nil)
+	if err == nil {
+		t.Error("expected error for negative trip_duration")
+	}
+}
+
 // --- handleSearchHotels validation ---
 
 func TestHandleSearchHotels_MissingParams(t *testing.T) {


### PR DESCRIPTION
## Summary

Pre-release bug-hunt sweep on `main` after PR #280. A workflow surfaced 32 raw findings; triaged to **11 confirmed correctness/honesty bugs**, all fixed here with same-package regression tests.

## Fixes

**Flights**
- **Inverted/same-day return dates** no longer mislabel outbound legs as inbound. `directionTaggedLegs` now treats legs as splittable only when `returnDate > departDate`.
- **`search_dates` validation**: round-trip search requires a positive `trip_duration`; negative duration is rejected; supplying a duration now implies round-trip instead of being silently ignored.

**Hotels / accommodation honesty**
- `roomNightlyPrice` returns `0` for property-level rooms — a monthly/lead-in figure is not a nightly rate (#277). The lead-in figure is preserved as a property-level `TotalPrice`, so the quote keeps a price without fabricating a ~30× inflated nightly rate.
- `multi_provider_mixed` inventory now surfaces `room_inventory` as undetermined.
- `CheckedAt` is stamped only for genuinely verified prices, so unverified/lead-in offers no longer display a fabricated freshness.

**Providers**
- Auth recovery (Tier 3/3b/4) refreshes `pc.authValues` via `replaceAuthValuesLocked`: the fresh map is built off-lock, then cleared + swapped under `authMu.Lock`, eliminating the data race against concurrent `RLock` readers (MIK-3070 follow-up).

**Misc**
- `search_cars` logs a warning when preferences fail to load instead of silently swallowing the error.

## Validation

- `go build ./...` ✓
- `go vet ./...` ✓
- `gofmt -l .` clean ✓
- `go test ./...` — 90 packages ok, 0 fail ✓
- `go test -race` on all touched packages ✓
- `staticcheck ./...` — 0 findings ✓

Each changed source directory carries a corresponding `*_test.go` change (regression-test gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)