### PR TITLE
fix(accommodations): unblock booking-ready room lookups behind Booking WAF (#277 defect 2)

### DIFF
--- a/mcp/tools_accommodations.go
+++ b/mcp/tools_accommodations.go
@@ -53,7 +53,19 @@ type accommodationCandidate struct {
 }
 
 var (
-	accommodationRoomLookupTimeout         = 20 * time.Second
+	// accommodationRoomLookupTimeout bounds one candidate's room-level fetch
+	// during stage-2 selection. The Booking.com path is the only source of
+	// exact_room_match prices, and behind Booking's WAF it needs >=2 HTTP
+	// round-trips (initial 202 challenge + cookie re-harvest retry). The old
+	// 20s budget equalled a single batchexec request timeout, so it could
+	// never complete the WAF dance — every WAF-gated hotel degraded to
+	// property_level_only and booking_ready_count stayed 0 (issue #277
+	// defect 2). Match the reverify budget so the first pass can also reach a
+	// room-level price. Per-candidate lookups run concurrently (worker pool),
+	// so this lifts wall-clock by ~one timeout, not N, and the outer tool
+	// deadline (toolTimeout / caller ctx) still clips it when the budget is
+	// already spent on search.
+	accommodationRoomLookupTimeout         = 45 * time.Second
 	accommodationReverifyRoomLookupTimeout = 45 * time.Second
 )
 

--- a/mcp/tools_accommodations_277_test.go
+++ b/mcp/tools_accommodations_277_test.go
@@ -2,7 +2,9 @@ package mcp
 
 import (
 	"testing"
+	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -71,5 +73,85 @@ func TestSelectAccommodationCandidateHotelsMinStars(t *testing.T) {
 	// No min_stars: every candidate is kept.
 	if all := selectAccommodationCandidateHotels(hotels, 10, models.AccommodationNeed{}); len(all) != 3 {
 		t.Fatalf("no min_stars filter should keep all 3, got %d", len(all))
+	}
+}
+
+// TestDefect2RoomLevelOfferIsBookingReady covers issue #277 defect 2: when the
+// Booking.com room path yields an exact-match, room-level, tax-inclusive price,
+// the offer MUST surface as booking_ready. This is the success criterion the
+// timeout fix unblocks — if the fetch completes, the wiring already produces a
+// bookable verdict. A lead-in property-level price MUST NOT (the honesty
+// invariant: never fake booking_ready on a property-level figure).
+func TestDefect2RoomLevelOfferIsBookingReady(t *testing.T) {
+	checkedAt := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	hotel := models.HotelResult{Name: "Hotel Central", HotelID: "h1", BookingURL: "https://www.booking.com/hotel/fr/central.html"}
+	need := models.AccommodationNeed{Adults: 2, Rooms: 1, Currency: "EUR"}
+	taxIncluded := true
+
+	// Booking.com exact-match room: room-level nightly + tax-inclusive total.
+	bookingRoom := hotels.RoomType{
+		Name:              "Deluxe Double",
+		NightlyPrice:      120,
+		TotalPrice:        240,
+		TaxesFeesIncluded: &taxIncluded,
+		Currency:          "EUR",
+		Provider:          "Booking.com",
+		MatchConfidence:   models.RoomInventoryMatchExact,
+		MaxGuests:         2,
+	}
+	offers := accommodationOffersFromRooms(hotel, []hotels.RoomType{bookingRoom}, need, checkedAt)
+	if len(offers) != 1 {
+		t.Fatalf("expected 1 offer from booking room, got %d", len(offers))
+	}
+	got := offers[0]
+	if !got.BookingReadyStatus {
+		t.Fatalf("exact-match room-level offer must be booking_ready: matched=%v occ=%v conf=%q missing=%v",
+			got.CriteriaMatched, got.OccupancyMatched, got.PriceConfidence, got.MissingCriteria)
+	}
+	if got.InventoryCompleteness == models.RoomInventoryCompletenessPropertyLevelOnly {
+		t.Fatalf("room-level offer must not be property_level_only, got %q", got.InventoryCompleteness)
+	}
+
+	// Honesty invariant: a property-level lead-in price is NOT booking_ready.
+	leadInRoom := hotels.RoomType{
+		Name:            "Standard Room",
+		Price:           99,
+		Currency:        "EUR",
+		Provider:        "Google",
+		MatchConfidence: models.RoomInventoryMatchPropertyLevelOnly,
+	}
+	leadOffers := accommodationOffersFromRooms(hotel, []hotels.RoomType{leadInRoom}, need, checkedAt)
+	if len(leadOffers) != 1 {
+		t.Fatalf("expected 1 lead-in offer, got %d", len(leadOffers))
+	}
+	if leadOffers[0].BookingReadyStatus {
+		t.Fatalf("property-level lead-in must never be booking_ready: %+v", leadOffers[0])
+	}
+}
+
+// TestDefect2BookingRoomSurvivesMergeWithSearchLeadIn proves the Booking.com
+// exact-match room is not dropped when merged with a property-level search
+// lead-in for the same hotel (rooms.go merge + mergeDetailAndSearchInventoryRooms),
+// so the booking_ready offer reaches the result set.
+func TestDefect2BookingRoomSurvivesMergeWithSearchLeadIn(t *testing.T) {
+	checkedAt := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	hotel := models.HotelResult{Name: "Hotel Central", HotelID: "h1"}
+	need := models.AccommodationNeed{Adults: 2, Rooms: 1, Currency: "EUR"}
+	taxIncluded := true
+
+	searchLeadIn := hotels.RoomType{Name: "Standard Room", Price: 99, Currency: "EUR", Provider: "Google", MatchConfidence: models.RoomInventoryMatchPropertyLevelOnly}
+	bookingRoom := hotels.RoomType{Name: "Deluxe Double", NightlyPrice: 120, TotalPrice: 240, TaxesFeesIncluded: &taxIncluded, Currency: "EUR", Provider: "Booking.com", MatchConfidence: models.RoomInventoryMatchExact, MaxGuests: 2}
+
+	merged := mergeDetailAndSearchInventoryRooms([]hotels.RoomType{bookingRoom}, []hotels.RoomType{searchLeadIn})
+	offers := accommodationOffersFromRooms(hotel, merged, need, checkedAt)
+
+	bookingReady := false
+	for _, o := range offers {
+		if o.BookingReadyStatus {
+			bookingReady = true
+		}
+	}
+	if !bookingReady {
+		t.Fatalf("merged rooms must still yield a booking_ready offer, got %d offers none ready", len(offers))
 	}
 }


### PR DESCRIPTION
## What

Fixes issue #277 defect 2: `search_accommodations` returned `booking_ready_count: 0` because the stage-2 first-pass room lookup could not complete the Booking.com fetch in its 20s budget.

## Why

The first-pass per-candidate room lookup budget was 20s, which is exactly one batchexec HTTP request timeout. Behind Booking.com's WAF, a room fetch needs at least two round-trips: the initial 202 challenge, then a retry that re-harvests the browser session cookie. With only 20s, that sequence times out before it finishes, so every WAF-gated hotel degrades to `property_level_only` and no offer ever reaches a room-level price.

The evaluator was already correct and stays untouched. An exact-match, room-level, tax-inclusive price produces a `booking_ready` offer; a property-level lead-in figure never does. That honesty boundary is the point of the verdict logic, so the fix is upstream in the fetch budget, not in the verdict.

## Change

- Raise `accommodationRoomLookupTimeout` from 20s to 45s to match the reverify budget. Per-candidate lookups run on a concurrent worker pool, so wall-clock rises by about one timeout rather than N, and the outer tool deadline still clips it when search has already consumed the budget.
- Three tests lock the behaviour: a room-level Booking offer is `booking_ready`, a property-level lead-in is not, and the Booking room survives the merge with a search lead-in.

## Remaining (tracked on #277)

The default 60s `toolTimeout` can still starve the room phase when the search phase consumes most of it. Operators can already raise it with `TRVL_MCP_TOOL_TIMEOUT`, and the `reverify_only` path gets a fresh budget. Confirming the end-to-end booking-ready rate needs live Booking.com validation, noted on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
