### PR TITLE
fix(accommodations): rank Booking-backed hotels into candidate pool (#277 defect 2)

### DIFF
--- a/mcp/tools_accommodations.go
+++ b/mcp/tools_accommodations.go
@@ -330,7 +330,7 @@ func handleSearchAccommodations(ctx context.Context, args map[string]any, elicit
 						Guests:       req.Options.Guests,
 						ChildrenAges: req.Options.ChildrenAges,
 						Rooms:        req.Options.Rooms,
-						BookingURL:   hotel.BookingURL,
+						BookingURL:   accommodationRoomLookupBookingURL(hotel),
 						Location:     req.Location,
 					})
 					cancelRoomLookup()
@@ -463,7 +463,7 @@ func handleReverifyAccommodation(ctx context.Context, req hotelSearchRequest, ne
 		Guests:       req.Options.Guests,
 		ChildrenAges: req.Options.ChildrenAges,
 		Rooms:        req.Options.Rooms,
-		BookingURL:   hotel.BookingURL,
+		BookingURL:   accommodationRoomLookupBookingURL(hotel),
 		Location:     req.Location,
 	})
 	cancelRoomLookup()

--- a/mcp/tools_accommodations_277_test.go
+++ b/mcp/tools_accommodations_277_test.go
@@ -155,3 +155,66 @@ func TestDefect2BookingRoomSurvivesMergeWithSearchLeadIn(t *testing.T) {
 		t.Fatalf("merged rooms must still yield a booking_ready offer, got %d offers none ready", len(offers))
 	}
 }
+
+// TestAccommodationRoomLookupBookingURLRecoversFromSources covers issue #277
+// defect 2: selectPrimaryHotelSource overwrites HotelResult.BookingURL with the
+// cheapest source (e.g. Agoda), which fails the booking.com/ gate. When a
+// Booking.com source still exists among hotel.Sources, the room lookup must
+// recover its URL so the only exact-room-match provider can run.
+func TestAccommodationRoomLookupBookingURLRecoversFromSources(t *testing.T) {
+	agoda := "https://www.agoda.com/hotel/fr/central.html"
+	booking := "https://www.booking.com/hotel/fr/central.html"
+
+	// Primary is Agoda (cheapest source clobbered it) but a Booking source exists.
+	hotel := models.HotelResult{
+		BookingURL: agoda,
+		Sources: []models.PriceSource{
+			{Provider: "agoda", BookingURL: agoda},
+			{Provider: "booking", BookingURL: booking},
+		},
+	}
+	if got := accommodationRoomLookupBookingURL(hotel); got != booking {
+		t.Fatalf("must recover booking.com source URL for room lookup, got %q", got)
+	}
+
+	// No Booking source: leave the primary URL untouched.
+	noBooking := models.HotelResult{BookingURL: agoda, Sources: []models.PriceSource{{Provider: "agoda", BookingURL: agoda}}}
+	if got := accommodationRoomLookupBookingURL(noBooking); got != agoda {
+		t.Fatalf("must preserve primary URL when no booking.com source, got %q", got)
+	}
+
+	// Primary already booking.com: returned as-is without scanning sources.
+	primaryBooking := models.HotelResult{BookingURL: booking}
+	if got := accommodationRoomLookupBookingURL(primaryBooking); got != booking {
+		t.Fatalf("booking.com primary must be returned unchanged, got %q", got)
+	}
+}
+
+// TestSelectAccommodationCandidateHotelsRanksBookingBacked covers issue #277
+// defect 2 L3: a hotel whose Booking.com source is hidden behind a cheaper
+// primary URL must still rank into the candidate pool, otherwise the room
+// lookup never runs on it. Before the fix it scored +15 (any URL) instead of
+// +60 (booking.com URL) and lost to non-bookable properties.
+func TestSelectAccommodationCandidateHotelsRanksBookingBacked(t *testing.T) {
+	agoda := "https://www.agoda.com/hotel/fr/central.html"
+	booking := "https://www.booking.com/hotel/fr/central.html"
+
+	bookingBacked := models.HotelResult{
+		Name:       "Booking Backed",
+		BookingURL: agoda, // primary clobbered to cheapest source
+		Sources: []models.PriceSource{
+			{Provider: "agoda", BookingURL: agoda},
+			{Provider: "booking", BookingURL: booking},
+		},
+	}
+	nonBookable := models.HotelResult{Name: "No Booking Source", BookingURL: agoda}
+
+	// nonBookable listed first to prove ranking, not input order, decides.
+	got := selectAccommodationCandidateHotels([]models.HotelResult{nonBookable, bookingBacked}, 1, models.AccommodationNeed{})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(got))
+	}
+	if got[0].Name != "Booking Backed" {
+		t.Fatalf("booking-backed hotel must rank into the top candidate, got %q", got[0].Name)
+	}
+}

--- a/mcp/tools_accommodations_evidence.go
+++ b/mcp/tools_accommodations_evidence.go
@@ -435,9 +435,16 @@ func accommodationVerificationCandidateScore(hotel models.HotelResult, need mode
 	} else if strings.TrimSpace(hotel.HotelID) != "" {
 		score += 10
 	}
-	if accommodationBookingURLSupportsRoomLookup(hotel.BookingURL) {
+	// Score the URL that the room lookup will actually use, not the user-facing
+	// primary. selectPrimaryHotelSource overwrites hotel.BookingURL with the
+	// cheapest source (often Agoda/Google), which would under-score a hotel that
+	// genuinely carries a Booking.com source among hotel.Sources — the only
+	// source that yields exact room matches. Under-scoring drops it below the
+	// top-N candidate pool, so the room lookup never runs on it (defect 2, #277).
+	roomLookupURL := accommodationRoomLookupBookingURL(hotel)
+	if accommodationBookingURLSupportsRoomLookup(roomLookupURL) {
 		score += 60
-	} else if strings.TrimSpace(hotel.BookingURL) != "" {
+	} else if strings.TrimSpace(roomLookupURL) != "" {
 		score += 15
 	}
 	bestRoomScore := 0
@@ -482,6 +489,26 @@ func accommodationHotelIDSupportsRoomLookup(hotel models.HotelResult) bool {
 func accommodationBookingURLSupportsRoomLookup(rawURL string) bool {
 	value := strings.ToLower(strings.TrimSpace(rawURL))
 	return strings.Contains(value, "booking.com/")
+}
+
+// accommodationRoomLookupBookingURL returns the best Booking.com property URL
+// to drive a room-level lookup. The user-facing hotel.BookingURL is set to the
+// cheapest primary source (often Agoda/Google), which fails the booking.com/
+// gate and skips Booking.com — the only source that yields exact room matches.
+// When a Booking.com source exists among the hotel's other sources, recover its
+// URL so the room fetch can actually run. Falls back to hotel.BookingURL
+// unchanged when no Booking.com source is present, preserving behaviour for
+// non-Booking hotels (defect 2, #277).
+func accommodationRoomLookupBookingURL(hotel models.HotelResult) string {
+	if accommodationBookingURLSupportsRoomLookup(hotel.BookingURL) {
+		return hotel.BookingURL
+	}
+	for _, s := range hotel.Sources {
+		if accommodationBookingURLSupportsRoomLookup(s.BookingURL) {
+			return s.BookingURL
+		}
+	}
+	return hotel.BookingURL
 }
 
 func accommodationSearchRoomTrustScore(room models.Room) int {


### PR DESCRIPTION
## What

`search_accommodations` returned zero booking-ready offers even when a hotel had a real Booking.com listing. This fixes the candidate pipeline so a Booking-backed hotel can actually reach the room-level lookup that produces a bookable verdict.

## Root cause

`selectPrimaryHotelSource` sets `HotelResult.BookingURL` to the cheapest price source, which is usually Agoda or Google rather than Booking.com. Two places read that field to decide whether the Booking.com room path can run, and the Booking.com path is the only source that yields exact room matches:

1. The room-lookup call sites (`handleSearchAccommodations`, `handleReverifyAccommodation`) passed the cheapest-source URL, so the fetch was skipped at the `booking.com/` gate.
2. Candidate ranking (`accommodationVerificationCandidateScore`) scored that URL at +15 instead of +60, so a bookable hotel ranked below non-bookable ones and dropped out of the top-N pool. The room lookup never got a chance to run on it.

When the merge matches a Booking.com listing to a hotel, that listing is preserved as an entry in `hotel.Sources` (the lowest price becomes the primary). The fix recovers the Booking.com URL from `hotel.Sources` for both decisions, and leaves `BookingURL` untouched for non-Booking hotels.

## Changes

- New `accommodationRoomLookupBookingURL`: returns the primary `BookingURL` if it already passes the `booking.com/` gate, otherwise scans `hotel.Sources` for a Booking.com URL, otherwise returns the primary unchanged.
- Used at both room-lookup call sites and in candidate scoring.

## Tests

- `accommodationRoomLookupBookingURL`: recovers from Sources, preserves the primary when no Booking source exists, returns a Booking primary unchanged.
- `selectAccommodationCandidateHotels`: ranks a booking-backed hotel above a non-bookable one regardless of input order.
- Full `mcp`, `internal/hotels`, `internal/models` suites pass.

## Scope

This fixes the candidate-selection and room-lookup wiring deterministically. End-to-end booking-ready output still depends on Booking.com's WAF allowing the detail-page fetch, which is a separate reliability concern tracked on #277. This change is necessary for that path to work and is verified by the unit tests above.

Refs #277 (defect 2).
