### PR TITLE
fix(hotels): wire Google yY52ce price RPC into room availability lookup (#277)

### DIFF
--- a/internal/hotels/rooms.go
+++ b/internal/hotels/rooms.go
@@ -121,6 +121,22 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 		}
 	}
 
+	// Google's entity-page inline room data is dead, but the yY52ce
+	// batchexecute RPC still returns the live booking-partner price matrix for
+	// the hotel. Pull it and convert each partner price into a property-level
+	// room entry. This surfaces the full OTA matrix — including any Booking.com
+	// partner URL, which the downstream exact-room Booking.com fetch needs to
+	// produce a booking-ready offer.
+	if len(rooms) == 0 {
+		rpcRooms, rpcName := tryBatchExecutePrices(ctx, opts)
+		if len(rpcRooms) > 0 {
+			rooms = rpcRooms
+			if hotelName == "" {
+				hotelName = rpcName
+			}
+		}
+	}
+
 	// Fallback: search for the hotel on the search page by location extracted
 	// from the hotel ID's geocoded area. The search page still has inline
 	// AF_initDataCallback data.
@@ -177,6 +193,65 @@ func tryEntityPage(ctx context.Context, opts RoomSearchOptions) ([]RoomType, str
 	location := extractLocationFromPage(page)
 
 	return rooms, hotelName, location
+}
+
+// tryBatchExecutePrices fetches Google's live booking-partner price matrix via
+// the yY52ce batchexecute RPC (the entity page's inline data is dead since
+// mid-2026) and converts each partner price into a room entry. The prices are
+// property-level OTA lead-ins, classified honestly as property_level_only
+// unless the partner reports a room-total basis — so they never fake a
+// booking-ready verdict. Their value is exposing the partner URLs (notably
+// Booking.com) so the downstream exact-room fetch can run.
+func tryBatchExecutePrices(ctx context.Context, opts RoomSearchOptions) ([]RoomType, string) {
+	res, err := GetHotelPricesWithOpts(ctx, HotelPriceOpts{
+		HotelID:  opts.HotelID,
+		CheckIn:  opts.CheckIn,
+		CheckOut: opts.CheckOut,
+		Currency: opts.Currency,
+		Location: opts.Location,
+	})
+	if err != nil || res == nil || len(res.Providers) == 0 {
+		return nil, ""
+	}
+
+	rooms := make([]RoomType, 0, len(res.Providers))
+	for _, p := range res.Providers {
+		price := p.Price
+		if price <= 0 {
+			price = p.NightlyPrice
+		}
+		if price <= 0 {
+			continue
+		}
+		currency := p.Currency
+		if currency == "" {
+			currency = opts.Currency
+		}
+		rooms = append(rooms, RoomType{
+			Name:            "Standard Room",
+			Price:           price,
+			NightlyPrice:    p.NightlyPrice,
+			TotalPrice:      p.TotalPrice,
+			Currency:        currency,
+			Provider:        p.Provider,
+			ProviderURL:     p.ProviderURL,
+			MatchConfidence: roomMatchFromPriceBasis(p.PriceBasis),
+		})
+	}
+	return rooms, res.Name
+}
+
+// roomMatchFromPriceBasis maps a provider PriceBasis to a room match
+// confidence. Only an explicit room-total / tax-inclusive / room-nightly basis
+// earns an exact match; every other basis is treated as property_level_only so
+// the honesty model never promotes a property lead-in to booking-ready.
+func roomMatchFromPriceBasis(basis string) string {
+	switch basis {
+	case models.PriceBasisRoomTotal, models.PriceBasisTaxInclusiveTotal, models.PriceBasisRoomNightly:
+		return models.RoomInventoryMatchExact
+	default:
+		return models.RoomInventoryMatchPropertyLevelOnly
+	}
 }
 
 // trySearchPageFallback searches for the hotel on the Google Hotels search

--- a/internal/hotels/rooms_test.go
+++ b/internal/hotels/rooms_test.go
@@ -3,6 +3,8 @@ package hotels
 import (
 	"context"
 	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
 func TestGetRoomAvailability_ParallelBookingFetch(t *testing.T) {
@@ -104,5 +106,27 @@ func TestRoomFallbackSearchOptionsDefaultsGuests(t *testing.T) {
 	})
 	if got.Guests != 2 {
 		t.Fatalf("fallback Guests = %d, want default guests 2", got.Guests)
+	}
+}
+
+// TestRoomMatchFromPriceBasis pins the honesty mapping used when converting
+// Google's yY52ce partner-price matrix into room entries: only an explicit
+// room-level basis earns an exact match; lead-in / unset bases stay
+// property_level_only so a property lead-in is never promoted to booking-ready.
+func TestRoomMatchFromPriceBasis(t *testing.T) {
+	exact := map[string]bool{
+		models.PriceBasisRoomTotal:         true,
+		models.PriceBasisTaxInclusiveTotal: true,
+		models.PriceBasisRoomNightly:       true,
+	}
+	for basis := range exact {
+		if got := roomMatchFromPriceBasis(basis); got != models.RoomInventoryMatchExact {
+			t.Fatalf("basis %q must map to exact_room_match, got %q", basis, got)
+		}
+	}
+	for _, basis := range []string{models.PriceBasisLeadIn, "", "weird_unseen_basis"} {
+		if got := roomMatchFromPriceBasis(basis); got != models.RoomInventoryMatchPropertyLevelOnly {
+			t.Fatalf("basis %q must map to property_level_only, got %q", basis, got)
+		}
 	}
 }


### PR DESCRIPTION
## What

`GetRoomAvailability` never called the `yY52ce` batchexecute RPC that
`GetHotelPrices` already uses to fetch Google's live booking-partner price
matrix. The room path only tried the entity page (inline data deferred since
mid-2026, returns empty), a property-level search fallback, and SerpAPI — so
it discarded Google's real partner prices, including the Booking.com partner
URLs the exact-room fetch needs to produce a room-level offer.

This wires that working RPC into the room lookup.

## How

- `tryBatchExecutePrices` calls `GetHotelPricesWithOpts` and converts each
  `ProviderPrice` into a `RoomType`, inserted after the dead entity page and
  before the lead-in fallbacks.
- Price basis maps to room match confidence honestly via
  `roomMatchFromPriceBasis`: only `room_total` / `tax_inclusive_total` /
  `room_nightly` earn `exact_room_match`; `lead_in` and unset bases stay
  `property_level_only`. A property lead-in is never promoted to booking-ready.

## Evidence

- V: `go build ./...` clean; `go test ./internal/hotels/` green (full suite, 74s).
- V: `TestRoomMatchFromPriceBasis` pins the honesty mapping (lead-in stays property-level).
- I: live `prices` run confirms the RPC executes; for hotels whose ID is a
  Google place ID it returns the partner matrix, for non-Google provider IDs
  (Flatio/Airbnb/Wunderflats apartment results) it falls back to a lead-in,
  which is the expected honest behavior.

## Scope note

This wires the Google room/price data into the room path. Reaching a live
booking-ready verdict additionally depends on the candidate carrying a Google
place ID (apartment-provider results carry their own IDs) and on the
Booking.com exact-room fetch clearing its WAF gate — tracked separately on #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
