### PR TITLE
fix(accommodations): rank genuine Google place IDs above unresolvable OTA IDs

### DIFF
--- a/mcp/tools_accommodations_277_test.go
+++ b/mcp/tools_accommodations_277_test.go
@@ -218,3 +218,31 @@ func TestSelectAccommodationCandidateHotelsRanksBookingBacked(t *testing.T) {
 		t.Fatalf("booking-backed hotel must rank into the top candidate, got %q", got[0].Name)
 	}
 }
+
+// TestSelectAccommodationCandidateHotelsRanksGooglePlaceID covers the #277
+// room-data follow-up: a hotel carrying a genuine Google place ID ("/g/..." or
+// "ChIJ...") must out-rank apartment/OTA candidates whose IDs Google cannot
+// resolve, so the wired room-price RPC actually fires on a priceable property.
+func TestSelectAccommodationCandidateHotelsRanksGooglePlaceID(t *testing.T) {
+	googleHotel := models.HotelResult{Name: "Google Hotel", HotelID: "/g/11b6d4_v_4"}
+	flatioApt := models.HotelResult{Name: "Flatio Apartment", HotelID: "125151", Sources: []models.PriceSource{{Provider: "flatio"}}}
+	airbnbApt := models.HotelResult{Name: "Airbnb Loft", HotelID: "QWlyYm5iSUQ=", Sources: []models.PriceSource{{Provider: "airbnb"}}}
+
+	// Apartments listed first to prove ranking, not input order, decides.
+	got := selectAccommodationCandidateHotels([]models.HotelResult{flatioApt, airbnbApt, googleHotel}, 1, models.AccommodationNeed{})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(got))
+	}
+	if got[0].Name != "Google Hotel" {
+		t.Fatalf("Google place-ID hotel must rank into the top candidate over apartments, got %q", got[0].Name)
+	}
+
+	// A ChIJ-shaped place ID is treated identically.
+	chij := models.HotelResult{Name: "ChIJ Hotel", HotelID: "ChIJN1t_tDeuEmsRUsoyG83frY4"}
+	if !accommodationHotelIDIsGooglePlaceID(chij) {
+		t.Fatal("ChIJ-prefixed ID must be recognised as a Google place ID")
+	}
+	if accommodationHotelIDIsGooglePlaceID(flatioApt) {
+		t.Fatal("apartment numeric ID must not be recognised as a Google place ID")
+	}
+}

--- a/mcp/tools_accommodations_evidence.go
+++ b/mcp/tools_accommodations_evidence.go
@@ -435,6 +435,15 @@ func accommodationVerificationCandidateScore(hotel models.HotelResult, need mode
 	} else if strings.TrimSpace(hotel.HotelID) != "" {
 		score += 10
 	}
+	// Reward a genuine Google place ID. The Google price/detail RPCs only
+	// resolve IDs shaped "/g/..." or "ChIJ..." into an exact-room partner
+	// matrix; apartment/OTA candidates (Flatio numeric, Airbnb base64,
+	// Wunderflats hex) carry IDs Google cannot resolve. Without this bonus those
+	// out-rank resolvable Google hotels, so the now-wired room-price RPC never
+	// fires on a property it could actually price (#277 room-data follow-up).
+	if accommodationHotelIDIsGooglePlaceID(hotel) {
+		score += 50
+	}
 	// Score the URL that the room lookup will actually use, not the user-facing
 	// primary. selectPrimaryHotelSource overwrites hotel.BookingURL with the
 	// cheapest source (often Agoda/Google), which would under-score a hotel that
@@ -473,6 +482,14 @@ func accommodationVerificationCandidateScore(hotel models.HotelResult, need mode
 		score -= 15
 	}
 	return score
+}
+
+// accommodationHotelIDIsGooglePlaceID reports whether the hotel carries a
+// Google place ID ("/g/..." or "ChIJ..."), the only ID shape the Google
+// price/detail RPCs can resolve into an exact-room partner matrix.
+func accommodationHotelIDIsGooglePlaceID(hotel models.HotelResult) bool {
+	id := strings.TrimSpace(hotel.HotelID)
+	return strings.HasPrefix(id, "/g/") || strings.HasPrefix(id, "ChIJ")
 }
 
 func accommodationHotelIDSupportsRoomLookup(hotel models.HotelResult) bool {


### PR DESCRIPTION
## Problem

Google's room-price and detail RPCs only resolve a hotel ID when it is prefixed `/g/` or `ChIJ` (`internal/.../detail.go:14`, `prices.go:35`). Apartment and OTA IDs — Flatio numeric, Airbnb base64, Wunderflats hex — are unresolvable. When those out-ranked Google hotels in candidate selection, the merged room-price RPC (PR #286) never fired, and apartments displaced hotels that actually carry room pricing.

## Fix

Add an additive `+50` candidate-score bonus for hotels carrying a genuine Google place ID, via a new `accommodationHotelIDIsGooglePlaceID` check in `accommodationVerificationCandidateScore`. Additive only — the booking-backed `+60` scoring from #277/#285 is untouched, so there is no ranking regression for booking-backed results.

## Test

`TestSelectAccommodationCandidateHotelsRanksGooglePlaceID`: a Google `/g/` hotel out-ranks Flatio and Airbnb apartments that carry Sources.

Full `go test ./mcp/` suite passes; `go vet ./mcp/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
