### PR TITLE
fix(accommodations): report missing accommodation type honestly, no guessing

### DIFF
--- a/mcp/tools_hotels_details_inventory.go
+++ b/mcp/tools_hotels_details_inventory.go
@@ -418,6 +418,8 @@ func accommodationTypeFromHotelOptions(opts hotels.HotelSearchOptions) string {
 
 func accommodationTypeFromString(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "hotel", "hotel_room", "hotel room":
+		return models.AccommodationTypeHotelRoom
 	case "apartment", "entire_home", "entire home", "entire_apartment", "vacation_rental":
 		return models.AccommodationTypeEntireApartment
 	case "private", "private_room", "private room":
@@ -429,7 +431,10 @@ func accommodationTypeFromString(value string) string {
 	case "villa":
 		return models.AccommodationTypeVilla
 	default:
-		return models.AccommodationTypeHotelRoom
+		// Honest default: an unrecognized or missing type string maps to ""
+		// (not evidenced), never a guessed "hotel_room". Callers decide what an
+		// empty type means; none of them fabricate a match from it.
+		return ""
 	}
 }
 
@@ -440,7 +445,12 @@ func offerAccommodationType(hotel models.HotelResult, need models.AccommodationN
 	if need.AccommodationType != "" {
 		return need.AccommodationType
 	}
-	return models.AccommodationTypeHotelRoom
+	// No property-type evidence and the caller stated no preference: leave the
+	// type empty rather than guessing "hotel_room". An unspecified field means
+	// all types are allowed, and a missing value must read as missing.
+	// EvaluateAccommodationOffer reports "" honestly as a not-evidenced field
+	// instead of a fabricated match.
+	return ""
 }
 
 func hotelAccommodationEvidenceType(hotel models.HotelResult) string {

--- a/mcp/tools_hotels_details_inventory_type_test.go
+++ b/mcp/tools_hotels_details_inventory_type_test.go
@@ -1,0 +1,44 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestOfferAccommodationTypeNoGuessing proves the honesty rule: an unspecified
+// accommodation type with no property-type evidence resolves to "" (not
+// evidenced), never a guessed "hotel_room". Evidence and an explicit caller
+// preference still win, in that order.
+func TestOfferAccommodationTypeNoGuessing(t *testing.T) {
+	tests := []struct {
+		name  string
+		hotel models.HotelResult
+		need  models.AccommodationNeed
+		want  string
+	}{
+		{
+			name:  "evidence wins",
+			hotel: models.HotelResult{Name: "Sunset Apartments"},
+			want:  models.AccommodationTypeEntireApartment,
+		},
+		{
+			name:  "explicit preference when no evidence",
+			hotel: models.HotelResult{Name: "The Place"},
+			need:  models.AccommodationNeed{AccommodationType: models.AccommodationTypeHotelRoom},
+			want:  models.AccommodationTypeHotelRoom,
+		},
+		{
+			name:  "no evidence and no preference stays empty",
+			hotel: models.HotelResult{Name: "The Place"},
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := offerAccommodationType(tt.hotel, tt.need); got != tt.want {
+				t.Errorf("offerAccommodationType = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a search returns an offer whose accommodation type cannot be evidenced, and the caller stated no type preference, the result is now reported as not-evidenced ("") instead of a guessed "hotel_room".

## Why

An unspecified field should mean all types are allowed, and missing data should read as missing. `accommodationTypeFromString` defaulted every unrecognized or missing value to `hotel_room`, so a single value carried two meanings: the genuine hotel type and the catch-all guess. Two consequences:

1. An offer with no property-type evidence and no caller preference was labeled `hotel_room`, asserting a type the underlying data never supported.
2. The `hotelAccommodationEvidenceType` guard meant to skip un-evidenced inferences could never fire, because the converter rewrote the un-evidenced sentinel into `hotel_room` before the guard saw it.

## Change

- `accommodationTypeFromString`: add an explicit `hotel` / `hotel_room` case; default to `""` (not evidenced) rather than guessing. This separates the real hotel mapping from the fallback.
- `offerAccommodationType`: return `""` when there is neither property-type evidence nor a stated preference.

`EvaluateAccommodationOffer` already treats `""` as a not-evidenced field, so an unspecified type now reads as missing end to end. This mirrors the existing `models.normalizeAccommodationType` pattern, which already had a `hotel` case and an honest passthrough default.

## Tests

- `TestOfferAccommodationTypeNoGuessing`: evidence-wins, explicit-preference-when-no-evidence, and no-evidence-no-preference-stays-empty.
- Full `mcp`, `internal/models`, `internal/hotels` suites pass; `go vet ./...` clean.

V: go test ./mcp/ ./internal/models/ ./internal/hotels/ -> ok. I: behavior change confined to the two functions above; downstream consumer (EvaluateAccommodationOffer, internal/models/accommodation.go:197) already handled the empty case. A: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)