### PR TITLE
feat(flights): real return-leg detail on native round-trip fares

### DIFF
--- a/internal/flights/roundtrip.go
+++ b/internal/flights/roundtrip.go
@@ -104,6 +104,18 @@ func searchRoundTripComposed(ctx context.Context, client *batchexec.Client, orig
 	statuses = append(statuses, kiwiStatuses...)
 	nativeRT = append(nativeRT, kiwiRT...)
 
+	// One hop further: native fares that priced the return "at booking" carry
+	// only an outbound leg, so there is nothing for a return-leg condition filter
+	// (carrier, stops, times) to act on. Enrich them with REAL return-leg detail
+	// reused from the inbound one-ways already fetched above (no extra network),
+	// bounded to the cheapest few and reported in status so nothing is silently
+	// dropped. Native fares that already carry both legs are left untouched.
+	if len(nativeRT) > 0 {
+		var enrichStatus models.ProviderStatus
+		nativeRT, enrichStatus = enrichNativeReturnLegs(nativeRT, inFlights, roundTripNativeReturnCandidates)
+		statuses = append(statuses, enrichStatus)
+	}
+
 	if len(nativeRT) > 0 {
 		merged := make([]models.FlightResult, 0, len(nativeRT)+len(composed))
 		merged = append(merged, nativeRT...)
@@ -511,6 +523,133 @@ func nativeRoundTripCurrency(opts SearchOptions, composed, outbound []models.Fli
 		return outbound[0].Currency
 	}
 	return ""
+}
+
+// roundTripNativeReturnCandidates bounds how many native round-trip fares get
+// their return leg enriched with real inbound detail. Native fares that come
+// back outbound-only ("return selected at booking") are enriched cheapest-first
+// and only the top N; the rest keep their honest booking-time note. The cap is
+// reported in provider status so coverage is never silently dropped.
+const roundTripNativeReturnCandidates = 3
+
+// flightHasInboundLeg reports whether a result already carries a tagged return
+// leg, so enrichment skips native fares that genuinely returned both halves.
+func flightHasInboundLeg(f models.FlightResult) bool {
+	for _, leg := range f.Legs {
+		if leg.Direction == "inbound" {
+			return true
+		}
+	}
+	return false
+}
+
+// enrichNativeReturnLegs fills in real return-leg detail for native round-trip
+// fares that came back outbound-only (the "return selected at booking" case).
+// It REUSES the inbound one-way results the composer already fetched (D->O on
+// the return date) — no extra network — attaching a real inbound itinerary's
+// legs to each of the top-N cheapest such native fares so downstream per-leg
+// condition filters (carrier, stops, times, aircraft) apply to the return half
+// instead of an empty outbound-only result.
+//
+// The native round-trip TOTAL stays the headline price: it is the single
+// bookable fare and already includes the return, so the inbound one-way price
+// is NOT summed in (that would double-count). Each enriched fare gets an honest
+// warning naming the real return shown and its indicative standalone price, and
+// noting the confirmed return is chosen at booking and may differ; the
+// booking-time-only warning is dropped once a real return is shown.
+//
+// Bounded + logged: only n fares are enriched; the returned status reports how
+// many were enriched vs left capped. With no inbound one-ways fetched this is a
+// no-op and native fares keep their existing warning (the provider could not
+// price the return per-leg without a booking session; composition covers
+// per-leg detail when it found inbound options). Never mutates inbound source
+// legs (taggedLegs copies), and one-way searches never reach this path.
+func enrichNativeReturnLegs(native, inbound []models.FlightResult, n int) ([]models.FlightResult, models.ProviderStatus) {
+	status := models.ProviderStatus{
+		ID:   "native_roundtrip_return_enrich",
+		Name: "Native round-trip return enrichment",
+	}
+
+	returns := topPricedFlights(inbound, n)
+	if len(returns) == 0 {
+		status.Status = models.StatusCheckedNoHit
+		status.FixHint = "no inbound one-way option fetched; native fares keep 'return selected at booking'"
+		return native, status
+	}
+
+	// Index native fares cheapest-first so the top-N enriched are the most
+	// likely to surface; pair each enriched fare with a distinct real return
+	// where available (clamped to the cheapest when fewer returns than fares).
+	order := make([]int, 0, len(native))
+	for i := range native {
+		order = append(order, i)
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		return compareFlightPrices(native[order[a]].PriceForRanking(), native[order[b]].PriceForRanking()) < 0
+	})
+
+	out := make([]models.FlightResult, len(native))
+	copy(out, native)
+
+	enriched, eligible := 0, 0
+	for _, idx := range order {
+		f := out[idx]
+		if f.FareType != models.FareRoundTrip || flightHasInboundLeg(f) {
+			continue // already two-legged, or not a native single fare
+		}
+		eligible++
+		if enriched >= n {
+			continue // capped — reported below, never silently dropped
+		}
+		out[idx] = attachReturnLeg(f, returns[min(enriched, len(returns)-1)])
+		enriched++
+	}
+
+	status.Status = okOrNoHit(enriched)
+	status.Results = enriched
+	switch {
+	case eligible == 0:
+		status.FixHint = "no outbound-only native fare to enrich (all carried both legs)"
+	case eligible > enriched:
+		status.FixHint = fmt.Sprintf("enriched cheapest %d of %d outbound-only native fares with real return-leg detail; the rest keep 'return selected at booking' (search one-way D->O for the full return list)", enriched, eligible)
+	default:
+		status.FixHint = fmt.Sprintf("enriched all %d outbound-only native fares with real return-leg detail", enriched)
+	}
+	return out, status
+}
+
+// attachReturnLeg returns a copy of an outbound-only native round-trip fare with
+// the real inbound itinerary's legs appended (tagged "inbound"), the now-false
+// booking-time warning removed, and an honest warning recording the indicative
+// return shown. The native TOTAL price is unchanged. Inbound source legs are
+// copied (taggedLegs), never mutated.
+func attachReturnLeg(f, ret models.FlightResult) models.FlightResult {
+	legs := make([]models.FlightLeg, 0, len(f.Legs)+len(ret.Legs))
+	legs = append(legs, f.Legs...)
+	legs = append(legs, taggedLegs(ret.Legs, "inbound")...)
+	f.Legs = legs
+
+	provider := ret.Provider
+	if provider == "" {
+		provider = "unspecified carrier"
+	}
+	price := ""
+	if ret.Price > 0 && ret.Currency != "" {
+		price = fmt.Sprintf(", ~%.0f %s one-way", ret.Price, ret.Currency)
+	}
+	warn := fmt.Sprintf("return leg shown is a real return option via %s%s; the native fare's confirmed return is selected at booking and may differ", provider, price)
+
+	warnings := make([]string, 0, len(f.Warnings)+1)
+	warnings = append(warnings, warn)
+	for _, w := range f.Warnings {
+		// A real return is now shown, so the booking-time-only note is misleading.
+		if w == googleNativeRoundTripWarning || w == kiwiNativeRoundTripWarning {
+			continue
+		}
+		warnings = append(warnings, w)
+	}
+	f.Warnings = warnings
+	return f
 }
 
 // topPricedFlights returns up to n cheapest flights that carry a usable price

--- a/internal/flights/roundtrip_enrich_test.go
+++ b/internal/flights/roundtrip_enrich_test.go
@@ -1,0 +1,225 @@
+package flights
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// nativeRTFare builds an outbound-only native round-trip fare, mirroring what
+// tagNativeRoundTrip produces when a provider prices the return "at booking":
+// FareRoundTrip, a single outbound-tagged leg, and the booking-time warning.
+func nativeRTFare(price float64, warning string) models.FlightResult {
+	return models.FlightResult{
+		Price: price, Currency: "EUR", Provider: "Google Flights",
+		FareType: models.FareRoundTrip,
+		Legs: []models.FlightLeg{{
+			DepartureAirport: models.AirportInfo{Code: "HEL"},
+			ArrivalAirport:   models.AirportInfo{Code: "BCN"},
+			DepartureTime:    "2026-07-15T08:00",
+			ArrivalTime:      "2026-07-15T11:00",
+			Direction:        "outbound",
+		}},
+		Warnings: []string{warning},
+	}
+}
+
+// inboundOneWay builds a fully-detailed inbound (D->O) one-way result, the kind
+// the composer already fetches and the enricher reuses.
+func inboundOneWay(price float64, airline, departTime string) models.FlightResult {
+	return models.FlightResult{
+		Price: price, Currency: "EUR", Provider: airline,
+		Legs: []models.FlightLeg{{
+			DepartureAirport: models.AirportInfo{Code: "BCN"},
+			ArrivalAirport:   models.AirportInfo{Code: "HEL"},
+			DepartureTime:    departTime,
+			ArrivalTime:      departTime,
+			Airline:          airline,
+			AirlineCode:      "RR",
+			FlightNumber:     "RR123",
+		}},
+	}
+}
+
+func TestEnrichNativeReturnLegs_AttachesRealReturnLeg(t *testing.T) {
+	native := []models.FlightResult{nativeRTFare(280, googleNativeRoundTripWarning)}
+	inbound := []models.FlightResult{inboundOneWay(60, "Ryanair", "2026-07-22T18:40")}
+
+	out, status := enrichNativeReturnLegs(native, inbound, roundTripNativeReturnCandidates)
+
+	if len(out) != 1 {
+		t.Fatalf("result count: got %d, want 1", len(out))
+	}
+	f := out[0]
+	// Real return leg attached and tagged inbound, outbound preserved.
+	if len(f.Legs) != 2 {
+		t.Fatalf("legs: got %d, want 2 (outbound + enriched inbound)", len(f.Legs))
+	}
+	if f.Legs[0].Direction != "outbound" {
+		t.Errorf("leg 0 direction: got %q, want outbound", f.Legs[0].Direction)
+	}
+	if f.Legs[1].Direction != "inbound" {
+		t.Errorf("leg 1 direction: got %q, want inbound", f.Legs[1].Direction)
+	}
+	// Native TOTAL is unchanged — the inbound one-way price is NOT summed in.
+	if f.Price != 280 {
+		t.Errorf("price: got %v, want 280 (native total unchanged)", f.Price)
+	}
+	if f.FareType != models.FareRoundTrip {
+		t.Errorf("fare type: got %q, want round_trip", f.FareType)
+	}
+	// Booking-time-only warning dropped; honest enrichment warning present.
+	for _, w := range f.Warnings {
+		if w == googleNativeRoundTripWarning {
+			t.Errorf("booking-time warning must be dropped once a real return is shown: %v", f.Warnings)
+		}
+	}
+	if len(f.Warnings) == 0 || !strings.Contains(f.Warnings[0], "selected at booking and may differ") {
+		t.Errorf("expected honest enrichment warning, got %v", f.Warnings)
+	}
+	if !strings.Contains(f.Warnings[0], "Ryanair") || !strings.Contains(f.Warnings[0], "60 EUR") {
+		t.Errorf("warning should record the indicative return provider+price, got %q", f.Warnings[0])
+	}
+	if status.Status != models.StatusOK || status.Results != 1 {
+		t.Errorf("status: got %q results=%d, want ok results=1", status.Status, status.Results)
+	}
+}
+
+func TestEnrichNativeReturnLegs_InboundLegFilterable(t *testing.T) {
+	// The whole point: a per-leg return-condition filter must have real detail to
+	// act on. Assert the attached inbound leg carries carrier + departure time.
+	native := []models.FlightResult{nativeRTFare(280, googleNativeRoundTripWarning)}
+	inbound := []models.FlightResult{inboundOneWay(60, "Ryanair", "2026-07-22T18:40")}
+
+	out, _ := enrichNativeReturnLegs(native, inbound, roundTripNativeReturnCandidates)
+	ret := out[0].Legs[1]
+	if ret.Airline != "Ryanair" {
+		t.Errorf("inbound carrier: got %q, want Ryanair (filterable)", ret.Airline)
+	}
+	if ret.DepartureTime != "2026-07-22T18:40" {
+		t.Errorf("inbound depart time: got %q, want 2026-07-22T18:40 (filterable)", ret.DepartureTime)
+	}
+	if ret.DepartureAirport.Code != "BCN" || ret.ArrivalAirport.Code != "HEL" {
+		t.Errorf("inbound route: got %s->%s, want BCN->HEL", ret.DepartureAirport.Code, ret.ArrivalAirport.Code)
+	}
+}
+
+func TestEnrichNativeReturnLegs_TopNCapEnforcedAndReported(t *testing.T) {
+	// 5 outbound-only native fares, only roundTripNativeReturnCandidates (3) may
+	// be enriched. The cap must be enforced AND reported, never silent.
+	native := []models.FlightResult{
+		nativeRTFare(200, googleNativeRoundTripWarning),
+		nativeRTFare(210, googleNativeRoundTripWarning),
+		nativeRTFare(220, googleNativeRoundTripWarning),
+		nativeRTFare(230, googleNativeRoundTripWarning),
+		nativeRTFare(240, googleNativeRoundTripWarning),
+	}
+	inbound := []models.FlightResult{
+		inboundOneWay(50, "A", "2026-07-22T06:00"),
+		inboundOneWay(60, "B", "2026-07-22T12:00"),
+		inboundOneWay(70, "C", "2026-07-22T18:00"),
+	}
+
+	out, status := enrichNativeReturnLegs(native, inbound, roundTripNativeReturnCandidates)
+
+	enriched := 0
+	for _, f := range out {
+		if flightHasInboundLeg(f) {
+			enriched++
+		}
+	}
+	if enriched != roundTripNativeReturnCandidates {
+		t.Errorf("enriched count: got %d, want %d (cap)", enriched, roundTripNativeReturnCandidates)
+	}
+	if status.Results != roundTripNativeReturnCandidates {
+		t.Errorf("status.Results: got %d, want %d", status.Results, roundTripNativeReturnCandidates)
+	}
+	// Honest cap reporting: names enriched vs total eligible.
+	if !strings.Contains(status.FixHint, "enriched cheapest 3 of 5") {
+		t.Errorf("cap must be reported in status, got %q", status.FixHint)
+	}
+	// The two cheapest-first enriched fares should pair with distinct returns.
+	var firstReturns []string
+	var warnings []string
+	for _, f := range out {
+		if flightHasInboundLeg(f) {
+			firstReturns = append(firstReturns, f.Legs[1].Airline)
+			warnings = append(warnings, f.Warnings[0])
+		}
+	}
+	if firstReturns[0] == firstReturns[1] {
+		t.Errorf("expected distinct return legs across enriched fares, got %v", firstReturns)
+	}
+	// The warning is built dynamically from each attached return's real carrier +
+	// price, so distinct returns MUST yield distinct warning strings (guards
+	// against regressing to a hardcoded literal).
+	if warnings[0] == warnings[1] {
+		t.Errorf("warnings must differ per real return, got identical: %q", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "A") || !strings.Contains(warnings[0], "50 EUR") {
+		t.Errorf("warning[0] should reflect its real return (A, 50 EUR), got %q", warnings[0])
+	}
+	if !strings.Contains(warnings[1], "B") || !strings.Contains(warnings[1], "60 EUR") {
+		t.Errorf("warning[1] should reflect its real return (B, 60 EUR), got %q", warnings[1])
+	}
+}
+
+func TestEnrichNativeReturnLegs_NoInboundIsNoOp(t *testing.T) {
+	// A provider that genuinely cannot price the return per-leg leaves no inbound
+	// one-way to reuse: the native fare must be returned unchanged (honest), with
+	// a no-hit status — never a fabricated return.
+	native := []models.FlightResult{nativeRTFare(280, googleNativeRoundTripWarning)}
+
+	out, status := enrichNativeReturnLegs(native, nil, roundTripNativeReturnCandidates)
+
+	if len(out[0].Legs) != 1 {
+		t.Errorf("legs: got %d, want 1 (unchanged, no fabricated return)", len(out[0].Legs))
+	}
+	if out[0].Warnings[0] != googleNativeRoundTripWarning {
+		t.Errorf("original booking-time warning must be preserved when no return found: %v", out[0].Warnings)
+	}
+	if status.Status != models.StatusCheckedNoHit {
+		t.Errorf("status: got %q, want checked_no_hit", status.Status)
+	}
+}
+
+func TestEnrichNativeReturnLegs_LeavesTwoLeggedAndOneWayUntouched(t *testing.T) {
+	// A native fare that already carries both halves, and a one-way (no FareType)
+	// result, must both be left untouched — only outbound-only native fares are
+	// enriched.
+	twoLegged := nativeRTFare(300, googleNativeRoundTripWarning)
+	twoLegged.Legs = append(twoLegged.Legs, models.FlightLeg{
+		DepartureAirport: models.AirportInfo{Code: "BCN"},
+		ArrivalAirport:   models.AirportInfo{Code: "HEL"},
+		DepartureTime:    "2026-07-22T18:40",
+		Direction:        "inbound",
+	})
+	oneWay := owFlight("Wizz", "EUR", 90, "HEL", "BCN") // FareType empty
+
+	native := []models.FlightResult{twoLegged, oneWay}
+	inbound := []models.FlightResult{inboundOneWay(60, "Ryanair", "2026-07-22T18:40")}
+
+	out, status := enrichNativeReturnLegs(native, inbound, roundTripNativeReturnCandidates)
+
+	if len(out[0].Legs) != 2 {
+		t.Errorf("already-two-legged fare must be untouched: legs=%d", len(out[0].Legs))
+	}
+	if len(out[1].Legs) != 1 {
+		t.Errorf("one-way result must be untouched: legs=%d", len(out[1].Legs))
+	}
+	if status.Results != 0 {
+		t.Errorf("nothing eligible to enrich: status.Results=%d, want 0", status.Results)
+	}
+}
+
+func TestEnrichNativeReturnLegs_DoesNotMutateInboundSource(t *testing.T) {
+	native := []models.FlightResult{nativeRTFare(280, googleNativeRoundTripWarning)}
+	inbound := []models.FlightResult{inboundOneWay(60, "Ryanair", "2026-07-22T18:40")}
+
+	_, _ = enrichNativeReturnLegs(native, inbound, roundTripNativeReturnCandidates)
+
+	if inbound[0].Legs[0].Direction != "" {
+		t.Errorf("inbound source leg mutated: Direction=%q, want empty", inbound[0].Legs[0].Direction)
+	}
+}


### PR DESCRIPTION
## Problem

Native round-trip fares (Google Flights, Kiwi, Skiplagged) quote the whole trip as a single total on the outbound leg, with the return chosen at booking (`roundtrip.go:308-324`). The inbound half came back with no price and no detail. A traveller who wants a non-default return date, or who has conditions on the return leg (carrier, number of stops, departure time, aircraft), had nothing to filter or price against.

## What this does

`enrichNativeReturnLegs` reuses the inbound D→O one-ways the composer already fetched, so there is no extra network call. It attaches a real inbound itinerary's legs to the cheapest outbound-only native fares, tagged `inbound`, so downstream per-leg filters can act on the return half.

Design choices:

- The native round-trip total stays the headline price. The inbound one-way price is not added on top, because the native fare already covers the return.
- Bounded to the cheapest 3 fares. The cap is reported in provider status so coverage is never silently dropped.
- The warning on each enriched fare is built from the actual attached return (real carrier, real indicative price). It states that the confirmed return is selected at booking and may differ.
- When no inbound one-way was fetched, enrichment does nothing and the fare keeps its honest booking-time note. No return is fabricated.
- One-way searches never reach this path. Native fares that already carry both legs are left alone.

## Tests

`internal/flights/roundtrip_enrich_test.go`, table-driven:

- `AttachesRealReturnLeg`
- `InboundLegFilterable`
- `TopNCapEnforcedAndReported`
- `NoInboundIsNoOp`
- `LeavesTwoLeggedAndOneWayUntouched`
- `DoesNotMutateInboundSource`

`go build ./...`, `go vet ./internal/flights/`, and `go test ./internal/flights/` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
