### PR TITLE
chore(gitnexus): share code-intelligence index via CI cache + local hook

### DIFF
--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -1,0 +1,56 @@
+name: gitnexus-index
+
+# Build and share the GitNexus code-intelligence index across agents/CI.
+#
+# Why this exists: branch protection on main has enforce_admins=true, so NOTHING
+# can push directly to main — the index counts in AGENTS.md/CLAUDE.md therefore
+# cannot be auto-committed on a cadence (and a 222MB binary index has no business
+# in git history anyway). Instead we share the real payload through the Actions
+# cache, keyed by commit SHA. Any downstream job restores the exact index for a
+# given commit with the same key; the warm-start restore-keys fallback makes the
+# analyze step incremental (GitNexus diffs file hashes in meta.json).
+#
+# Local machines stay fresh via scripts/gitnexus/install-hooks.sh (post-merge),
+# which reads meta.json:lastCommit — the authoritative staleness signal — and
+# re-analyzes only when it differs from HEAD.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gitnexus-index
+  cancel-in-progress: true
+
+jobs:
+  index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Restore/seed index cache
+        uses: actions/cache@v4
+        with:
+          path: .gitnexus
+          key: gitnexus-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            gitnexus-${{ runner.os }}-
+
+      - name: Analyze (incremental)
+        run: npx --yes gitnexus analyze
+
+      - name: Publish index metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitnexus-meta
+          path: .gitnexus/meta.json
+          retention-days: 14
+          if-no-files-found: error

--- a/scripts/gitnexus/README.md
+++ b/scripts/gitnexus/README.md
@@ -1,0 +1,61 @@
+# GitNexus index sharing
+
+GitNexus indexes this repo into `.gitnexus/` (~222 MB: a binary symbol graph plus
+`meta.json`). That directory is **gitignored** and never committed — it is fully
+derived from source, and a binary that changes on every commit does not belong in
+git history.
+
+## What is shared, and how
+
+| Thing | Where it lives | Why |
+| --- | --- | --- |
+| The index payload (`.gitnexus/`) | **Actions cache**, keyed by commit SHA (`gitnexus-index.yml`) | Lets any CI job restore the exact index for a commit without re-analyzing. Never in git history (would bloat the repo ~150 MB per commit). |
+| Staleness signal (`lastCommit`) | `.gitnexus/meta.json` on disk | The authoritative "is the index current?" check: compare `meta.json:lastCommit` to `git HEAD`. |
+| Symbol counts | the `<!-- gitnexus:start -->` block in `AGENTS.md` / `CLAUDE.md` | Cosmetic only. Not a staleness signal and not auto-committed (branch protection `enforce_admins=true` blocks direct pushes to main). |
+
+## Why not just commit the counts on a cadence
+
+Three reasons, in order of severity:
+
+1. **`main` is protected with `enforce_admins=true`** — no actor can push the
+   refreshed counts directly; they would each need a PR passing the required
+   checks. Auto-committing on a timer is simply not possible without weakening
+   that protection.
+2. **A count is not actionable** — another agent cannot navigate code with
+   "62826 relationships". It needs the index (shared via cache) or the ability to
+   rebuild it from source.
+3. **It manufactures merge conflicts** — if every feature branch re-indexed and
+   committed the count, every PR would collide on `AGENTS.md` + `CLAUDE.md`.
+
+## Local setup (keep your machine's index fresh)
+
+```sh
+scripts/gitnexus/install-hooks.sh    # one-time: install the post-merge hook
+```
+
+After that, every `git pull`/merge triggers a **background, lazy** refresh:
+`scripts/gitnexus/refresh.sh` re-analyzes only when `meta.json:lastCommit` differs
+from HEAD, and discards the cosmetic count churn so your tree stays clean.
+
+Manual controls:
+
+```sh
+scripts/gitnexus/check-staleness.sh  # exit 0 = fresh, 1 = stale
+scripts/gitnexus/refresh.sh          # refresh if stale (tree stays clean)
+scripts/gitnexus/refresh.sh --force  # refresh regardless
+scripts/gitnexus/refresh.sh --commit # refresh AND keep the count edits (for a deliberate PR)
+```
+
+## Consuming the cached index in another CI job
+
+Restore with the same key prefix; the SHA-exact entry hits first, the prefix
+fallback warm-starts from the latest index:
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: .gitnexus
+    key: gitnexus-${{ runner.os }}-${{ github.sha }}
+    restore-keys: |
+      gitnexus-${{ runner.os }}-
+```

--- a/scripts/gitnexus/check-staleness.sh
+++ b/scripts/gitnexus/check-staleness.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Exit 0 if the local GitNexus index matches HEAD, 1 if stale/missing.
+# Staleness is decided by .gitnexus/meta.json:lastCommit vs git HEAD —
+# NOT by the symbol counts in AGENTS.md/CLAUDE.md (those are cosmetic).
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+meta=".gitnexus/meta.json"
+if [ ! -f "$meta" ]; then
+  echo "gitnexus: stale (no index on disk)"
+  exit 1
+fi
+
+indexed="$(jq -r '.lastCommit // ""' "$meta" 2>/dev/null || echo "")"
+head="$(git rev-parse HEAD)"
+
+if [ "$indexed" = "$head" ]; then
+  echo "gitnexus: fresh (index at ${head:0:12})"
+  exit 0
+fi
+echo "gitnexus: stale (index at ${indexed:-none}, HEAD at ${head:0:12})"
+exit 1

--- a/scripts/gitnexus/install-hooks.sh
+++ b/scripts/gitnexus/install-hooks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Install a git post-merge hook that lazily refreshes the GitNexus index in the
+# background after every pull/merge (the "main advanced" event). The hook is a
+# no-op when the index is already fresh, and never blocks git because it
+# backgrounds the work. Existing non-gitnexus hooks are backed up, not clobbered.
+set -euo pipefail
+root="$(git rev-parse --show-toplevel)"
+hook="$root/.git/hooks/post-merge"
+
+if [ -f "$hook" ] && ! grep -q gitnexus "$hook"; then
+  cp "$hook" "$hook.pre-gitnexus.bak"
+  echo "backed up existing post-merge hook -> post-merge.pre-gitnexus.bak"
+fi
+
+cat > "$hook" <<'EOF'
+#!/usr/bin/env bash
+# gitnexus: lazily refresh the code-intelligence index after a merge/pull.
+root="$(git rev-parse --show-toplevel)"
+nohup "$root/scripts/gitnexus/refresh.sh" >/tmp/gitnexus-refresh.log 2>&1 &
+EOF
+chmod +x "$hook"
+echo "installed gitnexus post-merge hook (background, lazy refresh)"

--- a/scripts/gitnexus/refresh.sh
+++ b/scripts/gitnexus/refresh.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Refresh the local GitNexus index if (and only if) it is stale.
+#
+# The 222MB index lives in .gitnexus/ (gitignored) and is fully derived from
+# source — it is never committed. This script regenerates it from the current
+# checkout. By default it discards the cosmetic symbol-count churn GitNexus
+# writes into AGENTS.md / CLAUDE.md so `git status` stays clean; pass --commit
+# to keep those edits (e.g. when you deliberately want to refresh the counts
+# inside a PR).
+#
+#   refresh.sh           # re-analyze only if stale, keep tree clean
+#   refresh.sh --force   # re-analyze regardless of staleness
+#   refresh.sh --commit  # re-analyze and KEEP the AGENTS.md/CLAUDE.md count edits
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+force=0; keep_counts=0
+for a in "$@"; do
+  case "$a" in
+    --force)  force=1 ;;
+    --commit) keep_counts=1 ;;
+  esac
+done
+
+if [ "$force" -eq 0 ] && scripts/gitnexus/check-staleness.sh >/dev/null 2>&1; then
+  echo "gitnexus: index already fresh; nothing to do"
+  exit 0
+fi
+
+echo "gitnexus: re-analyzing (npx gitnexus analyze)..."
+npx --yes gitnexus analyze
+
+if [ "$keep_counts" -eq 0 ]; then
+  # Index (.gitnexus/, gitignored) is updated in place; drop the cosmetic
+  # count edits so the working tree is not left dirty after a hook-triggered run.
+  git checkout -- AGENTS.md CLAUDE.md 2>/dev/null || true
+fi
+
+echo "gitnexus: index refreshed to $(git rev-parse --short HEAD)"


### PR DESCRIPTION
## What

Shares the GitNexus code-intelligence index across agents and CI without committing it, and keeps each working copy fresh after a pull.

## Why this shape

The index in \`.gitnexus/\` is ~222MB and is regenerated from source on every change. Two facts drive the design:

- \`main\` is protected with \`enforce_admins=true\`, so no actor can push refreshed index state directly. Auto-committing the symbol counts on a cadence is not possible without weakening that protection.
- A binary index that changes every commit does not belong in git history; it would add roughly 150MB per commit and never stop growing.

So the real index payload is shared through the Actions cache keyed by commit SHA, and the authoritative staleness signal is \`meta.json:lastCommit\` rather than the cosmetic counts in \`AGENTS.md\`/\`CLAUDE.md\`.

## Changes

- \`.github/workflows/gitnexus-index.yml\` — on push to main, analyze incrementally and cache \`.gitnexus/\` keyed by SHA, with a prefix fallback for warm-start; publish \`meta.json\` as an artifact.
- \`scripts/gitnexus/check-staleness.sh\` — compare \`meta.json:lastCommit\` to HEAD.
- \`scripts/gitnexus/refresh.sh\` — re-analyze only when stale; keep the tree clean by default, \`--commit\` to retain the count edits for a deliberate refresh.
- \`scripts/gitnexus/install-hooks.sh\` — install a background, lazy post-merge hook (backs up any existing hook).
- \`scripts/gitnexus/README.md\` — rationale and instructions for consuming the cached index in other jobs.

## Verification

- All three scripts pass \`bash -n\`.
- \`check-staleness.sh\` correctly reports fresh against the live on-disk index (\`meta.lastCommit == HEAD\`).
- Workflow YAML parses.
- \`.gitnexus/\` remains gitignored; no index bytes are added to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)