### PR TITLE
Add keyless Open-Meteo Marine sea-state enrichment for ferry legs

### DIFF
--- a/internal/models/ground.go
+++ b/internal/models/ground.go
@@ -45,6 +45,23 @@ type GroundRoute struct {
 	// (innovation #3). Nil when not scored; an unrated Confidence means trvl
 	// lacked the signal to judge — it is never a fabricated number.
 	Confidence *Confidence `json:"confidence,omitempty"`
+	// SeaState is an optional, free Open-Meteo Marine sea-state enrichment for
+	// ferry legs (wave height + a coarse calm/moderate/rough label). Nil unless
+	// the route is a ferry and the lookup succeeded — it is never blocking and
+	// never fabricated.
+	SeaState *SeaState `json:"sea_state,omitempty"`
+}
+
+// SeaState is a coarse sea-state forecast for a ferry leg, sourced from the
+// keyless Open-Meteo Marine API. It is a "nice to have" enrichment: absent when
+// coordinates are unavailable or the lookup fails.
+type SeaState struct {
+	// WaveHeight is the maximum significant wave height in metres.
+	WaveHeight float64 `json:"wave_height_m"`
+	// SwellHeight is the maximum swell wave height in metres (0 if unavailable).
+	SwellHeight float64 `json:"swell_height_m,omitempty"`
+	// Label is a coarse human-readable state: "calm", "moderate", or "rough".
+	Label string `json:"label"`
 }
 
 // GroundStop represents a departure or arrival point.

--- a/internal/weather/marine.go
+++ b/internal/weather/marine.go
@@ -1,0 +1,132 @@
+package weather
+
+// Sea-state enrichment via the keyless Open-Meteo Marine API.
+//
+// https://marine-api.open-meteo.com/v1/marine — no API key required. Used to
+// add a coarse calm/moderate/rough label to ferry legs. This is a "nice to
+// have" enrichment: on any error or timeout it degrades silently (zero value +
+// nil-ish), so callers never block the core ground result.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// marineAPIURL is the Open-Meteo Marine endpoint. It is a var (not a const) so
+// tests can point GetSeaState at a local httptest server.
+var marineAPIURL = "https://marine-api.open-meteo.com/v1/marine"
+
+// marineClient has a short 5s timeout — sea state is a best-effort enrichment
+// and must never slow down the core ground result.
+var marineClient = &http.Client{Timeout: 5 * time.Second}
+
+// marineResponse is the raw daily payload from the Open-Meteo Marine API.
+type marineResponse struct {
+	Daily struct {
+		Time           []string  `json:"time"`
+		WaveHeightMax  []float64 `json:"wave_height_max"`
+		SwellHeightMax []float64 `json:"swell_wave_height_max"`
+	} `json:"daily"`
+}
+
+// GetSeaState fetches the maximum daily wave (and swell) height at a coordinate
+// from the keyless Open-Meteo Marine API and returns a coarse sea-state label.
+//
+// It is silent-failure by contract: on any error, timeout, non-200 response, or
+// empty payload it returns a zero-value models.SeaState and a non-nil error so
+// callers can simply ignore the result and leave the ferry leg unchanged. A nil
+// error is only returned when a real wave-height reading was parsed.
+func GetSeaState(ctx context.Context, lat, lon float64) (models.SeaState, error) {
+	params := url.Values{
+		"latitude":      {strconv.FormatFloat(lat, 'f', 4, 64)},
+		"longitude":     {strconv.FormatFloat(lon, 'f', 4, 64)},
+		"daily":         {"wave_height_max,swell_wave_height_max"},
+		"timezone":      {"auto"},
+		"forecast_days": {"1"},
+	}
+	apiURL := marineAPIURL + "?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return models.SeaState{}, fmt.Errorf("marine: build request: %w", err)
+	}
+	req.Header.Set("User-Agent", "trvl/1.0 (travel agent; github.com/MikkoParkkola/trvl)")
+
+	resp, err := marineClient.Do(req)
+	if err != nil {
+		return models.SeaState{}, fmt.Errorf("marine: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return models.SeaState{}, fmt.Errorf("marine: HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return models.SeaState{}, fmt.Errorf("marine: read response: %w", err)
+	}
+
+	return parseSeaState(body)
+}
+
+// SeaStateForCity resolves a port/city name to coordinates (via the same
+// Nominatim path used for weather) and returns its sea state. Silent-failure:
+// a geocode or fetch failure yields a zero value and a non-nil error.
+func SeaStateForCity(ctx context.Context, city string) (models.SeaState, error) {
+	coord, err := geocodeCity(ctx, city)
+	if err != nil {
+		return models.SeaState{}, fmt.Errorf("marine geocode: %w", err)
+	}
+	return GetSeaState(ctx, coord.lat, coord.lon)
+}
+
+// parseSeaState decodes a Marine API body into a SeaState. It is pure (no
+// network) so it is exercised directly by offline fixture tests.
+func parseSeaState(body []byte) (models.SeaState, error) {
+	var raw marineResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return models.SeaState{}, fmt.Errorf("marine: decode response: %w", err)
+	}
+	if len(raw.Daily.WaveHeightMax) == 0 {
+		return models.SeaState{}, fmt.Errorf("marine: no wave-height data")
+	}
+
+	wave := raw.Daily.WaveHeightMax[0]
+	if wave < 0 {
+		return models.SeaState{}, fmt.Errorf("marine: invalid wave height %.2f", wave)
+	}
+
+	var swell float64
+	if len(raw.Daily.SwellHeightMax) > 0 && raw.Daily.SwellHeightMax[0] > 0 {
+		swell = raw.Daily.SwellHeightMax[0]
+	}
+
+	return models.SeaState{
+		WaveHeight:  wave,
+		SwellHeight: swell,
+		Label:       seaStateLabel(wave),
+	}, nil
+}
+
+// seaStateLabel maps a maximum wave height (metres) to a coarse, honest label.
+// Thresholds follow the WMO/Douglas sea-scale boundaries: smooth-to-slight
+// (< 1.25 m) reads as calm; moderate up to 2.5 m; rough beyond that.
+func seaStateLabel(waveHeightMeters float64) string {
+	switch {
+	case waveHeightMeters < 1.25:
+		return "calm"
+	case waveHeightMeters < 2.5:
+		return "moderate"
+	default:
+		return "rough"
+	}
+}

--- a/internal/weather/marine_probe_test.go
+++ b/internal/weather/marine_probe_test.go
@@ -1,0 +1,39 @@
+package weather
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestLiveProbe_OpenMeteoMarine exercises the keyless Open-Meteo Marine sea-state
+// path against the live API. Gated by TRVL_TEST_LIVE_PROBES=1 (and skipped by
+// -short), it hits a real ferry route's coordinates (Helsinki harbour) and
+// asserts a non-negative wave height comes back. No API key required.
+func TestLiveProbe_OpenMeteoMarine(t *testing.T) {
+	if testing.Short() {
+		t.Skip("live probe skipped under -short")
+	}
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("live probes disabled (set TRVL_TEST_LIVE_PROBES=1)")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Helsinki South Harbour — a real Tallink/Viking ferry departure point.
+	state, err := GetSeaState(ctx, 60.16, 24.94)
+	if err != nil {
+		t.Fatalf("Open-Meteo Marine probe failed: %v", err)
+	}
+	if state.WaveHeight < 0 {
+		t.Fatalf("got negative wave height: %.2f", state.WaveHeight)
+	}
+	if state.Label == "" {
+		t.Error("expected a non-empty sea-state label")
+	}
+
+	t.Logf("Open-Meteo Marine @ Helsinki (60.16,24.94): wave_height=%.2fm swell=%.2fm label=%q",
+		state.WaveHeight, state.SwellHeight, state.Label)
+}

--- a/internal/weather/marine_test.go
+++ b/internal/weather/marine_test.go
@@ -1,0 +1,111 @@
+package weather
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSeaStateLabel(t *testing.T) {
+	tests := []struct {
+		wave float64
+		want string
+	}{
+		{0, "calm"},
+		{0.5, "calm"},
+		{1.24, "calm"},
+		{1.25, "moderate"},
+		{2.0, "moderate"},
+		{2.49, "moderate"},
+		{2.5, "rough"},
+		{4.0, "rough"},
+	}
+	for _, tc := range tests {
+		if got := seaStateLabel(tc.wave); got != tc.want {
+			t.Errorf("seaStateLabel(%.2f) = %q, want %q", tc.wave, got, tc.want)
+		}
+	}
+}
+
+func TestParseSeaState(t *testing.T) {
+	body := []byte(`{"daily":{"time":["2026-07-01"],"wave_height_max":[1.8],"swell_wave_height_max":[1.1]}}`)
+	state, err := parseSeaState(body)
+	if err != nil {
+		t.Fatalf("parseSeaState: %v", err)
+	}
+	if state.WaveHeight != 1.8 {
+		t.Errorf("WaveHeight = %.2f, want 1.8", state.WaveHeight)
+	}
+	if state.SwellHeight != 1.1 {
+		t.Errorf("SwellHeight = %.2f, want 1.1", state.SwellHeight)
+	}
+	if state.Label != "moderate" {
+		t.Errorf("Label = %q, want %q", state.Label, "moderate")
+	}
+}
+
+func TestParseSeaState_NoSwell(t *testing.T) {
+	body := []byte(`{"daily":{"time":["2026-07-01"],"wave_height_max":[0.4]}}`)
+	state, err := parseSeaState(body)
+	if err != nil {
+		t.Fatalf("parseSeaState: %v", err)
+	}
+	if state.SwellHeight != 0 {
+		t.Errorf("SwellHeight = %.2f, want 0", state.SwellHeight)
+	}
+	if state.Label != "calm" {
+		t.Errorf("Label = %q, want %q", state.Label, "calm")
+	}
+}
+
+func TestParseSeaState_Empty(t *testing.T) {
+	if _, err := parseSeaState([]byte(`{"daily":{"time":[],"wave_height_max":[]}}`)); err == nil {
+		t.Error("expected error for empty wave-height data, got nil")
+	}
+}
+
+func TestGetSeaState_HTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("daily"); got != "wave_height_max,swell_wave_height_max" {
+			t.Errorf("daily param = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"daily":{"time":["2026-07-01"],"wave_height_max":[3.2],"swell_wave_height_max":[2.4]}}`))
+	}))
+	defer srv.Close()
+
+	prev := marineAPIURL
+	marineAPIURL = srv.URL
+	defer func() { marineAPIURL = prev }()
+
+	state, err := GetSeaState(context.Background(), 60.16, 24.94)
+	if err != nil {
+		t.Fatalf("GetSeaState: %v", err)
+	}
+	if state.WaveHeight != 3.2 {
+		t.Errorf("WaveHeight = %.2f, want 3.2", state.WaveHeight)
+	}
+	if state.Label != "rough" {
+		t.Errorf("Label = %q, want %q", state.Label, "rough")
+	}
+}
+
+func TestGetSeaState_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	prev := marineAPIURL
+	marineAPIURL = srv.URL
+	defer func() { marineAPIURL = prev }()
+
+	state, err := GetSeaState(context.Background(), 60.16, 24.94)
+	if err == nil {
+		t.Error("expected error on HTTP 503, got nil")
+	}
+	if state.Label != "" {
+		t.Errorf("expected zero-value SeaState on error, got %+v", state)
+	}
+}

--- a/mcp/tools_ground.go
+++ b/mcp/tools_ground.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/ground"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/profile"
 	"github.com/MikkoParkkola/trvl/internal/transfer"
 	"github.com/MikkoParkkola/trvl/internal/trip"
+	"github.com/MikkoParkkola/trvl/internal/weather"
 )
 
 func searchGroundTool() ToolDef {
@@ -166,6 +168,10 @@ func handleSearchGround(ctx context.Context, args map[string]any, elicit ElicitF
 		return []ContentBlock{{Type: "text", Text: msg}}, result, nil
 	}
 
+	// Best-effort, free sea-state enrichment for ferry legs only. Never blocks
+	// the core result: failures and missing coordinates leave routes unchanged.
+	enrichFerrySeaState(ctx, result.Routes)
+
 	summary := buildGroundRouteSummary(
 		fmt.Sprintf("Found %d ground routes from %s to %s on %s", result.Count, from, to, date),
 		result.Routes,
@@ -244,6 +250,44 @@ func handleSearchAirportTransfers(ctx context.Context, args map[string]any, elic
 type airportTransferResponse struct {
 	*trip.AirportTransferResult
 	Comparison models.TransferComparison `json:"comparison"`
+}
+
+// enrichFerrySeaState attaches a coarse Open-Meteo Marine sea-state forecast to
+// ferry routes only. It is context-gated and silent-failure: non-ferry routes
+// are skipped, and a missing departure port or a failed/timed-out marine lookup
+// leaves the route unchanged. Ports are geocoded at most once per call.
+func enrichFerrySeaState(ctx context.Context, routes []models.GroundRoute) {
+	// Short, bounded budget so the enrichment can never stall the response.
+	enrichCtx, cancel := context.WithTimeout(ctx, 6*time.Second)
+	defer cancel()
+
+	cache := make(map[string]*models.SeaState)
+	for i := range routes {
+		if routes[i].Type != "ferry" {
+			continue
+		}
+		port := strings.TrimSpace(routes[i].Departure.City)
+		if port == "" {
+			port = strings.TrimSpace(routes[i].Departure.Station)
+		}
+		if port == "" {
+			continue
+		}
+
+		if cached, ok := cache[port]; ok {
+			routes[i].SeaState = cached
+			continue
+		}
+
+		state, err := weather.SeaStateForCity(enrichCtx, port)
+		if err != nil {
+			cache[port] = nil // negative-cache so we don't retry the same port
+			continue
+		}
+		s := state
+		cache[port] = &s
+		routes[i].SeaState = &s
+	}
 }
 
 func groundRoutesHaveProvider(routes []models.GroundRoute, provider string) bool {


### PR DESCRIPTION
## Summary

Adds a keyless Open-Meteo Marine sea-state enrichment for ferry legs, following the repo's existing "nice-to-have, silent-failure" enrichment pattern.

- New Open-Meteo Marine client mirroring the existing Open-Meteo weather client: 5s HTTP timeout, no API key, typed JSON. On any error, timeout, non-200, or empty payload it returns a zero value plus a non-nil error so callers degrade silently.
- A `SeaState` field is added to the shared `GroundRoute` type (omitempty; nil unless the route is a ferry and the lookup succeeds). Wave height in metres, optional swell height, and a coarse `calm` / `moderate` / `rough` label using WMO/Douglas sea-scale boundaries.
- The ground MCP handler attaches sea state to ferry routes only, context-gated, after a successful search. It reuses the existing Nominatim geocode path to turn a departure port name into coordinates, caches per port, runs under a bounded budget, and never blocks or alters the core ground result when coordinates are missing or the call fails.

## Tests

- Offline unit test: httptest URL-override mock of the marine JSON, label-threshold table, swell-absent and empty-payload paths, and an HTTP-error path asserting the zero-value degradation. Stays green offline.
- Live probe `TestLiveProbe_OpenMeteoMarine`, gated by `TRVL_TEST_LIVE_PROBES=1` and skipped under `-short`, hitting Helsinki harbour coordinates and asserting a non-negative wave height returns.

Verification:

- `GOTOOLCHAIN=local go test ./...` passes offline.
- `go vet ./...` clean; `gofmt -l` empty; staticcheck clean on the touched packages.
- Live probe output (Helsinki, 60.16, 24.94): `wave_height=0.36m swell=0.34m label="calm"`.

Generated with Claude Code
