### PR TITLE
feat(cli): destination intelligence on default hotel, flight, ground searches

### DIFF
--- a/cmd/trvl/destination.go
+++ b/cmd/trvl/destination.go
@@ -65,6 +65,52 @@ func runDestination(cmd *cobra.Command, args []string) error {
 	return formatDestinationCard(info)
 }
 
+// showDestinationFooter enriches the arrival location best-effort and prints a
+// compact destination footer beneath search results. A blank location or a
+// failed lookup prints nothing, so search commands call it unconditionally on
+// their human-readable output path.
+func showDestinationFooter(ctx context.Context, location string, dates models.DateRange) {
+	printDestinationFooter(destinations.EnrichBestEffort(ctx, location, dates))
+}
+
+// printDestinationFooter renders a compact one-block destination summary
+// beneath search results (hotels, flights, ground). Unlike formatDestinationCard
+// — the full card behind `trvl destination` — this is a tight footer: current
+// weather, safety level, holidays falling during the stay, and the currency
+// rate, each printed only when present. A nil info prints nothing, so callers
+// can pass best-effort enrichment straight through without guarding.
+func printDestinationFooter(info *models.DestinationInfo) {
+	if info == nil {
+		return
+	}
+	var lines []string
+	if w := info.Weather.Current; w.Description != "" || w.TempHigh != 0 || w.TempLow != 0 {
+		lines = append(lines, fmt.Sprintf("Weather: %s, %.0f–%.0f°C", w.Description, w.TempLow, w.TempHigh))
+	}
+	if info.Safety.Source != "" {
+		lines = append(lines, fmt.Sprintf("Safety: %.1f/5.0 — %s", info.Safety.Level, info.Safety.Advisory))
+	}
+	if len(info.Holidays) > 0 {
+		names := make([]string, 0, len(info.Holidays))
+		for _, h := range info.Holidays {
+			names = append(names, fmt.Sprintf("%s (%s)", h.Name, h.Date))
+		}
+		lines = append(lines, "Holidays during stay: "+strings.Join(names, ", "))
+	}
+	if info.Currency.LocalCurrency != "" && info.Currency.ExchangeRate > 0 {
+		lines = append(lines, fmt.Sprintf("Currency: 1 %s = %.2f %s",
+			info.Currency.BaseCurrency, info.Currency.ExchangeRate, info.Currency.LocalCurrency))
+	}
+	if len(lines) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Printf("  Destination: %s\n", info.Location)
+	for _, l := range lines {
+		fmt.Printf("    %s\n", l)
+	}
+}
+
 func formatDestinationCard(info *models.DestinationInfo) error {
 	// Header
 	fmt.Printf("\n  %s\n", info.Location)

--- a/cmd/trvl/destination_footer_test.go
+++ b/cmd/trvl/destination_footer_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// capture redirects stdout for the duration of fn and returns what was written.
+func capture(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	fn()
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	return buf.String()
+}
+
+// A nil info must print nothing — callers pass best-effort enrichment straight
+// through, so the footer is a no-op when the lookup degraded.
+func TestPrintDestinationFooter_NilPrintsNothing(t *testing.T) {
+	if out := capture(t, func() { printDestinationFooter(nil) }); out != "" {
+		t.Errorf("expected no output for nil info, got %q", out)
+	}
+}
+
+// An info with no usable signal (every field empty) must also print nothing —
+// no bare "Destination:" header with an empty body.
+func TestPrintDestinationFooter_EmptyInfoPrintsNothing(t *testing.T) {
+	out := capture(t, func() { printDestinationFooter(&models.DestinationInfo{Location: "Nowhere"}) })
+	if out != "" {
+		t.Errorf("expected no output when no signal present, got %q", out)
+	}
+}
+
+// A populated info renders the location header plus each present signal line.
+func TestPrintDestinationFooter_RendersPresentSignals(t *testing.T) {
+	info := &models.DestinationInfo{
+		Location: "Paris, France",
+		Weather:  models.WeatherInfo{Current: models.WeatherDay{Description: "clear", TempLow: 14, TempHigh: 24}},
+		Safety:   models.SafetyInfo{Level: 2, Advisory: "normal caution", Source: "travel-advisory"},
+		Holidays: []models.Holiday{{Name: "Bastille Day", Date: "2026-07-14", Type: "public"}},
+		Currency: models.CurrencyInfo{LocalCurrency: "EUR", BaseCurrency: "EUR", ExchangeRate: 1},
+	}
+	out := capture(t, func() { printDestinationFooter(info) })
+	for _, want := range []string{"Paris, France", "Weather: clear", "Safety: 2.0/5.0", "Bastille Day", "Currency: 1 EUR"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("footer missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -281,6 +281,11 @@ Examples:
 			printPricePosition(os.Stdout, pricePos)
 			printSavings(os.Stdout, savings, time.Now())
 
+			// Additive destination intelligence for the arrival city. destArg is
+			// the user's typed destination (city or airport code); Nominatim
+			// resolves either. Best-effort: nil prints nothing.
+			showDestinationFooter(cmd.Context(), destArg, models.DateRange{CheckIn: date, CheckOut: returnDate})
+
 			// Auto-trigger: run applicable hack detectors and print tips
 			// below the flight results.
 			maybeShowFlightHackTips(cmd.Context(), origins, destinations, date, returnDate, adults, result, flightRailFly)

--- a/cmd/trvl/ground.go
+++ b/cmd/trvl/ground.go
@@ -85,6 +85,10 @@ Examples:
 				return err
 			}
 
+			// Additive destination intelligence for the arrival city. to is
+			// already a resolved city name. Best-effort: nil prints nothing.
+			showDestinationFooter(cmd.Context(), to, models.DateRange{CheckIn: date, CheckOut: opts.ReturnDate})
+
 			if openFlag && result.Success && len(result.Routes) > 0 && result.Routes[0].BookingURL != "" {
 				_ = openBrowser(result.Routes[0].BookingURL)
 			}

--- a/cmd/trvl/hotels.go
+++ b/cmd/trvl/hotels.go
@@ -223,6 +223,10 @@ func runHotels(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Additive destination intelligence beneath the results — weather, safety,
+	// holidays during the stay, currency. Best-effort: nil prints nothing.
+	showDestinationFooter(ctx, location, models.DateRange{CheckIn: checkin, CheckOut: checkout})
+
 	if openFlag && len(result.Hotels) > 0 && result.Hotels[0].BookingURL != "" {
 		_ = openBrowser(result.Hotels[0].BookingURL)
 	}

--- a/internal/destinations/enrich.go
+++ b/internal/destinations/enrich.go
@@ -1,0 +1,36 @@
+package destinations
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// enrichBestEffortTimeout bounds a search-footer enrichment so a slow free API
+// never drags out a flight/hotel/ground search.
+const enrichBestEffortTimeout = 8 * time.Second
+
+// EnrichBestEffort returns destination intelligence (weather, safety, holidays,
+// currency, country facts) for a search footer, or nil. It is the additive,
+// non-blocking enrichment used by the default CLI and MCP search paths:
+//
+//   - context-gated: an empty/blank location returns nil without any network call
+//   - bounded: capped by an 8s timeout regardless of the caller's context
+//   - silently degrading: any error (geocode miss, API down) returns nil
+//
+// It never blocks or fails the core search — a missing field is honest absence,
+// not a fabricated value.
+func EnrichBestEffort(ctx context.Context, location string, dates models.DateRange) *models.DestinationInfo {
+	if strings.TrimSpace(location) == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, enrichBestEffortTimeout)
+	defer cancel()
+	info, err := GetDestinationInfo(ctx, location, dates)
+	if err != nil {
+		return nil
+	}
+	return info
+}

--- a/internal/destinations/enrich_test.go
+++ b/internal/destinations/enrich_test.go
@@ -1,0 +1,28 @@
+package destinations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// EnrichBestEffort must never call the network for a blank location — it is the
+// context-gate that keeps enrichment additive and free on the default paths.
+func TestEnrichBestEffort_BlankLocationReturnsNil(t *testing.T) {
+	for _, loc := range []string{"", "   ", "\t"} {
+		if got := EnrichBestEffort(context.Background(), loc, models.DateRange{}); got != nil {
+			t.Errorf("location %q: expected nil (no enrichment, no network), got %+v", loc, got)
+		}
+	}
+}
+
+// A cancelled context makes geocoding fail; EnrichBestEffort must degrade to nil
+// rather than surface the error (it never blocks or fails the core search).
+func TestEnrichBestEffort_SilentDegradeOnContextError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if got := EnrichBestEffort(ctx, "Paris", models.DateRange{}); got != nil {
+		t.Errorf("expected nil on cancelled context (silent degrade), got %+v", got)
+	}
+}


### PR DESCRIPTION
## What

Destination intelligence now appears beneath the three default CLI searches — `trvl hotels`, `trvl flights`, `trvl ground` — matching what the MCP handlers already do after #298. A search for a place now also tells you what the weather is, whether a public holiday lands during your stay, the safety advisory, and the currency rate. No new flags, no API keys.

```
$ trvl hotels "Lisbon" --checkin 2026-07-13 --checkout 2026-07-16
... hotel table ...

  Destination: Lisbon, Portugal
    Weather: clear sky, 19–29°C
    Safety: 2.0/5.0 — exercise normal caution
    Holidays during stay: Feast of Saint Anthony (2026-07-13)
    Currency: 1 EUR = 1.00 EUR
```

## How

- `destinations.EnrichBestEffort` — one shared, best-effort enricher. Blank location returns nil with no network call; an 8-second timeout caps it; any error returns nil. It never blocks or fails the core search, so a flaky free API leaves the field absent rather than breaking the result.
- `showDestinationFooter` / `printDestinationFooter` in the CLI — a compact footer for the search context. The full weather card stays behind the dedicated `trvl destination` command; search results get a tight summary instead.
- Wired into the human-readable output path of all three commands. JSON output is unchanged.

The footer only renders signals that are present, and prints nothing at all when the lookup degrades — no empty headers.

## Tests

- `internal/destinations`: blank-location gate (no network), silent degrade on a cancelled context.
- `cmd/trvl`: nil prints nothing, empty info prints nothing, populated info renders each present signal.
- Full `cmd/trvl` + `internal/destinations` suites pass under `-race`.

Generated with Claude Code
