### PR TITLE
feat(cli): destination intelligence in JSON output (hotels, flights, ground)

### DIFF
--- a/cmd/trvl/destination.go
+++ b/cmd/trvl/destination.go
@@ -70,7 +70,15 @@ func runDestination(cmd *cobra.Command, args []string) error {
 // failed lookup prints nothing, so search commands call it unconditionally on
 // their human-readable output path.
 func showDestinationFooter(ctx context.Context, location string, dates models.DateRange) {
-	printDestinationFooter(destinations.EnrichBestEffort(ctx, location, dates))
+	printDestinationFooter(enrichArrival(ctx, location, dates))
+}
+
+// enrichArrival returns best-effort destination intelligence for an arrival
+// location, or nil when the location is blank and when the lookup fails. It is
+// the shared enricher behind both the human-readable footer and the JSON
+// `destination` field, so text and JSON output stay at parity.
+func enrichArrival(ctx context.Context, location string, dates models.DateRange) *models.DestinationInfo {
+	return destinations.EnrichBestEffort(ctx, location, dates)
 }
 
 // printDestinationFooter renders a compact one-block destination summary

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -265,6 +265,12 @@ Examples:
 			}
 
 			if format == "json" {
+				// JSON parity with the text path: attach best-effort
+				// destination intelligence. The wrapper embeds *result, so
+				// setting it once covers both the wrapped and bare branches.
+				if result != nil {
+					result.Destination = enrichArrival(cmd.Context(), destArg, models.DateRange{CheckIn: date, CheckOut: returnDate})
+				}
 				if pricePos != nil || len(savings) > 0 {
 					return models.FormatJSON(os.Stdout, struct {
 						*models.FlightSearchResult

--- a/cmd/trvl/ground.go
+++ b/cmd/trvl/ground.go
@@ -78,6 +78,11 @@ Examples:
 			}
 
 			if format == "json" {
+				// JSON parity with the text path: attach best-effort
+				// destination intelligence for the arrival city.
+				if result != nil {
+					result.Destination = enrichArrival(cmd.Context(), to, models.DateRange{CheckIn: date, CheckOut: opts.ReturnDate})
+				}
 				return models.FormatJSON(os.Stdout, result)
 			}
 

--- a/cmd/trvl/hotels.go
+++ b/cmd/trvl/hotels.go
@@ -216,6 +216,11 @@ func runHotels(cmd *cobra.Command, args []string) error {
 	}
 
 	if format == "json" {
+		// JSON parity with the text path: attach best-effort destination
+		// intelligence so machine consumers get the same enrichment.
+		if result != nil {
+			result.Destination = enrichArrival(ctx, location, models.DateRange{CheckIn: checkin, CheckOut: checkout})
+		}
 		return models.FormatJSON(os.Stdout, result)
 	}
 

--- a/internal/models/destination_json_parity_test.go
+++ b/internal/models/destination_json_parity_test.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSearchResultDestinationJSONParity guards the text/JSON parity contract:
+// every default-search result type that prints a destination footer on the
+// text path must also serialize a `destination` field on the JSON path. The
+// gap this guards against is adding the human-readable footer while forgetting
+// the JSON field, so machine consumers silently lose the enrichment.
+func TestSearchResultDestinationJSONParity(t *testing.T) {
+	info := &DestinationInfo{Location: "Lisbon"}
+
+	cases := []struct {
+		name string
+		val  any
+	}{
+		{"hotels", &HotelSearchResult{Destination: info}},
+		{"flights", &FlightSearchResult{Destination: info}},
+		{"ground", &GroundSearchResult{Destination: info}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b, err := json.Marshal(c.val)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !strings.Contains(string(b), `"destination"`) {
+				t.Errorf("%s JSON missing destination field: %s", c.name, b)
+			}
+			if !strings.Contains(string(b), `"Lisbon"`) {
+				t.Errorf("%s JSON missing destination payload: %s", c.name, b)
+			}
+		})
+	}
+}
+
+// TestSearchResultDestinationOmittedWhenNil confirms the field is absent (not
+// a null) when enrichment degrades, so the additive contract holds: a failed
+// lookup leaves no trace in the output.
+func TestSearchResultDestinationOmittedWhenNil(t *testing.T) {
+	cases := []struct {
+		name string
+		val  any
+	}{
+		{"hotels", &HotelSearchResult{}},
+		{"flights", &FlightSearchResult{}},
+		{"ground", &GroundSearchResult{}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b, err := json.Marshal(c.val)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if strings.Contains(string(b), `"destination"`) {
+				t.Errorf("%s JSON should omit destination when nil: %s", c.name, b)
+			}
+		})
+	}
+}

--- a/internal/models/flight.go
+++ b/internal/models/flight.go
@@ -144,7 +144,11 @@ type FlightSearchResult struct {
 	// It is additive — the naive Flights are never replaced — and is only
 	// populated when a real, lower-priced option exists.
 	HackSaving *HackSaving `json:"hack_saving,omitempty"`
-	Error      string      `json:"error,omitempty"`
+	// Destination carries best-effort destination intelligence (weather, safety,
+	// holidays, currency, country facts) for the arrival city. Additive and
+	// silently degrading — absent when the lookup fails; never blocks the search.
+	Destination *DestinationInfo `json:"destination,omitempty"`
+	Error       string           `json:"error,omitempty"`
 }
 
 // DatePriceResult represents the cheapest price for a single departure date.

--- a/internal/models/hotel.go
+++ b/internal/models/hotel.go
@@ -135,7 +135,11 @@ type HotelSearchResult struct {
 	Hotels           []HotelResult    `json:"hotels"`
 	ProviderStatuses []ProviderStatus `json:"provider_statuses,omitempty"`
 	Completeness     Completeness     `json:"completeness,omitempty"`
-	Error            string           `json:"error,omitempty"`
+	// Destination carries best-effort destination intelligence (weather, safety,
+	// holidays, currency, country facts) for the searched location. Additive and
+	// silently degrading — absent when the lookup fails; never blocks the search.
+	Destination *DestinationInfo `json:"destination,omitempty"`
+	Error       string           `json:"error,omitempty"`
 }
 
 // ProviderPrice represents a single booking provider's price for a hotel.


### PR DESCRIPTION
## What

JSON output now carries the same destination intelligence the text output already shows. Run `trvl hotels`, `trvl flights`, or `trvl ground` with `--format json` and the result includes a `destination` block — weather, safety advisory, holidays during the stay, currency rate — matching what the human-readable footer prints.

Before this, only the text path had it. A script reading JSON got a hotel list with no destination context, while a person reading the table got the footer. Same search, two different answers depending on output format.

```json
{
  "success": true,
  "hotels": [ ... ],
  "destination": {
    "location": "Lisbon",
    "weather": { "current": { "description": "clear sky", "temp_high": 29, "temp_low": 19 } },
    "safety": { "level": 2.0, "advisory": "exercise normal caution" },
    "holidays": [ { "name": "Feast of Saint Anthony", "date": "2026-07-13" } ],
    "currency": { "base_currency": "EUR", "exchange_rate": 1.0, "local_currency": "EUR" }
  }
}
```

## How

- Added a `destination` field to `HotelSearchResult` and `FlightSearchResult`. `GroundSearchResult` already had one from #298. All three use `omitempty`, so a degraded lookup leaves the field absent rather than emitting a null.
- One enricher, `enrichArrival`, sits behind both the text footer and the JSON field. Text and JSON read from the same source, so they cannot drift.
- Wired the JSON branch of all three commands. The flights JSON wrapper embeds the result pointer, so a single assignment covers both the wrapped (price-position/savings) and bare branches.

Enrichment stays best-effort: a blank location skips the network, an 8-second timeout caps it, any error returns nil. The search itself never blocks or fails on it.

## Tests

- `internal/models`: a marshal guard asserting all three result types serialize `destination` when set and omit it when nil. This is the regression that bites if someone adds the text footer to a new search type but forgets the JSON field.
- Full `cmd/trvl` and `internal/models` suites pass under `-race`.

Generated with Claude Code
