### PR TITLE
feat(hotels): push requested occupancy into Google price RPC (#290 MIK-277G.1)

### DIFF
--- a/internal/batchexec/encode.go
+++ b/internal/batchexec/encode.go
@@ -159,14 +159,49 @@ func BuildHotelSearchPayload(location string, checkIn, checkOut [3]int, adults i
 	return EncodeBatchExecute("AtySUc", args)
 }
 
-// BuildHotelPricePayload constructs a batchexecute payload for hotel price lookup.
+// BuildHotelPricePayload constructs a batchexecute payload for hotel price
+// lookup with the default occupancy (2 adults, no children).
+//
+// It preserves the historical request shape. Callers that know the real party
+// size should use BuildHotelPricePayloadWithOccupancy so Google filters the
+// partner-price matrix to the requested occupancy server-side instead of
+// returning the generic two-adult quote.
 //
 // rpcid "yY52ce" looks up prices for a specific hotel ID.
 // Date arrays are [year, month, day].
 func BuildHotelPricePayload(hotelID string, checkIn, checkOut [3]int, currency string) string {
-	args := fmt.Sprintf(`[null,[%d,%d,%d],[%d,%d,%d],[2,[],0],%q,%q]`,
+	return BuildHotelPricePayloadWithOccupancy(hotelID, checkIn, checkOut, currency, 2, nil)
+}
+
+// BuildHotelPricePayloadWithOccupancy is like BuildHotelPricePayload but carries
+// the requested occupancy into the yY52ce RPC, so Google scopes partner prices
+// to that party size at the source rather than after the fetch.
+//
+// The occupancy block is [adults, [childAge...], 0]. adults and the child-age
+// list are the verified fields and are plumbed from the caller. The trailing
+// field's exact meaning is not confirmed upstream, so it is left at its
+// historical 0.
+// ponytail: third occupancy field unverified — left at 0; revisit only if
+// Google starts keying multi-room quotes off it.
+func BuildHotelPricePayloadWithOccupancy(hotelID string, checkIn, checkOut [3]int, currency string, adults int, childAges []int) string {
+	if adults <= 0 {
+		adults = 2
+	}
+	children := "[]"
+	if len(childAges) > 0 {
+		children = "["
+		for i, age := range childAges {
+			if i > 0 {
+				children += ","
+			}
+			children += fmt.Sprintf("%d", age)
+		}
+		children += "]"
+	}
+	args := fmt.Sprintf(`[null,[%d,%d,%d],[%d,%d,%d],[%d,%s,0],%q,%q]`,
 		checkIn[0], checkIn[1], checkIn[2],
 		checkOut[0], checkOut[1], checkOut[2],
+		adults, children,
 		hotelID, currency)
 	return EncodeBatchExecute("yY52ce", args)
 }

--- a/internal/batchexec/encode_occupancy_test.go
+++ b/internal/batchexec/encode_occupancy_test.go
@@ -1,0 +1,44 @@
+package batchexec
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestBuildHotelPricePayloadWithOccupancy_RequestShape pins the yY52ce request
+// shape so the requested occupancy reaches Google server-side (MIK-277G.1).
+// The occupancy block is [adults, [childAge...], 0].
+func TestBuildHotelPricePayloadWithOccupancy_RequestShape(t *testing.T) {
+	checkIn := [3]int{2026, 6, 15}
+	checkOut := [3]int{2026, 6, 18}
+
+	decode := func(t *testing.T, payload string) string {
+		t.Helper()
+		got, err := url.QueryUnescape(payload)
+		if err != nil {
+			t.Fatalf("unescape payload: %v", err)
+		}
+		return got
+	}
+
+	// The occupancy-aware payload carries adults + child ages into the RPC.
+	withChildren := decode(t, BuildHotelPricePayloadWithOccupancy("/g/11test", checkIn, checkOut, "EUR", 3, []int{5, 9}))
+	if !strings.Contains(withChildren, "[3,[5,9],0]") {
+		t.Fatalf("occupancy payload missing block [3,[5,9],0]; got %s", withChildren)
+	}
+
+	// The default helper preserves the historical two-adult block, so existing
+	// callers see a byte-identical request.
+	def := decode(t, BuildHotelPricePayload("/g/11test", checkIn, checkOut, "EUR"))
+	if !strings.Contains(def, "[2,[],0]") {
+		t.Fatalf("default payload missing block [2,[],0]; got %s", def)
+	}
+
+	// Zero/empty occupancy degrades to the safe default rather than emitting a
+	// nonsensical zero-adult query.
+	zero := decode(t, BuildHotelPricePayloadWithOccupancy("/g/11test", checkIn, checkOut, "EUR", 0, nil))
+	if !strings.Contains(zero, "[2,[],0]") {
+		t.Fatalf("zero occupancy should default to [2,[],0]; got %s", zero)
+	}
+}

--- a/internal/hotels/prices.go
+++ b/internal/hotels/prices.go
@@ -23,11 +23,13 @@ func isNoProviderPricesError(err error) bool {
 // HotelPriceOpts configures a hotel price lookup with optional fallback search
 // for hotels where Google's batchexecute RPC has no booking partner data.
 type HotelPriceOpts struct {
-	HotelID  string // Google place ID
-	CheckIn  string // YYYY-MM-DD
-	CheckOut string // YYYY-MM-DD
-	Currency string // e.g. "EUR", "USD"
-	Location string // optional city/hotel name hint for search-page fallback
+	HotelID      string // Google place ID
+	CheckIn      string // YYYY-MM-DD
+	CheckOut     string // YYYY-MM-DD
+	Currency     string // e.g. "EUR", "USD"
+	Guests       int    // requested adult count; defaults to 2
+	ChildrenAges []int  // requested child ages
+	Location     string // optional city/hotel name hint for search-page fallback
 }
 
 // GetHotelPrices looks up booking provider prices for a specific hotel.
@@ -73,7 +75,7 @@ func GetHotelPricesWithOpts(ctx context.Context, opts HotelPriceOpts) (*models.H
 	}
 
 	client := DefaultClient()
-	encoded := batchexec.BuildHotelPricePayload(opts.HotelID, checkInArr, checkOutArr, opts.Currency)
+	encoded := batchexec.BuildHotelPricePayloadWithOccupancy(opts.HotelID, checkInArr, checkOutArr, opts.Currency, opts.Guests, opts.ChildrenAges)
 
 	status, body, err := client.BatchExecute(ctx, encoded)
 	if err != nil {

--- a/internal/hotels/rooms.go
+++ b/internal/hotels/rooms.go
@@ -220,11 +220,13 @@ func tryEntityPage(ctx context.Context, opts RoomSearchOptions) ([]RoomType, str
 // partner URLs (notably Booking.com) so the downstream exact-room fetch can run.
 func tryBatchExecutePrices(ctx context.Context, opts RoomSearchOptions) ([]RoomType, string) {
 	res, err := GetHotelPricesWithOpts(ctx, HotelPriceOpts{
-		HotelID:  opts.HotelID,
-		CheckIn:  opts.CheckIn,
-		CheckOut: opts.CheckOut,
-		Currency: opts.Currency,
-		Location: opts.Location,
+		HotelID:      opts.HotelID,
+		CheckIn:      opts.CheckIn,
+		CheckOut:     opts.CheckOut,
+		Currency:     opts.Currency,
+		Guests:       opts.Guests,
+		ChildrenAges: opts.ChildrenAges,
+		Location:     opts.Location,
 	})
 	if err != nil || res == nil || len(res.Providers) == 0 {
 		return nil, ""


### PR DESCRIPTION
## What

Google's `yY52ce` price RPC accepts an occupancy block, but the payload builder hardcoded it to two adults with no children. Every Google partner-price lookup therefore asked for a generic two-adult quote, and any occupancy filtering had to happen on the client after fetching the full matrix.

This pushes the requested occupancy into the RPC so Google scopes the partner-price matrix at the source.

## Why this shape

Issue #290 is explicit that naive "fetch all rooms then filter" multiplies request volume and risks rate limits, and its fail-fast says to confirm the RPC accepts a server-side filter param before building anything. It does: the request arguments already contain an occupancy block, previously frozen at two adults. Sending the real party size is the rate-limit-safe path the issue asks for, with no extra calls.

## Changes

- New `BuildHotelPricePayloadWithOccupancy` emits `[adults, [childAge...], 0]` from the caller's values.
- `Guests` and `ChildrenAges` now flow through `HotelPriceOpts` and the batch-execute price lookup.
- The original builder stays and delegates with the historical two-adult values, so existing callers and their golden payloads are byte-identical. Zero or empty occupancy degrades to that same default.
- The occupancy block's trailing field has no confirmed meaning upstream, so it stays at its historical `0`, with a comment recording why and when to revisit.

## Scope

This is the keystone the issue's fail-fast required first (`MIK-277G.1`): occupancy reaches the RPC server-side. It plumbs the two verified fields, adult count and child ages. Remaining #290 work, tracked on the issue: `MIK-277G.2` per-room call-count guard, `MIK-277G.3` a live booking-ready run on a Google-strong market, `MIK-277G.4` a no-real-price regression check.

## Tests

- `MIK-277G.1` request-shape test asserts the occupancy block reaches the RPC for a 3-adult, two-child party, that the default helper still emits the historical block, and that zero occupancy degrades to the default.
- `internal/batchexec` and `internal/hotels` suites pass.

Refs #290

Generated with Claude Code
