### PR TITLE
fix(hotels): derive Agoda stay total from per-night rate

### DIFF
--- a/internal/hotels/agoda.go
+++ b/internal/hotels/agoda.go
@@ -495,6 +495,16 @@ func agodaNights(checkIn, checkOut string) int {
 	return n
 }
 
+// agodaStayTotal derives the stay total from a per-night rate. Returns 0 when
+// either input is non-positive so callers leave TotalPrice unset rather than
+// publish a misleading zero.
+func agodaStayTotal(nightly float64, nights int) float64 {
+	if nightly <= 0 || nights < 1 {
+		return 0
+	}
+	return nightly * float64(nights)
+}
+
 // agodaIntSlice converts an []int to a []any for JSON map embedding, returning a
 // non-nil empty slice so the marshaled field is an empty array, not null.
 func agodaIntSlice(in []int) []any {
@@ -520,6 +530,10 @@ func parseAgodaSearch(resp *agodaSearchResponse, opts HotelSearchOptions) []mode
 		return nil
 	}
 	out := make([]models.HotelResult, 0, len(resp.Data.CitySearch.Properties))
+	// Agoda quotes a per-room-per-night rate; derive the stay total once so
+	// multi-night offers are comparable and displayable alongside providers
+	// that return a room total (Google/Booking). nights is floored at 1.
+	nights := agodaNights(opts.CheckIn, opts.CheckOut)
 	for _, p := range resp.Data.CitySearch.Properties {
 		info := p.Content.InformationSummary
 		if info.DisplayName == "" {
@@ -580,6 +594,7 @@ func parseAgodaSearch(resp *agodaSearchResponse, opts HotelSearchOptions) []mode
 				Name:            "Agoda room rate",
 				Price:           price,
 				NightlyPrice:    price,
+				TotalPrice:      agodaStayTotal(price, nights),
 				Currency:        currency,
 				Provider:        "agoda",
 				ProviderURL:     hr.BookingURL,

--- a/internal/hotels/agoda_roomlevel_test.go
+++ b/internal/hotels/agoda_roomlevel_test.go
@@ -57,3 +57,65 @@ func TestParseAgodaSearchEmitsRoomLevelInventory(t *testing.T) {
 		t.Errorf("MatchConfidence=%q, want similar_room_match", rt.MatchConfidence)
 	}
 }
+
+// TestParseAgodaSearchDerivesStayTotal proves a multi-night search turns Agoda's
+// per-night rate into a stay total, so its offers compare and display alongside
+// providers that return a room total. The nightly rate is preserved.
+func TestParseAgodaSearchDerivesStayTotal(t *testing.T) {
+	resp := &agodaSearchResponse{}
+	p := agodaProperty{PropertyID: 7}
+	p.Content.InformationSummary.DisplayName = "Hotel Nights"
+	offer := struct {
+		RoomOffers []struct {
+			Room struct {
+				Pricing []agodaRoomPricing `json:"pricing"`
+			} `json:"room"`
+		} `json:"roomOffers"`
+	}{}
+	ro := struct {
+		Room struct {
+			Pricing []agodaRoomPricing `json:"pricing"`
+		} `json:"room"`
+	}{}
+	pr := agodaRoomPricing{Currency: "EUR"}
+	pr.Price.PerRoomPerNight.Exclusive.Display = 120
+	ro.Room.Pricing = []agodaRoomPricing{pr}
+	offer.RoomOffers = append(offer.RoomOffers, ro)
+	p.Pricing.Offers = append(p.Pricing.Offers, offer)
+	resp.Data.CitySearch.Properties = []agodaProperty{p}
+
+	// 3-night stay → total = 120 * 3.
+	out := parseAgodaSearch(resp, HotelSearchOptions{CheckIn: "2026-07-10", CheckOut: "2026-07-13"})
+	if len(out) != 1 || len(out[0].RoomTypes) != 1 {
+		t.Fatalf("expected 1 hotel with 1 room, got %d hotels", len(out))
+	}
+	rt := out[0].RoomTypes[0]
+	if rt.NightlyPrice != 120 {
+		t.Errorf("NightlyPrice=%v, want 120 (per-night rate preserved)", rt.NightlyPrice)
+	}
+	if rt.TotalPrice != 360 {
+		t.Errorf("TotalPrice=%v, want 360 (120 x 3 nights)", rt.TotalPrice)
+	}
+}
+
+// TestAgodaStayTotal pins the derivation helper, including the guards that keep
+// it from publishing a misleading zero or negative total.
+func TestAgodaStayTotal(t *testing.T) {
+	cases := []struct {
+		nightly float64
+		nights  int
+		want    float64
+	}{
+		{120, 3, 360},
+		{99.5, 2, 199},
+		{120, 1, 120},
+		{0, 3, 0},   // no rate → no total
+		{120, 0, 0}, // no nights → no total
+		{-50, 2, 0}, // negative rate guarded
+	}
+	for _, tc := range cases {
+		if got := agodaStayTotal(tc.nightly, tc.nights); got != tc.want {
+			t.Errorf("agodaStayTotal(%v, %d) = %v, want %v", tc.nightly, tc.nights, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Agoda quotes a per-room-per-night rate. It never returns a stay total. `parseAgodaSearch` left `TotalPrice` unset, so a multi-night Agoda offer showed only a nightly figure while Google and Booking room-level offers carried a room total. Same stay, different price shape, no way to rank the two on equal footing.

This derives the stay total once per search: nightly times nights, nights floored at 1, set on the room-level inventory.

## Why this is honest, not invented

The per-night rate stays on `NightlyPrice`. `PriceBasis` stays `room_nightly`. The source rate is per night and the total is derived, so the offer keeps the lower-confidence basis rather than claiming a quoted room total. A reader sees both numbers, and the basis tells them which one Agoda actually returned.

`agodaStayTotal` returns 0 when the rate or night count is non-positive. A missing rate leaves `TotalPrice` unset instead of publishing a misleading zero.

## Evidence

- V: `go test ./internal/hotels/ -run 'Agoda|RoomLevel|StayTotal'` passes (`internal/hotels/agoda_roomlevel_test.go:64` multi-night derivation, `:103` helper guard cases).
- I: `agodaStayTotal` guards non-positive inputs to 0 (`internal/hotels/agoda.go:498`).
- A: night count comes from the existing `agodaNights` over the search options (`internal/hotels/agoda.go:495`).

Refs #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
