### PR TITLE
feat(accommodations): label nightly vs total in best-match summary

### DIFF
--- a/mcp/tools_accommodations_evidence.go
+++ b/mcp/tools_accommodations_evidence.go
@@ -635,6 +635,27 @@ func accommodationComparablePrice(offer models.AccommodationOffer) float64 {
 	return offer.NightlyPrice
 }
 
+// accommodationPriceDisplay renders an offer's price for humans, labeling the
+// nightly rate and the stay total so the figure is never ambiguous. Providers
+// disagree on which they quote (Agoda nightly, Google a room total), so an
+// unlabeled number invited apples-to-oranges reading across offers. When both
+// are present and differ it shows the nightly rate with the total in
+// parentheses; when they are equal (a single night) it shows the nightly rate
+// alone; when only one is known it labels that one. Returns "" with no price.
+func accommodationPriceDisplay(offer models.AccommodationOffer) string {
+	cur := offer.Currency
+	switch {
+	case offer.NightlyPrice > 0 && offer.TotalPrice > 0 && offer.NightlyPrice != offer.TotalPrice:
+		return fmt.Sprintf("%s %.0f/night (%s %.0f total)", cur, offer.NightlyPrice, cur, offer.TotalPrice)
+	case offer.NightlyPrice > 0:
+		return fmt.Sprintf("%s %.0f/night", cur, offer.NightlyPrice)
+	case offer.TotalPrice > 0:
+		return fmt.Sprintf("%s %.0f total", cur, offer.TotalPrice)
+	default:
+		return ""
+	}
+}
+
 func accommodationSearchWarnings(result *models.HotelSearchResult, offers, rejected []models.AccommodationOffer, evidence []models.AccommodationEvidence, candidateCount int) []string {
 	warnings := []string{"lead_in_prices_are_candidates_only"}
 	if note := result.Completeness.IncompleteNote(); note != "" {
@@ -703,8 +724,8 @@ func accommodationSearchSummary(resp accommodationSearchResponse) string {
 		summary += fmt.Sprintf(" %d final-trip-cost-ready.", resp.FinalTripCostReadyCount)
 	}
 	best := resp.Offers[0]
-	if price := accommodationComparablePrice(best); price > 0 {
-		summary += fmt.Sprintf(" Best verified match: %s %.0f at %s (%s).", best.Currency, price, best.PropertyName, best.RoomName)
+	if disp := accommodationPriceDisplay(best); disp != "" {
+		summary += fmt.Sprintf(" Best verified match: %s at %s (%s).", disp, best.PropertyName, best.RoomName)
 	}
 	return summary
 }

--- a/mcp/tools_accommodations_pricedisplay_test.go
+++ b/mcp/tools_accommodations_pricedisplay_test.go
@@ -1,0 +1,51 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestAccommodationPriceDisplay pins the labeled price rendering. Providers
+// disagree on whether they quote a nightly rate or a stay total, so the
+// human-facing string must always say which number it is showing.
+func TestAccommodationPriceDisplay(t *testing.T) {
+	cases := []struct {
+		name  string
+		offer models.AccommodationOffer
+		want  string
+	}{
+		{
+			name:  "nightly and total both shown and labeled",
+			offer: models.AccommodationOffer{Currency: "EUR", NightlyPrice: 120, TotalPrice: 360},
+			want:  "EUR 120/night (EUR 360 total)",
+		},
+		{
+			name:  "single night collapses to nightly only",
+			offer: models.AccommodationOffer{Currency: "EUR", NightlyPrice: 120, TotalPrice: 120},
+			want:  "EUR 120/night",
+		},
+		{
+			name:  "nightly only is labeled per night",
+			offer: models.AccommodationOffer{Currency: "USD", NightlyPrice: 99},
+			want:  "USD 99/night",
+		},
+		{
+			name:  "total only is labeled total",
+			offer: models.AccommodationOffer{Currency: "GBP", TotalPrice: 500},
+			want:  "GBP 500 total",
+		},
+		{
+			name:  "no price yields empty string",
+			offer: models.AccommodationOffer{Currency: "EUR"},
+			want:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := accommodationPriceDisplay(tc.offer); got != tc.want {
+				t.Fatalf("accommodationPriceDisplay = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

The best-match line in an accommodation search summary printed one bare number: `EUR 450 at Hotel X`. That number was whatever `accommodationComparablePrice` picked, total if present, otherwise nightly. Nothing told the reader which one it was.

This is a real ambiguity, not a cosmetic one. Providers disagree on what they quote. Agoda returns a per-night rate. Google returns a room total. So the same summary line could show a nightly figure for one search and a stay total for the next, and the reader had no way to tell them apart, let alone compare two offers.

`accommodationPriceDisplay` now renders the price with explicit labels:

- both known and different: `EUR 120/night (EUR 360 total)`
- single night (nightly equals total): `EUR 120/night`
- only one known: `EUR 99/night` or `GBP 500 total`
- no price: empty, so the line is omitted rather than printed blank

## Scope

Display only. The ranking helper `accommodationComparablePrice` is untouched, so ordering does not change. This pairs with #306, which fills in the Agoda stay total so the `(... total)` half of the label has a value to show.

## Evidence

- V: `go test ./mcp/ -run 'PriceDisplay|Accommodation|Sort'` passes. `mcp/tools_accommodations_pricedisplay_test.go` covers all five branches.
- I: the helper returns `""` for a priceless offer, and the caller skips the line on empty.
- A: the summary builder in `mcp/tools_accommodations_evidence.go` calls the helper in place of the old bare `%.0f`.

Refs #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
