### PR TITLE
fix(watch): cross-platform desktop notifications with graceful degradation

### DIFF
--- a/internal/watch/notify.go
+++ b/internal/watch/notify.go
@@ -3,6 +3,7 @@ package watch
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -240,11 +241,42 @@ func (n *Notifier) yellow(s string) string {
 	return "\033[33m" + s + "\033[0m"
 }
 
-// desktopNotify sends a macOS notification via osascript. Best-effort; errors are ignored.
+// desktopNotify sends a native desktop notification. Best-effort by contract:
+// callers ignore failures, so it never returns an error or blocks. When the
+// platform's native channel is unavailable it logs at debug level rather than
+// failing silently, so the degradation is observable in logs.
 func (n *Notifier) desktopNotify(title, message string) {
-	if runtime.GOOS != "darwin" {
-		return
+	desktopNotifyDispatch(runtime.GOOS, title, message)
+}
+
+// desktopNotifyDispatch routes a desktop notification to the platform-native
+// channel. It is factored out (taking goos explicitly) so the dispatch logic is
+// testable without depending on the host OS, mirroring providers.defaultOpenURL.
+func desktopNotifyDispatch(goos, title, message string) {
+	switch goos {
+	case "darwin":
+		script := fmt.Sprintf(`display notification %q with title %q`, message, title)
+		if err := exec.Command("osascript", "-e", script).Run(); err != nil {
+			slog.Debug("desktop notification unavailable", "goos", goos, "channel", "osascript", "err", err)
+		}
+	case "linux":
+		// notify-send is the standard libnotify CLI on Linux desktops.
+		if err := exec.Command("notify-send", title, message).Run(); err != nil {
+			slog.Debug("desktop notification unavailable", "goos", goos, "channel", "notify-send", "err", err)
+		}
+	case "windows":
+		// Best-effort balloon via PowerShell, no third-party module required.
+		ps := fmt.Sprintf(
+			`[reflection.assembly]::LoadWithPartialName('System.Windows.Forms') | Out-Null; `+
+				`$n = New-Object System.Windows.Forms.NotifyIcon; `+
+				`$n.Icon = [System.Drawing.SystemIcons]::Information; `+
+				`$n.BalloonTipTitle = %q; $n.BalloonTipText = %q; `+
+				`$n.Visible = $true; $n.ShowBalloonTip(5000)`,
+			title, message)
+		if err := exec.Command("powershell", "-NoProfile", "-Command", ps).Run(); err != nil {
+			slog.Debug("desktop notification unavailable", "goos", goos, "channel", "powershell", "err", err)
+		}
+	default:
+		slog.Debug("desktop notification unavailable", "goos", goos, "channel", "none")
 	}
-	script := fmt.Sprintf(`display notification %q with title %q`, message, title)
-	_ = exec.Command("osascript", "-e", script).Run()
 }

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -183,3 +183,32 @@ func TestDefaultStore(t *testing.T) {
 		t.Fatal("DefaultStore returned nil")
 	}
 }
+
+// TestDesktopNotifyDispatch_NonDarwinNoPanic asserts the dispatch helper degrades
+// gracefully on non-darwin platforms: it must not panic regardless of whether the
+// native channel (notify-send, PowerShell) is present. Best-effort by contract.
+func TestDesktopNotifyDispatch_NoPanic(t *testing.T) {
+	for _, goos := range []string{"linux", "windows", "plan9", "freebsd", ""} {
+		goos := goos
+		t.Run(goos, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("desktopNotifyDispatch(%q) panicked: %v", goos, r)
+				}
+			}()
+			desktopNotifyDispatch(goos, "trvl: test", "graceful degradation")
+		})
+	}
+}
+
+// TestDesktopNotify_NoPanic exercises the Notifier method wrapper end-to-end on
+// the host OS; it must never panic since callers ignore failures.
+func TestDesktopNotify_NoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("desktopNotify panicked: %v", r)
+		}
+	}()
+	n := &Notifier{}
+	n.desktopNotify("trvl: test", "no panic")
+}


### PR DESCRIPTION
## Summary

`desktopNotify` in the watch package sent desktop notifications only on macOS via osascript. On Linux and Windows it returned immediately with no output and no log line. A cross-platform audit flagged that silent no-op against the policy that platform-specific features must degrade observably rather than disappear quietly.

## What changed

- **V:** notify.go line 243 previously read `if runtime.GOOS != "darwin"` then returned, then ran osascript only. Confirmed the silent return on non-darwin paths by reading the function.
- **I:** Factored dispatch behind a testable `desktopNotifyDispatch(goos, title, message)` helper that takes `goos` explicitly, mirroring the existing `defaultOpenURL(goos, ...)` helper at cookies.go line 80 in the providers package. macOS keeps osascript. Linux uses the standard libnotify command-line tool notify-send. Windows uses a dependency-free PowerShell balloon. Any unavailable channel emits a `slog.Debug` line so the degradation is observable in logs. Best-effort by contract, so it never returns an error or blocks.
- **A:** Added `TestDesktopNotifyDispatch_NoPanic` (table over linux, windows, plan9, freebsd, empty) and `TestDesktopNotify_NoPanic` in notify_test.go, asserting no panic on simulated non-darwin paths.

Pure Go plus the standard exec package only, no new dependencies.

## Validation

- `gofmt -l` on both files: empty (clean)
- `go vet` on the watch package: clean
- `go build` across the module: ok
- `go test` on the watch package: ok (3.4s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
