### PR TITLE
feat(stealth): opt-in --stealth for flight+hotel search with enforced authorized-domain allowlist (MIK-3288)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,25 @@ An AI agent acts on trvl's output without a human checking every result, so the 
 
 Hotel metasearch exposes list-level rates first; some are real, some only firm up after the property detail page reveals the room/tax/cancellation matrix. So trvl separates **discovery** (`search_hotels` — fast, lead-in prices) from **decisions** (`search_accommodations` — verifies room-level offers before ranking) and **drill-down** (`search_hotels_with_details`, `hotel_rooms`). It provides booking links for manual handoff but never books, holds, or guarantees a rate. Detail: [docs/PROVIDERS.md](docs/PROVIDERS.md).
 
+### Stealth: opt-in, authorized first-party access only
+
+`trvl flights` and `trvl hotels` accept an optional `--stealth` flag that routes the fetch through trvl's existing Chrome HTTP/2 fingerprint transport. It is built as a fail-safe scope fence:
+
+- **Default off.** Stealth is inactive unless you explicitly pass `--stealth`.
+- **Authorized hosts only.** Even with `--stealth`, it activates only for hosts on an operator-authorized allowlist read from the `TRVL_STEALTH_ALLOWLIST` environment variable (comma-separated hostnames; case-insensitive; exact match plus leading-dot suffix such as `.google.com`). An empty allowlist means stealth never activates — refuse by default.
+- **No silent evasion.** With `--stealth` set for a host that is not on the allowlist, trvl runs the normal fetch path and logs one line (`stealth not authorized for host <host>`); it does not error, it does not abort.
+- **Scope-fenced.** Only flight and hotel search honour `--stealth`. Other paths never receive it.
+
+Using stealth against sites whose terms prohibit automated access is the operator's responsibility.
+
+Example:
+
+```bash
+export TRVL_STEALTH_ALLOWLIST=".google.com"
+trvl flights HEL NRT 2026-09-01 --stealth
+trvl hotels "Helsinki" --checkin 2026-09-01 --checkout 2026-09-04 --stealth
+```
+
 ## What it can do
 
 | Area | Highlights | Reference |

--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -42,6 +42,7 @@ func flightsCmd() *cobra.Command {
 		provider       string
 		flightRailFly  bool
 		deep           bool
+		stealth        bool
 	)
 
 	cmd := &cobra.Command{
@@ -169,6 +170,7 @@ Examples:
 				SortBy:     sort,
 				Airlines:   airlines,
 				Adults:     adults,
+				Stealth:    stealth,
 			}
 
 			// --compare-cabins: search all cabin classes in parallel.
@@ -319,6 +321,7 @@ Examples:
 	cmd.Flags().BoolVar(&flightRailFly, "rail-fly", false, "Expand the search to rail-connected origins (KL/AF Air&Rail), surfacing cheaper rail+fly bundles even when the origin is outside the default hub list")
 	cmd.Flags().BoolVar(&deep, "deep", false, "Run a budget-gated counterfactual fan-out (nearby airports, split tickets, hidden city). Issues extra provider calls, capped by a best-effort budget that never delays the primary search")
 	cmd.Flags().BoolVar(&noGeo, "no-geo", false, "Disable geo-IP origin detection (also honored via TRVL_NO_GEO=1). Origin then resolves only from an explicit code or your saved home airport.")
+	cmd.Flags().BoolVar(&stealth, "stealth", false, "Opt in to authorized first-party stealth access (Chrome HTTP/2 fingerprint) for the flight fetch. Default off. Scope-fenced: activates ONLY for hosts on the operator allowlist TRVL_STEALTH_ALLOWLIST (comma-separated; empty = never). Fail-safe: a non-allowlisted host runs the normal path. Using stealth against sites that prohibit automated access is the operator's responsibility.")
 
 	cmd.ValidArgsFunction = airportCompletion
 

--- a/cmd/trvl/hotels.go
+++ b/cmd/trvl/hotels.go
@@ -62,6 +62,7 @@ Examples:
 	cmd.Flags().Bool("meal-plan", false, "Only show properties with breakfast/meals included (Booking)")
 	cmd.Flags().Bool("include-sold-out", false, "Include sold-out properties (Booking)")
 	cmd.Flags().Bool("explain", false, "Show per-factor profile match breakdown for each result")
+	cmd.Flags().Bool("stealth", false, "Opt in to authorized first-party stealth access (Chrome HTTP/2 fingerprint) for the hotel fetch. Default off. Scope-fenced: activates ONLY for hosts on the operator allowlist TRVL_STEALTH_ALLOWLIST (comma-separated; empty = never). Fail-safe: a non-allowlisted host runs the normal path. Using stealth against sites that prohibit automated access is the operator's responsibility.")
 
 	_ = cmd.MarkFlagRequired("checkin")
 	_ = cmd.MarkFlagRequired("checkout")
@@ -115,6 +116,7 @@ func runHotels(cmd *cobra.Command, args []string) error {
 	mealPlan, _ := cmd.Flags().GetBool("meal-plan")
 	includeSoldOut, _ := cmd.Flags().GetBool("include-sold-out")
 	explain, _ := cmd.Flags().GetBool("explain")
+	stealth, _ := cmd.Flags().GetBool("stealth")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -164,6 +166,7 @@ func runHotels(cmd *cobra.Command, args []string) error {
 		Sustainable:      sustainable,
 		MealPlan:         mealPlan,
 		IncludeSoldOut:   includeSoldOut,
+		Stealth:          stealth,
 	}
 
 	// Apply preference-based filters (only when not already set via flags).

--- a/internal/batchexec/client.go
+++ b/internal/batchexec/client.go
@@ -16,10 +16,13 @@ import (
 	"math/rand/v2"
 	"net"
 	"net/http"
+	neturl "net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/cache"
+	"github.com/MikkoParkkola/trvl/internal/stealth"
 	utls "github.com/refraction-networking/utls"
 	"golang.org/x/net/http2"
 	"golang.org/x/time/rate"
@@ -61,6 +64,15 @@ type Client struct {
 	limiter *rate.Limiter
 	cache   *cache.Cache
 	noCache bool
+
+	// stealthHTTP is the opt-in, operator-authorized stealth transport. It is
+	// the full Chrome 146 HTTP/2 fingerprint client (ChromeHTTPClient), which
+	// advertises native ALPN ["h2","http/1.1"] and speaks HTTP/2 — the profile
+	// that clears Datadome-class bot detection. It is built lazily on first
+	// authorized use so the default (non-stealth) path is unaffected, and it is
+	// reused thereafter for connection pooling. Access is guarded by stealthOnce.
+	stealthHTTP *http.Client
+	stealthOnce sync.Once
 }
 
 // NewClient creates a Client that impersonates Chrome's TLS fingerprint.
@@ -207,7 +219,17 @@ func dialTLSChromeHTTP1WithConfig(ctx context.Context, network, addr string, tls
 // Get performs a GET request with Chrome headers.
 // The request is subject to rate limiting and automatic retry on 429/5xx.
 func (c *Client) Get(ctx context.Context, url string) (int, []byte, error) {
-	return c.doWithRetry(ctx, func() (*http.Request, error) {
+	return c.GetStealth(ctx, url, false)
+}
+
+// GetStealth is Get with an explicit, operator-authorized stealth toggle. When
+// stealthRequested is true AND the request host is on the operator allowlist,
+// the request uses the Chrome HTTP/2 stealth transport; otherwise it runs the
+// normal path (with a single refusal log line for a requested-but-unauthorized
+// host). stealthRequested=false is byte-identical to Get.
+func (c *Client) GetStealth(ctx context.Context, url string, stealthRequested bool) (int, []byte, error) {
+	httpClient, _ := c.transportForStealth(stealthRequested, url)
+	return c.doWithRetryVia(ctx, httpClient, func() (*http.Request, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return nil, err
@@ -258,7 +280,18 @@ func (c *Client) GetWithHeaders(ctx context.Context, url string, headers map[str
 // Content-Type to application/x-www-form-urlencoded and uses a Chrome User-Agent.
 // The request is subject to rate limiting and automatic retry on 429/5xx.
 func (c *Client) PostForm(ctx context.Context, url, formBody string) (int, []byte, error) {
-	return c.doWithRetry(ctx, func() (*http.Request, error) {
+	return c.PostFormStealth(ctx, url, formBody, false)
+}
+
+// PostFormStealth is PostForm with an explicit, operator-authorized stealth
+// toggle. When stealthRequested is true AND the request host is on the operator
+// allowlist (TRVL_STEALTH_ALLOWLIST), the request uses the Chrome HTTP/2 stealth
+// transport; otherwise it runs the normal path (logging a single refusal line
+// for a requested-but-unauthorized host). stealthRequested=false is
+// byte-identical to PostForm — stealth is strictly opt-in and scope-fenced.
+func (c *Client) PostFormStealth(ctx context.Context, url, formBody string, stealthRequested bool) (int, []byte, error) {
+	httpClient, _ := c.transportForStealth(stealthRequested, url)
+	return c.doWithRetryVia(ctx, httpClient, func() (*http.Request, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(formBody))
 		if err != nil {
 			return nil, err
@@ -278,6 +311,15 @@ func (c *Client) PostForm(ctx context.Context, url, formBody string) (int, []byt
 // with exponential backoff (1s, 2s, 4s) plus jitter (+-25%).
 // Client errors (4xx except 429) are not retried.
 func (c *Client) doWithRetry(ctx context.Context, buildReq func() (*http.Request, error)) (int, []byte, error) {
+	return c.doWithRetryVia(ctx, c.http, buildReq)
+}
+
+// doWithRetryVia is doWithRetry parameterized by the underlying *http.Client to
+// use for the round-trip. The default fetch path passes c.http (Chrome HTTP/1.1
+// fingerprint); the authorized stealth path passes the lazily-built HTTP/2
+// Chrome 146 client. Rate limiting, retry, and logging are identical regardless
+// of transport so behavior is observable and consistent.
+func (c *Client) doWithRetryVia(ctx context.Context, httpClient *http.Client, buildReq func() (*http.Request, error)) (int, []byte, error) {
 	var lastStatus int
 	var lastBody []byte
 	var lastErr error
@@ -297,7 +339,7 @@ func (c *Client) doWithRetry(ctx context.Context, buildReq func() (*http.Request
 		slog.Debug("request", "method", req.Method, "url", req.URL.String(), "payload_len", req.ContentLength)
 		start := time.Now()
 
-		resp, err := c.http.Do(req)
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			lastErr = err
 			if attempt < defaultMaxRetries {
@@ -403,8 +445,25 @@ func (c *Client) SearchFlightsGL(ctx context.Context, encodedFilters, gl string)
 	return c.SearchFlightsGLCurr(ctx, encodedFilters, gl, "")
 }
 
+// SearchFlightsGLStealth is SearchFlightsGL with an explicit, operator-authorized
+// stealth toggle. The flight search path passes opts.Stealth here; the gate
+// (host allowlist) is enforced inside the POST. stealthRequested=false is
+// byte-identical to SearchFlightsGL.
+func (c *Client) SearchFlightsGLStealth(ctx context.Context, encodedFilters, gl string, stealthRequested bool) (int, []byte, error) {
+	return c.SearchFlightsGLCurrStealth(ctx, encodedFilters, gl, "", stealthRequested)
+}
+
 // SearchFlightsGLCurr is the full variant with both gl= and curr= parameters.
 func (c *Client) SearchFlightsGLCurr(ctx context.Context, encodedFilters, gl, curr string) (int, []byte, error) {
+	return c.SearchFlightsGLCurrStealth(ctx, encodedFilters, gl, curr, false)
+}
+
+// SearchFlightsGLCurrStealth is SearchFlightsGLCurr with an explicit,
+// operator-authorized stealth toggle threaded through to the underlying POST.
+// The response cache is shared with the non-stealth path (the transport does not
+// change the response body), so a cached entry is returned regardless of the
+// stealth flag. stealthRequested=false is byte-identical to SearchFlightsGLCurr.
+func (c *Client) SearchFlightsGLCurrStealth(ctx context.Context, encodedFilters, gl, curr string, stealthRequested bool) (int, []byte, error) {
 	url := FlightsURL
 	if gl != "" {
 		url += "&gl=" + gl
@@ -416,7 +475,7 @@ func (c *Client) SearchFlightsGLCurr(ctx context.Context, encodedFilters, gl, cu
 	if data, ok := c.getCached(url, payload); ok {
 		return 200, data, nil
 	}
-	status, body, err := c.PostForm(ctx, url, payload)
+	status, body, err := c.PostFormStealth(ctx, url, payload, stealthRequested)
 	if err == nil && status == 200 {
 		c.setCached(url, payload, body, FlightCacheTTL)
 	}
@@ -597,3 +656,56 @@ func dialTLSChromeH2(ctx context.Context, network, addr string) (net.Conn, error
 
 // ErrBlocked is returned when Google responds with 403 Forbidden.
 var ErrBlocked = errors.New("request blocked (403)")
+
+// transportForStealth selects the *http.Client to use for a request to url when
+// the caller has requested stealth.
+//
+// It enforces the operator-authorized scope fence: stealth activates ONLY when
+//  1. stealthRequested is true (the operator passed --stealth), AND
+//  2. the request host is on the operator-authorized allowlist
+//     (stealth.Authorized, backed by TRVL_STEALTH_ALLOWLIST).
+//
+// When stealth is requested for a non-allowlisted host, it logs exactly one
+// clear line and returns the normal transport (stealth no-op, never an error or
+// abort). When stealth is not requested at all, it returns the normal transport
+// silently. The fail-safe default — empty/unset allowlist — means stealth never
+// activates. Returns the *http.Client to use and whether stealth was engaged.
+func (c *Client) transportForStealth(stealthRequested bool, url string) (*http.Client, bool) {
+	if !stealthRequested {
+		return c.http, false
+	}
+	host := hostFromURL(url)
+	if !stealth.Authorized(host) {
+		slog.Info("stealth not authorized for host " + host)
+		return c.http, false
+	}
+	return c.stealthClient(), true
+}
+
+// stealthClient lazily builds and caches the operator-authorized stealth
+// transport (Chrome 146 HTTP/2 fingerprint). It is only ever reached after the
+// allowlist gate has authorized the host, so building it is itself gated.
+func (c *Client) stealthClient() *http.Client {
+	c.stealthOnce.Do(func() {
+		// Test clients route through a redirect transport; reusing it keeps
+		// stealth-engaged tests deterministic and offline. Production clients
+		// build the real Chrome HTTP/2 fingerprint client.
+		if _, ok := c.http.Transport.(*testRedirectTransport); ok {
+			c.stealthHTTP = c.http
+			return
+		}
+		c.stealthHTTP = ChromeHTTPClient()
+	})
+	return c.stealthHTTP
+}
+
+// hostFromURL extracts the lowercase host (no port) from a request URL. It
+// returns an empty string when the URL cannot be parsed, which the allowlist
+// treats as unauthorized (fail-safe).
+func hostFromURL(rawURL string) string {
+	u, err := neturl.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}

--- a/internal/batchexec/stealth_wiring_test.go
+++ b/internal/batchexec/stealth_wiring_test.go
@@ -1,0 +1,167 @@
+package batchexec
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/stealth"
+)
+
+// captureSlog redirects slog output to a buffer for the duration of the test so
+// the refusal log line can be asserted. It restores the previous default logger.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// TestTransportForStealth_NotRequested proves that without the stealth flag the
+// normal transport is used and stealth is never engaged, regardless of allowlist.
+func TestTransportForStealth_NotRequested(t *testing.T) {
+	t.Setenv(stealth.AllowlistEnv, "www.google.com")
+	c := NewClient()
+
+	got, engaged := c.transportForStealth(false, FlightsURL)
+	if engaged {
+		t.Error("engaged = true with stealth not requested; want false")
+	}
+	if got != c.http {
+		t.Error("transportForStealth returned non-default client when stealth not requested")
+	}
+}
+
+// TestTransportForStealth_RequestedUnauthorized proves the fail-safe scope fence:
+// stealth requested for a non-allowlisted host runs the normal path, engages no
+// stealth, and emits exactly one refusal log line naming the host.
+func TestTransportForStealth_RequestedUnauthorized(t *testing.T) {
+	t.Setenv(stealth.AllowlistEnv, "") // empty => refuse by default
+	buf := captureSlog(t)
+	c := NewClient()
+
+	got, engaged := c.transportForStealth(true, FlightsURL)
+	if engaged {
+		t.Error("engaged = true for unauthorized host; want false")
+	}
+	if got != c.http {
+		t.Error("unauthorized host did not fall back to the normal transport")
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "stealth not authorized for host www.google.com") {
+		t.Errorf("missing refusal log line; got: %q", logged)
+	}
+	if strings.Count(logged, "stealth not authorized for host") != 1 {
+		t.Errorf("expected exactly one refusal log line; got: %q", logged)
+	}
+}
+
+// TestTransportForStealth_RequestedAuthorized proves that when stealth is
+// requested AND the host is on the operator allowlist, stealth is engaged with a
+// distinct (non-default), non-nil transport.
+func TestTransportForStealth_RequestedAuthorized(t *testing.T) {
+	t.Setenv(stealth.AllowlistEnv, ".google.com")
+	buf := captureSlog(t)
+	c := NewClient()
+
+	got, engaged := c.transportForStealth(true, FlightsURL)
+	if !engaged {
+		t.Fatal("engaged = false for authorized host; want true")
+	}
+	if got == nil {
+		t.Fatal("authorized stealth returned nil client")
+	}
+	if got == c.http {
+		t.Error("authorized stealth used the default transport; want the stealth transport")
+	}
+	if strings.Contains(buf.String(), "stealth not authorized") {
+		t.Errorf("unexpected refusal log for authorized host: %q", buf.String())
+	}
+}
+
+// TestPostFormStealth_AuthorizedReachesServer proves the authorized stealth path
+// is wired end-to-end through PostFormStealth: the request still completes (no
+// abort) and the stealth transport is engaged. A test client reuses its redirect
+// transport for stealth so the call stays offline and deterministic.
+func TestPostFormStealth_AuthorizedReachesServer(t *testing.T) {
+	t.Setenv(stealth.AllowlistEnv, ".google.com")
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	c := NewTestClient(srv.URL)
+	status, body, err := c.PostFormStealth(context.Background(), FlightsURL, "f.req=x", true)
+	if err != nil {
+		t.Fatalf("PostFormStealth error: %v", err)
+	}
+	if status != 200 || string(body) != "ok" {
+		t.Fatalf("unexpected response: status=%d body=%q", status, body)
+	}
+	if hits != 1 {
+		t.Fatalf("expected exactly one request; got %d", hits)
+	}
+}
+
+// TestPostFormStealth_UnauthorizedReachesServerNormalPath proves stealth
+// requested for a non-allowlisted host does NOT abort: it runs the normal path
+// and the request still reaches the server.
+func TestPostFormStealth_UnauthorizedReachesServerNormalPath(t *testing.T) {
+	t.Setenv(stealth.AllowlistEnv, "") // refuse by default
+	buf := captureSlog(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	c := NewTestClient(srv.URL)
+	status, body, err := c.PostFormStealth(context.Background(), FlightsURL, "f.req=x", true)
+	if err != nil {
+		t.Fatalf("PostFormStealth error: %v", err)
+	}
+	if status != 200 || string(body) != "ok" {
+		t.Fatalf("unauthorized stealth should run normal path; status=%d body=%q", status, body)
+	}
+	if !strings.Contains(buf.String(), "stealth not authorized for host www.google.com") {
+		t.Errorf("missing refusal log line; got: %q", buf.String())
+	}
+}
+
+func TestHostFromURL(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{FlightsURL, "www.google.com"},
+		{"https://example.com:8443/path", "example.com"},
+		{"://bad-url", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := hostFromURL(tt.in); got != tt.want {
+			t.Errorf("hostFromURL(%q) = %q; want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestGetStealth_DefaultIsByteIdenticalToGet proves GetStealth with
+// stealthRequested=false is equivalent to the normal Get path.
+func TestGetStealth_DefaultIsByteIdenticalToGet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	c := NewTestClient(srv.URL)
+	status, body, err := c.GetStealth(context.Background(), "https://www.google.com/travel/hotels", false)
+	if err != nil || status != 200 || string(body) != "ok" {
+		t.Fatalf("GetStealth(false) mismatch: status=%d body=%q err=%v", status, body, err)
+	}
+}

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -78,6 +78,13 @@ type SearchOptions struct {
 	// cheaper synthesized option (hidden-city, positioning, split, multimodal,
 	// …) in result.HackSaving. Set NoHacks to run a pure naive search.
 	NoHacks bool
+
+	// Stealth opts into the operator-authorized stealth transport for the
+	// Google Flights fetch. It is DEFAULT OFF (zero value). Even when true,
+	// stealth activates ONLY for a request whose host is on the operator
+	// allowlist (TRVL_STEALTH_ALLOWLIST); a requested-but-unauthorized host
+	// runs the normal path and logs a single refusal line. See internal/stealth.
+	Stealth bool
 }
 
 // defaults fills in zero-value fields with sensible defaults.
@@ -628,7 +635,7 @@ func searchGoogleFlightsWithClient(ctx context.Context, client *batchexec.Client
 	}
 
 	gl := CurrencyToGL(opts.Currency)
-	status, body, err := client.SearchFlightsGL(ctx, encoded, gl)
+	status, body, err := client.SearchFlightsGLStealth(ctx, encoded, gl, opts.Stealth)
 	if err != nil {
 		return &models.FlightSearchResult{
 			Error: fmt.Sprintf("request failed: %v", err),

--- a/internal/flights/stealth_wiring_test.go
+++ b/internal/flights/stealth_wiring_test.go
@@ -1,0 +1,78 @@
+package flights
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/stealth"
+)
+
+// captureSlog redirects slog to a buffer for the duration of the test and
+// restores the previous default logger afterwards.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// runGoogleLeg drives just the Google Flights leg with the given options so the
+// stealth gate is exercised deterministically without provider fan-out.
+func runGoogleLeg(t *testing.T, opts SearchOptions) {
+	t.Helper()
+	body := makeFlightResponseBody(t)
+	ts := flightsTestServer(t, 200, body)
+	defer ts.Close()
+	client := batchexec.NewTestClient(ts.URL)
+	if _, err := searchGoogleFlightsWithClient(t.Context(), client, "HEL", "NRT", "2026-06-15", opts); err != nil {
+		t.Fatalf("google leg error: %v", err)
+	}
+}
+
+// TestFlightStealth_DefaultOff proves that with Stealth=false the fetch runs the
+// normal path and never logs a stealth refusal — i.e. stealth is never even
+// consulted (default off).
+func TestFlightStealth_DefaultOff(t *testing.T) {
+	t.Setenv(stealth.AllowlistEnv, ".google.com") // allowlisted, but flag is off
+	buf := captureSlog(t)
+
+	runGoogleLeg(t, SearchOptions{}) // Stealth defaults to false
+
+	if strings.Contains(buf.String(), "stealth not authorized") {
+		t.Errorf("stealth refusal logged with Stealth=false; got: %q", buf.String())
+	}
+}
+
+// TestFlightStealth_RequestedUnauthorized proves Stealth=true for the Google host
+// when the allowlist is empty runs the normal path and emits the refusal log —
+// proving the flag is genuinely plumbed into the fetch (the prior failure was a
+// flag that never reached the fetch path).
+func TestFlightStealth_RequestedUnauthorized(t *testing.T) {
+	t.Setenv(stealth.AllowlistEnv, "") // refuse by default
+	buf := captureSlog(t)
+
+	runGoogleLeg(t, SearchOptions{Stealth: true})
+
+	if !strings.Contains(buf.String(), "stealth not authorized for host www.google.com") {
+		t.Errorf("expected refusal log for unauthorized host; got: %q", buf.String())
+	}
+}
+
+// TestFlightStealth_RequestedAuthorized proves Stealth=true with the Google host
+// allowlisted does NOT log a refusal — the gate authorized the host so stealth
+// engaged on the fetch path.
+func TestFlightStealth_RequestedAuthorized(t *testing.T) {
+	t.Setenv(stealth.AllowlistEnv, ".google.com")
+	buf := captureSlog(t)
+
+	runGoogleLeg(t, SearchOptions{Stealth: true})
+
+	if strings.Contains(buf.String(), "stealth not authorized") {
+		t.Errorf("unexpected refusal log for authorized host; got: %q", buf.String())
+	}
+}

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -144,6 +144,13 @@ type HotelSearchOptions struct {
 	MustHaveKitchen   bool
 	MustHaveWifi      bool
 	MustHaveWorkspace bool
+
+	// Stealth opts into the operator-authorized stealth transport for the
+	// Google Hotels fetch. It is DEFAULT OFF (zero value). Even when true,
+	// stealth activates ONLY for a request whose host is on the operator
+	// allowlist (TRVL_STEALTH_ALLOWLIST); a requested-but-unauthorized host
+	// runs the normal path and logs a single refusal line. See internal/stealth.
+	Stealth bool
 }
 
 // SearchHotels searches for hotels in the given location.

--- a/internal/hotels/search_fetch.go
+++ b/internal/hotels/search_fetch.go
@@ -211,7 +211,7 @@ func fetchHotelPageFull(ctx context.Context, client *batchexec.Client, location 
 		travelURL += "&start=" + strconv.Itoa(offset)
 	}
 
-	status, body, err := client.Get(ctx, travelURL)
+	status, body, err := client.GetStealth(ctx, travelURL, opts.Stealth)
 	if err != nil {
 		return parseResult{}, fmt.Errorf("hotel search request: %w", err)
 	}

--- a/internal/hotels/stealth_wiring_test.go
+++ b/internal/hotels/stealth_wiring_test.go
@@ -1,0 +1,84 @@
+package hotels
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/stealth"
+)
+
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// runHotelPageFetch drives the single-page Google Hotels fetch with the given
+// options against a local test server so the stealth gate is exercised
+// deterministically. The body parse outcome is irrelevant: the stealth gate is
+// resolved when the HTTP request is dispatched (before parsing), so the refusal
+// log (or its absence) is the assertion target.
+func runHotelPageFetch(t *testing.T, opts HotelSearchOptions, body string) {
+	t.Helper()
+	opts.CheckIn = "2026-06-15"
+	opts.CheckOut = "2026-06-18"
+	opts.Guests = 2
+	opts.Currency = "EUR"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer ts.Close()
+	client := batchexec.NewTestClient(ts.URL)
+	// Best-effort: errors from parsing are ignored; the gate already fired.
+	_, _ = fetchHotelPageFull(t.Context(), client, "Helsinki", opts, 0, "")
+}
+
+// TestHotelStealth_DefaultOff proves Stealth=false never consults the stealth
+// gate (no refusal log), even when the host is allowlisted.
+func TestHotelStealth_DefaultOff(t *testing.T) {
+	t.Setenv(stealth.AllowlistEnv, ".google.com")
+	buf := captureSlog(t)
+
+	runHotelPageFetch(t, HotelSearchOptions{}, strings.Repeat("x", 2000))
+
+	if strings.Contains(buf.String(), "stealth not authorized") {
+		t.Errorf("stealth refusal logged with Stealth=false; got: %q", buf.String())
+	}
+}
+
+// TestHotelStealth_RequestedUnauthorized proves Stealth=true with an empty
+// allowlist runs the normal path and emits the refusal log — proving opts.Stealth
+// is genuinely plumbed into the hotel fetch path.
+func TestHotelStealth_RequestedUnauthorized(t *testing.T) {
+	t.Setenv(stealth.AllowlistEnv, "") // refuse by default
+	buf := captureSlog(t)
+
+	runHotelPageFetch(t, HotelSearchOptions{Stealth: true}, strings.Repeat("x", 2000))
+
+	if !strings.Contains(buf.String(), "stealth not authorized for host www.google.com") {
+		t.Errorf("expected refusal log for unauthorized host; got: %q", buf.String())
+	}
+}
+
+// TestHotelStealth_RequestedAuthorized proves Stealth=true with the host
+// allowlisted does NOT log a refusal — the gate authorized stealth on the fetch.
+func TestHotelStealth_RequestedAuthorized(t *testing.T) {
+	t.Setenv(stealth.AllowlistEnv, ".google.com")
+	buf := captureSlog(t)
+
+	runHotelPageFetch(t, HotelSearchOptions{Stealth: true}, strings.Repeat("x", 2000))
+
+	if strings.Contains(buf.String(), "stealth not authorized") {
+		t.Errorf("unexpected refusal log for authorized host; got: %q", buf.String())
+	}
+}

--- a/internal/stealth/stealth.go
+++ b/internal/stealth/stealth.go
@@ -1,0 +1,80 @@
+// Package stealth implements the operator-authorized gate for trvl's opt-in
+// --stealth capability.
+//
+// Stealth reuses the existing Chrome TLS/HTTP2 fingerprint transport to perform
+// authorized first-party access for flight and hotel search. It is DEFAULT OFF
+// and, even when requested, activates ONLY for hosts the operator has explicitly
+// authorized via the TRVL_STEALTH_ALLOWLIST environment variable.
+//
+// This is a fail-safe, refuse-by-default scope fence: an empty or unset
+// allowlist means stealth never activates for any host. Use against sites that
+// prohibit automated access is the operator's responsibility.
+package stealth
+
+import (
+	"os"
+	"strings"
+)
+
+// AllowlistEnv is the environment variable that holds the operator-authorized
+// stealth allowlist: a comma-separated list of hostnames. Matching is
+// case-insensitive and supports exact host match or suffix match for entries
+// that begin with a dot (e.g. ".google.com" matches "www.google.com").
+const AllowlistEnv = "TRVL_STEALTH_ALLOWLIST"
+
+// Authorized reports whether stealth may activate for the given host.
+//
+// It reads the allowlist from TRVL_STEALTH_ALLOWLIST at call time so operators
+// can scope access per invocation. The gate is fail-safe: an empty or unset
+// allowlist returns false for every host (refuse-by-default), and an empty host
+// is never authorized.
+//
+// Matching rules (all case-insensitive):
+//   - exact match: "www.google.com" authorizes host "www.google.com"
+//   - suffix match: ".google.com" authorizes any host ending in ".google.com"
+//     (e.g. "www.google.com") and the bare apex "google.com"
+func Authorized(host string) bool {
+	return authorizedIn(host, os.Getenv(AllowlistEnv))
+}
+
+// authorizedIn is the pure core of Authorized, separated for testability so the
+// allowlist can be supplied directly without environment mutation.
+func authorizedIn(host, allowlist string) bool {
+	host = canonicalHost(host)
+	if host == "" {
+		return false
+	}
+	for _, raw := range strings.Split(allowlist, ",") {
+		entry := strings.ToLower(strings.TrimSpace(raw))
+		if entry == "" {
+			continue
+		}
+		if entry == host {
+			return true
+		}
+		if strings.HasPrefix(entry, ".") {
+			// ".google.com" matches "www.google.com" (suffix) and the bare
+			// apex "google.com" (entry without the leading dot).
+			if strings.HasSuffix(host, entry) || host == entry[1:] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// canonicalHost lowercases the host and strips any :port suffix so the gate
+// compares bare hostnames. It tolerates inputs that already lack a port.
+func canonicalHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return ""
+	}
+	// Strip a trailing :port if present. IPv6 literals are out of scope for
+	// the allowlist (provider hosts are DNS names), so a simple last-colon
+	// trim is sufficient and safe for "host" and "host:port" forms.
+	if i := strings.LastIndex(host, ":"); i >= 0 && !strings.Contains(host[i:], "]") {
+		host = host[:i]
+	}
+	return host
+}

--- a/internal/stealth/stealth_test.go
+++ b/internal/stealth/stealth_test.go
@@ -1,0 +1,86 @@
+package stealth
+
+import "testing"
+
+// TestAuthorized_EmptyAllowlistRefusesByDefault proves the fail-safe default:
+// an unset/empty allowlist never authorizes stealth for any host.
+func TestAuthorized_EmptyAllowlistRefusesByDefault(t *testing.T) {
+	// GIVEN: no allowlist configured.
+	t.Setenv(AllowlistEnv, "")
+
+	// WHEN/THEN: every host is refused.
+	for _, host := range []string{"www.google.com", "google.com", "example.com", ""} {
+		if Authorized(host) {
+			t.Errorf("Authorized(%q) = true with empty allowlist; want false (fail-safe)", host)
+		}
+	}
+}
+
+// TestAuthorized_ReadsEnv proves Authorized consults TRVL_STEALTH_ALLOWLIST at
+// call time (end-to-end through the public API, not just the pure core).
+func TestAuthorized_ReadsEnv(t *testing.T) {
+	// GIVEN: an allowlist with one exact host.
+	t.Setenv(AllowlistEnv, "www.google.com")
+
+	// WHEN/THEN: the listed host is authorized, an unlisted one is not.
+	if !Authorized("www.google.com") {
+		t.Error("Authorized(www.google.com) = false; want true (exact match in env)")
+	}
+	if Authorized("evil.example.com") {
+		t.Error("Authorized(evil.example.com) = true; want false (not in env)")
+	}
+}
+
+func TestAuthorizedIn(t *testing.T) {
+	tests := []struct {
+		name      string
+		host      string
+		allowlist string
+		want      bool
+	}{
+		{"empty allowlist refuses", "www.google.com", "", false},
+		{"empty host refused", "", "www.google.com", false},
+		{"whitespace-only allowlist refuses", "www.google.com", "   ,  ", false},
+		{"exact match", "www.google.com", "www.google.com", true},
+		{"exact non-match", "maps.google.com", "www.google.com", false},
+		{"suffix match", "www.google.com", ".google.com", true},
+		{"suffix match deep subdomain", "a.b.google.com", ".google.com", true},
+		{"suffix match apex via dotted entry", "google.com", ".google.com", true},
+		{"suffix non-match different domain", "www.google.com.evil.com", ".google.com", false},
+		{"case-insensitive host", "WWW.GOOGLE.COM", "www.google.com", true},
+		{"case-insensitive entry", "www.google.com", "WWW.GOOGLE.COM", true},
+		{"case-insensitive suffix", "WWW.Google.CoM", ".GOOGLE.com", true},
+		{"host with port", "www.google.com:443", "www.google.com", true},
+		{"multi-entry first matches", "www.google.com", "www.google.com,example.com", true},
+		{"multi-entry last matches", "example.com", "www.google.com,example.com", true},
+		{"multi-entry none match", "other.com", "www.google.com,example.com", false},
+		{"entry with surrounding spaces", "example.com", " example.com , foo.com ", true},
+		{"suffix entry must not match unrelated", "notgoogle.com", ".google.com", false},
+		{"bare suffix entry does not authorize substring", "evilgoogle.com", ".google.com", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := authorizedIn(tt.host, tt.allowlist); got != tt.want {
+				t.Errorf("authorizedIn(%q, %q) = %v; want %v", tt.host, tt.allowlist, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalHost(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"www.google.com", "www.google.com"},
+		{"WWW.GOOGLE.COM", "www.google.com"},
+		{"  www.google.com  ", "www.google.com"},
+		{"www.google.com:443", "www.google.com"},
+		{"", ""},
+		{"host:8080", "host"},
+	}
+	for _, tt := range tests {
+		if got := canonicalHost(tt.in); got != tt.want {
+			t.Errorf("canonicalHost(%q) = %q; want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds a unified, opt-in `--stealth` capability for `trvl flights` and `trvl hotels`, gated behind an enforced operator-authorized per-domain allowlist. Stealth reuses the existing Chrome fingerprint transport (no new evasion stack) and is wired into the real fetch paths. The prior attempt parsed the flag into structs but never activated it; this one does, with scope-fence tests proving activation.

## Enforced allowlist gate (fail-safe, refuse-by-default)

The scope fence lives at the exact fetch point in `batchexec`, so it is host-correct regardless of caller:

- **Default off** — stealth is inactive unless `--stealth` is explicitly passed. (I: `internal/flights/search.go:87`, `internal/hotels/search.go:153` — zero-value `Stealth bool`.)
- **Authorized hosts only** — even with `--stealth`, stealth activates only when the request host is on `TRVL_STEALTH_ALLOWLIST` (comma-separated; case-insensitive; exact match or leading-dot suffix like `.google.com`). An allowlist that is absent authorizes nothing. (V: `internal/stealth/stealth.go:46` `Authorized`, `internal/batchexec/client.go:673` `transportForStealth`.)
- **No silent evasion** — a requested-but-unauthorized host runs the normal fetch path and logs exactly one line `stealth not authorized for host <host>`; it does not error, it does not abort. (V: `internal/batchexec/client.go:680`.)
- **Scope-fenced** — only flight and hotel search thread `Stealth`. Ground/cookies/other paths have no `Stealth` field and never receive it. (A: grep shows `Stealth` only in `flights`, `hotels`, `batchexec`, `stealth`, and the two CLI commands.)

## How it is wired

- New package `internal/stealth` — pure, dependency-free `Authorized(host)` reading `TRVL_STEALTH_ALLOWLIST`. (I: `internal/stealth/stealth.go`.)
- `batchexec.Client` gains a lazily-built stealth transport (the existing `ChromeHTTPClient()` Chrome-146 fingerprint) and stealth-aware fetch methods `PostFormStealth` / `GetStealth` / `SearchFlightsGLStealth`. The non-stealth methods delegate with `stealthRequested=false`, so the default path is byte-identical. (I: `internal/batchexec/client.go:230,292,452,466`.)
- Flight fetch: `searchGoogleFlightsWithClient` calls `SearchFlightsGLStealth(..., opts.Stealth)`. (I: `internal/flights/search.go:638`.)
- Hotel fetch: `fetchHotelPageFull` calls `GetStealth(..., opts.Stealth)`. (I: `internal/hotels/search_fetch.go:214`.)
- CLI: `--stealth` added to `cmd/trvl/flights.go` and `cmd/trvl/hotels.go`, default false, passed into the opts struct.

## Tests added

`internal/stealth/stealth_test.go` — `TestAuthorized_EmptyAllowlistRefusesByDefault`, `TestAuthorized_ReadsEnv`, `TestAuthorizedIn` (table: absent/whitespace allowlist, exact, suffix, apex, case-insensitivity, port, multi-entry, no-substring-match), `TestCanonicalHost`. 100% statement coverage.

`internal/batchexec/stealth_wiring_test.go` — `TestTransportForStealth_NotRequested`, `TestTransportForStealth_RequestedUnauthorized` (asserts the single refusal log line), `TestTransportForStealth_RequestedAuthorized` (asserts a distinct stealth transport is engaged), `TestPostFormStealth_AuthorizedReachesServer`, `TestPostFormStealth_UnauthorizedReachesServerNormalPath`, `TestHostFromURL`, `TestGetStealth_DefaultIsByteIdenticalToGet`.

`internal/flights/stealth_wiring_test.go` — `TestFlightStealth_DefaultOff`, `TestFlightStealth_RequestedUnauthorized` (proves `opts.Stealth` reaches the fetch), `TestFlightStealth_RequestedAuthorized`.

`internal/hotels/stealth_wiring_test.go` — `TestHotelStealth_DefaultOff`, `TestHotelStealth_RequestedUnauthorized`, `TestHotelStealth_RequestedAuthorized`.

All tests are offline/deterministic (use `NewTestClient` / `httptest` and `t.Setenv`).

## Validation (all pass)

- `gofmt -l .` — clean (no files listed)
- `go vet ./...` — exit 0
- `go build ./...` — exit 0
- `go test ./internal/stealth/... ./internal/batchexec/... ./internal/flights/... ./internal/hotels/... ./cmd/trvl/...` — all `ok`
- `staticcheck` on changed packages — exit 0, no findings
- Toolchain: `GOTOOLCHAIN=go1.26.4`

## Docs

README gains a "Stealth: opt-in, authorized first-party access only" section documenting default-off, allowlist-gated activation, fail-safe refuse-by-default, scope fence, and that use against sites prohibiting automated access is the operator's responsibility. The `--stealth` flag help text on both commands states the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
