### PR TITLE
Wire inboxparser + daygraph into the CLI (MIK-3088)

### DIFF
--- a/cmd/trvl/commands_test.go
+++ b/cmd/trvl/commands_test.go
@@ -23,7 +23,9 @@ func TestRootCmd_SubcommandCount(t *testing.T) {
 	// 68 -> 69 with `status` (operational health/circuit/rate-limit snapshot).
 	// 69 -> 70 with `nudges` (MIK-6233 personal travel graph nudges).
 	// 70 -> 71 with `digest` (MIK-3067 daily Gmail deal-radar digest).
-	const want = 71
+	// 71 -> 73 with `import-inbox` + `plan-days` (MIK-3088 trip-composition
+	// wiring: inbox confirmation import and day-graph itinerary compose).
+	const want = 73
 	got := len(rootCmd.Commands())
 	if got != want {
 		names := make([]string, 0, got)

--- a/cmd/trvl/import_inbox.go
+++ b/cmd/trvl/import_inbox.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/inboxparser"
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/trips"
+	"github.com/spf13/cobra"
+)
+
+// importInboxResult is the structured outcome of an import-inbox run. It is the
+// return value of the pure collectInbox helper so tests can assert on parsing
+// without touching the on-disk trip store.
+type importInboxResult struct {
+	Trip    trips.Trip                `json:"trip"`
+	Summary inboxparser.IngestSummary `json:"summary"`
+	Read    []string                  `json:"read"`    // files successfully read
+	Skipped []skippedFile             `json:"skipped"` // files that could not be read
+}
+
+// skippedFile records a path that was skipped along with the reason, so the run
+// is fail-soft per file rather than aborting the whole import.
+type skippedFile struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+// importInboxCmd implements `trvl import-inbox` — the no-manual-entry path that
+// turns travel-confirmation emails into a trip with bookings and legs.
+//
+// It accepts one or more .eml file paths and/or directories of them, parses
+// each via internal/inboxparser, and either prints the resulting summary
+// (default) or persists it: --save NAME creates a new trip, --trip-id updates
+// an existing one. Re-importing the same mail is idempotent on provider+ref.
+//
+// Examples:
+//
+//	trvl import-inbox confirmation.eml
+//	trvl import-inbox ~/Mail/travel/                 # all .eml in a directory
+//	trvl import-inbox klm.eml booking.eml --save "Paris weekend"
+//	trvl import-inbox klm.eml --trip-id trip_abc123
+//	trvl import-inbox ~/Mail/travel/ --format json
+func importInboxCmd() *cobra.Command {
+	var (
+		save   string
+		tripID string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "import-inbox FILE_OR_DIR [FILE_OR_DIR...]",
+		Short: "Import travel-confirmation emails (.eml) into a trip",
+		Long: `Parse travel-confirmation emails and build a trip from them — no manual entry.
+
+Each argument is an .eml file or a directory containing .eml files. Recognised
+providers (KLM, Booking.com, Airbnb) are turned into trip legs and bookings;
+unrecognised or unreadable files are skipped without aborting the run.
+
+By default the parsed trip is summarised to stdout. To persist:
+  --save NAME      create a new saved trip from the imported mail
+  --trip-id ID     merge the imported mail into an existing saved trip
+
+Re-importing the same confirmation is idempotent (deduplicated on provider +
+booking reference).
+
+Examples:
+  trvl import-inbox confirmation.eml
+  trvl import-inbox ~/Mail/travel/
+  trvl import-inbox klm.eml booking.eml --save "Paris weekend"
+  trvl import-inbox klm.eml --trip-id trip_abc123
+  trvl import-inbox ~/Mail/travel/ --format json`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if save != "" && tripID != "" {
+				return fmt.Errorf("use only one of --save or --trip-id, not both")
+			}
+
+			paths, err := expandEmlPaths(args)
+			if err != nil {
+				return err
+			}
+			if len(paths) == 0 {
+				return fmt.Errorf("no .eml files found in: %s", strings.Join(args, ", "))
+			}
+
+			base := trips.Trip{Name: save, Status: "planning"}
+			if tripID != "" {
+				store, err := loadTripStore()
+				if err != nil {
+					return err
+				}
+				existing, err := store.Get(tripID)
+				if err != nil {
+					return err
+				}
+				base = *existing
+			}
+
+			result := collectInbox(base, paths, os.ReadFile)
+
+			switch {
+			case tripID != "":
+				store, err := loadTripStore()
+				if err != nil {
+					return err
+				}
+				if err := store.Update(tripID, func(t *trips.Trip) error {
+					*t = result.Trip
+					return nil
+				}); err != nil {
+					return err
+				}
+				result.Trip.ID = tripID
+			case save != "":
+				store, err := loadTripStore()
+				if err != nil {
+					return err
+				}
+				id, err := store.Add(result.Trip)
+				if err != nil {
+					return err
+				}
+				result.Trip.ID = id
+			}
+
+			if format == "json" {
+				return models.FormatJSON(cmd.OutOrStdout(), result)
+			}
+			printImportInbox(cmd.OutOrStdout(), result, save != "" || tripID != "")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&save, "save", "", "Save the import as a new trip with this name")
+	cmd.Flags().StringVar(&tripID, "trip-id", "", "Merge the import into an existing saved trip")
+	return cmd
+}
+
+// collectInbox is the pure core of import-inbox: it reads each path with the
+// supplied reader, parses recognised confirmations into the base trip, and
+// returns the merged trip plus a summary. It never panics and treats a read
+// error or unrecognised mail as a soft per-file skip. The reader is injected so
+// tests can exercise the logic without an on-disk store.
+func collectInbox(base trips.Trip, paths []string, readFile func(string) ([]byte, error)) importInboxResult {
+	res := importInboxResult{}
+
+	raws := make([][]byte, 0, len(paths))
+	for _, p := range paths {
+		raw, err := readFile(p)
+		if err != nil {
+			res.Skipped = append(res.Skipped, skippedFile{Path: p, Reason: err.Error()})
+			continue
+		}
+		raws = append(raws, raw)
+		res.Read = append(res.Read, p)
+	}
+
+	merged, summary := inboxparser.IngestConfirmations(base, raws)
+	res.Trip = merged
+	res.Summary = summary
+	return res
+}
+
+// expandEmlPaths turns the CLI arguments (files and/or directories) into a
+// sorted, de-duplicated list of .eml file paths. A file argument is taken as-is
+// regardless of extension (the user pointed at it explicitly); a directory is
+// scanned one level deep for *.eml entries.
+func expandEmlPaths(args []string) ([]string, error) {
+	seen := make(map[string]bool)
+	var out []string
+
+	add := func(p string) {
+		if !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+
+	for _, arg := range args {
+		info, err := os.Stat(arg)
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", arg, err)
+		}
+		if !info.IsDir() {
+			add(arg)
+			continue
+		}
+		entries, err := os.ReadDir(arg)
+		if err != nil {
+			return nil, fmt.Errorf("read dir %s: %w", arg, err)
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.EqualFold(filepath.Ext(e.Name()), ".eml") {
+				continue
+			}
+			add(filepath.Join(arg, e.Name()))
+		}
+	}
+
+	sort.Strings(out)
+	return out, nil
+}
+
+// printImportInbox renders a concise human-readable summary of an import run.
+func printImportInbox(w io.Writer, res importInboxResult, persisted bool) {
+	s := res.Summary
+	_, _ = fmt.Fprintf(w, "Imported %d file(s): %d parsed, %d unrecognised, %d skipped\n",
+		len(res.Read)+len(res.Skipped), s.Parsed, s.Unrecognised, len(res.Skipped))
+	_, _ = fmt.Fprintf(w, "  Legs in trip:    %d\n", len(res.Trip.Legs))
+	_, _ = fmt.Fprintf(w, "  Bookings added:  %d (total %d)\n", s.BookingsAdded, len(res.Trip.Bookings))
+
+	for _, b := range res.Trip.Bookings {
+		ref := b.Reference
+		if ref == "" {
+			ref = "(no ref)"
+		}
+		_, _ = fmt.Fprintf(w, "    • %-10s %s %s\n", b.Provider, ref, b.Type)
+	}
+	for _, sk := range res.Skipped {
+		_, _ = fmt.Fprintf(w, "  skipped %s: %s\n", sk.Path, sk.Reason)
+	}
+	if persisted && res.Trip.ID != "" {
+		_, _ = fmt.Fprintf(w, "Saved trip: %s\n", res.Trip.ID)
+	}
+}

--- a/cmd/trvl/import_inbox_test.go
+++ b/cmd/trvl/import_inbox_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/trips"
+)
+
+// fixtureDir is the inboxparser test-fixture directory, reached from cmd/trvl.
+const fixtureDir = "../../internal/inboxparser/testdata"
+
+func fixturePath(name string) string { return filepath.Join(fixtureDir, name) }
+
+// --- import-inbox: pure core ---
+
+func TestCollectInbox_ParsesFixturesIntoBookings(t *testing.T) {
+	paths := []string{
+		fixturePath("klm.eml"),
+		fixturePath("booking.eml"),
+		fixturePath("airbnb.eml"),
+		fixturePath("negative.eml"),
+	}
+
+	res := collectInbox(trips.Trip{Name: "x", Status: "planning"}, paths, os.ReadFile)
+
+	if res.Summary.Parsed != 3 {
+		t.Errorf("Parsed = %d, want 3", res.Summary.Parsed)
+	}
+	if res.Summary.Unrecognised != 1 {
+		t.Errorf("Unrecognised = %d, want 1 (negative.eml)", res.Summary.Unrecognised)
+	}
+	if res.Summary.BookingsAdded != 3 {
+		t.Errorf("BookingsAdded = %d, want 3", res.Summary.BookingsAdded)
+	}
+	if len(res.Trip.Bookings) != 3 {
+		t.Fatalf("Bookings = %d, want 3", len(res.Trip.Bookings))
+	}
+
+	refs := map[string]bool{}
+	for _, b := range res.Trip.Bookings {
+		refs[b.Reference] = true
+	}
+	for _, want := range []string{"ABC123", "1234567890", "HMABCDEF"} {
+		if !refs[want] {
+			t.Errorf("expected booking reference %q to be present, have %v", want, refs)
+		}
+	}
+}
+
+func TestCollectInbox_Idempotent(t *testing.T) {
+	paths := []string{fixturePath("klm.eml")}
+
+	first := collectInbox(trips.Trip{Name: "x", Status: "planning"}, paths, os.ReadFile)
+	if first.Summary.BookingsAdded != 1 {
+		t.Fatalf("first BookingsAdded = %d, want 1", first.Summary.BookingsAdded)
+	}
+
+	// Re-ingesting the same mail into the already-populated trip must add nothing.
+	second := collectInbox(first.Trip, paths, os.ReadFile)
+	if second.Summary.BookingsAdded != 0 {
+		t.Errorf("second BookingsAdded = %d, want 0 (idempotent)", second.Summary.BookingsAdded)
+	}
+	if len(second.Trip.Bookings) != 1 {
+		t.Errorf("Bookings after re-ingest = %d, want 1", len(second.Trip.Bookings))
+	}
+}
+
+func TestCollectInbox_FailSoftOnReadError(t *testing.T) {
+	paths := []string{"missing-a.eml", fixturePath("klm.eml"), "missing-b.eml"}
+
+	reader := func(p string) ([]byte, error) {
+		if strings.HasPrefix(filepath.Base(p), "missing") {
+			return nil, errors.New("no such file")
+		}
+		return os.ReadFile(p)
+	}
+
+	res := collectInbox(trips.Trip{Name: "x", Status: "planning"}, paths, reader)
+
+	if len(res.Skipped) != 2 {
+		t.Errorf("Skipped = %d, want 2", len(res.Skipped))
+	}
+	if len(res.Read) != 1 {
+		t.Errorf("Read = %d, want 1", len(res.Read))
+	}
+	if res.Summary.Parsed != 1 {
+		t.Errorf("Parsed = %d, want 1 (the readable fixture)", res.Summary.Parsed)
+	}
+}
+
+// --- import-inbox: path expansion ---
+
+func TestExpandEmlPaths_DirAndFile(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "a.eml"), "x")
+	mustWrite(t, filepath.Join(dir, "b.EML"), "x") // case-insensitive ext
+	mustWrite(t, filepath.Join(dir, "skip.txt"), "x")
+
+	explicit := filepath.Join(dir, "skip.txt") // explicit file kept despite ext
+	got, err := expandEmlPaths([]string{dir, explicit})
+	if err != nil {
+		t.Fatalf("expandEmlPaths: %v", err)
+	}
+
+	// a.eml + b.EML from dir, plus explicit skip.txt = 3, sorted, de-duped.
+	if len(got) != 3 {
+		t.Fatalf("got %d paths, want 3: %v", len(got), got)
+	}
+	for _, want := range []string{"a.eml", "b.EML", "skip.txt"} {
+		if !containsBase(got, want) {
+			t.Errorf("missing %q in %v", want, got)
+		}
+	}
+}
+
+func TestExpandEmlPaths_MissingArgErrors(t *testing.T) {
+	if _, err := expandEmlPaths([]string{"definitely-not-here-xyz"}); err == nil {
+		t.Error("expected error for missing path")
+	}
+}
+
+// --- import-inbox: command wiring + persistence ---
+
+func TestImportInboxCmd_SavePersistsTrip(t *testing.T) {
+	setTestHome(t, t.TempDir())
+
+	cmd := importInboxCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{fixturePath("klm.eml"), fixturePath("booking.eml"), "--save", "Krakow"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	store, err := loadTripStore()
+	if err != nil {
+		t.Fatalf("loadTripStore: %v", err)
+	}
+	list := store.List()
+	if len(list) != 1 {
+		t.Fatalf("stored trips = %d, want 1", len(list))
+	}
+	if got := len(list[0].Bookings); got != 2 {
+		t.Errorf("persisted bookings = %d, want 2", got)
+	}
+	if !strings.Contains(out.String(), "Bookings added:  2") {
+		t.Errorf("summary missing booking count, got:\n%s", out.String())
+	}
+}
+
+func TestImportInboxCmd_NoEmlFound(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	emptyDir := t.TempDir()
+
+	cmd := importInboxCmd()
+	cmd.SetArgs([]string{emptyDir})
+
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when no .eml files found")
+	}
+}
+
+func TestImportInboxCmd_SaveAndTripIDConflict(t *testing.T) {
+	setTestHome(t, t.TempDir())
+
+	cmd := importInboxCmd()
+	cmd.SetArgs([]string{fixturePath("klm.eml"), "--save", "x", "--trip-id", "y"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when both --save and --trip-id are set")
+	}
+}
+
+// --- trip-id merge + json format ---
+
+func TestImportInboxCmd_TripIDMergesIntoExisting(t *testing.T) {
+	setTestHome(t, t.TempDir())
+
+	store, err := loadTripStore()
+	if err != nil {
+		t.Fatalf("loadTripStore: %v", err)
+	}
+	id, err := store.Add(trips.Trip{Name: "Existing", Status: "planning"})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	cmd := importInboxCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{fixturePath("klm.eml"), "--trip-id", id})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	reloaded, err := loadTripStore()
+	if err != nil {
+		t.Fatalf("reload store: %v", err)
+	}
+	got, err := reloaded.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.Bookings) != 1 {
+		t.Errorf("merged bookings = %d, want 1", len(got.Bookings))
+	}
+	if !strings.Contains(out.String(), "Saved trip: "+id) {
+		t.Errorf("expected saved-trip line for %s, got:\n%s", id, out.String())
+	}
+}
+
+func TestImportInboxCmd_JSONFormat(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	t.Cleanup(func() { format = "" })
+	format = "json"
+
+	cmd := importInboxCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{fixturePath("klm.eml")})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "\"summary\"") {
+		t.Errorf("JSON output missing summary key:\n%s", out.String())
+	}
+}
+
+// --- helpers ---
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func containsBase(paths []string, base string) bool {
+	for _, p := range paths {
+		if filepath.Base(p) == base {
+			return true
+		}
+	}
+	return false
+}
+
+// bindPersistentFormat is intentionally omitted: the package-level `format`
+// var defaults to the table path, which these tests assert against.

--- a/cmd/trvl/plan_days.go
+++ b/cmd/trvl/plan_days.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/MikkoParkkola/trvl/internal/daygraph"
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/trips"
+	"github.com/spf13/cobra"
+)
+
+// planDaysResult is the structured outcome of a plan-days run, returned by the
+// pure composeDays helper so tests can assert without an on-disk trip store.
+type planDaysResult struct {
+	TripID string          `json:"trip_id"`
+	Days   []trips.DayPlan `json:"days"`
+}
+
+// planDaysCmd implements `trvl plan-days` — it composes a per-day itinerary for
+// a saved trip from its workspace places and the trip's date span.
+//
+// It loads the trip by ID, calls internal/daygraph.Compose on the trip's
+// places, and prints one day per trip day with the assigned places and a
+// deterministic route-time estimate.
+//
+// Examples:
+//
+//	trvl plan-days trip_abc123
+//	trvl plan-days trip_abc123 --format json
+func planDaysCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plan-days TRIP_ID",
+		Short: "Compose a per-day itinerary for a saved trip",
+		Long: `Build a per-day plan for a saved trip from its workspace places and date span.
+
+Places are distributed across the trip's days and each day gets a deterministic
+walking/transit route-time estimate. Places without coordinates are still
+assigned to a day but flagged in that day's warnings.
+
+The trip must have a leg with a parseable date (so the day span is known).
+Populate places via the trip workspace before composing.
+
+Examples:
+  trvl plan-days trip_abc123
+  trvl plan-days trip_abc123 --format json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := loadTripStore()
+			if err != nil {
+				return err
+			}
+			trip, err := store.Get(args[0])
+			if err != nil {
+				return err
+			}
+
+			result, err := composeDays(*trip)
+			if err != nil {
+				return err
+			}
+
+			if format == "json" {
+				return models.FormatJSON(cmd.OutOrStdout(), result)
+			}
+			printPlanDays(cmd.OutOrStdout(), result)
+			return nil
+		},
+	}
+	return cmd
+}
+
+// composeDays is the pure core of plan-days: it runs daygraph.Compose over the
+// trip's workspace places and returns the day plans. It is independent of the
+// on-disk store so tests can drive it directly.
+func composeDays(t trips.Trip) (planDaysResult, error) {
+	var places []trips.Place
+	if t.Workspace != nil {
+		places = t.Workspace.Places
+	}
+	days, err := daygraph.Compose(t, places)
+	if err != nil {
+		return planDaysResult{}, err
+	}
+	return planDaysResult{TripID: t.ID, Days: days}, nil
+}
+
+// printPlanDays renders a human-readable day-by-day itinerary.
+func printPlanDays(w io.Writer, res planDaysResult) {
+	if len(res.Days) == 0 {
+		_, _ = fmt.Fprintln(w, "No days to plan (trip has no date span).")
+		return
+	}
+	_, _ = fmt.Fprintf(w, "Itinerary — %d day(s):\n", len(res.Days))
+	for _, d := range res.Days {
+		_, _ = fmt.Fprintf(w, "  %s — %d place(s), ~%d min route\n",
+			d.Date, len(d.PlaceIDs), d.EstimatedRouteMinutes)
+		if d.Title != "" {
+			_, _ = fmt.Fprintf(w, "    %s\n", d.Title)
+		}
+		for _, warn := range d.Warnings {
+			_, _ = fmt.Fprintf(w, "    ! %s\n", warn)
+		}
+	}
+}

--- a/cmd/trvl/plan_days_test.go
+++ b/cmd/trvl/plan_days_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/trips"
+)
+
+// sampleTrip builds a two-day trip with two coordinate-bearing places and one
+// without, so composeDays exercises both the route estimate and the warning.
+func sampleTrip() trips.Trip {
+	return trips.Trip{
+		Name:   "Krakow",
+		Status: "planning",
+		Legs: []trips.TripLeg{{
+			Type:      "flight",
+			From:      "AMS",
+			To:        "KRK",
+			StartTime: "2026-06-16T07:30",
+			EndTime:   "2026-06-17T09:05",
+		}},
+		Workspace: &trips.Workspace{
+			Places: []trips.Place{
+				{Name: "Wawel Castle", City: "Krakow", Lat: 50.0540, Lon: 19.9354},
+				{Name: "Main Square", City: "Krakow", Lat: 50.0617, Lon: 19.9373},
+				{Name: "Mystery spot", City: "Krakow"}, // no coords -> warning
+			},
+		},
+	}
+}
+
+func TestComposeDays_ProducesDaysWithRouteEstimate(t *testing.T) {
+	res, err := composeDays(sampleTrip())
+	if err != nil {
+		t.Fatalf("composeDays: %v", err)
+	}
+
+	// Span 2026-06-16 .. 2026-06-17 inclusive = 2 days.
+	if len(res.Days) != 2 {
+		t.Fatalf("Days = %d, want 2", len(res.Days))
+	}
+
+	totalPlaces := 0
+	sawRoute := false
+	sawWarning := false
+	for _, d := range res.Days {
+		totalPlaces += len(d.PlaceIDs)
+		if d.EstimatedRouteMinutes > 0 {
+			sawRoute = true
+		}
+		if len(d.Warnings) > 0 {
+			sawWarning = true
+		}
+	}
+	if totalPlaces != 3 {
+		t.Errorf("assigned places = %d, want 3", totalPlaces)
+	}
+	if !sawRoute {
+		t.Error("expected at least one day with a non-zero route estimate")
+	}
+	if !sawWarning {
+		t.Error("expected a warning for the coordinate-less place")
+	}
+}
+
+func TestComposeDays_NoDateSpanErrors(t *testing.T) {
+	t.Parallel()
+	// A trip with no parseable leg date has no resolvable day span.
+	_, err := composeDays(trips.Trip{Name: "x", Status: "planning"})
+	if err == nil {
+		t.Error("expected error for trip with no date span")
+	}
+}
+
+func TestComposeDays_NilWorkspace(t *testing.T) {
+	t.Parallel()
+	trip := sampleTrip()
+	trip.Workspace = nil // must not panic; days have no places
+	res, err := composeDays(trip)
+	if err != nil {
+		t.Fatalf("composeDays: %v", err)
+	}
+	if len(res.Days) != 2 {
+		t.Errorf("Days = %d, want 2", len(res.Days))
+	}
+}
+
+func TestPlanDaysCmd_RendersItinerary(t *testing.T) {
+	setTestHome(t, t.TempDir())
+
+	store, err := loadTripStore()
+	if err != nil {
+		t.Fatalf("loadTripStore: %v", err)
+	}
+	id, err := store.Add(sampleTrip())
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	cmd := planDaysCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{id})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Itinerary") {
+		t.Errorf("output missing itinerary header:\n%s", got)
+	}
+	if !strings.Contains(got, "2026-06-16") {
+		t.Errorf("output missing first day date:\n%s", got)
+	}
+}
+
+func TestPlanDaysCmd_MissingTripErrors(t *testing.T) {
+	setTestHome(t, t.TempDir())
+
+	cmd := planDaysCmd()
+	cmd.SetArgs([]string{"trip_does_not_exist"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error for a trip id that is not present")
+	}
+}
+
+func TestPlanDaysCmd_JSONFormat(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	t.Cleanup(func() { format = "" })
+	format = "json"
+
+	store, err := loadTripStore()
+	if err != nil {
+		t.Fatalf("loadTripStore: %v", err)
+	}
+	id, err := store.Add(sampleTrip())
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	cmd := planDaysCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{id})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "\"days\"") {
+		t.Errorf("JSON output missing days key:\n%s", out.String())
+	}
+}

--- a/cmd/trvl/root.go
+++ b/cmd/trvl/root.go
@@ -115,6 +115,8 @@ func init() {
 	rootCmd.AddCommand(multimodalPlanCmd())
 	rootCmd.AddCommand(planAllCmd())
 	rootCmd.AddCommand(nudgesCmd())
+	rootCmd.AddCommand(importInboxCmd())
+	rootCmd.AddCommand(planDaysCmd())
 }
 
 // airportCompletion provides IATA code completion for cobra commands.


### PR DESCRIPTION
## Summary

MIK-3088 (trip composition, merged in PR #312) added `internal/inboxparser`
and `internal/daygraph`, but both packages had tests and **zero production
consumers** outside tests, leaving the DoD WIRED gate open. This PR closes
that gate by adding two user-invocable CLI subcommands that consume the real
package APIs.

## What is now wired

| Package | New consumer | Invoke |
|---|---|---|
| `internal/inboxparser` | `trvl import-inbox` | `trvl import-inbox FILE_OR_DIR [...] [--save NAME \| --trip-id ID]` |
| `internal/daygraph` | `trvl plan-days` | `trvl plan-days TRIP_ID` |

- **V:** `import-inbox` calls the real ingest API `inboxparser.IngestConfirmations` — `cmd/trvl/import_inbox.go:163`. Before this PR the only caller was the package's own test (`internal/inboxparser/inboxparser_test.go`).
- **V:** `plan-days` calls the real compose API `daygraph.Compose` — `cmd/trvl/plan_days.go:84`. Before this PR the only caller was `internal/daygraph/daygraph_test.go`.
- **V:** Both commands are registered on the root command — `cmd/trvl/root.go:119-120`.

## Design notes (minimal, no new deps)

- **I:** Logic is split so the pure cores are store-independent and fully testable: `collectInbox` (`cmd/trvl/import_inbox.go:149`) takes an injected file reader; `composeDays` (`cmd/trvl/plan_days.go:76`) takes a `trips.Trip`. The cobra `RunE` handlers are thin wrappers.
- **I:** `import-inbox` is fail-soft per file — an unreadable path becomes a recorded skip rather than aborting the run (`cmd/trvl/import_inbox.go:153-161`), and re-ingest is idempotent because it reuses the package's provider+reference dedupe.
- **I:** Default output is a human-readable summary; `--format json` (the existing root persistent flag) emits structured JSON. `--save NAME` persists a new trip, `--trip-id ID` merges into an existing one; setting both is rejected.
- **I:** No module dependency added — stdlib (`net/mail` lives inside the parser; the commands use `os`, `path/filepath`, `sort`, `strings`) plus the already-present `cobra` and internal packages only.

## Tests (TDD, no source-without-test)

- **V:** `import-inbox` is driven against the existing `internal/inboxparser/testdata/*.eml` fixtures and asserts 3 bookings are produced (KLM `ABC123`, Booking `1234567890`, Airbnb `HMABCDEF`) with the negative fixture counted unrecognised — `cmd/trvl/import_inbox_test.go`. Idempotency, fail-soft read errors, path expansion (file + dir), `--save` persistence, `--trip-id` merge, JSON output, and conflict handling are all covered.
- **V:** `plan-days` compose surface is covered for the route estimate, the no-coordinates warning, the no-date-span error, nil workspace, command rendering, missing-trip error, and JSON output — `cmd/trvl/plan_days_test.go`.
- **V:** Updated the exact-count guard `TestRootCmd_SubcommandCount` (71 → 73) for the two new subcommands — `cmd/trvl/commands_test.go:26`.

## Validation (local, `GOTOOLCHAIN=go1.26.4`)

| Gate | Result |
|---|---|
| `gofmt -l .` | empty (clean) |
| `go vet ./...` | exit 0 |
| `go build ./...` | exit 0 |
| `go test ./... -cover` | all packages pass |

Coverage on the touched/wired packages:

- `cmd/trvl` — 64.7% (above the CI 50% gate)
- `internal/inboxparser` — 94.0%
- `internal/daygraph` — 95.5%

Per-function coverage for the new code: `collectInbox` 100%, `composeDays`
100%, `expandEmlPaths` 95.5%, command wrappers 83–87%, printers 80–85%.
The uncovered lines are defensive store-error branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
