### PR TITLE
docs(providers): TheFork API discovery — blocked by DataDome (MIK-2949)

### DIFF
--- a/docs/providers/thefork-api-map.md
+++ b/docs/providers/thefork-api-map.md
@@ -1,0 +1,96 @@
+# TheFork API Map — Discovery Capture (MIK-2949)
+
+**Status: BLOCKED by anti-bot. No connector shipped. Docs-only, fail-fast outcome.**
+
+This document records what was **actually observed** in a live network capture on
+**2026-06-24**, when attempting to reverse-engineer the JSON API behind the TheFork
+restaurant search SPA (Phase 1 of MIK-2949). It is built only from captured traffic.
+No endpoint shapes are guessed or fabricated; where I tried candidate URLs by hand,
+that is labelled explicitly and the result was a uniform 403.
+
+## What was attempted
+
+- Tool: `agent-browser` (headed Chrome via CDP), full HAR capture.
+- Target: `https://www.thefork.com/` → intent to search restaurants in **Amsterdam**,
+  apply a filter, open one restaurant detail page.
+- HAR evidence (trimmed, no PII): `docs/providers/thefork-capture-2026-06-24.evidence.json`.
+
+## What was observed
+
+The TheFork SPA **never loaded**. The very first navigation was blocked:
+
+| # | Status | Method | URL (host/path) | Note |
+|---|--------|--------|-----------------|------|
+| 1 | **403** | GET | `https://www.thefork.com/` | Initial document blocked outright |
+| 2 | 200 | GET | `ct.captcha-delivery.com/i.js` | DataDome bot-defense loader |
+| 3 | 200 | GET | `geo.captcha-delivery.com/interstitial/?initialCid=…` | DataDome "Device Check" interstitial |
+| 4 | 200 | GET | `www.thefork.com/favicon.ico` | — |
+| 5 | — | GET | `blob:…geo.captcha-delivery.com/…` | DataDome challenge script (blob) |
+| 6 | 200 | POST | `geo.captcha-delivery.com/interstitial/` | DataDome challenge solve attempt |
+| 7 | 200 | GET | `geo.captcha-delivery.com/captcha/?…&t=bv&…` | DataDome CAPTCHA escalation |
+| 8–11 | 200 | GET | `static.captcha-delivery.com/…` | CAPTCHA template CSS / fonts / logo |
+
+The rendered page is a **DataDome "Device Check" iframe**, not the TheFork app. Page
+body content at capture time was the DataDome bootstrap object
+(`var dd={'rt':'i','cid':'…','host':'geo.captcha-delivery.com', …}`), confirming the
+provider behind the wall is **DataDome** (`*.captcha-delivery.com`).
+
+**Zero** TheFork application/API requests were observed: no GraphQL, no `/api/`,
+no `_next/data`, no XHR/fetch to any `thefork.com` JSON endpoint. Because the SPA's
+JavaScript never executed past the interstitial, there is nothing real to document
+for search / restaurant-detail / reviews endpoints. I will not invent them.
+
+## Replay probe (plain HTTP client, no browser)
+
+To confirm the wall is not merely browser-fingerprint specific, I probed candidate
+hosts directly. **These URLs are hand-guessed candidates, NOT observed traffic** —
+all returned 403 (or unresolvable), so none are confirmed endpoints:
+
+| Probe URL (guessed) | Result |
+|---------------------|--------|
+| `https://www.thefork.com/` | 403 |
+| `https://www.thefork.com/api/graphql` | 403 |
+| `https://api.thefork.com/graphql` | 403 |
+| `https://graphql.thefork.com/` | unresolved (000) |
+| `https://www.thefork.com/_next/data` | 403 |
+
+## Auth posture for discovery endpoints
+
+**Undetermined — and unreachable.** Discovery (search / detail / reviews) could not be
+observed because the SPA never loaded. The gate is at the **edge / CDN layer (DataDome
+device attestation)**, *before* any application or auth layer. Whether the underlying
+discovery API is anonymous-session or token-gated is moot until the DataDome challenge
+is solved, which a plain HTTP client cannot replay.
+
+## Anti-bot / what blocks replay
+
+- **DataDome** device-check + CAPTCHA on the root document itself (`*.captcha-delivery.com`).
+- The challenge is a JS/blob-based device-attestation flow that issues a signed
+  `datadome` cookie only after passing browser-environment checks; it escalates to a
+  visual/behavioural CAPTCHA (`t=bv`, `dc_ir`).
+- This cannot be replayed from a plain `net/http` client: there is no static API key
+  or replayable token — the gate requires solving a per-session device challenge.
+
+## Verdict (fail-fast per MIK-2949 ABSOLUTE RULES)
+
+> "if unauthenticated discovery calls are blocked by device-attestation / … hard
+> bot-defense that cannot be replayed from a plain HTTP client, STOP building the
+> connector."
+
+This condition is met. **No connector was built.** No fixtures were frozen (there is
+no real captured discovery response to freeze — fabricating one is forbidden).
+
+### Parked (out of scope / blocked)
+
+- Phase 1 connector — **blocked**: no observable discovery endpoints behind DataDome.
+- Phase 2 (airlok auth), Phase 4 (reservations), Phase 5 (Botnaut translation) —
+  parked per ticket scope.
+
+### If revisited later
+
+Replay would require a path that legitimately solves/holds the DataDome session
+(e.g. a real browser-driven session via the repo's existing `tier2_chromedp` /
+`internal/stealth` machinery feeding a captured `datadome` cookie + matching TLS/UA
+fingerprint into the JSON calls), and re-capturing the SPA's real XHR/fetch traffic
+*after* the wall is passed. That is a materially different effort than a plain-client
+JSON connector and was explicitly out of scope for this discovery pass.

--- a/docs/providers/thefork-capture-2026-06-24.evidence.json
+++ b/docs/providers/thefork-capture-2026-06-24.evidence.json
@@ -1,0 +1,72 @@
+{
+  "capturedAt": "2026-06-24",
+  "note": "agent-browser HAR, headed Chrome, Amsterdam search attempt. Trimmed to status+method+url; no personal/account data (no login attempted).",
+  "entries": [
+    {
+      "status": 403,
+      "method": "GET",
+      "url": "https://www.thefork.com/",
+      "resourceType": "Document"
+    },
+    {
+      "status": 200,
+      "method": "GET",
+      "url": "https://ct.captcha-delivery.com/i.js",
+      "resourceType": "Script"
+    },
+    {
+      "status": 200,
+      "method": "GET",
+      "url": "https://geo.captcha-delivery.com/interstitial/?initialCid=AHrlqAAAAAMA0mVOd5K0PP0AH5faMw%3D%3D&hash=4980A61279181687DE605B235F81B9&cid=JpXKWhheF2IumMAfBfvY6vgPqvK6p9xYgMad~RG9gGaFfB4pI1UNlvhn24F7HNdKr7BWrKXzZ40OLA0M0SmfYTjMaPemSUoebfExB5zkUY0ZItS1vMd2WfUOVU7SQ_YJ&referer=https%3A%2F%2Fwww.thefork.com%2F&s=326&e=692214a5060755336b8ed77825b8c25a8a86d5fbc1fab74e451baf5df298baeaeef6cb376bc445768e8bc66b15a1def7&b=1637&dm=cd",
+      "resourceType": "Document"
+    },
+    {
+      "status": 200,
+      "method": "GET",
+      "url": "https://www.thefork.com/favicon.ico",
+      "resourceType": "Other"
+    },
+    {
+      "status": 0,
+      "method": "GET",
+      "url": "blob:https://geo.captcha-delivery.com/090d14b9-d1ef-4b8d-bd8e-a1397701cce3",
+      "resourceType": "Script"
+    },
+    {
+      "status": 200,
+      "method": "POST",
+      "url": "https://geo.captcha-delivery.com/interstitial/",
+      "resourceType": "XHR"
+    },
+    {
+      "status": 200,
+      "method": "GET",
+      "url": "https://geo.captcha-delivery.com/captcha/?initialCid=AHrlqAAAAAMA0mVOd5K0PP0AH5faMw==&cid=qnTk~9NpY7PkclBzOr8P2MgNsQwnpYvowm1Ee~ciPEcrwCXF~55djEoaz4rXBFLQ6rkGhNeFEapLkk1jJQG9xLG6ULoHu1SUWFy9WbtOoikn7l9LEUCzKDJF2pX0tEce&referer=https%3A%2F%2Fwww.thefork.com%2F&hash=4980A61279181687DE605B235F81B9&t=bv&s=326&e=b2b462b6e430ecff641a27238681e33720f16f5b23c2b436a2d0fb0177160f0ec8744240e049ff6402954a9826c02f5a&ir=40%2C32%2C5%2C29&dm=dc_ir&b=1637",
+      "resourceType": "Document"
+    },
+    {
+      "status": 200,
+      "method": "GET",
+      "url": "https://static.captcha-delivery.com/captcha/assets/tpl/6dc485c0c428c35b53577b146dc6f9179f55ef9ad41b327a2a179998839364bf/index.css",
+      "resourceType": "Stylesheet"
+    },
+    {
+      "status": 200,
+      "method": "GET",
+      "url": "https://static.captcha-delivery.com/common/fonts/roboto/font-face.css",
+      "resourceType": "Stylesheet"
+    },
+    {
+      "status": 200,
+      "method": "GET",
+      "url": "https://static.captcha-delivery.com/captcha/assets/set/f525eef4f03ab81983392564bc44fea01267b8cd/logo.png?update_cache=2458297828603096150",
+      "resourceType": "Image"
+    },
+    {
+      "status": 200,
+      "method": "GET",
+      "url": "https://static.captcha-delivery.com/common/fonts/roboto/roboto.woff2",
+      "resourceType": "Font"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Phase 1 discovery for a TheFork restaurant provider (MIK-2949). Outcome is a
**fail-fast, docs-only** deliverable: discovery is **BLOCKED by DataDome** anti-bot,
so no connector was built and no fixtures were fabricated. The provider is built
from **captured** traffic only, and the capture shows the SPA never loaded.

## Evidence (V: / I: / A:)

- **V:** Root document blocked at the edge. First request `GET https://www.thefork.com` (root)
  returns **403** before any application or API call. Captured live 2026-06-24.
  `docs/providers/thefork-capture-2026-06-24.evidence.json:1` (HAR extract, entry 1).
- **V:** The session is served a DataDome device-check plus CAPTCHA interstitial
  (captcha-delivery hosts); rendered page body is the DataDome bootstrap object, not
  the TheFork app. `docs/providers/thefork-api-map.md:31` (observed request table).
- **V:** Zero TheFork application or API requests observed. No GraphQL, no api path,
  no XHR or fetch JSON. `docs/providers/thefork-api-map.md:39`.
- **V:** Plain-client probes of candidate endpoints all returned 403 (or unresolved);
  these are hand-guessed, NOT observed, and are labelled as such.
  `docs/providers/thefork-api-map.md:52`.
- **I:** Auth posture for discovery is undetermined-and-unreachable: the gate sits at
  the CDN device-attestation layer, before any application or auth layer.
  `docs/providers/thefork-api-map.md:62`.
- **A:** No personal or account data captured (no login attempted, no request cookies,
  the only POST is to DataDome's own interstitial), so nothing required redaction.

## Endpoints captured

None replayable. The only observable hosts were the TheFork root (403) and DataDome
infra (captcha-delivery). No TheFork JSON API was reachable.

## Replayable vs blocked

**BLOCKED.** DataDome device attestation cannot be replayed from a plain Go net.http
client. There is no static api-key or replayable token; the gate requires solving a
per-session device challenge that escalates to a visual or behavioural CAPTCHA. Per the
ticket's ABSOLUTE fail-fast rule, building (or faking) a connector is not permitted
here.

## What changed

- `docs/providers/thefork-api-map.md` (+118): one-page API map of the wall, observed
  request table, auth posture, anti-bot analysis, fail-fast verdict, revisit path.
- `docs/providers/thefork-capture-2026-06-24.evidence.json` (+50): trimmed, PII-free
  HAR evidence (status, method, url only).

No Go source changed. `gofmt -l .` empty; `go vet ./...` exit 0; `go build ./...`
exit 0; `internal/destinations` tests pass (85.7% coverage, unchanged by this PR).

## Parked

- TheFork discovery connector: blocked (no observable endpoints behind DataDome).
- Phase 2 (airlok auth), Phase 4 (reservations), Phase 5 (Botnaut translation):
  out of scope per ticket; parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
