### PR TITLE
docs(thefork): key-free stealth-tier discovery — DataDome blocks, + DataDome challenge detection (MIK-2949)

### DIFF
--- a/docs/providers/thefork-api-map.md
+++ b/docs/providers/thefork-api-map.md
@@ -1,50 +1,130 @@
-# TheFork API Map — Discovery Capture (MIK-2949)
+# TheFork API Map — Key-Free Stealth-Tier Discovery (MIK-2949)
 
-**Status: BLOCKED by anti-bot. No connector shipped. Docs-only, fail-fast outcome.**
+**Status: BLOCKED by DataDome behavioural CAPTCHA. No connector shipped. Docs-only,
+fail-fast outcome — plus one honest detection fix (DataDome is now recognized as a
+challenge page).**
 
-This document records what was **actually observed** in a live network capture on
-**2026-06-24**, when attempting to reverse-engineer the JSON API behind the TheFork
-restaurant search SPA (Phase 1 of MIK-2949). It is built only from captured traffic.
-No endpoint shapes are guessed or fabricated; where I tried candidate URLs by hand,
-that is labelled explicitly and the result was a uniform 403.
+This document records what was **actually observed** when driving trvl's own stealth
+browser machinery (`internal/providers/tier2_chromedp.go` + `challenge.go`, and the
+Chrome-TLS-impersonating `tier1_client.go`) against TheFork on **2026-06-24**, to try
+to reach the JSON API behind the restaurant-search SPA **without any API keys**.
 
-## What was attempted
+It supersedes the prior discovery pass (PR #314, headed `agent-browser`), which was
+walled at the root document. This pass used the repo's real stealth tier with an
+extended behavioural warm-up. The wall held. Every endpoint shape below is from
+captured traffic; nothing is guessed or fabricated. The prior pass's HAR evidence
+remains at `docs/providers/thefork-capture-2026-06-24.evidence.json`.
 
-- Tool: `agent-browser` (headed Chrome via CDP), full HAR capture.
-- Target: `https://www.thefork.com/` → intent to search restaurants in **Amsterdam**,
-  apply a filter, open one restaurant detail page.
-- HAR evidence (trimmed, no PII): `docs/providers/thefork-capture-2026-06-24.evidence.json`.
+## What was attempted (this pass — the key-free route)
+
+Three independent vectors against `https://www.thefork.com/` and the Amsterdam search
+route `https://www.thefork.com/search?cityId=415144`:
+
+| # | Vector | Machinery | Warm-up |
+|---|--------|-----------|---------|
+| 1 | **Headless Chrome via CDP** | same as `runCDPChallenge` (`chromedp`, user's installed Chrome, `chromedp.Headless`) | 12 s device-check window + 6 synthetic mouse-move events + scroll-down/scroll-up + 36 s total dwell |
+| 2 | **Headed Chrome via CDP** | identical, `Headless` removed (real visible window) | identical warm-up |
+| 3 | **Tier-1 Chrome-TLS client** | `providers.NewTier1ClientForURL` (JA3/JA4 + HTTP/2 Chrome fingerprint via `bogdanfinn/tls-client`), seeded with 6 real browser cookies | n/a (single round-trip) |
+
+A fourth vector — driving the user's **real Chrome profile** (`--user-data-dir`) to
+carry any human-warmed `datadome` cookie — could not run: the user's Chrome was already
+holding the profile's `SingletonLock`, and forcing it risks profile corruption. It is
+noted under "What a key-free pass would require".
 
 ## What was observed
 
-The TheFork SPA **never loaded**. The very first navigation was blocked:
+The TheFork SPA **never loaded** on any vector. All three were walled by DataDome.
 
-| # | Status | Method | URL (host/path) | Note |
-|---|--------|--------|-----------------|------|
-| 1 | **403** | GET | `https://www.thefork.com/` | Initial document blocked outright |
-| 2 | 200 | GET | `ct.captcha-delivery.com/i.js` | DataDome bot-defense loader |
-| 3 | 200 | GET | `geo.captcha-delivery.com/interstitial/?initialCid=…` | DataDome "Device Check" interstitial |
-| 4 | 200 | GET | `www.thefork.com/favicon.ico` | — |
-| 5 | — | GET | `blob:…geo.captcha-delivery.com/…` | DataDome challenge script (blob) |
-| 6 | 200 | POST | `geo.captcha-delivery.com/interstitial/` | DataDome challenge solve attempt |
-| 7 | 200 | GET | `geo.captcha-delivery.com/captcha/?…&t=bv&…` | DataDome CAPTCHA escalation |
-| 8–11 | 200 | GET | `static.captcha-delivery.com/…` | CAPTCHA template CSS / fonts / logo |
+### Vector 1 & 2 (CDP, headless and headed) — identical outcome
 
-The rendered page is a **DataDome "Device Check" iframe**, not the TheFork app. Page
-body content at capture time was the DataDome bootstrap object
-(`var dd={'rt':'i','cid':'…','host':'geo.captcha-delivery.com', …}`), confirming the
-provider behind the wall is **DataDome** (`*.captcha-delivery.com`).
+- Document navigation returned **HTTP 403**.
+- Rendered page was the **DataDome interstitial**, not the TheFork app: page title
+  `"thefork.com"`, body is the DataDome bootstrap
+  `var dd={'rt':'c', … ,'t':'fe','host':'geo.captcha-delivery.com', …}` followed by a
+  `<iframe … title="DataDome CAPTCHA" …>` pointing at
+  `geo.captcha-delivery.com/captcha/?…&t=fe&…`.
+- `'t':'fe'` = DataDome **full device-check** that escalates to the visual/behavioural
+  CAPTCHA; the iframe is the CAPTCHA itself.
+- A `datadome` cookie (128 chars, domain `.thefork.com`) **was** issued — but it is the
+  *unsolved challenge* cookie, not a cleared-session cookie. It does not unlock content.
+- Captured network on each run (4 requests):
 
-**Zero** TheFork application/API requests were observed: no GraphQL, no `/api/`,
-no `_next/data`, no XHR/fetch to any `thefork.com` JSON endpoint. Because the SPA's
-JavaScript never executed past the interstitial, there is nothing real to document
-for search / restaurant-detail / reviews endpoints. I will not invent them.
+  | Status | Type | URL |
+  |--------|------|-----|
+  | 403 | Document | `https://www.thefork.com/search?cityId=415144` |
+  | 200 | Script | `https://ct.captcha-delivery.com/c.js` |
+  | 200 | Document | `https://geo.captcha-delivery.com/captcha/?…&t=fe&…` |
+  | 200 | Other | `https://www.thefork.com/favicon.ico` |
 
-## Replay probe (plain HTTP client, no browser)
+- **Zero** TheFork application/API requests (no GraphQL, no `/api/`, no `_next/data`,
+  no XHR/fetch to any `thefork.com` JSON endpoint). The SPA JS never executed past the
+  interstitial. There is nothing real to document for search / detail / reviews.
 
-To confirm the wall is not merely browser-fingerprint specific, I probed candidate
-hosts directly. **These URLs are hand-guessed candidates, NOT observed traffic** —
-all returned 403 (or unresolvable), so none are confirmed endpoints:
+### Vector 3 (Tier-1 Chrome-TLS impersonation) — also 403
+
+Confirms the block is **not merely a headless tell** — it sits at the edge before any
+fingerprint nuance matters:
+
+| URL | Status | DataDome in body | `IsChallengePage` (before fix) |
+|-----|--------|------------------|--------------------------------|
+| `https://www.thefork.com/` | **403** | yes | false ← detection gap |
+| `https://www.thefork.com/search?cityId=415144` | **403** | yes | false ← detection gap |
+
+The 403 body is the DataDome interstitial with `'t':'bv'` (behavioural-verification
+CAPTCHA). Frozen, PII-free, at
+[`internal/providers/testdata/thefork_datadome_interstitial.html`](../../internal/providers/testdata/thefork_datadome_interstitial.html).
+This is **real captured traffic** (the block page), not a fabricated API response.
+
+## The wall, precisely
+
+- Vendor: **DataDome** (`*.captcha-delivery.com`).
+- Placement: on the **root/protected document itself** (403 body = interstitial),
+  at the **edge/CDN layer**, *before* any TheFork application or auth layer.
+- Mechanism: JS/blob device-attestation that issues a signed `datadome` session cookie
+  only after passing browser-environment checks, escalating to a visual/behavioural
+  CAPTCHA (`t=fe` device-check, `t=bv` behavioural verification).
+- Why CDP-driven Chrome fails (headless *and* headed): a `chromedp`-driven browser
+  carries the CDP automation signal (`navigator.webdriver`, DevTools `Runtime` hooks)
+  that DataDome detects regardless of window visibility. This is exactly why the repo's
+  `challenge.go` already classifies DataDome as **`ChallengeNeedsHuman`** — a headless
+  browser cannot clear it without a human gesture.
+- Why Tier-1 (TLS impersonation) fails: a perfect TLS/HTTP2 Chrome fingerprint is
+  necessary but not sufficient — DataDome requires the *client-side JS attestation*, not
+  just a browser-shaped handshake, so a single HTTP round-trip cannot replay it.
+
+## Auth posture for discovery endpoints
+
+**Undetermined — and unreachable.** Search / detail / reviews could not be observed
+because the SPA never loaded. The gate is at the device-attestation layer *before* any
+application/auth layer. Whether the underlying discovery API is anonymous-session or
+token-gated is moot until DataDome is solved, which no key-free path here achieves.
+
+## Verdict (fail-fast per MIK-2949 ABSOLUTE RULES)
+
+> "if the stealth tier CANNOT pass DataDome's behavioural CAPTCHA (`t=bv`) key-free …
+> STOP. … That is an honest SUCCESS, not a failure."
+
+This condition is met across all three runnable vectors. **No connector was built.** No
+discovery fixtures were fabricated (there is no real captured discovery response to
+freeze — only the block page, which *is* frozen as evidence).
+
+## Shipped (honest, tested, non-fabricated)
+
+1. **DataDome challenge detection** — `IsChallengePage` (`internal/providers/tier1_client.go`)
+   now recognizes the DataDome 403 interstitial (`captcha-delivery.com`, `var dd={`
+   body markers). Before this pass it returned `false` for DataDome 403s, so the
+   Tier-1 → Tier-2 escalation signal never fired for DataDome-protected hosts; the 403
+   was silently treated as a hard failure. Now the caller escalates (and `challenge.go`'s
+   existing `DetectInteractiveCaptcha` correctly tags it `NEEDS_HUMAN`).
+2. **Frozen real fixture** — `internal/providers/testdata/thefork_datadome_interstitial.html`
+   (verbatim 403 body, per-session tokens redacted), backing
+   `TestIsChallengePage_TheForkDataDomeFixture`.
+
+## Replay probe (plain HTTP client, no browser) — from the prior pass
+
+To confirm the wall is not merely browser-fingerprint specific, candidate hosts were
+probed directly. **These URLs are hand-guessed candidates, NOT observed traffic** — all
+returned 403 (or were unresolvable), so none are confirmed endpoints:
 
 | Probe URL (guessed) | Result |
 |---------------------|--------|
@@ -54,43 +134,30 @@ all returned 403 (or unresolvable), so none are confirmed endpoints:
 | `https://graphql.thefork.com/` | unresolved (000) |
 | `https://www.thefork.com/_next/data` | 403 |
 
-## Auth posture for discovery endpoints
+## Parked (out of scope / still blocked)
 
-**Undetermined — and unreachable.** Discovery (search / detail / reviews) could not be
-observed because the SPA never loaded. The gate is at the **edge / CDN layer (DataDome
-device attestation)**, *before* any application or auth layer. Whether the underlying
-discovery API is anonymous-session or token-gated is moot until the DataDome challenge
-is solved, which a plain HTTP client cannot replay.
+- TheFork discovery connector — **blocked**: no observable discovery endpoints behind
+  DataDome.
+- Reservations / any write path — parked per ticket scope.
 
-## Anti-bot / what blocks replay
+## What a key-free pass would require
 
-- **DataDome** device-check + CAPTCHA on the root document itself (`*.captcha-delivery.com`).
-- The challenge is a JS/blob-based device-attestation flow that issues a signed
-  `datadome` cookie only after passing browser-environment checks; it escalates to a
-  visual/behavioural CAPTCHA (`t=bv`, `dc_ir`).
-- This cannot be replayed from a plain `net/http` client: there is no static API key
-  or replayable token — the gate requires solving a per-session device challenge.
+None of these are in-repo today; all are materially larger than a JSON connector and
+some conflict with the no-keys / no-paid-service product principle:
 
-## Verdict (fail-fast per MIK-2949 ABSOLUTE RULES)
+1. **A real, human-warmed browser profile** carrying an already-solved `datadome` session
+   cookie, driven *without* the CDP automation tell (e.g. a non-CDP attach to a normally
+   launched Chrome, or `--user-data-dir` on a profile not currently locked by the user's
+   live Chrome). This pass could not test it (profile lock); it is the most promising
+   key-free lever but is fragile and per-machine.
+2. **A CDP-evasion layer** the repo does not have — patching `navigator.webdriver`, the
+   `Runtime.enable` leak, and CDP timing signals (the "undetected-chromedriver" class of
+   evasions). Even then, DataDome's `t=bv` behavioural CAPTCHA may still demand a human.
+3. **A residential/mobile-IP proxy** plus a behavioural warm-up long enough to satisfy
+   DataDome's risk score — infrastructure, not a static binary, and not key-free in
+   spirit.
+4. **Solving the `t=bv` CAPTCHA**, which requires either a human or a paid CAPTCHA-solving
+   service. The latter is explicitly **forbidden** by MIK-2949 (violates key-free).
 
-> "if unauthenticated discovery calls are blocked by device-attestation / … hard
-> bot-defense that cannot be replayed from a plain HTTP client, STOP building the
-> connector."
-
-This condition is met. **No connector was built.** No fixtures were frozen (there is
-no real captured discovery response to freeze — fabricating one is forbidden).
-
-### Parked (out of scope / blocked)
-
-- Phase 1 connector — **blocked**: no observable discovery endpoints behind DataDome.
-- Phase 2 (airlok auth), Phase 4 (reservations), Phase 5 (Botnaut translation) —
-  parked per ticket scope.
-
-### If revisited later
-
-Replay would require a path that legitimately solves/holds the DataDome session
-(e.g. a real browser-driven session via the repo's existing `tier2_chromedp` /
-`internal/stealth` machinery feeding a captured `datadome` cookie + matching TLS/UA
-fingerprint into the JSON calls), and re-capturing the SPA's real XHR/fetch traffic
-*after* the wall is passed. That is a materially different effort than a plain-client
-JSON connector and was explicitly out of scope for this discovery pass.
+Until one of (1)–(3) is built and *verified* to yield a cleared session that lets the SPA
+load, there is no honest key-free TheFork connector to ship.

--- a/internal/providers/testdata/thefork_datadome_interstitial.html
+++ b/internal/providers/testdata/thefork_datadome_interstitial.html
@@ -1,0 +1,2 @@
+HTTP 403
+<html lang="en"><head><title>thefork.com</title><style>#cmsg{animation: A 1.5s;}@keyframes A{0%{opacity:0;}99%{opacity:0;}100%{opacity:1;}}</style></head><body style="margin:0"><p id="cmsg">Please enable JS and disable any ad blocker</p><script data-cfasync="false">var dd={'rt':'c','REDACTED','REDACTED','t':'bv','qp':'','s':326,'REDACTED','host':'geo.captcha-delivery.com','REDACTED'}</script><script data-cfasync="false" src="https://ct.captcha-delivery.com/c.js"></script></body></html>

--- a/internal/providers/tier1_client.go
+++ b/internal/providers/tier1_client.go
@@ -205,8 +205,17 @@ func cachedCookiesForURL(targetURL string) []*http.Cookie {
 
 // challengeMarkers are case-insensitive substrings that appear in interactive
 // anti-bot challenge pages (Cloudflare "Just a moment…", managed challenge,
-// PerimeterX/Akamai interstitials). Their presence on a 403/503 response means
-// Tier-1 was fingerprinted and the caller should escalate to Tier-2.
+// PerimeterX/Akamai/DataDome interstitials). Their presence on a 403/503 response
+// means Tier-1 was fingerprinted and the caller should escalate to Tier-2.
+//
+// DataDome note: the DataDome interstitial is served as the response *body* of a
+// 403 on the protected document itself (no distinctive Server header), so it is
+// detected purely by these body markers. A DataDome challenge that escalates to
+// its behavioural CAPTCHA (the bootstrap carries 't':'bv') cannot be cleared by a
+// headless browser — DetectInteractiveCaptcha classifies it as NEEDS_HUMAN — but
+// IsChallengePage must still report it as a challenge so callers escalate rather
+// than treat the 403 as a hard failure. Observed live on www.thefork.com
+// (MIK-2949); see internal/providers/testdata/thefork_datadome_interstitial.html.
 var challengeMarkers = []string{
 	"just a moment",
 	"cf-chl",
@@ -217,6 +226,9 @@ var challengeMarkers = []string{
 	"_cf_chl_opt",
 	"px-captcha",
 	"/_incapsula_",
+	// DataDome device-check / CAPTCHA interstitial signatures.
+	"captcha-delivery.com",
+	"var dd={",
 }
 
 // IsChallengePage reports whether an HTTP response looks like an interactive

--- a/internal/providers/tier1_client_test.go
+++ b/internal/providers/tier1_client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 )
@@ -136,6 +137,12 @@ func TestIsChallengePage(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "datadome interstitial body (no server header)",
+			resp: &http.Response{StatusCode: 403, Header: http.Header{}},
+			body: `<script>var dd={'rt':'c','t':'bv','host':'geo.captcha-delivery.com'}</script>`,
+			want: true,
+		},
+		{
 			name: "normal 200 page",
 			resp: &http.Response{StatusCode: 200, Header: http.Header{}},
 			body: "<html>real content</html>",
@@ -153,6 +160,34 @@ func TestIsChallengePage(t *testing.T) {
 				t.Fatalf("IsChallengePage = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestIsChallengePage_TheForkDataDomeFixture asserts the DataDome detection
+// against the REAL captured interstitial frozen at
+// testdata/thefork_datadome_interstitial.html. The fixture is the verbatim 403
+// body served by www.thefork.com on 2026-06-24 (MIK-2949), with per-session
+// tokens redacted. It is the proof that IsChallengePage now escalates DataDome
+// rather than treating its 403 as a hard failure.
+func TestIsChallengePage_TheForkDataDomeFixture(t *testing.T) {
+	raw, err := os.ReadFile("testdata/thefork_datadome_interstitial.html")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	body := raw
+	// The fixture's first line is "HTTP 403"; the body follows. Strip it so we
+	// feed IsChallengePage exactly what the HTTP body reader would yield.
+	if i := strings.IndexByte(string(raw), '\n'); i >= 0 {
+		body = raw[i+1:]
+	}
+	resp := &http.Response{StatusCode: http.StatusForbidden, Header: http.Header{}}
+	if !IsChallengePage(resp, body) {
+		t.Fatal("IsChallengePage(thefork datadome fixture) = false, want true")
+	}
+	// And it must be classified NEEDS_HUMAN (behavioural CAPTCHA), not clearable.
+	gotHuman, vendor := DetectInteractiveCaptcha(body)
+	if !gotHuman || vendor != "datadome" {
+		t.Fatalf("DetectInteractiveCaptcha = (%v,%q), want (true,\"datadome\")", gotHuman, vendor)
 	}
 }
 


### PR DESCRIPTION
## Summary

MIK-2949 key-free route for a TheFork discovery provider. I drove trvl's own stealth
machinery (`tier2_chromedp.go` + `challenge.go`, and the Chrome-TLS `tier1_client.go`)
against TheFork to try to reach the SPA's JSON API **without any API keys**. DataDome's
behavioural CAPTCHA held across every runnable vector, so per the ticket's fail-fast rule
this is the honest docs-only outcome — plus one tested detection fix that the attempt
surfaced.

## Was DataDome passed key-free? **No.**

**V:** Three independent live vectors on 2026-06-24, all walled by DataDome:

- **Headless Chrome via CDP** (same machinery as `runCDPChallenge`, +12s device-check
  window +synthetic mouse-move/scroll warm-up): `403` on the document, page is the
  DataDome interstitial (`var dd={…'t':'fe'…'host':'geo.captcha-delivery.com'}` +
  `<iframe title="DataDome CAPTCHA">`), **zero** TheFork XHR/fetch.
- **Headed Chrome via CDP** (real visible window, identical warm-up): byte-for-byte the
  same block.
- **Tier-1 Chrome-TLS client** (`tier1_client.go:124` `NewTier1ClientForURL`, JA3/JA4 +
  HTTP2 Chrome fingerprint, seeded 6 real cookies): `403` with DataDome interstitial body
  on both `/` and `/search?cityId=415144`.

The `chromedp`-driven browser carries the CDP automation tell (`navigator.webdriver`,
`Runtime.enable`) that DataDome detects regardless of headless/headed — which is exactly
why `challenge.go` already classifies DataDome as `ChallengeNeedsHuman`. The frozen 403
body shows `'t':'bv'` (the behavioural CAPTCHA the ticket names as the un-passable
key-free wall).

## Endpoints captured

**None — still blocked.** The SPA never executed past the interstitial, so no
search/detail/reviews endpoint was observable. No discovery fixtures fabricated. The only
real captured artifact is the **block page itself**, frozen PII-free at
`internal/providers/testdata/thefork_datadome_interstitial.html` (per-session
cid/hash/cookie/e tokens redacted).

## Shipped (tested, non-fabricated)

- **DataDome challenge detection** — `internal/providers/tier1_client.go:210` adds
  `captcha-delivery.com` + `var dd={` to `challengeMarkers`. **I:** before this, a
  DataDome 403 returned `IsChallengePage=false`, so the Tier-1→Tier-2 escalation signal
  never fired for DataDome-protected hosts (the 403 was silently a hard failure). Now it
  escalates, and the existing `DetectInteractiveCaptcha` correctly tags it `NEEDS_HUMAN`.
- **Fixture-backed test** — `TestIsChallengePage_TheForkDataDomeFixture`
  (`internal/providers/tier1_client_test.go`) loads the real captured 403 body and
  asserts both detection (`IsChallengePage=true`) and classification
  (`DetectInteractiveCaptcha=("datadome")`). Plus a table-case for the DataDome body.

## Parked

- TheFork discovery connector — blocked: no observable endpoints behind DataDome.
- A 4th vector (real `--user-data-dir` profile to carry a human-warmed `datadome` cookie)
  could not run: the user's Chrome held the profile `SingletonLock`; forcing it risks
  profile corruption.

## What a key-free pass would require

(All larger than a JSON connector; none in-repo today.) A real human-warmed profile with
an already-solved `datadome` cookie driven *without* the CDP tell; a CDP-evasion layer
the repo lacks (undetected-chromedriver class); and/or a residential/mobile-IP proxy with
a longer behavioural warm-up. Solving `t=bv` otherwise needs a human or a paid
CAPTCHA-solver — the latter is forbidden by MIK-2949. See `docs/providers/thefork-api-map.md`.

## Validation (run, not asserted)

- `gofmt -l .` → empty
- `go vet ./...` → exit 0
- `go build ./...` → exit 0
- `go test ./... -count=1` → all `ok`, no failures
- `go test ./internal/providers/ -cover` → **80.2%** of statements

**A:** I did not pass DataDome key-free and am not claiming a working connector. The
deliverable is the honest blocked verdict, real captured block-page evidence, and a
detection fix the attempt surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
