### PR TITLE
fix(flights): rank price-less round-trip fares below real-priced results

### DIFF
--- a/internal/flights/results.go
+++ b/internal/flights/results.go
@@ -207,8 +207,24 @@ func sortFlightResults(flights []models.FlightResult, sortBy models.SortBy) {
 	})
 }
 
+// compareFlightPrices orders two ranking prices ascending (cheapest first),
+// EXCEPT that a non-positive price (<= 0) always sorts AFTER any real positive
+// price. A price-less fare — e.g. a native Google round-trip whose total is only
+// revealed at booking, which arrives with Price 0 — must never be treated as the
+// cheapest (EUR 0) and outrank genuinely-priced results. Such fares are still
+// retained (they carry a "price selected at booking" note); they just rank last
+// among themselves rather than first overall. Two non-positive prices compare
+// equal so the remaining tiebreakers (duration, departure, route) still apply.
 func compareFlightPrices(left, right float64) int {
+	leftReal := left > 0
+	rightReal := right > 0
 	switch {
+	case leftReal && !rightReal:
+		return -1
+	case !leftReal && rightReal:
+		return 1
+	case !leftReal && !rightReal:
+		return 0
 	case left < right:
 		return -1
 	case left > right:

--- a/internal/flights/results_test.go
+++ b/internal/flights/results_test.go
@@ -67,6 +67,77 @@ func TestMergeFlightResults_SortsCheapestAndFiltersStops(t *testing.T) {
 	}
 }
 
+// TestSortFlightResults_ZeroPriceRanksLast proves a price-less native round-trip
+// fare (Google prices the return "at booking", so Price==0) never outranks a
+// real-priced result. A 0/nil ranking price must sort BELOW all positive-priced
+// results instead of being treated as the cheapest (EUR 0). Regression for the
+// operator-visible "#1 is a Price: - round_trip" bug.
+func TestSortFlightResults_ZeroPriceRanksLast(t *testing.T) {
+	leg := func(dep, arr string) []models.FlightLeg {
+		return []models.FlightLeg{{
+			DepartureAirport: models.AirportInfo{Code: dep},
+			ArrivalAirport:   models.AirportInfo{Code: arr},
+			DepartureTime:    "2026-07-10T08:00",
+			ArrivalTime:      "2026-07-10T10:00",
+		}}
+	}
+	cases := []struct {
+		name       string
+		flights    []models.FlightResult
+		wantFirst  string // provider of #1
+		wantLastPx float64
+	}{
+		{
+			name: "priceless native round-trip does not outrank real fares",
+			flights: []models.FlightResult{
+				{Price: 0, Currency: "EUR", Provider: "google_flights", FareType: models.FareRoundTrip, Legs: leg("HEL", "BCN")},
+				{Price: 334, Currency: "EUR", Provider: "kiwi", Legs: leg("HEL", "BCN")},
+				{Price: 330, Currency: "EUR", Provider: "skiplagged", Legs: leg("HEL", "BCN")},
+			},
+			wantFirst:  "skiplagged",
+			wantLastPx: 0,
+		},
+		{
+			name: "all real prices unaffected (cheapest still first)",
+			flights: []models.FlightResult{
+				{Price: 334, Currency: "EUR", Provider: "kiwi", Legs: leg("HEL", "BCN")},
+				{Price: 330, Currency: "EUR", Provider: "skiplagged", Legs: leg("HEL", "BCN")},
+			},
+			wantFirst:  "skiplagged",
+			wantLastPx: 334,
+		},
+		{
+			name: "multiple priceless fares all sink below real ones",
+			flights: []models.FlightResult{
+				{Price: 0, Currency: "EUR", Provider: "google_flights", FareType: models.FareRoundTrip, Legs: leg("HEL", "BCN")},
+				{Price: 0, Currency: "EUR", Provider: "kiwi", FareType: models.FareRoundTrip, Legs: leg("HEL", "BCN")},
+				{Price: 290, Currency: "EUR", Provider: "ryanair", Legs: leg("HEL", "BCN")},
+			},
+			wantFirst:  "ryanair",
+			wantLastPx: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sortFlightResults(tc.flights, models.SortCheapest)
+			if got := tc.flights[0].Provider; got != tc.wantFirst {
+				t.Errorf("#1 provider = %q (price %.0f), want %q", got, tc.flights[0].PriceForRanking(), tc.wantFirst)
+			}
+			if got := tc.flights[len(tc.flights)-1].PriceForRanking(); got != tc.wantLastPx {
+				t.Errorf("last ranking price = %.0f, want %.0f", got, tc.wantLastPx)
+			}
+			// No positive-priced result may sit below a non-positive one.
+			for i := 1; i < len(tc.flights); i++ {
+				prev := tc.flights[i-1].PriceForRanking()
+				cur := tc.flights[i].PriceForRanking()
+				if prev <= 0 && cur > 0 {
+					t.Errorf("priceless result at index %d outranks real-priced result at %d", i-1, i)
+				}
+			}
+		})
+	}
+}
+
 // TestApplyComparableBaseline_LCCBagRanking proves an LCC bare fare ranks by its
 // all-in (fare + carry-on fee) so it no longer unfairly beats an included fare.
 func TestApplyComparableBaseline_LCCBagRanking(t *testing.T) {


### PR DESCRIPTION
## Fix: price-less round-trip fares no longer rank above real-priced results

### The bug (operator-visible)

`trvl flights HEL BCN 2026-07-10 --return 2026-07-20`

The TOP-ranked result (#1) was a native Google round-trip fare with **no price** — the
table showed `Price: -` and JSON showed `"price": 0`, `"fare_type": "round_trip"`,
`"provider": "google_flights"`. It outranked genuinely-priced results (e.g. EUR 330–334).
A fare with no resolvable price was being treated as if it were the cheapest (EUR 0),
so it sorted to #1 — the first thing the operator sees.

This is correctness/ranking-accuracy: Google legitimately hides the round-trip total
until booking, so these fares honestly arrive with `Price == 0` (they carry a
"return selected at booking and may differ" note). They are valid leads — they just
must not masquerade as the cheapest option.

### Root cause

V: Native round-trip fares can arrive with `Price == 0` because Google prices the
return at booking time (`internal/flights/roundtrip.go:100`, `:107`,
`tagNativeRoundTrip` at `internal/flights/roundtrip.go:401`). These are merged with
the composed/split itineraries and ranked by `sortFlightResults`
(`internal/flights/roundtrip.go:123`).

V: The ranking comparator `compareFlightPrices`
(`internal/flights/results.go:210` pre-fix) did a plain ascending numeric compare, so
`0 < 334` made the price-less fare the "cheapest" and pushed it to position #1. The
same comparator backs both the default-price sort branch and the price tiebreaker in
`sortFlightResults` (`internal/flights/results.go:189`, `:194`).

### The fix (honest, minimal — no fabricated prices)

I: Changed `compareFlightPrices` so a non-positive price (`<= 0`) always sorts **after**
any real positive price, while positive prices keep their normal cheapest-first order
and two non-positive prices compare equal (so the remaining duration/departure/route
tiebreakers still apply). `internal/flights/results.go:210`.

I: No price is invented. Price-less fares are retained (they keep their "price selected
at booking" note) — they simply rank last instead of first. Results that already carry
real prices are unaffected. The composed/split-ticket path and the bounded native-fare
enrichment path are unchanged: `topPricedFlights`
(`internal/flights/roundtrip.go:658`) already filters to `Price > 0` before sorting, and
the enrichment ordering at `internal/flights/roundtrip.go:587` only ranks among
price-less fares that compare equal under both old and new code (`SliceStable` preserves
order). No provider is removed.

The fix lives in the single comparator shared by every sort call site
(`results.go`, `roundtrip.go`, `multi.go`, `lcc_search.go`), so it corrects every path
without touching `PriceForRanking` (which display/savings code also relies on).

### Before / after (real repro)

`trvl flights HEL BCN 2026-07-10 --return 2026-07-20`

- Before: `flights[0].price == 0`, `fare_type round_trip`, `provider google_flights`
  (table `Price: -`), ahead of EUR 330–334 results.
- After: `flights[0]` is `EUR 330` (a real-priced fare); the native round-trip is
  retained at a lower rank with its "return selected at booking" note intact.

### Regression test

I: `TestSortFlightResults_ZeroPriceRanksLast`
(`internal/flights/results_test.go`) — a table test with synthetic, offline
`FlightResult`s. It fails before the fix (price-0 `google_flights` ranked #1) and passes
after. Cases: (1) a price-less round-trip must not outrank real fares; (2) all-real-price
input is unchanged (cheapest still first); (3) multiple price-less fares all sink below
real-priced ones. No network access in the test.

### DoD

- `gofmt -l .` → empty (clean)
- `go vet ./...` → exit 0
- `go build ./...` → exit 0
- `go test ./...` → exit 0 (95 packages ok, 0 fail); affected `internal/flights` +
  `internal/models` green
- §11 WIRED: re-ran the live CLI repro — `flights[0]` is now a real-priced result
  (EUR 330), not the price-0 round_trip

A: No prices fabricated. No provider removed. No branch protection changed. Behaviour
for already-priced results is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
