### PR TITLE
fix(serpapi): expose per-provider prices for detail-verified island properties

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -79,6 +79,46 @@ trvl rooms "Hotel Lutetia Paris" --checkin 2026-06-15 --checkout 2026-06-18
 
 **Booking readiness:** `trvl prices` and `trvl rooms` show a readiness verdict (ready / caution / unverified) composed from verified price, stable link, confirmed property identity, and known refundability. Any unknown signal downgrades the verdict conservatively. In `--format json` the fields are `booking_readiness` and `booking_readiness_reasons`.
 
+### Islands and unindexed destinations
+
+Small islands and out-of-the-way towns often have properties that Google Hotels never assigns a stable hotel ID. The usual `trvl rooms <name>` path needs that ID to resolve room-level data, so it can come up empty for exactly the places where a verified price matters most. Roberto Reale tested this on Ischia and reported the gap; the sequence below is what works there.
+
+1. Discover what exists in the area:
+
+   ```bash
+   trvl hotels "Ischia, Italy" --checkin 2026-07-30 --checkout 2026-08-04 --format json
+   ```
+
+   This lists properties and, where Google exposes one, a place ID you can feed to `trvl prices`.
+
+2. Try room-level data for a named property:
+
+   ```bash
+   trvl rooms "Hotel Continental Mare" --checkin 2026-07-30 --checkout 2026-08-04
+   ```
+
+   If the property has no Google Hotel ID, this no longer fails silently. It tells you so and points you at the paths that do resolve island stays, including the `trvl serpapi` command below.
+
+3. Use `trvl serpapi` as the first tool for islands, not a last resort:
+
+   ```bash
+   trvl serpapi "Ischia, Italy" --checkin 2026-07-30 --checkout 2026-08-04 --currency EUR --adults 2
+   ```
+
+   For unindexed areas this is the most reliable verified-price path. It searches Google Hotels through SerpAPI, then fetches each top property's detail endpoint by `property_token` so the total is a per-provider quote rather than the list-level lead-in price. Each property carries a `price_verification` status, so verified and unverified results stay distinguishable. It needs a free `SERPAPI_KEY`; without one, trvl behaves exactly as before and this path stays off.
+
+   Detail lookups cost one API call per property, so trvl bounds them with `--max-details` (default 8). Properties past that limit, and properties whose `property_token` returns no provider rows, are labelled unverified instead of being shown as a verified total.
+
+4. Compare providers for a property that does have a Google place ID:
+
+   ```bash
+   trvl prices "PLACE_ID" --checkin 2026-07-30 --checkout 2026-08-04 --currency EUR
+   ```
+
+   When `SERPAPI_KEY` is set, this fetches the selected property's detail matrix and returns each OTA/provider row with a durable link, so the comparison survives the teaser price expiring at checkout.
+
+Sequence tested and contributed by Roberto Reale. See `docs/PUBLIC_ARTICLE_FEEDBACK.md` for the underlying feedback and retest history.
+
 ### Explore Destinations
 
 ```bash

--- a/docs/PUBLIC_ARTICLE_FEEDBACK.md
+++ b/docs/PUBLIC_ARTICLE_FEEDBACK.md
@@ -65,3 +65,34 @@ Follow-up product work:
 - Track provider trust tiers separately from price. A lower Google Hotels matrix
   price from a lesser-known OTA can be real, but users may still prefer a
   mainstream OTA, the official hotel site, or a refundable rate.
+
+## Retest log
+
+### Roberto Reale, v1.15.0 — `trvl serpapi` on Ischia (island / unindexed)
+
+Roberto retested `trvl serpapi` against Ischia (2026-07-30 to 2026-08-04, 2
+adults, 5 nights, EUR) and reported that the per-OTA `prices` breakdown was
+populated for only about half of the properties. For the rest `prices` came
+back null, so the total shown was the list-level Google Hotels minimum (the
+lead-in teaser) rather than a per-provider verified total. He measured this
+understating real cost by up to 24%: Sorriso Thermae showed EUR 779 in trvl
+against a EUR 1,024 reference and a live Booking.com rate of EUR 1,102. The
+root distinction he identified is list-level minimum versus the per-property
+detail-endpoint price reached through `property_token`.
+
+Outcome:
+
+- Detail-verified properties whose provider rows arrived only under
+  `featured_prices` were leaving `prices` null even though the total had
+  already been promoted to the verified figure. The verified provider
+  breakdown is now mirrored into `prices`, so a detail-verified property
+  always exposes its per-provider rows.
+- Provider-row aggregation deduplicates across `featured_prices` and `prices`,
+  so a quote present in both is counted once.
+- The honest limits stand: SerpAPI's detail endpoint genuinely returns no
+  provider rows for some properties, and detail lookups are bounded by
+  `--max-details` (default 8) to respect the quota cost of one call per
+  property. Those properties are labelled unverified via `price_verification`
+  rather than presented as a verified per-provider total.
+- Roberto also contributed an island / unindexed command sequence, now in
+  `docs/CLI.md` under "Islands and unindexed destinations".

--- a/internal/serpapi/serpapi_test.go
+++ b/internal/serpapi/serpapi_test.go
@@ -144,6 +144,77 @@ func TestSearchHotelsVerifiedFetchesPropertyDetailsAndPromotesProviderTotal(t *t
 	}
 }
 
+func TestSearchHotelsVerifiedPopulatesPricesFromFeaturedOnlyDetail(t *testing.T) {
+	// Roberto Reale's symptom: the detail endpoint returned provider rows only
+	// under featured_prices (prices was null). The verified total promoted
+	// correctly, but the inspectable Prices array stayed null, so the result
+	// looked unverified even though it was detail-checked. After the fix the
+	// verified provider breakdown is mirrored into Prices.
+	t.Setenv("SERPAPI_KEY", "test_key")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("property_token") == "" {
+			json.NewEncoder(w).Encode(Response{
+				SearchMetadata: struct {
+					ID     string `json:"id"`
+					Status string `json:"status"`
+				}{Status: "Success"},
+				Properties: []Hotel{{
+					Name:          "Sorriso Thermae",
+					PropertyToken: "sorriso-token",
+					RatePerNight:  Rate{Extracted: 156, Lowest: "€156"},
+					TotalRate:     Rate{Extracted: 779, Lowest: "€779"},
+					Prices:        nil,
+				}},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(propertyDetailsResponse{
+			SearchMetadata: struct {
+				ID     string `json:"id"`
+				Status string `json:"status"`
+			}{Status: "Success"},
+			Hotel: Hotel{
+				Name:          "Sorriso Thermae",
+				PropertyToken: "sorriso-token",
+				Prices:        nil,
+				FeaturedPrices: []PriceOption{{
+					Source:       "Booking.com",
+					RatePerNight: Rate{Extracted: 205, Lowest: "€205"},
+					TotalRate:    Rate{Extracted: 1024, Lowest: "€1,024"},
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	origSearch := searchURL
+	searchURL = srv.URL + "/search"
+	defer func() { searchURL = origSearch }()
+
+	result, err := SearchHotelsVerified(context.Background(), SearchOptions{
+		Query:      "Ischia",
+		CheckIn:    "2026-07-30",
+		CheckOut:   "2026-08-04",
+		Currency:   "EUR",
+		Adults:     2,
+		MaxDetails: 8,
+	})
+	if err != nil {
+		t.Fatalf("SearchHotelsVerified failed: %v", err)
+	}
+	hotel := result.Properties[0]
+	if hotel.TotalPrice() != 1024 {
+		t.Fatalf("verified total = %.0f, want 1024", hotel.TotalPrice())
+	}
+	if len(hotel.Prices) != 1 || hotel.Prices[0].Source != "Booking.com" {
+		t.Fatalf("prices = %#v, want Booking.com provider row mirrored from featured_prices", hotel.Prices)
+	}
+	if hotel.PriceVerification == nil || hotel.PriceVerification.Status != "detail_verified" {
+		t.Fatalf("verification = %#v, want detail_verified", hotel.PriceVerification)
+	}
+}
+
 func TestSearchHotelsVerifiedMarksPropertiesBeyondDetailLimit(t *testing.T) {
 	t.Setenv("SERPAPI_KEY", "test_key")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/serpapi/serpapi_verify.go
+++ b/internal/serpapi/serpapi_verify.go
@@ -113,6 +113,19 @@ func mergePropertyDetails(hotel *Hotel, detail Hotel, currency string, checkedAt
 	hotel.RatePerNight = best.RatePerNight
 	hotel.TotalRate = best.TotalRate
 
+	// SerpAPI's property-details endpoint sometimes returns the provider
+	// breakdown only under featured_prices, leaving prices null. The total still
+	// promotes (LowestProviderOption spans both lists), but the inspectable
+	// Prices array would stay null and read as unverified. Mirror the verified
+	// provider rows into Prices so a detail-verified property always exposes its
+	// per-provider breakdown. (Reported by Roberto Reale: about half of Ischia
+	// properties showed prices: null despite being detail-checked.)
+	if len(hotel.Prices) == 0 {
+		if options := hotel.ProviderOptions(); len(options) > 0 {
+			hotel.Prices = options
+		}
+	}
+
 	delta := best.TotalRate.Extracted - listTotal.Extracted
 	deltaPct := 0.0
 	if listTotal.Extracted > 0 {
@@ -181,9 +194,29 @@ func (h *Hotel) ProviderOptions() []PriceOption {
 		return nil
 	}
 	options := make([]PriceOption, 0, len(h.FeaturedPrices)+len(h.Prices))
-	options = append(options, h.FeaturedPrices...)
-	options = append(options, h.Prices...)
+	seen := make(map[string]struct{}, len(h.FeaturedPrices)+len(h.Prices))
+	add := func(list []PriceOption) {
+		for _, opt := range list {
+			key := providerOptionKey(opt)
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			options = append(options, opt)
+		}
+	}
+	add(h.FeaturedPrices)
+	add(h.Prices)
 	return options
+}
+
+// providerOptionKey identifies a provider quote so the same offer appearing in
+// both featured_prices and prices (or mirrored across them) is not counted
+// twice.
+func providerOptionKey(opt PriceOption) string {
+	return strings.ToLower(strings.TrimSpace(opt.Source)) + "|" +
+		strconv.FormatFloat(opt.TotalRate.Extracted, 'f', 2, 64) + "|" +
+		strconv.FormatFloat(opt.RatePerNight.Extracted, 'f', 2, 64)
 }
 
 func (h *Hotel) ProviderPrices(currency string) string {


### PR DESCRIPTION
## serpapi: populate per-provider `prices` for detail-verified island properties

Addresses Roberto Reale's tested feedback that `trvl serpapi` left the per-OTA
`prices` breakdown null for roughly half of properties on island / unindexed
destinations, so the displayed total was the list-level Google Hotels minimum
(lead-in teaser) instead of a per-provider verified total. Retested against
Ischia (2026-07-30 to 2026-08-04, 2 adults, 5 nights, EUR), he measured this
understating real cost by up to 24% (Sorriso Thermae: trvl EUR 779 vs EUR 1,024
reference vs live Booking.com EUR 1,102).

### Root cause

V: `internal/serpapi/serpapi_verify.go:80` `mergePropertyDetails` promoted the
verified total correctly (`LowestProviderOption` spans both `featured_prices`
and `prices`), but only mirrored the breakdown into the inspectable `Prices`
field when the detail response carried rows under `prices`
(`serpapi_verify.go:81`, `if detail.Prices != nil`). SerpAPI's property-details
endpoint frequently returns the provider rows only under `featured_prices`,
leaving `prices` null. The result read as unverified even though it was
detail-checked. That is the "prices: null for ~50%" Roberto observed: not a
missing detail fetch, but a verified breakdown that never reached the `prices`
field.

### The fix

I: When a property is detail-verified and `Prices` is empty, mirror the
verified provider options into `Prices` so a verified property always exposes
its per-provider rows (`internal/serpapi/serpapi_verify.go`, in
`mergePropertyDetails` after the total promotion).

I: `Hotel.ProviderOptions()` (`internal/serpapi/serpapi_verify.go`) now
deduplicates across `featured_prices` and `prices` by source + total + nightly,
so mirroring (or SerpAPI returning the same quote in both arrays) never
double-counts a provider.

### Quota tradeoff decision

The detail enrichment was already bounded and configurable: `runSerpapi`
(`cmd/trvl/serpapi.go:73`) exposes `--max-details` (default 8), and
`verifyPropertyDetails` (`internal/serpapi/serpapi_verify.go:10`) stops after
that many detail calls and marks the remainder `detail_not_checked_limit`. The
cost is 1 list call + up to N detail calls, exactly Roberto's tradeoff. I wired
to the existing flag rather than inventing new config. This change adds no API
calls; it only stops discarding provider rows that were already fetched.

### Before / after

- Before: a property whose detail endpoint returned providers only under
  `featured_prices` showed the promoted verified total but `prices: null`,
  reading as unverified.
- After: the same property exposes its `prices` rows (e.g. Booking.com EUR
  1,024 total) with `price_verification.status = detail_verified`.

### Honest scope of what SerpAPI can and cannot provide

A: Some properties genuinely have no detail data: SerpAPI's detail endpoint
returns no provider rows for them, and properties past `--max-details` are not
fetched at all to respect quota. These are not fabricated. They keep their
honest `price_verification` labels (`detail_prices_missing`,
`detail_not_checked_limit`, `list_only_unverified`, `detail_fetch_failed`) and
are surfaced as list-level candidates, never as verified per-provider totals.
This PR closes the wiring gap for properties SerpAPI *did* verify; it does not
and cannot manufacture a per-provider price where the upstream has none.

### Key-optional contract

A: Unchanged. `runSerpapi` errors before any network path when `SERPAPI_KEY` is
unset (`cmd/trvl/serpapi.go:128`). The fix runs only inside
`mergePropertyDetails`, reached only after a successful keyed detail fetch.

### Tests (RED -> GREEN)

`internal/serpapi/serpapi_test.go`
`TestSearchHotelsVerifiedPopulatesPricesFromFeaturedOnlyDetail` is an offline
httptest table test: the detail endpoint returns provider rows only under
`featured_prices` (`prices` null). It fails before the fix
(`prices = []serpapi.PriceOption(nil)`) and passes after (Booking.com row in
`prices`, total promoted to 1024, status `detail_verified`).

### Docs (Part 2)

`docs/CLI.md` gains an "Islands and unindexed destinations" section adapting
Roberto's serpapi-first command sequence (discover with `trvl hotels` ->
`trvl rooms` which now errors actionably with no Google Hotel ID -> `trvl serpapi`
as the right first tool for islands -> `trvl prices <id>` for the full
comparison). `docs/PUBLIC_ARTICLE_FEEDBACK.md` gains a retest log with Roberto's
v1.15.0 Ischia outcome. Roberto Reale is credited in both.

### DoD

- `gofmt -l .`: empty
- `go vet ./...`: exit 0
- `go build ./...`: exit 0
- `go test ./...`: green (full suite); `go test -race ./internal/serpapi/...`: green
- staticcheck on changed packages: clean
- anti-ai-tell Tier-1 lint on both docs: clean
- WIRED: `cmd/trvl/root.go:57` -> `serpapiCmd` -> `serpapi.go:167`
  `SearchHotelsVerified` -> `verifyPropertyDetails` -> `mergePropertyDetails`
  (the changed path is the one the CLI calls by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
