### PR TITLE
fix(ground): echo ferryhopper tool-error reason for diagnosability

### DIFF
--- a/internal/ground/ferryhopper.go
+++ b/internal/ground/ferryhopper.go
@@ -289,6 +289,17 @@ func SearchFerryhopper(ctx context.Context, from, to, date, currency string) ([]
 	}
 
 	if rpcResult.Result.IsError {
+		// MCP-spec tool error: content[0].text carries the human-readable
+		// reason. Echo it (bounded) so the caller sees what Ferryhopper
+		// actually said instead of an opaque "tool returned error".
+		if c := rpcResult.Result.Content; len(c) > 0 {
+			if msg := strings.TrimSpace(c[0].Text); msg != "" {
+				if len(msg) > 256 {
+					msg = msg[:256]
+				}
+				return nil, fmt.Errorf("ferryhopper: tool error: %s", msg)
+			}
+		}
 		return nil, fmt.Errorf("ferryhopper: tool returned error")
 	}
 

--- a/internal/ground/ferryhopper_test.go
+++ b/internal/ground/ferryhopper_test.go
@@ -503,3 +503,34 @@ func TestSearchFerryhopper_Integration(t *testing.T) {
 		t.Error("booking URL should not be empty")
 	}
 }
+
+// TestSearchFerryhopper_ToolErrorEchoesMessage proves the IsError path surfaces
+// the tool's human-readable reason (content[0].text) instead of an opaque
+// "tool returned error". Regression guard: before the fix the message was
+// discarded, leaving callers blind to why Ferryhopper declined.
+func TestSearchFerryhopper_ToolErrorEchoesMessage(t *testing.T) {
+	const reason = "Narnia is not a recognized port"
+	frame := `data: {"jsonrpc":"2.0","id":1,"result":{"isError":true,"content":[{"type":"text","text":"` + reason + `"}]}}` + "\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, frame)
+	}))
+	defer srv.Close()
+
+	origClient, origURL := ferryhopperClient, ferryhopperMCPURL
+	ferryhopperClient, ferryhopperMCPURL = srv.Client(), srv.URL
+	defer func() { ferryhopperClient, ferryhopperMCPURL = origClient, origURL }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := SearchFerryhopper(ctx, "Narnia", "Santorini", "2026-07-10", "EUR")
+	if err == nil {
+		t.Fatal("expected an error for tool isError, got nil")
+	}
+	if !strings.Contains(err.Error(), reason) {
+		t.Fatalf("error should echo the tool reason %q, got: %v", reason, err)
+	}
+}


### PR DESCRIPTION
## What

When the Ferryhopper MCP tool returns an error, `IsError` threw away the
`content[0].text` field — the human-readable reason for the failure — and
surfaced a generic `ferryhopper: tool returned error`. A caller saw the same
opaque message whether they'd typed an unknown port or the upstream was down.

This echoes the reason back (capped at 256 chars), so an unrecognized-port
error reads as `ferryhopper: tool error: <port> is not a recognized port`
instead of a blank wall. It follows the same body-echo pattern already used
for the Wizz Air provider.

## Why

Diagnosability. The reason text is already on the wire; discarding it forced
guesswork on every Ferryhopper failure. Keeping it bounded avoids unbounded
upstream strings leaking into our error path.

## Test

- `TestSearchFerryhopper_ToolErrorEchoesMessage` asserts the reason survives
  into the returned error.
- `go test -race ./internal/ground/` green (38s).

V: race suite green · I: `internal/ground/ferryhopper.go` IsError branch · A: regression test added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
