### PR TITLE
fix(models): classify bot-wall blocks and 5xx as retryable, not failed

### DIFF
--- a/internal/models/evidence.go
+++ b/internal/models/evidence.go
@@ -41,9 +41,11 @@ var ErrRateLimited = errors.New("upstream provider rate-limited or temporarily u
 
 // ClassifyProviderError maps an error to a provider status. A typed rate-limit
 // (ErrRateLimited) wins first so a 429/challenge never renders as a hard parse
-// failure; deadlines map to StatusTimeout; everything else is StatusFailed. This
-// is the distinction that prevents a timeout/rate-limit from being presented to
-// the user as "nothing found".
+// failure; deadlines map to StatusTimeout; retryable upstream signatures (rate
+// limits, bot-wall blocks, transient 5xx) surfaced as plain strings map to
+// StatusRateLimited; everything else is StatusFailed. This is the distinction
+// that prevents a timeout/rate-limit/block from being presented to the user as
+// "nothing found" or as a permanent failure.
 func ClassifyProviderError(err error) string {
 	if err == nil {
 		return StatusOK
@@ -57,6 +59,24 @@ func ClassifyProviderError(err error) string {
 	msg := strings.ToLower(err.Error())
 	if strings.Contains(msg, "timeout") || strings.Contains(msg, "timed out") || strings.Contains(msg, "deadline") {
 		return StatusTimeout
+	}
+	// Retryable upstream conditions a provider may surface as a plain string
+	// error rather than wrapping ErrRateLimited: rate limits, bot-wall blocks,
+	// challenges, and transient 5xx. These are RETRYABLE (the documented intent
+	// of StatusRateLimited) — classifying them as StatusFailed would tell the
+	// user the provider is permanently broken when retrying (or supplying
+	// cookies) would succeed. Substring match is deliberately broad: in this
+	// domain "forbidden"/"blocked"/"captcha"/"datadome"/"cloudfront"/"akamai"
+	// overwhelmingly mean an anti-bot wall, not a logic bug.
+	for _, sig := range []string{
+		"429", "rate limit", "rate-limit", "ratelimit", "too many requests",
+		"403", "forbidden", "blocked", "captcha", "challenge", "bot detect",
+		"datadome", "cloudfront", "akamai",
+		"503", "service unavailable", "temporarily unavailable",
+	} {
+		if strings.Contains(msg, sig) {
+			return StatusRateLimited
+		}
 	}
 	return StatusFailed
 }

--- a/internal/models/evidence_test.go
+++ b/internal/models/evidence_test.go
@@ -17,8 +17,28 @@ func TestClassifyProviderError(t *testing.T) {
 	if got := ClassifyProviderError(fmt.Errorf("request timed out after 30s")); got != StatusTimeout {
 		t.Errorf("timed-out msg -> %q, want timeout", got)
 	}
-	if got := ClassifyProviderError(fmt.Errorf("403 forbidden")); got != StatusFailed {
+	// A genuine hard failure (parse bug, unexpected shape) stays StatusFailed.
+	if got := ClassifyProviderError(fmt.Errorf("unexpected flight data format: missing legs array")); got != StatusFailed {
 		t.Errorf("hard err -> %q, want failed", got)
+	}
+	// Retryable upstream conditions surfaced as plain strings (no ErrRateLimited
+	// wrap) must classify as rate_limited, not a permanent failure: bot-wall
+	// blocks, 429s, and transient 5xx are all retryable (StatusRateLimited's
+	// documented intent). Misclassifying these as failed tells the user the
+	// provider is broken when a retry / cookies would succeed.
+	for _, msg := range []string{
+		"403 forbidden",
+		"HTTP 429: too many requests",
+		"request blocked by DataDome challenge",
+		"akamai bot detection triggered",
+		"CloudFront 403: Request blocked",
+		"503 service unavailable",
+		"upstream temporarily unavailable",
+		"rate limit exceeded",
+	} {
+		if got := ClassifyProviderError(fmt.Errorf("%s", msg)); got != StatusRateLimited {
+			t.Errorf("retryable %q -> %q, want rate_limited", msg, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

`ClassifyProviderError` is the central map from a provider error to a status
shown to the user. It routed the typed `ErrRateLimited` sentinel and request
deadlines to their own statuses, but **every other error fell through to
`StatusFailed`** — the "this provider is broken" bucket.

That swept up a whole class of *retryable* conditions that providers surface as
plain string errors rather than wrapping the sentinel: a bare `403 forbidden`,
`HTTP 429`, a DataDome / CloudFront / Akamai bot-wall challenge, or a transient
`503`. None of those are permanent failures — a retry, or supplying browser
cookies, would succeed.

This adds a substring fallback for those signatures so they classify as
`StatusRateLimited`, which the enum already documents as "rate-limited / blocked
/ challenge — RETRYABLE". Genuine hard errors (parse bugs, unexpected response
shapes) still classify as `StatusFailed`.

## Why

Honest, actionable status. A user (or an AI assistant reading the result) should
be able to tell "this source is temporarily walled, try again or add cookies"
from "this source returned something we couldn't parse". Folding both into
`failed` hid that distinction on every provider that didn't hand-wrap the
sentinel.

## Test

`TestClassifyProviderError` now covers eight retryable strings (403, 429, the
three named bot-walls, 503, "temporarily unavailable", "rate limit") plus a
genuine parse-error case that must stay `failed`.

V: `go test ./internal/{models,flights,hotels,ground}` all green · I: `internal/models/evidence.go` · A: 9 new assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
