### PR TITLE
fix(hotels): lead room results with bookable prices first

### DIFF
--- a/internal/hotels/rooms.go
+++ b/internal/hotels/rooms.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -173,6 +174,14 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 		rooms = mergeRoomTypes(rooms, bookingRooms)
 	}
 
+	// Lead with the rooms that carry a real, bookable price. Sources are merged
+	// in fetch order (Google entity, partner matrix, search fallback, SerpAPI,
+	// Booking) so a property-level lead-in can otherwise sit above a verified
+	// room-level rate. Order by bookability (exact > similar > property-level
+	// lead-in), then cheapest-first within a tier, so the most actionable price
+	// surfaces first and unpriced lead-ins sink to the bottom.
+	sortRoomsByBookability(rooms)
+
 	return &RoomAvailability{
 		Success:  true,
 		HotelID:  opts.HotelID,
@@ -182,6 +191,55 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 		Rooms:    rooms,
 		Notice:   notice,
 	}, nil
+}
+
+// sortRoomsByBookability orders rooms so the most actionable, real prices lead.
+// Primary key: bookability rank (exact room-level price first, then a real
+// "similar" bookable rate, then property-level-only lead-ins). Secondary key:
+// effective price ascending so the cheapest real offer in each tier surfaces
+// first; rooms with no usable price sink to the bottom of their tier. The sort
+// is stable, preserving provider fetch order among otherwise-equal rooms.
+func sortRoomsByBookability(rooms []RoomType) {
+	sort.SliceStable(rooms, func(i, j int) bool {
+		ri, rj := roomBookabilityRank(rooms[i]), roomBookabilityRank(rooms[j])
+		if ri != rj {
+			return ri < rj
+		}
+		pi, pj := roomEffectivePrice(rooms[i]), roomEffectivePrice(rooms[j])
+		// A usable price (>0) always leads a missing one within the same tier.
+		if (pi > 0) != (pj > 0) {
+			return pi > 0
+		}
+		return pi < pj
+	})
+}
+
+// roomBookabilityRank maps a room's match confidence to a sort rank where a
+// lower value leads. An explicit room-level match is the most bookable; a
+// "similar" rate is a real bookable price without a nameable room identity;
+// everything else (property-level lead-ins, unset) trails.
+func roomBookabilityRank(r RoomType) int {
+	switch strings.TrimSpace(r.MatchConfidence) {
+	case models.RoomInventoryMatchExact:
+		return 0
+	case models.RoomInventoryMatchSimilar:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// roomEffectivePrice returns the room's most representative bookable price,
+// preferring the headline Price, then nightly, then total. Returns 0 when the
+// room carries no usable price.
+func roomEffectivePrice(r RoomType) float64 {
+	if r.Price > 0 {
+		return r.Price
+	}
+	if r.NightlyPrice > 0 {
+		return r.NightlyPrice
+	}
+	return r.TotalPrice
 }
 
 // tryEntityPage attempts to extract room data from the Google Hotels entity

--- a/internal/hotels/rooms_test.go
+++ b/internal/hotels/rooms_test.go
@@ -204,3 +204,42 @@ func TestRoomMatchFromPriceBasis(t *testing.T) {
 		}
 	}
 }
+
+// TestSortRoomsByBookability locks the room ordering contract: rooms with a
+// real, bookable price lead (exact > similar > property-level lead-in), then
+// cheapest-first within a tier, and rooms with no usable price sink to the
+// bottom of their tier. This delivers "lead with the ones that have proper
+// price available" at the room level.
+func TestSortRoomsByBookability(t *testing.T) {
+	rooms := []RoomType{
+		{Name: "lead-in cheap", Price: 50, MatchConfidence: models.RoomInventoryMatchPropertyLevelOnly},
+		{Name: "exact pricey", Price: 200, MatchConfidence: models.RoomInventoryMatchExact},
+		{Name: "no price", MatchConfidence: models.RoomInventoryMatchSimilar},
+		{Name: "similar mid", Price: 120, MatchConfidence: models.RoomInventoryMatchSimilar},
+		{Name: "exact cheap", Price: 100, MatchConfidence: models.RoomInventoryMatchExact},
+		{Name: "similar nightly", NightlyPrice: 90, MatchConfidence: models.RoomInventoryMatchSimilar},
+	}
+
+	sortRoomsByBookability(rooms)
+
+	want := []string{
+		"exact cheap",     // exact tier, cheapest
+		"exact pricey",    // exact tier
+		"similar nightly", // similar tier, 90 (nightly counts)
+		"similar mid",     // similar tier, 120
+		"no price",        // similar tier, no usable price -> bottom of tier
+		"lead-in cheap",   // property-level lead-in last regardless of price
+	}
+	if len(rooms) != len(want) {
+		t.Fatalf("len = %d, want %d", len(rooms), len(want))
+	}
+	for i, name := range want {
+		if rooms[i].Name != name {
+			got := make([]string, len(rooms))
+			for k, r := range rooms {
+				got[k] = r.Name
+			}
+			t.Fatalf("order[%d] = %q, want %q (full: %v)", i, rooms[i].Name, name, got)
+		}
+	}
+}


### PR DESCRIPTION
## What

Order room-level results by bookability so the rooms with a real, usable price lead, and unpriced lead-ins sink to the bottom.

`GetRoomAvailabilityWithOpts` merges room sources in fetch order — Google entity page, the partner price matrix, the search-page fallback, SerpAPI, and Booking.com (`internal/hotels/rooms.go:106-174`). Until now the merged slice was returned in that fetch order with no sort, so a property-level lead-in (an unverified "from" price with no nameable room) could sit above a verified room-level rate. A caller asking for room pricing saw the least actionable price first.

## Change

Added `sortRoomsByBookability` (`internal/hotels/rooms.go`), called once before the result is returned:

1. **Bookability tier** — exact room-level match first, then a real "similar" bookable rate, then property-level lead-ins.
2. **Cheapest-first within a tier** — the lowest usable price leads; a room with no usable price goes to the bottom of its tier.

The sort is stable, so provider fetch order is preserved among otherwise-equal rooms. Effective price prefers the headline price, then nightly, then total.

## Why

Room results should lead with the prices a user can act on. Ordering by confidence then price keeps verified, bookable rooms at the top and pushes lead-in placeholders down, without dropping any data.

## Evidence

- I: `internal/hotels/rooms.go` — `sortRoomsByBookability`, `roomBookabilityRank`, `roomEffectivePrice`; call site after the Booking merge.
- V: `TestSortRoomsByBookability` (`internal/hotels/rooms_test.go`) locks the exact > similar > property-level order, cheapest-first within a tier, and unpriced rooms sinking to the bottom of their tier.
- V: `go test ./internal/hotels/` passes (76.9s); `gofmt` and `go vet ./internal/hotels/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
