### PR TITLE
feat(hotels): wire Agoda into room-level drill-down

### DIFF
--- a/internal/hotels/rooms.go
+++ b/internal/hotels/rooms.go
@@ -169,6 +169,22 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 		}
 	}
 
+	// Consult Agoda for a room-level rate when the free Google paths (and the
+	// optional SerpAPI upgrade) still produced no verified room price. Agoda is
+	// key-free and its search already carries per-room inventory, so this adds a
+	// real second priced provider to the drill-down without burning the hot
+	// path. Merge so any Google lead-ins stay; bookability sort below leads with
+	// whichever provider actually has a bookable price.
+	if len(rooms) == 0 || !hasVerifiedRoom(rooms) {
+		if agodaRooms := tryAgodaRoomLevel(ctx, opts); len(agodaRooms) > 0 {
+			if len(rooms) == 0 {
+				rooms = agodaRooms
+			} else {
+				rooms = mergeRoomTypes(rooms, agodaRooms)
+			}
+		}
+	}
+
 	// Merge Booking.com rooms with Google rooms if both are available.
 	if len(bookingRooms) > 0 {
 		rooms = mergeRoomTypes(rooms, bookingRooms)
@@ -240,6 +256,95 @@ func roomEffectivePrice(r RoomType) float64 {
 		return r.NightlyPrice
 	}
 	return r.TotalPrice
+}
+
+// tryAgodaRoomLevel consults Agoda for the hotel's room-level rate so the
+// drill-into-one-hotel path includes Agoda alongside Google, SerpAPI, and
+// Booking. Agoda's search response already carries per-room-per-night inventory
+// (parseAgodaSearch populates HotelResult.RoomTypes), so we run a location
+// search, match the target property by ID then name, and convert its rooms.
+// Gated on a location hint (same contract as the Google search-page fallback);
+// the caller invokes it only when the free Google paths produced no verified
+// room price, keeping the live Agoda request off the hot path. Agoda is
+// key-free, so this adds a real second priced provider with no credentials.
+func tryAgodaRoomLevel(ctx context.Context, opts RoomSearchOptions) []RoomType {
+	if strings.TrimSpace(opts.Location) == "" {
+		return nil
+	}
+	searchOpts := roomFallbackSearchOptions(opts)
+	var results []models.HotelResult
+	for _, loc := range buildLocationCandidates(opts.Location) {
+		r, err := SearchAgoda(ctx, loc, searchOpts)
+		if err == nil && len(r) > 0 {
+			results = r
+			break
+		}
+	}
+	if len(results) == 0 {
+		return nil
+	}
+	var hotel *models.HotelResult
+	for i := range results {
+		if opts.HotelID != "" && results[i].HotelID == opts.HotelID {
+			hotel = &results[i]
+			break
+		}
+	}
+	if hotel == nil {
+		hotel = findBestNameMatch(results, opts.Location)
+	}
+	if hotel == nil || len(hotel.RoomTypes) == 0 {
+		return nil
+	}
+	return hotelRoomsToRoomTypes(hotel.RoomTypes, opts.Currency)
+}
+
+// hotelRoomsToRoomTypes converts provider-search model rooms into
+// room-availability RoomType entries, defaulting the currency when a room omits
+// it. The bool to *bool widening preserves the not-yet-known state for the
+// cancellation and breakfast flags a search response did not populate (a bare
+// false would wrongly claim "no free cancellation" when the rate simply did not
+// say either way).
+func hotelRoomsToRoomTypes(rooms []models.Room, defaultCurrency string) []RoomType {
+	out := make([]RoomType, 0, len(rooms))
+	for _, r := range rooms {
+		currency := r.Currency
+		if currency == "" {
+			currency = defaultCurrency
+		}
+		rt := RoomType{
+			Name:               r.Name,
+			Price:              r.Price,
+			NightlyPrice:       r.NightlyPrice,
+			TotalPrice:         r.TotalPrice,
+			TaxesAndFees:       r.TaxesAndFees,
+			TaxesFeesIncluded:  r.TaxesFeesIncluded,
+			Currency:           currency,
+			Provider:           r.Provider,
+			ProviderURL:        r.ProviderURL,
+			RateID:             r.RateID,
+			RatePlanName:       r.RatePlanName,
+			MatchConfidence:    r.MatchConfidence,
+			MaxGuests:          r.MaxGuests,
+			BedType:            r.BedType,
+			SizeM2:             r.SizeM2,
+			Description:        r.Description,
+			Amenities:          r.Amenities,
+			CancellationPolicy: r.CancellationPolicy,
+			Refundable:         r.Refundable,
+			Board:              r.Board,
+		}
+		if r.FreeCancellation {
+			v := true
+			rt.FreeCancellation = &v
+		}
+		if r.BreakfastIncluded {
+			v := true
+			rt.BreakfastIncluded = &v
+		}
+		out = append(out, rt)
+	}
+	return out
 }
 
 // tryEntityPage attempts to extract room data from the Google Hotels entity

--- a/internal/hotels/rooms_test.go
+++ b/internal/hotels/rooms_test.go
@@ -205,7 +205,70 @@ func TestRoomMatchFromPriceBasis(t *testing.T) {
 	}
 }
 
-// TestSortRoomsByBookability locks the room ordering contract: rooms with a
+// TestHotelRoomsToRoomTypes locks the Agoda room-level converter: model rooms
+// (as parseAgodaSearch emits them) map field-for-field into RoomType, the
+// currency falls back to the request default when a room omits it, and the
+// bool->*bool widening only sets the flag when the source said true (a source
+// false stays nil = not-claimed, never a hard "no").
+func TestHotelRoomsToRoomTypes(t *testing.T) {
+	taxIncl := true
+	rooms := []models.Room{
+		{
+			Name:              "Deluxe King",
+			Price:             180,
+			NightlyPrice:      90,
+			TotalPrice:        180,
+			TaxesAndFees:      20,
+			TaxesFeesIncluded: &taxIncl,
+			Currency:          "USD",
+			Provider:          "Agoda",
+			MatchConfidence:   models.RoomInventoryMatchExact,
+			MaxGuests:         2,
+			FreeCancellation:  true,
+			BreakfastIncluded: false,
+		},
+		{
+			Name:     "Standard Twin",
+			Price:    120,
+			Currency: "", // should fall back to default
+			Provider: "Agoda",
+		},
+	}
+
+	got := hotelRoomsToRoomTypes(rooms, "EUR")
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+
+	d := got[0]
+	if d.Name != "Deluxe King" || d.Price != 180 || d.NightlyPrice != 90 || d.TotalPrice != 180 {
+		t.Fatalf("deluxe prices wrong: %+v", d)
+	}
+	if d.Currency != "USD" {
+		t.Fatalf("deluxe currency = %q, want USD (room had its own)", d.Currency)
+	}
+	if d.TaxesFeesIncluded == nil || !*d.TaxesFeesIncluded {
+		t.Fatal("deluxe TaxesFeesIncluded should carry through as true")
+	}
+	if d.FreeCancellation == nil || !*d.FreeCancellation {
+		t.Fatal("source FreeCancellation=true must widen to *bool true")
+	}
+	if d.BreakfastIncluded != nil {
+		t.Fatal("source BreakfastIncluded=false must stay nil (not-claimed), not a hard false")
+	}
+	if d.MatchConfidence != models.RoomInventoryMatchExact {
+		t.Fatalf("deluxe match = %q, want exact", d.MatchConfidence)
+	}
+
+	s := got[1]
+	if s.Currency != "EUR" {
+		t.Fatalf("twin currency = %q, want default EUR fallback", s.Currency)
+	}
+	if s.FreeCancellation != nil {
+		t.Fatal("twin FreeCancellation must stay nil when source false/unset")
+	}
+}
+
 // real, bookable price lead (exact > similar > property-level lead-in), then
 // cheapest-first within a tier, and rooms with no usable price sink to the
 // bottom of their tier. This delivers "lead with the ones that have proper


### PR DESCRIPTION
## What

Wires Agoda into the per-hotel room-level lookup (`GetRoomAvailabilityWithOpts`). That path already consults Google (entity page, partner-price matrix, search-page fallback), SerpAPI, and Booking.com for a single hotel's rooms, but it never asked Agoda — so the drill-down was missing a real, key-free priced provider.

## Why it matters

Agoda's search response already carries per-room-per-night inventory: `parseAgodaSearch` populates `HotelResult.RoomTypes`, and Agoda needs no API key (`SearchAgoda`, `agoda.go:215`). The data was there; the drill-down just wasn't reading it. Adding it gives the room view a second priced provider to lead with when Google comes back weak.

## How

- `tryAgodaRoomLevel` runs an Agoda location search, matches the target property by ID then name, and converts its rooms. It is gated on a location hint and only fires when the free Google paths produced no verified room price — the same eligibility contract used for the SerpAPI upgrade, so the live request stays off the hot path.
- `hotelRoomsToRoomTypes` maps `models.Room` to `RoomType` field-for-field, defaults the currency to the request currency when a room omits it, and widens `bool` to `*bool` for the cancellation / breakfast flags so a source `false` reads as "not stated" rather than a hard "no free cancellation".
- The existing bookability sort already orders by real-price-first, so Agoda rates surface ahead of unpriced Google lead-ins with no extra ordering code.

## Validation

- `TestHotelRoomsToRoomTypes` covers the converter: field mapping, currency fallback, and the `bool`->`*bool` not-stated semantics.
- Full `go test ./internal/hotels/` passes (72s); `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
