### PR TITLE
test(hotels): lock Google partner-matrix room-level expansion (#290)

### DIFF
--- a/internal/hotels/rooms.go
+++ b/internal/hotels/rooms.go
@@ -394,19 +394,23 @@ func tryBatchExecutePrices(ctx context.Context, opts RoomSearchOptions) ([]RoomT
 	if err != nil || res == nil || len(res.Providers) == 0 {
 		return nil, ""
 	}
+	return partnersToRoomTypes(res.Providers, opts.Currency), res.Name
+}
 
-	rooms := make([]RoomType, 0, len(res.Providers))
-	// The yY52ce partner matrix is a dated, occupancy-specific quote, so the
-	// cheapest partner price is a real bookable rate for the stay, not a
-	// property lead-in. Promote it to room-level "similar" (no nameable room
-	// identity) so it reaches the booking-ready gate — mirroring the Agoda fix
-	// (PR #289) and the search-page fallback. Only the cheapest is promoted:
-	// the rest keep their basis-derived confidence (an explicit room basis
-	// still earns "exact"; everything else stays property-level), because
-	// promoting the whole identity-less ladder trips the multi-provider-mixed
-	// completeness flag and re-blocks the offer.
+// partnersToRoomTypes expands Google's yY52ce partner-price matrix into room
+// entries. The matrix is a dated, occupancy-specific quote, so the cheapest
+// partner price is a real bookable rate for the stay, not a property lead-in:
+// it is promoted to room-level "similar" (no nameable room identity) so it
+// reaches the booking-ready gate — mirroring the Agoda and search-page
+// fallbacks. Only the cheapest is promoted; the rest keep their basis-derived
+// confidence (an explicit room basis still earns "exact"; everything else stays
+// property-level), because promoting the whole identity-less ladder trips the
+// multi-provider-mixed completeness flag and re-blocks the offer. Partners with
+// no usable price are dropped, never emitted as a fabricated room match.
+func partnersToRoomTypes(providers []models.ProviderPrice, defaultCurrency string) []RoomType {
+	rooms := make([]RoomType, 0, len(providers))
 	cheapestIdx, cheapestPrice := -1, 0.0
-	for i, p := range res.Providers {
+	for i, p := range providers {
 		price := p.Price
 		if price <= 0 {
 			price = p.NightlyPrice
@@ -418,7 +422,7 @@ func tryBatchExecutePrices(ctx context.Context, opts RoomSearchOptions) ([]RoomT
 			cheapestIdx, cheapestPrice = i, price
 		}
 	}
-	for i, p := range res.Providers {
+	for i, p := range providers {
 		price := p.Price
 		if price <= 0 {
 			price = p.NightlyPrice
@@ -428,7 +432,7 @@ func tryBatchExecutePrices(ctx context.Context, opts RoomSearchOptions) ([]RoomT
 		}
 		currency := p.Currency
 		if currency == "" {
-			currency = opts.Currency
+			currency = defaultCurrency
 		}
 		match := roomMatchFromPriceBasis(p.PriceBasis)
 		nightly := p.NightlyPrice
@@ -449,7 +453,7 @@ func tryBatchExecutePrices(ctx context.Context, opts RoomSearchOptions) ([]RoomT
 			MatchConfidence: match,
 		})
 	}
-	return rooms, res.Name
+	return rooms
 }
 
 // roomMatchFromPriceBasis maps a provider PriceBasis to a room match

--- a/internal/hotels/rooms_test.go
+++ b/internal/hotels/rooms_test.go
@@ -269,6 +269,52 @@ func TestHotelRoomsToRoomTypes(t *testing.T) {
 	}
 }
 
+// TestPartnersToRoomTypes locks the Google partner-matrix expansion (issue
+// #290 AC.3/AC.4): the cheapest priced partner is promoted to room-level
+// "similar" so it reaches the booking-ready gate, an explicit room-basis
+// partner keeps its "exact" confidence, a non-cheapest lead-in stays
+// property-level (never a fabricated match), and a zero-price partner is
+// dropped entirely rather than emitted as a free room.
+func TestPartnersToRoomTypes(t *testing.T) {
+	providers := []models.ProviderPrice{
+		{Provider: "Expedia", Price: 150, Currency: "EUR", PriceBasis: models.PriceBasisLeadIn},
+		{Provider: "Booking.com", Price: 120, Currency: "", PriceBasis: models.PriceBasisLeadIn}, // cheapest -> promote
+		{Provider: "Hotels.com", Price: 200, Currency: "EUR", PriceBasis: models.PriceBasisRoomTotal},
+		{Provider: "Dead", Price: 0, NightlyPrice: 0, Currency: "EUR"}, // no price -> dropped
+	}
+
+	rooms := partnersToRoomTypes(providers, "USD")
+	if len(rooms) != 3 {
+		t.Fatalf("len = %d, want 3 (zero-price partner dropped)", len(rooms))
+	}
+
+	byProvider := map[string]RoomType{}
+	for _, r := range rooms {
+		byProvider[r.Provider] = r
+	}
+
+	cheap := byProvider["Booking.com"]
+	if cheap.MatchConfidence != models.RoomInventoryMatchSimilar {
+		t.Fatalf("cheapest lead-in match = %q, want similar (promoted to booking-ready)", cheap.MatchConfidence)
+	}
+	if cheap.Currency != "USD" {
+		t.Fatalf("cheapest currency = %q, want USD default fallback", cheap.Currency)
+	}
+	if cheap.NightlyPrice != 120 {
+		t.Fatalf("cheapest nightly = %v, want 120 (filled from price when no nightly/total)", cheap.NightlyPrice)
+	}
+
+	if got := byProvider["Hotels.com"].MatchConfidence; got != models.RoomInventoryMatchExact {
+		t.Fatalf("room-total partner match = %q, want exact", got)
+	}
+	if got := byProvider["Expedia"].MatchConfidence; got != models.RoomInventoryMatchPropertyLevelOnly {
+		t.Fatalf("non-cheapest lead-in match = %q, want property_level_only (no fabricated promotion)", got)
+	}
+	if _, dead := byProvider["Dead"]; dead {
+		t.Fatal("zero-price partner must be dropped, not emitted as a free room")
+	}
+}
+
 // real, bookable price lead (exact > similar > property-level lead-in), then
 // cheapest-first within a tier, and rooms with no usable price sink to the
 // bottom of their tier. This delivers "lead with the ones that have proper


### PR DESCRIPTION
## What

Adds a regression test that locks Google's partner-price-matrix expansion into room-level inventory, and extracts the expansion logic into a pure, testable function. Closes the verification gap behind issue #290.

## Context: #290 is already delivered

Issue #290 ("Google room-level pricing via server-side-filtered batchexec") describes `tryBatchExecutePrices` as synthesizing a single property-level placeholder. That description is stale. The current code already:

- Expands the **whole** partner matrix, emitting one room per priced partner.
- Promotes the cheapest partner to room-level (`similar`) so it reaches the booking-ready gate, while keeping explicit room-basis partners at `exact`.
- Threads occupancy, dates, and currency into the request server-side via `BuildHotelPricePayloadWithOccupancy` (`prices.go:78`), covered by `TestBuildHotelPricePayloadWithOccupancy_RequestShape` — that is AC.1's request-shape test.
- Drops zero-price partners rather than fabricating free rooms (AC.4).

The RPC args carry no price-ceiling slot, so the "(price ceiling where the RPC supports it)" sub-clause of AC.1 is not buildable without inventing request fields — out of scope by the issue's own fail-fast.

## The real gap this PR closes

The matrix-expansion honesty logic was inline in `tryBatchExecutePrices` and coupled to the live HTTP fetch, so it had no direct test. This extracts it into a pure `partnersToRoomTypes(providers, currency)` and regression-locks the contract:

- cheapest lead-in is promoted to `similar` (reaches booking-ready),
- an explicit room-total basis stays `exact`,
- a non-cheapest lead-in stays `property_level_only` (no fabricated promotion),
- a zero-price partner is dropped.

Behavior is identical to the prior inline code — a pure refactor plus the test.

## Validation

- `TestPartnersToRoomTypes` covers the promotion, currency fallback, and no-fabrication paths.
- Full `go test ./internal/hotels/` passes (68s); `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
