### PR TITLE
fix(hotels): surface retryable Booking room bot-walls instead of dropping them

### DIFF
--- a/internal/hotels/rooms.go
+++ b/internal/hotels/rooms.go
@@ -394,19 +394,23 @@ func tryBatchExecutePrices(ctx context.Context, opts RoomSearchOptions) ([]RoomT
 	if err != nil || res == nil || len(res.Providers) == 0 {
 		return nil, ""
 	}
+	return partnersToRoomTypes(res.Providers, opts.Currency), res.Name
+}
 
-	rooms := make([]RoomType, 0, len(res.Providers))
-	// The yY52ce partner matrix is a dated, occupancy-specific quote, so the
-	// cheapest partner price is a real bookable rate for the stay, not a
-	// property lead-in. Promote it to room-level "similar" (no nameable room
-	// identity) so it reaches the booking-ready gate — mirroring the Agoda fix
-	// (PR #289) and the search-page fallback. Only the cheapest is promoted:
-	// the rest keep their basis-derived confidence (an explicit room basis
-	// still earns "exact"; everything else stays property-level), because
-	// promoting the whole identity-less ladder trips the multi-provider-mixed
-	// completeness flag and re-blocks the offer.
+// partnersToRoomTypes expands Google's yY52ce partner-price matrix into room
+// entries. The matrix is a dated, occupancy-specific quote, so the cheapest
+// partner price is a real bookable rate for the stay, not a property lead-in:
+// it is promoted to room-level "similar" (no nameable room identity) so it
+// reaches the booking-ready gate — mirroring the Agoda and search-page
+// fallbacks. Only the cheapest is promoted; the rest keep their basis-derived
+// confidence (an explicit room basis still earns "exact"; everything else stays
+// property-level), because promoting the whole identity-less ladder trips the
+// multi-provider-mixed completeness flag and re-blocks the offer. Partners with
+// no usable price are dropped, never emitted as a fabricated room match.
+func partnersToRoomTypes(providers []models.ProviderPrice, defaultCurrency string) []RoomType {
+	rooms := make([]RoomType, 0, len(providers))
 	cheapestIdx, cheapestPrice := -1, 0.0
-	for i, p := range res.Providers {
+	for i, p := range providers {
 		price := p.Price
 		if price <= 0 {
 			price = p.NightlyPrice
@@ -418,7 +422,7 @@ func tryBatchExecutePrices(ctx context.Context, opts RoomSearchOptions) ([]RoomT
 			cheapestIdx, cheapestPrice = i, price
 		}
 	}
-	for i, p := range res.Providers {
+	for i, p := range providers {
 		price := p.Price
 		if price <= 0 {
 			price = p.NightlyPrice
@@ -428,7 +432,7 @@ func tryBatchExecutePrices(ctx context.Context, opts RoomSearchOptions) ([]RoomT
 		}
 		currency := p.Currency
 		if currency == "" {
-			currency = opts.Currency
+			currency = defaultCurrency
 		}
 		match := roomMatchFromPriceBasis(p.PriceBasis)
 		nightly := p.NightlyPrice
@@ -449,7 +453,7 @@ func tryBatchExecutePrices(ctx context.Context, opts RoomSearchOptions) ([]RoomT
 			MatchConfidence: match,
 		})
 	}
-	return rooms, res.Name
+	return rooms
 }
 
 // roomMatchFromPriceBasis maps a provider PriceBasis to a room match

--- a/internal/hotels/rooms.go
+++ b/internal/hotels/rooms.go
@@ -113,10 +113,18 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 	// Runs synchronously before the fallback so Booking data is available
 	// regardless of whether the Google entity page returns room data.
 	var bookingRooms []RoomType
+	var bookingNotice string
 	if opts.BookingURL != "" {
 		br, brErr := FetchBookingRooms(ctx, opts.BookingURL, opts.CheckIn, opts.CheckOut, opts.Currency)
 		if brErr != nil {
 			slog.Debug("booking rooms fetch failed", "error", brErr)
+			// A bot-wall / 429 / transient 5xx is retryable, not a genuine
+			// "no rooms" result. Surface it so the caller knows Booking room
+			// pricing was withheld this time rather than silently absent — the
+			// same rate-limited-vs-failed distinction the completeness model
+			// preserves at the search layer. Hard parse failures stay quiet
+			// (the debug log above) since a retry won't help.
+			bookingNotice = bookingRateLimitNotice(brErr)
 		} else {
 			bookingRooms = br
 		}
@@ -188,6 +196,9 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 	// Merge Booking.com rooms with Google rooms if both are available.
 	if len(bookingRooms) > 0 {
 		rooms = mergeRoomTypes(rooms, bookingRooms)
+	} else if bookingNotice != "" {
+		// Booking room data was withheld by a retryable bot-wall, not absent.
+		notice = appendNotice(notice, bookingNotice)
 	}
 
 	// Lead with the rooms that carry a real, bookable price. Sources are merged
@@ -207,6 +218,30 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 		Rooms:    rooms,
 		Notice:   notice,
 	}, nil
+}
+
+// bookingRateLimitNotice returns a user-facing caution when a Booking room
+// fetch failed with a retryable condition (bot-wall, 429, transient 5xx) — a
+// retry may surface room-level pricing. It returns "" for a genuine hard
+// failure or no error, where nothing actionable should be surfaced.
+func bookingRateLimitNotice(brErr error) string {
+	if brErr != nil && models.ClassifyProviderError(brErr) == models.StatusRateLimited {
+		return "Booking.com room pricing was temporarily unavailable (rate-limited); a retry may surface more room-level offers."
+	}
+	return ""
+}
+
+// appendNotice joins a new notice clause onto an existing notice string,
+// space-separated, so multiple degradation cautions (e.g. SerpAPI plus a
+// rate-limited Booking fetch) can coexist without one clobbering the other.
+func appendNotice(existing, add string) string {
+	if existing == "" {
+		return add
+	}
+	if add == "" {
+		return existing
+	}
+	return existing + " " + add
 }
 
 // sortRoomsByBookability orders rooms so the most actionable, real prices lead.

--- a/internal/hotels/rooms_test.go
+++ b/internal/hotels/rooms_test.go
@@ -269,6 +269,52 @@ func TestHotelRoomsToRoomTypes(t *testing.T) {
 	}
 }
 
+// TestPartnersToRoomTypes locks the Google partner-matrix expansion (issue
+// #290 AC.3/AC.4): the cheapest priced partner is promoted to room-level
+// "similar" so it reaches the booking-ready gate, an explicit room-basis
+// partner keeps its "exact" confidence, a non-cheapest lead-in stays
+// property-level (never a fabricated match), and a zero-price partner is
+// dropped entirely rather than emitted as a free room.
+func TestPartnersToRoomTypes(t *testing.T) {
+	providers := []models.ProviderPrice{
+		{Provider: "Expedia", Price: 150, Currency: "EUR", PriceBasis: models.PriceBasisLeadIn},
+		{Provider: "Booking.com", Price: 120, Currency: "", PriceBasis: models.PriceBasisLeadIn}, // cheapest -> promote
+		{Provider: "Hotels.com", Price: 200, Currency: "EUR", PriceBasis: models.PriceBasisRoomTotal},
+		{Provider: "Dead", Price: 0, NightlyPrice: 0, Currency: "EUR"}, // no price -> dropped
+	}
+
+	rooms := partnersToRoomTypes(providers, "USD")
+	if len(rooms) != 3 {
+		t.Fatalf("len = %d, want 3 (zero-price partner dropped)", len(rooms))
+	}
+
+	byProvider := map[string]RoomType{}
+	for _, r := range rooms {
+		byProvider[r.Provider] = r
+	}
+
+	cheap := byProvider["Booking.com"]
+	if cheap.MatchConfidence != models.RoomInventoryMatchSimilar {
+		t.Fatalf("cheapest lead-in match = %q, want similar (promoted to booking-ready)", cheap.MatchConfidence)
+	}
+	if cheap.Currency != "USD" {
+		t.Fatalf("cheapest currency = %q, want USD default fallback", cheap.Currency)
+	}
+	if cheap.NightlyPrice != 120 {
+		t.Fatalf("cheapest nightly = %v, want 120 (filled from price when no nightly/total)", cheap.NightlyPrice)
+	}
+
+	if got := byProvider["Hotels.com"].MatchConfidence; got != models.RoomInventoryMatchExact {
+		t.Fatalf("room-total partner match = %q, want exact", got)
+	}
+	if got := byProvider["Expedia"].MatchConfidence; got != models.RoomInventoryMatchPropertyLevelOnly {
+		t.Fatalf("non-cheapest lead-in match = %q, want property_level_only (no fabricated promotion)", got)
+	}
+	if _, dead := byProvider["Dead"]; dead {
+		t.Fatal("zero-price partner must be dropped, not emitted as a free room")
+	}
+}
+
 // real, bookable price lead (exact > similar > property-level lead-in), then
 // cheapest-first within a tier, and rooms with no usable price sink to the
 // bottom of their tier. This delivers "lead with the ones that have proper

--- a/internal/hotels/rooms_test.go
+++ b/internal/hotels/rooms_test.go
@@ -2,6 +2,7 @@ package hotels
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
@@ -350,5 +351,47 @@ func TestSortRoomsByBookability(t *testing.T) {
 			}
 			t.Fatalf("order[%d] = %q, want %q (full: %v)", i, rooms[i].Name, name, got)
 		}
+	}
+}
+
+// TestBookingRateLimitNotice locks the rate-limited-vs-failed distinction for
+// the Booking room drill-down: a retryable bot-wall / 429 must surface a
+// caution (so a withheld price is not mistaken for "no rooms"), while a hard
+// parse failure or no error stays silent (a retry would not help).
+func TestBookingRateLimitNotice(t *testing.T) {
+	// Retryable conditions -> caution surfaced.
+	for _, brErr := range []error{
+		models.ErrRateLimited,
+		fmt.Errorf("request blocked by DataDome challenge"),
+		fmt.Errorf("HTTP 429: too many requests"),
+		fmt.Errorf("503 service unavailable"),
+	} {
+		if got := bookingRateLimitNotice(brErr); got == "" {
+			t.Errorf("retryable %v -> empty notice, want caution", brErr)
+		}
+	}
+	// Hard failure / nil -> silent.
+	for _, brErr := range []error{
+		nil,
+		fmt.Errorf("no room offers found on booking detail page"),
+		fmt.Errorf("unexpected JSON-LD shape"),
+	} {
+		if got := bookingRateLimitNotice(brErr); got != "" {
+			t.Errorf("non-retryable %v -> %q, want empty", brErr, got)
+		}
+	}
+}
+
+// TestAppendNotice covers the notice-join helper: clauses accumulate
+// space-separated and an empty operand never adds a stray separator.
+func TestAppendNotice(t *testing.T) {
+	if got := appendNotice("", "a"); got != "a" {
+		t.Errorf("empty+a = %q, want a", got)
+	}
+	if got := appendNotice("a", ""); got != "a" {
+		t.Errorf("a+empty = %q, want a", got)
+	}
+	if got := appendNotice("a", "b"); got != "a b" {
+		t.Errorf("a+b = %q, want 'a b'", got)
 	}
 }


### PR DESCRIPTION
## What

The Booking room drill-down used to log a failed fetch at debug level and throw the error away. That hid a real distinction: a hotel that genuinely has no Booking rooms looked identical to a Booking page that bot-walled or returned a 429, where a retry would have produced room-level pricing.

This change classifies the error with `ClassifyProviderError`. When it's a retryable condition (bot-wall, 429, transient 5xx) the room result now carries a caution through the existing `RoomAvailability.Notice` channel. A genuine hard failure stays silent, since a retry there wouldn't help.

It's the same rate-limited-vs-failed distinction the search-layer completeness model already keeps; this extends it to the per-hotel room view.

## Why it matters

The feature's purpose is room-level pricing from every accommodation provider. Silently dropping a retryable Booking block tells the user "no Booking rooms here" when the honest answer is "withheld this time, try again." Surfacing it keeps the result honest and points the user at a retry that may succeed.

## Changes

- `bookingRateLimitNotice(err)` — returns a caution string for retryable Booking failures, empty otherwise.
- `appendNotice(existing, add)` — joins notice clauses so a Booking caution and a SerpAPI notice can coexist without one overwriting the other.
- Both are pure functions with unit tests (`TestBookingRateLimitNotice`, `TestAppendNotice`).

## Testing

- New unit tests pass.
- `go vet`, `gofmt -l`, and the full `internal/hotels` suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
