### PR TITLE
fix(hotels): surface retryable Agoda room bot-walls instead of dropping them

### DIFF
--- a/internal/hotels/rooms.go
+++ b/internal/hotels/rooms.go
@@ -184,12 +184,15 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 	// path. Merge so any Google lead-ins stay; bookability sort below leads with
 	// whichever provider actually has a bookable price.
 	if len(rooms) == 0 || !hasVerifiedRoom(rooms) {
-		if agodaRooms := tryAgodaRoomLevel(ctx, opts); len(agodaRooms) > 0 {
+		if agodaRooms, agodaNotice := tryAgodaRoomLevel(ctx, opts); len(agodaRooms) > 0 {
 			if len(rooms) == 0 {
 				rooms = agodaRooms
 			} else {
 				rooms = mergeRoomTypes(rooms, agodaRooms)
 			}
+		} else if agodaNotice != "" {
+			// Agoda room data was withheld by a retryable bot-wall, not absent.
+			notice = appendNotice(notice, agodaNotice)
 		}
 	}
 
@@ -220,15 +223,21 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 	}, nil
 }
 
-// bookingRateLimitNotice returns a user-facing caution when a Booking room
+// providerRateLimitNotice returns a user-facing caution when a provider room
 // fetch failed with a retryable condition (bot-wall, 429, transient 5xx) — a
 // retry may surface room-level pricing. It returns "" for a genuine hard
 // failure or no error, where nothing actionable should be surfaced.
-func bookingRateLimitNotice(brErr error) string {
-	if brErr != nil && models.ClassifyProviderError(brErr) == models.StatusRateLimited {
-		return "Booking.com room pricing was temporarily unavailable (rate-limited); a retry may surface more room-level offers."
+func providerRateLimitNotice(provider string, err error) string {
+	if err != nil && models.ClassifyProviderError(err) == models.StatusRateLimited {
+		return provider + " room pricing was temporarily unavailable (rate-limited); a retry may surface more room-level offers."
 	}
 	return ""
+}
+
+// bookingRateLimitNotice is the Booking.com-specific caution; see
+// providerRateLimitNotice for the rate-limited-vs-failed contract.
+func bookingRateLimitNotice(brErr error) string {
+	return providerRateLimitNotice("Booking.com", brErr)
 }
 
 // appendNotice joins a new notice clause onto an existing notice string,
@@ -302,21 +311,29 @@ func roomEffectivePrice(r RoomType) float64 {
 // the caller invokes it only when the free Google paths produced no verified
 // room price, keeping the live Agoda request off the hot path. Agoda is
 // key-free, so this adds a real second priced provider with no credentials.
-func tryAgodaRoomLevel(ctx context.Context, opts RoomSearchOptions) []RoomType {
+func tryAgodaRoomLevel(ctx context.Context, opts RoomSearchOptions) ([]RoomType, string) {
 	if strings.TrimSpace(opts.Location) == "" {
-		return nil
+		return nil, ""
 	}
 	searchOpts := roomFallbackSearchOptions(opts)
 	var results []models.HotelResult
+	var lastErr error
 	for _, loc := range buildLocationCandidates(opts.Location) {
 		r, err := SearchAgoda(ctx, loc, searchOpts)
-		if err == nil && len(r) > 0 {
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if len(r) > 0 {
 			results = r
 			break
 		}
 	}
 	if len(results) == 0 {
-		return nil
+		// No candidate returned rooms. If the last attempt was a retryable
+		// bot-wall rather than a genuine miss, surface it so a withheld Agoda
+		// price is not mistaken for absent inventory.
+		return nil, providerRateLimitNotice("Agoda", lastErr)
 	}
 	var hotel *models.HotelResult
 	for i := range results {
@@ -329,9 +346,9 @@ func tryAgodaRoomLevel(ctx context.Context, opts RoomSearchOptions) []RoomType {
 		hotel = findBestNameMatch(results, opts.Location)
 	}
 	if hotel == nil || len(hotel.RoomTypes) == 0 {
-		return nil
+		return nil, ""
 	}
-	return hotelRoomsToRoomTypes(hotel.RoomTypes, opts.Currency)
+	return hotelRoomsToRoomTypes(hotel.RoomTypes, opts.Currency), ""
 }
 
 // hotelRoomsToRoomTypes converts provider-search model rooms into

--- a/internal/hotels/rooms_test.go
+++ b/internal/hotels/rooms_test.go
@@ -395,3 +395,28 @@ func TestAppendNotice(t *testing.T) {
 		t.Errorf("a+b = %q, want 'a b'", got)
 	}
 }
+
+// TestProviderRateLimitNotice locks the generalized helper that both Booking
+// and Agoda drill-down paths use: a retryable failure names the provider in a
+// caution; a hard failure or nil stays silent.
+func TestProviderRateLimitNotice(t *testing.T) {
+	got := providerRateLimitNotice("Agoda", fmt.Errorf("akamai bot detection triggered"))
+	if got == "" || !containsSubstr(got, "Agoda") {
+		t.Errorf("retryable Agoda -> %q, want caution naming Agoda", got)
+	}
+	if got := providerRateLimitNotice("Agoda", nil); got != "" {
+		t.Errorf("nil err -> %q, want empty", got)
+	}
+	if got := providerRateLimitNotice("Agoda", fmt.Errorf("no hotel matched")); got != "" {
+		t.Errorf("hard failure -> %q, want empty", got)
+	}
+}
+
+func containsSubstr(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

`tryAgodaRoomLevel` looped over location candidates and threw away every `SearchAgoda` error. A bot-wall or 429 on Agoda therefore looked identical to a hotel that genuinely has no Agoda inventory: both returned an empty result with no signal.

Now the loop keeps the last candidate error. When it classifies as rate-limited, the room result carries a caution through the existing `RoomAvailability.Notice` channel. A genuine no-match stays silent.

This follows the same fix already applied to the Booking path in #324. The shared logic moved into a `providerRateLimitNotice(provider, err)` helper that both paths call.

## Why it matters

Agoda is the key-free provider the drill-down leads with for room-level pricing, so a silent block there is the worst place to lose the signal. Telling the user "no Agoda rooms" when the real answer is "withheld this time, retry may work" misrepresents coverage. Surfacing it keeps the result honest and points at a retry that may succeed.

## Changes

- `providerRateLimitNotice(provider, err)` — shared caution builder; returns "" for hard failures or no error. `bookingRateLimitNotice` now delegates to it.
- `tryAgodaRoomLevel` returns `([]RoomType, string)`; the call site appends the notice when Agoda was rate-limited and produced no rooms.
- Test `TestProviderRateLimitNotice` covers the generalized helper.

## Testing

- New and existing helper tests pass.
- `go vet`, `gofmt -l`, and the full `internal/hotels` suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
