### PR TITLE
fix(hotels): mark Google search-level bot-walls as missing coverage, not no-hit

### DIFF
--- a/internal/hotels/rooms.go
+++ b/internal/hotels/rooms.go
@@ -174,6 +174,10 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 			if hotelName == "" {
 				hotelName = serpName
 			}
+		} else if serpNotice != "" {
+			// SerpAPI returned no rooms but flagged a retryable rate-limit;
+			// surface it rather than silently degrading to no upgrade.
+			notice = appendNotice(notice, serpNotice)
 		}
 	}
 

--- a/internal/hotels/rooms.go
+++ b/internal/hotels/rooms.go
@@ -184,12 +184,15 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 	// path. Merge so any Google lead-ins stay; bookability sort below leads with
 	// whichever provider actually has a bookable price.
 	if len(rooms) == 0 || !hasVerifiedRoom(rooms) {
-		if agodaRooms := tryAgodaRoomLevel(ctx, opts); len(agodaRooms) > 0 {
+		if agodaRooms, agodaNotice := tryAgodaRoomLevel(ctx, opts); len(agodaRooms) > 0 {
 			if len(rooms) == 0 {
 				rooms = agodaRooms
 			} else {
 				rooms = mergeRoomTypes(rooms, agodaRooms)
 			}
+		} else if agodaNotice != "" {
+			// Agoda room data was withheld by a retryable bot-wall, not absent.
+			notice = appendNotice(notice, agodaNotice)
 		}
 	}
 
@@ -220,15 +223,21 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 	}, nil
 }
 
-// bookingRateLimitNotice returns a user-facing caution when a Booking room
+// providerRateLimitNotice returns a user-facing caution when a provider room
 // fetch failed with a retryable condition (bot-wall, 429, transient 5xx) — a
 // retry may surface room-level pricing. It returns "" for a genuine hard
 // failure or no error, where nothing actionable should be surfaced.
-func bookingRateLimitNotice(brErr error) string {
-	if brErr != nil && models.ClassifyProviderError(brErr) == models.StatusRateLimited {
-		return "Booking.com room pricing was temporarily unavailable (rate-limited); a retry may surface more room-level offers."
+func providerRateLimitNotice(provider string, err error) string {
+	if err != nil && models.ClassifyProviderError(err) == models.StatusRateLimited {
+		return provider + " room pricing was temporarily unavailable (rate-limited); a retry may surface more room-level offers."
 	}
 	return ""
+}
+
+// bookingRateLimitNotice is the Booking.com-specific caution; see
+// providerRateLimitNotice for the rate-limited-vs-failed contract.
+func bookingRateLimitNotice(brErr error) string {
+	return providerRateLimitNotice("Booking.com", brErr)
 }
 
 // appendNotice joins a new notice clause onto an existing notice string,
@@ -302,21 +311,29 @@ func roomEffectivePrice(r RoomType) float64 {
 // the caller invokes it only when the free Google paths produced no verified
 // room price, keeping the live Agoda request off the hot path. Agoda is
 // key-free, so this adds a real second priced provider with no credentials.
-func tryAgodaRoomLevel(ctx context.Context, opts RoomSearchOptions) []RoomType {
+func tryAgodaRoomLevel(ctx context.Context, opts RoomSearchOptions) ([]RoomType, string) {
 	if strings.TrimSpace(opts.Location) == "" {
-		return nil
+		return nil, ""
 	}
 	searchOpts := roomFallbackSearchOptions(opts)
 	var results []models.HotelResult
+	var lastErr error
 	for _, loc := range buildLocationCandidates(opts.Location) {
 		r, err := SearchAgoda(ctx, loc, searchOpts)
-		if err == nil && len(r) > 0 {
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if len(r) > 0 {
 			results = r
 			break
 		}
 	}
 	if len(results) == 0 {
-		return nil
+		// No candidate returned rooms. If the last attempt was a retryable
+		// bot-wall rather than a genuine miss, surface it so a withheld Agoda
+		// price is not mistaken for absent inventory.
+		return nil, providerRateLimitNotice("Agoda", lastErr)
 	}
 	var hotel *models.HotelResult
 	for i := range results {
@@ -329,9 +346,9 @@ func tryAgodaRoomLevel(ctx context.Context, opts RoomSearchOptions) []RoomType {
 		hotel = findBestNameMatch(results, opts.Location)
 	}
 	if hotel == nil || len(hotel.RoomTypes) == 0 {
-		return nil
+		return nil, ""
 	}
-	return hotelRoomsToRoomTypes(hotel.RoomTypes, opts.Currency)
+	return hotelRoomsToRoomTypes(hotel.RoomTypes, opts.Currency), ""
 }
 
 // hotelRoomsToRoomTypes converts provider-search model rooms into

--- a/internal/hotels/rooms_test.go
+++ b/internal/hotels/rooms_test.go
@@ -395,3 +395,28 @@ func TestAppendNotice(t *testing.T) {
 		t.Errorf("a+b = %q, want 'a b'", got)
 	}
 }
+
+// TestProviderRateLimitNotice locks the generalized helper that both Booking
+// and Agoda drill-down paths use: a retryable failure names the provider in a
+// caution; a hard failure or nil stays silent.
+func TestProviderRateLimitNotice(t *testing.T) {
+	got := providerRateLimitNotice("Agoda", fmt.Errorf("akamai bot detection triggered"))
+	if got == "" || !containsSubstr(got, "Agoda") {
+		t.Errorf("retryable Agoda -> %q, want caution naming Agoda", got)
+	}
+	if got := providerRateLimitNotice("Agoda", nil); got != "" {
+		t.Errorf("nil err -> %q, want empty", got)
+	}
+	if got := providerRateLimitNotice("Agoda", fmt.Errorf("no hotel matched")); got != "" {
+		t.Errorf("hard failure -> %q, want empty", got)
+	}
+}
+
+func containsSubstr(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -317,7 +317,19 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 			rawBatches = append(rawBatches, tagHotelSource(pageHotels, "google_hotels"))
 		}
 	}
-	addProviderStatus(hotelProviderStatusFromResults("google_hotels", "Google Hotels", countHotelBatchResults(rawBatches)))
+	if googlePrimaryErr != nil && countHotelBatchResults(rawBatches) == 0 {
+		// Google's primary-sort fetch was blocked/failed and returned nothing
+		// (a primary failure breaks the sort loop before any batch is kept, so
+		// rawBatches is empty here). Classify the error — rate-limited bot-wall
+		// vs hard failure — so the completeness model marks Google as MISSING
+		// coverage rather than a definitive no-hit. Otherwise a bot-walled
+		// primary provider would let renderers claim exhaustive coverage the
+		// search never actually had. Mirrors the per-provider error handling the
+		// auxiliary providers below already use.
+		addProviderStatus(hotelProviderStatusFromError("google_hotels", "Google Hotels", googlePrimaryErr))
+	} else {
+		addProviderStatus(hotelProviderStatusFromResults("google_hotels", "Google Hotels", countHotelBatchResults(rawBatches)))
+	}
 
 	// Run parallel searches against Trivago, optional Booking.com, and
 	// user-configured external providers. All auxiliary providers are non-fatal:

--- a/internal/hotels/search_test.go
+++ b/internal/hotels/search_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -570,5 +571,55 @@ func TestSearchHotels_GoogleBlockedDegradesGracefully(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected Booking Test Hotel to survive a blocked Google fetch")
+	}
+}
+
+// TestSearchHotels_GoogleRateLimitedMarksMissingCoverage guards the completeness
+// model: when Google's primary fetch is bot-walled (a retryable rate-limit), its
+// ProviderStatus must classify as rate-limited and coverage must be MISSING
+// Google — never a definitive no-hit. A count-only status would mislabel a
+// blocked primary provider as "checked, found nothing", letting renderers claim
+// exhaustive coverage the search never actually had.
+func TestSearchHotels_GoogleRateLimitedMarksMissingCoverage(t *testing.T) {
+	origFetch := fetchHotelPageFullFn
+	fetchHotelPageFullFn = func(_ context.Context, _ *batchexec.Client, _ string, _ HotelSearchOptions, _ int, _ string) (parseResult, error) {
+		// A bot-wall block: retryable, classifies as StatusRateLimited.
+		return parseResult{}, fmt.Errorf("google hotels blocked: %w", models.ErrRateLimited)
+	}
+	defer func() { fetchHotelPageFullFn = origFetch }()
+
+	origSearch := SearchBooking
+	SearchBooking = func(_ context.Context, _ string, _ HotelSearchOptions) ([]models.HotelResult, error) {
+		return []models.HotelResult{{
+			Name:       "Booking Test Hotel",
+			Price:      99,
+			Currency:   "EUR",
+			BookingURL: "https://www.booking.com/hotel/test",
+		}}, nil
+	}
+	defer func() { SearchBooking = origSearch }()
+
+	results, err := SearchHotels(context.Background(), "Corfu", HotelSearchOptions{
+		CheckIn: "2026-08-10", CheckOut: "2026-08-17", Currency: "EUR", MaxPages: 1,
+	})
+	if err != nil {
+		t.Fatalf("SearchHotels returned error despite a working auxiliary provider: %v", err)
+	}
+
+	var googleStatus *models.ProviderStatus
+	for i := range results.ProviderStatuses {
+		if results.ProviderStatuses[i].ID == "google_hotels" {
+			googleStatus = &results.ProviderStatuses[i]
+			break
+		}
+	}
+	if googleStatus == nil {
+		t.Fatal("expected a google_hotels provider status")
+	}
+	if googleStatus.Status != models.StatusRateLimited {
+		t.Errorf("google_hotels status = %q, want rate_limited (bot-wall must not look like a clean no-hit)", googleStatus.Status)
+	}
+	if results.Completeness.MayClaimExhaustive() {
+		t.Errorf("completeness = %+v, must not claim exhaustive when the primary provider was blocked", results.Completeness)
 	}
 }

--- a/internal/hotels/serpapi_fallback.go
+++ b/internal/hotels/serpapi_fallback.go
@@ -102,10 +102,12 @@ func trySerpAPIRoomFallback(ctx context.Context, opts RoomSearchOptions) ([]Room
 	const serpapiFallbackMaxPages = 3
 	var hotel *serpapi.Hotel
 	scanned := 0
+	var lastErr error
 	for page := 0; page < serpapiFallbackMaxPages; page++ {
 		result, err := serpapiSearchHotelsFunc(ctx, searchOpts)
 		if err != nil || result == nil {
 			log.Printf("DEBUG serpapi room fallback: search failed page=%d query=%q err=%v", page, query, err)
+			lastErr = err
 			break
 		}
 		scanned += len(result.Properties)
@@ -120,7 +122,10 @@ func trySerpAPIRoomFallback(ctx context.Context, opts RoomSearchOptions) ([]Room
 	}
 	if hotel == nil {
 		log.Printf("DEBUG serpapi room fallback: no hotel matched in %d properties across pages (query=%q name=%q)", scanned, query, opts.Location)
-		return nil, "", ""
+		// A retryable bot-wall / 429 on the metered search is not a genuine
+		// "no match"; surface it so a withheld Google Hotels price is not read
+		// as absent inventory. Hard failures and plain misses stay silent.
+		return nil, "", providerRateLimitNotice("Google Hotels", lastErr)
 	}
 	searchOpts.NextPageToken = "" // detail fetch is by property token; drop stale page cursor
 	hotel = selectedSerpAPIPropertyDetails(ctx, hotel, searchOpts)

--- a/internal/hotels/serpapi_fallback_test.go
+++ b/internal/hotels/serpapi_fallback_test.go
@@ -488,3 +488,28 @@ func stubSerpAPIFallbackWithDetail(t *testing.T, place *serpapi.MapsPlace, respo
 		serpapiGetPropertyDetailsFunc = origDetails
 	}
 }
+
+// TestSerpAPIRoomFallbackSurfacesRateLimit locks the honesty signal: a
+// rate-limited metered search returns no rooms but a Google Hotels caution,
+// so a withheld upgrade is not mistaken for "no better price available".
+func TestSerpAPIRoomFallbackSurfacesRateLimit(t *testing.T) {
+	origKey, origResolve, origSearch := serpapiAPIKeyFunc, serpapiResolveGoogleMapsPlaceFunc, serpapiSearchHotelsFunc
+	t.Cleanup(func() {
+		serpapiAPIKeyFunc, serpapiResolveGoogleMapsPlaceFunc, serpapiSearchHotelsFunc = origKey, origResolve, origSearch
+	})
+	serpapiAPIKeyFunc = func() string { return "test-key" }
+	serpapiResolveGoogleMapsPlaceFunc = func(context.Context, string) (*serpapi.MapsPlace, error) { return nil, nil }
+	serpapiSearchHotelsFunc = func(context.Context, serpapi.SearchOptions) (*serpapi.Response, error) {
+		return nil, models.ErrRateLimited
+	}
+
+	rooms, name, notice := trySerpAPIRoomFallback(context.Background(), RoomSearchOptions{
+		Location: "Madeira", CheckIn: "2026-07-30", CheckOut: "2026-08-04", Currency: "EUR", Guests: 2,
+	})
+	if rooms != nil || name != "" {
+		t.Fatalf("rooms/name = %#v/%q, want empty on rate-limited search", rooms, name)
+	}
+	if notice == "" || !containsSubstr(notice, "Google Hotels") {
+		t.Fatalf("notice = %q, want Google Hotels rate-limit caution", notice)
+	}
+}


### PR DESCRIPTION
## What

Google's primary hotel search reports its outcome to the completeness model with a count-only status helper. When that fetch is bot-walled (rate-limit, 429, transient 5xx) it returns zero results, which resolved to `CheckedNoHit`, a definitive "we checked Google and it had nothing." The error was captured but only surfaced as a fatal when *every* provider came back empty.

So in the common case (Google blocked, Booking/Trivago/Agoda still returning hotels) the user got results with Google silently marked as a clean no-hit. `ComputeCompleteness` then saw the primary provider as reached and could let renderers claim exhaustive coverage the search never actually had.

## Fix

When the captured primary error is present (and Google returned nothing), classify it through `hotelProviderStatusFromError`, the same path every auxiliary provider already uses. A rate-limit reads as `rate_limited` and a hard failure as `failed`. Either way Google is now counted as missing coverage, and completeness stops claiming exhaustive.

## Test

`TestSearchHotels_GoogleRateLimitedMarksMissingCoverage`: bot-walls Google's fetch with a retryable error, keeps an auxiliary provider working, asserts the `google_hotels` status is `rate_limited` and `Completeness.MayClaimExhaustive()` is false. Full `internal/hotels` suite green.

This completes the rate-limited-vs-failed honesty sweep. Room drilldown was covered for Booking (#324), Agoda (#325), and Google Hotels (#326); this closes the same gap at the search level for the primary provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
