### PR TITLE
feat(trip): surface hotel provider coverage in headline trip plan

### DIFF
--- a/cmd/trvl/display_coverage2_split3_test.go
+++ b/cmd/trvl/display_coverage2_split3_test.go
@@ -666,6 +666,57 @@ func TestFormatTripMarkdown_NoLegs_Extra(t *testing.T) {
 	}
 }
 
+// TestPrintTripPlan_HotelCoverageHonesty proves the headline trip plan surfaces
+// partial accommodation coverage instead of presenting a thinned list as if it
+// were exhaustive — and distinguishes a rate-limited (retryable) provider from a
+// hard failure. This is the user-facing payoff of the per-provider evidence the
+// hotel search already computes (PASS-13..17): without it, a bot-walled Booking
+// or rate-limited Google silently shrinks the results with no signal to the user.
+func TestPrintTripPlan_HotelCoverageHonesty(t *testing.T) {
+	models.UseColor = false
+
+	result := &trip.PlanResult{
+		Success:     true,
+		Origin:      "HEL",
+		Destination: "BCN",
+		DepartDate:  "2026-07-01",
+		ReturnDate:  "2026-07-08",
+		Nights:      7,
+		Guests:      2,
+		Hotels: []trip.PlanHotel{
+			{Name: "Hotel Arts", Rating: 9.1, Reviews: 500, PerNight: 180, Total: 1260, Currency: "EUR"},
+		},
+		HotelProviders: []models.ProviderStatus{
+			{ID: "agoda", Name: "Agoda", Status: models.StatusCheckedHit, Results: 1},
+			{ID: "google_hotels", Name: "Google Hotels", Status: models.StatusRateLimited, Error: "blocked"},
+			{ID: "booking", Name: "Booking.com", Status: models.StatusFailed, Error: "no cookies", FixHint: "sign in to a browser"},
+		},
+		Summary: trip.PlanSummary{GrandTotal: 1260, Currency: "EUR"},
+	}
+	result.HotelCoverage = models.ComputeCompleteness(result.HotelProviders)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	out := captureStdout(t, func() {
+		if err := printTripPlan(ctx, "", result); err != nil {
+			t.Errorf("printTripPlan returned error: %v", err)
+		}
+	})
+
+	for _, want := range []string{
+		"Hotel coverage",       // the caveat header is shown
+		"Google Hotels",        // the rate-limited provider is named
+		"rate-limited",         // and tagged as retryable
+		"Booking.com",          // the hard-failed provider is named
+		"sign in to a browser", // with its actionable fix hint
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("coverage output missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Suppress unused import errors
 // ---------------------------------------------------------------------------

--- a/cmd/trvl/trip.go
+++ b/cmd/trvl/trip.go
@@ -204,7 +204,27 @@ func printTripPlan(ctx context.Context, targetCurrency string, result *trip.Plan
 		fmt.Println()
 	}
 
-	// Destination context from Wikivoyage.
+	// Accommodation coverage honesty: if some hotel providers were rate-limited
+	// or failed, say so instead of presenting a thinned list as exhaustive. The
+	// prices shown lead with whichever providers returned real availability;
+	// this note tells the user which sources are missing and whether retrying
+	// is worthwhile (rate-limited is retryable; a hard failure usually is not).
+	if !result.HotelCoverage.MayClaimExhaustive() {
+		fmt.Printf("  %s %s\n", models.Bold("⚠ Hotel coverage:"), result.HotelCoverage.IncompleteNote())
+		for _, s := range result.HotelProviders {
+			switch s.Status {
+			case models.StatusRateLimited:
+				fmt.Printf("    • %s: rate-limited (retryable — try again shortly)\n", s.Name)
+			case models.StatusFailed, models.StatusError, models.StatusTimeout, models.StatusCircuitBroken:
+				line := fmt.Sprintf("    • %s: unavailable this attempt", s.Name)
+				if s.FixHint != "" {
+					line += " — " + s.FixHint
+				}
+				fmt.Println(line)
+			}
+		}
+		fmt.Println()
+	}
 	if result.Context != nil {
 		fmt.Printf("  %s About %s\n\n", models.Bold("📖"), destName)
 		if result.Context.Summary != "" {

--- a/internal/trip/plan.go
+++ b/internal/trip/plan.go
@@ -113,6 +113,15 @@ type PlanResult struct {
 	Context         *PlanDestinationContext `json:"context,omitempty"`
 	Summary         PlanSummary             `json:"summary"`
 	Error           string                  `json:"error,omitempty"`
+
+	// HotelCoverage / HotelProviders carry the per-provider evidence so the
+	// renderer can be honest about partial accommodation coverage instead of
+	// silently presenting a thinned list as if it were exhaustive. A provider
+	// that was rate-limited (retryable) is distinct from one that genuinely had
+	// no availability — the user needs that distinction to decide whether to
+	// retry or trust the prices shown.
+	HotelCoverage  models.Completeness     `json:"hotel_coverage,omitempty"`
+	HotelProviders []models.ProviderStatus `json:"hotel_providers,omitempty"`
 }
 
 // PlanTrip searches flights and hotels in parallel and returns the top options
@@ -228,6 +237,14 @@ func PlanTrip(ctx context.Context, input PlanInput) (*PlanResult, error) {
 	// Extract top hotels (up to 5).
 	if hotelErr == nil && hotelResult != nil && hotelResult.Success {
 		result.Hotels = extractTopHotels(hotelResult.Hotels, nights, 5)
+	}
+
+	// Surface accommodation coverage so the renderer can be honest about a
+	// thinned provider set (rate-limited != no availability). Provider statuses
+	// are populated even on a non-Success search, so read them unconditionally.
+	if hotelResult != nil {
+		result.HotelProviders = hotelResult.ProviderStatuses
+		result.HotelCoverage = hotelResult.Completeness
 	}
 
 	// Find breakfast spots within walking distance.


### PR DESCRIPTION
## What

The headline `trip` command now tells you when accommodation coverage is partial. Before this, the render read only `result.Hotels` and ignored the `ProviderStatuses` / `Completeness` evidence the hotel search already produces. A rate-limited Google Hotels or a bot-walled Booking.com would quietly shrink the hotel list, and you had no way to tell a short list of real availability from a short list caused by a blocked provider.

## Why it matters

The prices shown lead with whichever providers returned real availability. The new note says which sources are missing and why, and it separates two cases that look identical in a thinned list but are not:

- **rate-limited** — retryable, so trying again shortly may fill the gap
- **hard failure** — shown with its fix hint (for example, sign in to a browser so Booking cookies are available)

That keeps the output honest: a partial search is labelled as partial instead of reading like the whole market.

## Changes

- `PlanResult` carries `HotelCoverage` (`Completeness`) and `HotelProviders` (`[]ProviderStatus`), populated from the hotel search result even when the search was not fully successful — provider status is most useful exactly when results are thin.
- `printTripPlan` renders a coverage caveat after the hotels table when the search was not exhaustive, naming degraded providers and their status.

## Tests

`TestPrintTripPlan_HotelCoverageHonesty` feeds a result with one healthy provider, one rate-limited, and one hard-failed, and asserts the rendered output names each and tags the rate-limited one as retryable. Existing render tests (`TestPrintTripPlan_Full`, the `internal/trip` suite) stay green.

```
go test ./cmd/trvl/ ./internal/trip/   # ok
go vet ./...                            # clean
staticcheck ./internal/trip/... ./cmd/trvl/...  # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
