### PR TITLE
feat(trip): surface flight provider coverage in headline trip plan

### DIFF
--- a/cmd/trvl/display_coverage2_split3_test.go
+++ b/cmd/trvl/display_coverage2_split3_test.go
@@ -717,6 +717,59 @@ func TestPrintTripPlan_HotelCoverageHonesty(t *testing.T) {
 	}
 }
 
+// TestPrintTripPlan_FlightCoverageHonesty proves the headline trip plan is just
+// as honest about partial flight coverage as it is about hotels. Both legs hit
+// the same upstream providers, so a provider degraded on either leg means the
+// displayed flight prices are not a complete sweep — the user needs that signal
+// to decide whether to retry (rate-limited) or trust what is shown.
+func TestPrintTripPlan_FlightCoverageHonesty(t *testing.T) {
+	models.UseColor = false
+
+	result := &trip.PlanResult{
+		Success:     true,
+		Origin:      "HEL",
+		Destination: "BCN",
+		DepartDate:  "2026-07-01",
+		ReturnDate:  "2026-07-08",
+		Nights:      7,
+		Guests:      2,
+		OutboundFlights: []trip.PlanFlight{
+			{Price: 120, Currency: "EUR", Airline: "Finnair", Flight: "AY1", Stops: 0, Duration: 240},
+		},
+		ReturnFlights: []trip.PlanFlight{
+			{Price: 130, Currency: "EUR", Airline: "Vueling", Flight: "VY2", Stops: 0, Duration: 250},
+		},
+		FlightProviders: []models.ProviderStatus{
+			{ID: "kiwi", Name: "Kiwi", Status: models.StatusCheckedHit, Results: 2},
+			{ID: "google_flights", Name: "Google Flights", Status: models.StatusRateLimited, Error: "blocked"},
+			{ID: "ryanair", Name: "Ryanair", Status: models.StatusFailed, Error: "timeout", FixHint: "retry later"},
+		},
+		Summary: trip.PlanSummary{GrandTotal: 250, Currency: "EUR"},
+	}
+	result.FlightCoverage = models.ComputeCompleteness(result.FlightProviders)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	out := captureStdout(t, func() {
+		if err := printTripPlan(ctx, "", result); err != nil {
+			t.Errorf("printTripPlan returned error: %v", err)
+		}
+	})
+
+	for _, want := range []string{
+		"Flight coverage", // the caveat header is shown
+		"Google Flights",  // the rate-limited provider is named
+		"rate-limited",    // and tagged as retryable
+		"Ryanair",         // the hard-failed provider is named
+		"retry later",     // with its actionable fix hint
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("flight coverage output missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Suppress unused import errors
 // ---------------------------------------------------------------------------

--- a/cmd/trvl/trip.go
+++ b/cmd/trvl/trip.go
@@ -172,6 +172,27 @@ func printTripPlan(ctx context.Context, targetCurrency string, result *trip.Plan
 		fmt.Println()
 	}
 
+	// Flight coverage honesty: both legs query the same upstream providers, so
+	// the union (worst status per provider) tells the user whether the flight
+	// prices above can be trusted as a complete sweep. A rate-limited provider
+	// is retryable; a hard failure usually is not. Mirrors the hotel note below.
+	if !result.FlightCoverage.MayClaimExhaustive() {
+		fmt.Printf("  %s %s\n", models.Bold("⚠ Flight coverage:"), result.FlightCoverage.IncompleteNote())
+		for _, s := range result.FlightProviders {
+			switch s.Status {
+			case models.StatusRateLimited:
+				fmt.Printf("    • %s: rate-limited (retryable — try again shortly)\n", s.Name)
+			case models.StatusFailed, models.StatusError, models.StatusTimeout, models.StatusCircuitBroken:
+				line := fmt.Sprintf("    • %s: unavailable this attempt", s.Name)
+				if s.FixHint != "" {
+					line += " — " + s.FixHint
+				}
+				fmt.Println(line)
+			}
+		}
+		fmt.Println()
+	}
+
 	// Hotels.
 	if len(result.Hotels) > 0 {
 		fmt.Printf("  %s Hotels in %s (%d nights)\n\n", models.Bold("🏨"), destName, result.Nights)

--- a/internal/trip/plan.go
+++ b/internal/trip/plan.go
@@ -122,6 +122,13 @@ type PlanResult struct {
 	// retry or trust the prices shown.
 	HotelCoverage  models.Completeness     `json:"hotel_coverage,omitempty"`
 	HotelProviders []models.ProviderStatus `json:"hotel_providers,omitempty"`
+
+	// FlightCoverage / FlightProviders mirror the hotel fields for air travel.
+	// Both legs query the same upstream providers, so per-leg statuses are merged
+	// into one union (worst status per provider wins): a provider rate-limited or
+	// failed on either leg means the displayed flight prices are not exhaustive.
+	FlightCoverage  models.Completeness     `json:"flight_coverage,omitempty"`
+	FlightProviders []models.ProviderStatus `json:"flight_providers,omitempty"`
 }
 
 // PlanTrip searches flights and hotels in parallel and returns the top options
@@ -246,6 +253,12 @@ func PlanTrip(ctx context.Context, input PlanInput) (*PlanResult, error) {
 		result.HotelProviders = hotelResult.ProviderStatuses
 		result.HotelCoverage = hotelResult.Completeness
 	}
+
+	// Surface flight coverage as the union of both legs (worst status per
+	// provider wins), so a provider degraded on either the outbound or return
+	// search flags the flight prices as potentially incomplete.
+	result.FlightProviders = mergeFlightProviders(outResult, retResult)
+	result.FlightCoverage = models.ComputeCompleteness(result.FlightProviders)
 
 	// Find breakfast spots within walking distance.
 	// Searches top hotels in order — the first one with at least 3 spots
@@ -746,4 +759,45 @@ func applyOSMEnrichment(hotel *PlanHotel, extra *destinations.HotelEnrichment) {
 	if extra.Wheelchair != "" {
 		hotel.Wheelchair = extra.Wheelchair
 	}
+}
+
+// provSeverity ranks a provider status for union merging: a hard failure
+// outranks a retryable rate-limit, which outranks a definitive (succeeded or
+// empty) result. Higher wins when the same provider appears on both legs.
+func provSeverity(status string) int {
+	switch status {
+	case models.StatusFailed, models.StatusError, models.StatusTimeout, models.StatusCircuitBroken:
+		return 3
+	case models.StatusRateLimited:
+		return 2
+	default:
+		return 1
+	}
+}
+
+// mergeFlightProviders unions the per-provider statuses from the outbound and
+// return flight searches. Both legs hit the same upstream providers, so a
+// provider is reported once, keeping the worst (most severe) status seen across
+// the two legs — the honest signal for "can we trust these prices as complete".
+func mergeFlightProviders(legs ...*models.FlightSearchResult) []models.ProviderStatus {
+	worst := map[string]models.ProviderStatus{}
+	var order []string
+	for _, leg := range legs {
+		if leg == nil {
+			continue
+		}
+		for _, s := range leg.ProviderStatuses {
+			if cur, ok := worst[s.ID]; !ok {
+				worst[s.ID] = s
+				order = append(order, s.ID)
+			} else if provSeverity(s.Status) > provSeverity(cur.Status) {
+				worst[s.ID] = s
+			}
+		}
+	}
+	out := make([]models.ProviderStatus, 0, len(order))
+	for _, id := range order {
+		out = append(out, worst[id])
+	}
+	return out
 }

--- a/internal/trip/plan_coverage_test.go
+++ b/internal/trip/plan_coverage_test.go
@@ -1,6 +1,10 @@
 package trip
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
 
 // ============================================================
 // PlanTrip validation paths
@@ -90,5 +94,59 @@ func TestPlanTrip_SameDay(t *testing.T) {
 	})
 	if err == nil {
 		t.Error("expected error for same-day trip")
+	}
+}
+
+// TestMergeFlightProviders_WorstStatusWins proves the two-leg union keeps the
+// most severe status per provider: a provider that succeeded outbound but was
+// rate-limited or failed on the return leg must surface as degraded, never as
+// the rosier outbound result. This is what makes the flight-coverage note honest.
+func TestMergeFlightProviders_WorstStatusWins(t *testing.T) {
+	out := &models.FlightSearchResult{ProviderStatuses: []models.ProviderStatus{
+		{ID: "kiwi", Name: "Kiwi", Status: models.StatusCheckedHit, Results: 3},
+		{ID: "google_flights", Name: "Google Flights", Status: models.StatusCheckedHit, Results: 2},
+		{ID: "ryanair", Name: "Ryanair", Status: models.StatusRateLimited},
+	}}
+	ret := &models.FlightSearchResult{ProviderStatuses: []models.ProviderStatus{
+		{ID: "kiwi", Name: "Kiwi", Status: models.StatusCheckedHit, Results: 1},
+		{ID: "google_flights", Name: "Google Flights", Status: models.StatusRateLimited}, // degraded on return
+		{ID: "ryanair", Name: "Ryanair", Status: models.StatusFailed},                    // worse on return
+		{ID: "wizzair", Name: "Wizz Air", Status: models.StatusCheckedHit, Results: 4},   // only on return leg
+	}}
+
+	merged := mergeFlightProviders(out, ret)
+
+	byID := map[string]models.ProviderStatus{}
+	for _, s := range merged {
+		byID[s.ID] = s
+	}
+	if len(merged) != 4 {
+		t.Fatalf("expected 4 unioned providers, got %d: %+v", len(merged), merged)
+	}
+	if got := byID["kiwi"].Status; got != models.StatusCheckedHit {
+		t.Errorf("kiwi clean on both legs should stay ok, got %q", got)
+	}
+	if got := byID["google_flights"].Status; got != models.StatusRateLimited {
+		t.Errorf("google_flights rate-limited on return should win, got %q", got)
+	}
+	if got := byID["ryanair"].Status; got != models.StatusFailed {
+		t.Errorf("ryanair failed on return should beat rate-limited outbound, got %q", got)
+	}
+	if got := byID["wizzair"].Status; got != models.StatusCheckedHit {
+		t.Errorf("wizzair seen only on return leg should appear, got %q", got)
+	}
+}
+
+// TestMergeFlightProviders_NilLegs proves a missing leg (search errored, nil
+// result) never panics and simply contributes nothing to the union.
+func TestMergeFlightProviders_NilLegs(t *testing.T) {
+	if got := mergeFlightProviders(nil, nil); len(got) != 0 {
+		t.Errorf("two nil legs should merge to empty, got %+v", got)
+	}
+	only := &models.FlightSearchResult{ProviderStatuses: []models.ProviderStatus{
+		{ID: "kiwi", Name: "Kiwi", Status: models.StatusCheckedHit},
+	}}
+	if got := mergeFlightProviders(nil, only); len(got) != 1 || got[0].ID != "kiwi" {
+		t.Errorf("one nil + one real leg should yield the real leg, got %+v", got)
 	}
 }


### PR DESCRIPTION
## What

Flights, now honest about partial coverage. The headline trip plan tells the user when a provider dropped out, the same way #328 fixed hotels.

Both flight legs hit the same upstream providers: Google Flights, Kiwi, Ryanair, Wizz Air, Transavia, easyJet. If one is rate-limited or fails on either leg, the prices shown are no longer a complete sweep. Before this change `printTripPlan` gave no signal at all. A bot-walled or rate-limited provider just quietly shrank the results.

## How

- `PlanResult` gains `FlightCoverage` / `FlightProviders`, mirroring the hotel fields.
- `mergeFlightProviders` unions the per-provider statuses from both legs, keeping the worst status per provider (a hard failure outranks a rate-limit, which outranks a clean result). A provider degraded on either leg is reported as degraded.
- `printTripPlan` renders a coverage note after the return-flights table: it names each degraded provider and separates retryable rate-limits from hard failures, attaching fix hints where the provider supplied one. Shape matches the hotel note exactly.

## Tests

- Render honesty: a rate-limited provider and a hard-failed provider are both named, tagged correctly, and the fix hint is shown.
- Worst-status-wins: a provider clean outbound but rate-limited/failed on return surfaces as degraded; a provider seen only on the return leg still appears.
- Nil-leg safety: a missing leg contributes nothing. No panic.

Coverage is computed with the existing `models.ComputeCompleteness`, so the note appears only when the search was not exhaustive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
