### PR TITLE
feat(hotels): lead with providers that have real room-level prices

### DIFF
--- a/internal/hotels/hotel_price_confidence_sort_test.go
+++ b/internal/hotels/hotel_price_confidence_sort_test.go
@@ -1,0 +1,69 @@
+package hotels
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestSortHotelsLeadsWithRoomLevelPriceConfidence verifies the confidence-aware
+// secondary sort: a real per-night room price (room_level/verified) leads even
+// when a headline-only teaser (unverified) is cheaper, and zero-price listings
+// stay demoted to the end. Confidence values mirror the constants in
+// internal/models/hotel_price_trust.go.
+func TestSortHotelsLeadsWithRoomLevelPriceConfidence(t *testing.T) {
+	hotels := []models.HotelResult{
+		{Name: "Google headline", Price: 80, PriceConfidence: models.PriceConfidenceUnverified},
+		{Name: "Agoda room", Price: 110, PriceConfidence: models.PriceConfidenceRoomLevel},
+		{Name: "No price", Price: 0, PriceConfidence: models.PriceConfidenceUnverified},
+		{Name: "Booking verified", Price: 130, PriceConfidence: models.PriceConfidenceVerified},
+	}
+
+	sortHotels(hotels, "cheapest", 0, 0)
+
+	gotOrder := make([]string, len(hotels))
+	for i, h := range hotels {
+		gotOrder[i] = h.Name
+	}
+	wantOrder := []string{"Booking verified", "Agoda room", "Google headline", "No price"}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Fatalf("sort order = %v, want %v", gotOrder, wantOrder)
+		}
+	}
+
+	// The pricier room-level provider must lead the cheaper headline teaser.
+	if hotels[0].Name != "Booking verified" || hotels[1].Name != "Agoda room" {
+		t.Errorf("room-level/verified providers did not lead: got %q then %q", hotels[0].Name, hotels[1].Name)
+	}
+	// Zero-price listing must stay last.
+	if hotels[len(hotels)-1].Price != 0 {
+		t.Errorf("zero-price listing not demoted to end: %+v", hotels[len(hotels)-1])
+	}
+}
+
+// TestLessPriceConfidenceTiers checks the comparator directly across tiers.
+func TestLessPriceConfidenceTiers(t *testing.T) {
+	roomLevel := models.HotelResult{Price: 110, PriceConfidence: models.PriceConfidenceRoomLevel}
+	headline := models.HotelResult{Price: 80, PriceConfidence: models.PriceConfidenceUnverified}
+	empty := models.HotelResult{Price: 90, PriceConfidence: ""}
+	zero := models.HotelResult{Price: 0, PriceConfidence: models.PriceConfidenceRoomLevel}
+
+	if !lessPrice(roomLevel, headline) {
+		t.Error("pricier room_level should sort before cheaper unverified")
+	}
+	if lessPrice(headline, roomLevel) {
+		t.Error("cheaper unverified should not sort before room_level")
+	}
+	// Empty confidence ranks the same as unverified (lowest priced tier).
+	if !lessPrice(headline, empty) {
+		t.Error("within lowest tier, cheaper price should win (80 < 90)")
+	}
+	// Zero price always sinks below any priced entry.
+	if lessPrice(zero, headline) {
+		t.Error("zero-price entry should never sort before a priced one")
+	}
+	if !lessPrice(headline, zero) {
+		t.Error("priced entry should sort before a zero-price entry")
+	}
+}

--- a/internal/hotels/search_filter.go
+++ b/internal/hotels/search_filter.go
@@ -152,12 +152,43 @@ func degreesToRadians(deg float64) float64 {
 	return deg * math.Pi / 180
 }
 
+// priceConfidenceRank maps a HotelResult.PriceConfidence value to a sort
+// rank, higher rank = more trustworthy headline price. The values mirror the
+// constants in internal/models/hotel_price_trust.go:
+//
+//	verified   (3) — price re-confirmed against a bookable room rate
+//	room_level (2) — a real per-night room rate (Agoda/Booking/Trivago path)
+//	unverified (1) — headline / lead-in teaser (e.g. Google's single price)
+//
+// Empty or unrecognised confidence ranks lowest among priced entries (1) so
+// listings without a trustworthy basis still sort below real room prices while
+// staying ahead of zero-price entries.
+func priceConfidenceRank(confidence string) int {
+	switch confidence {
+	case models.PriceConfidenceVerified:
+		return 3
+	case models.PriceConfidenceRoomLevel:
+		return 2
+	default:
+		return 1
+	}
+}
+
+// lessPrice orders hotels for the "cheapest" sort. Zero-price listings always
+// sink to the end. Among priced listings, those with a higher price-confidence
+// rank lead (a real per-night room price beats a headline teaser even when the
+// teaser is cheaper); within the same confidence tier, the cheaper price wins.
 func lessPrice(a, b models.HotelResult) bool {
 	if a.Price == 0 {
 		return false
 	}
 	if b.Price == 0 {
 		return true
+	}
+	rankA := priceConfidenceRank(a.PriceConfidence)
+	rankB := priceConfidenceRank(b.PriceConfidence)
+	if rankA != rankB {
+		return rankA > rankB
 	}
 	return a.Price < b.Price
 }


### PR DESCRIPTION
# Lead with providers that have real room-level prices

## What changed

The "cheapest" hotel sort used to rank only by price magnitude. A headline-only teaser price could land above a provider that returns a genuine per-night room rate, simply because the teaser number was smaller. That is misleading: the teaser is a single lead-in figure, not something a traveller can book at that price.

`lessPrice` now applies a confidence-aware secondary key. Real per-night room prices lead. The cheapest entry still wins within the same confidence tier, and zero-price listings stay at the end exactly as before.

## How it ranks

The secondary key reads `HotelResult.PriceConfidence`. Those values are defined in `internal/models/hotel_price_trust.go`:

| Confidence | Rank | Set by |
|---|---|---|
| `verified` | 3 | SerpApi fallback (`serpapi_fallback.go`) |
| `room_level` | 2 | Agoda path (`agoda.go`) |
| `unverified` / empty | 1 | Google lead-in path (`prices.go`) |

The order is:

1. A zero price sinks to the end.
2. Among priced entries, the higher confidence rank leads.
3. Within one tier, the cheaper price wins.

Empty or unrecognised confidence shares the lowest priced tier, so a listing without a trustworthy basis still sorts below real room prices while staying ahead of zero-price entries. The result is deterministic and stable.

## Tests

`internal/hotels/hotel_price_confidence_sort_test.go` adds two cases. One builds a slice mixing a cheap Google headline entry, a pricier Agoda room-level entry, a verified Booking entry, and a zero-price entry, then asserts the room-level and verified providers lead despite costing more and that the zero-price entry lands last. The second exercises the comparator across tiers, including the empty-confidence and zero-price edges.

## Verification

- `gofmt -w` on both changed files
- `go vet ./internal/hotels/` clean
- `go test ./internal/hotels/ -count=1` passes, including the existing sort tests
- `staticcheck ./internal/hotels/` reports nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
