### PR TITLE
test(hotels): live-capture proof harness for Google room pricing (#290 AC.3)

### DIFF
--- a/internal/hotels/pricing_proof_test.go
+++ b/internal/hotels/pricing_proof_test.go
@@ -1,0 +1,82 @@
+//go:build proof
+
+package hotels
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestGoogleRoomPricingLiveCapture hits the real Google hotel room-pricing path
+// and captures whether it returns at least one bookable, priced room.
+//
+// This is on-demand instrumentation for #290 AC.3, not a CI gate: it is excluded
+// from default builds via the `proof` build tag and only runs under
+// `go test -tags proof`. Live anti-bot walls are expected in sandboxed
+// environments, so a total transport failure skips rather than fails.
+func TestGoogleRoomPricingLiveCapture(t *testing.T) {
+	now := time.Now()
+	checkIn := now.AddDate(0, 0, 30).Format("2006-01-02")
+	checkOut := now.AddDate(0, 0, 33).Format("2006-01-02")
+	t.Logf("search window: check-in=%s check-out=%s", checkIn, checkOut)
+
+	hotelIDs := []string{
+		"/g/11b6d4_v_4",               // Hotel Kamp Helsinki
+		"ChIJy7MSZP0LkkYRZw2dDekQP78", // Helsinki hotel
+	}
+
+	var (
+		bookingReadyCount   int
+		anySuccessWithRooms bool
+	)
+
+	for _, hotelID := range hotelIDs {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
+		result, err := GetRoomAvailabilityWithOpts(ctx, RoomSearchOptions{
+			HotelID:  hotelID,
+			CheckIn:  checkIn,
+			CheckOut: checkOut,
+			Currency: "EUR",
+			Guests:   2,
+		})
+		cancel()
+
+		if err != nil {
+			t.Logf("[%s] transport error: %v", hotelID, err)
+			continue
+		}
+
+		t.Logf("[%s] success=%v rooms=%d notice=%q error=%q",
+			hotelID, result.Success, len(result.Rooms), result.Notice, result.Error)
+
+		if len(result.Rooms) > 0 {
+			anySuccessWithRooms = true
+		}
+
+		for i, room := range result.Rooms {
+			t.Logf("  room %d: name=%q price=%.2f currency=%s provider=%q provider_url=%q",
+				i+1, room.Name, room.Price, room.Currency, room.Provider, room.ProviderURL)
+			if room.Price > 0 && room.ProviderURL != "" {
+				bookingReadyCount++
+			}
+		}
+	}
+
+	// Anti-bot / unreachable source is instrumentation noise, not a regression:
+	// skip when no hotel call yielded any rooms.
+	if !anySuccessWithRooms {
+		t.Skipf("live Google room-pricing source returned no rooms for any hotel " +
+			"(likely unreachable or bot-walled in this environment) — skipping")
+	}
+
+	// Real signal: the pricing path returned rooms but none were bookable. This is
+	// exactly the #290 AC.3 regression this harness exists to catch.
+	if bookingReadyCount == 0 {
+		t.Fatalf("pricing path returned rooms but none were bookable " +
+			"(no room had both price > 0 and a provider URL) — #290 AC.3 regression")
+	}
+
+	t.Logf("booking_ready_count=%d", bookingReadyCount)
+}


### PR DESCRIPTION
## What

Adds an on-demand instrumentation test that exercises the live Google hotel
room-pricing path and records whether it returns a bookable, priced room.
The new file is `internal/hotels/pricing_proof_test.go`, carrying the `proof`
build tag, so it stays out of CI and default builds. It runs only when you
ask for it with `go test -tags proof ./internal/hotels/`.

## Why

#290 AC.3 wants a way to confirm the room-pricing path still surfaces rooms
you can actually book. A plain CI test can't do that. The live source is often
bot-walled, and a flaky network would turn a green pipeline red for reasons
that have nothing to do with the code. So we gate it behind the `proof` tag.
CI stays deterministic, and we keep a button to press for a real capture.

## Behavior

- Computes a future window from `time.Now()`: check-in at +30 days, check-out
  at +33 days.
- Calls `GetRoomAvailabilityWithOpts` for two known Google Hotels entity IDs
  with currency EUR, two guests, and a 20s timeout each.
- Logs a per-hotel capture report (success flag, room count, and each room's
  name, price, currency, provider, and provider URL).
- Counts rooms that have both a positive price and a provider URL, then reports
  `booking_ready_count`.

If every hotel call hit a transport or anti-bot failure, or returned zero
rooms, the test skips with an explanation — instrumentation should not flag an
unreachable upstream as a defect. The test fails only when a call succeeds with
rooms but none are bookable, which is the regression #290 AC.3 targets.

## Verification

- `gofmt -l` reports nothing.
- `go vet -tags proof ./internal/hotels/` compiles the tagged file clean.
- `go build ./...` is unaffected.
- The default suite still passes and never sees the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
