### PR TITLE
feat(flights): add Vueling (VY) as opt-in LCC provider

### DIFF
--- a/internal/flights/lcc_search.go
+++ b/internal/flights/lcc_search.go
@@ -8,7 +8,7 @@ import (
 )
 
 // lccSearcher is the shared signature of the direct low-cost-carrier one-way
-// search functions (Ryanair, Wizz Air, Transavia, easyJet). Each returns a flat
+// search functions (Ryanair, Wizz Air, Transavia, easyJet, Vueling). Each returns a flat
 // slice of one-way FlightResults for a single date.
 type lccSearcher func(ctx context.Context, origin, destination, date, currency string, opts SearchOptions) ([]models.FlightResult, error)
 
@@ -23,6 +23,8 @@ var lccRegistry = map[string]struct {
 	"wizz":      {"Wizz Air", SearchWizzair},
 	"transavia": {"Transavia", SearchTransavia},
 	"easyjet":   {"easyJet", SearchEasyjet},
+	"vueling":   {"Vueling", SearchVueling},
+	"vy":        {"Vueling", SearchVueling},
 }
 
 // SearchLowCostCarrier runs a single low-cost carrier as an explicitly

--- a/internal/flights/lcc_search_test.go
+++ b/internal/flights/lcc_search_test.go
@@ -129,7 +129,7 @@ func TestSearchLowCostCarrier_UnrecognisedProvider(t *testing.T) {
 // dispatches is registered, so a new CLI case can never reference a missing
 // searcher.
 func TestLCCRegistryCoversCLIProviders(t *testing.T) {
-	for _, name := range []string{"ryanair", "wizzair", "wizz", "transavia", "easyjet"} {
+	for _, name := range []string{"ryanair", "wizzair", "wizz", "transavia", "easyjet", "vueling", "vy"} {
 		if _, ok := lccRegistry[name]; !ok {
 			t.Errorf("lccRegistry missing CLI provider %q", name)
 		}

--- a/internal/flights/providers_concurrent.go
+++ b/internal/flights/providers_concurrent.go
@@ -213,3 +213,40 @@ func runEasyjetProvider(ctx context.Context, client *batchexec.Client, origin, d
 		Results: len(flights),
 	}}
 }
+
+func runVuelingProvider(ctx context.Context, client *batchexec.Client, origin, destination, date, currency string, opts SearchOptions) providerOutcome {
+	if !vuelingSearchEligible(client, opts) {
+		fixHint := "search one-way economy; drop the alliance/airline filter"
+		reason := "options not supported by Vueling direct (round-trip / non-economy cabin / alliance filter / non-VY airline filter)"
+		fixHintCode := ""
+		if !vuelingConfigured() {
+			reason = "Vueling's public booking/availability engine is Akamai Bot Manager-defended; it is opt-in and requires a reachable endpoint"
+			fixHint = "set VUELING_API_BASE to an authorised partner endpoint or a self-hosted proxy that returns the JSON availability API"
+			fixHintCode = "AKAMAI_BLOCK"
+		}
+		return providerOutcome{status: models.ProviderStatus{
+			ID:          "vueling",
+			Name:        "Vueling",
+			Status:      "skipped",
+			Error:       reason,
+			FixHint:     fixHint,
+			FixHintCode: fixHintCode,
+		}}
+	}
+	flights, err := SearchVueling(ctx, origin, destination, date, currency, opts)
+	if err != nil {
+		slog.Warn("vueling flight search failed", "origin", origin, "destination", destination, "date", date, "error", err)
+		return providerOutcome{err: err, status: models.ProviderStatus{
+			ID:     "vueling",
+			Name:   "Vueling",
+			Status: models.ClassifyProviderError(err),
+			Error:  err.Error(),
+		}}
+	}
+	return providerOutcome{flights: flights, succeeded: true, status: models.ProviderStatus{
+		ID:      "vueling",
+		Name:    "Vueling",
+		Status:  okOrNoHit(len(flights)),
+		Results: len(flights),
+	}}
+}

--- a/internal/flights/results.go
+++ b/internal/flights/results.go
@@ -509,6 +509,50 @@ func easyjetEligibleOptions(opts SearchOptions) bool {
 	return true
 }
 
+// vuelingSearchEligible gates the Vueling provider. Like easyJet it is opt-in:
+// the public booking/availability engine is Akamai Bot Manager-defended, so it
+// only fires when the operator supplies a reachable endpoint via
+// VUELING_API_BASE. The shared-client guard keeps it out of injected-client unit
+// tests.
+func vuelingSearchEligible(client *batchexec.Client, opts SearchOptions) bool {
+	if client == nil || client != batchexec.SharedClient() {
+		return false
+	}
+	if !vuelingConfigured() {
+		return false
+	}
+	return vuelingEligibleOptions(opts)
+}
+
+// vuelingEligibleOptions reports whether a search can be served by Vueling's
+// availability endpoint. Vueling is non-aligned and the availability search here
+// is one-way nonstop economy; round-trip / non-economy / alliance filters skip
+// it. An airline filter, if present, must include Vueling (VY).
+func vuelingEligibleOptions(opts SearchOptions) bool {
+	if opts.ReturnDate != "" {
+		return false
+	}
+	if len(opts.Alliances) > 0 {
+		return false
+	}
+	if opts.CabinClass != 0 && opts.CabinClass != models.Economy {
+		return false
+	}
+	if len(opts.Airlines) > 0 {
+		ok := false
+		for _, a := range opts.Airlines {
+			if strings.EqualFold(strings.TrimSpace(a), "VY") {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // okOrNoHit returns StatusCheckedNoHit when a provider succeeded but returned
 // zero results (a definitive "checked, found nothing"), else StatusOK.
 // Distinguishing this from a failure/timeout is the evidence-envelope contract.

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -400,6 +400,9 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 		{name: "easyjet", run: withFlightNegCache("easyjet", origin, destination, date, func(ctx context.Context) providerOutcome {
 			return runEasyjetProvider(ctx, client, origin, destination, date, currency, opts)
 		})},
+		{name: "vueling", run: withFlightNegCache("vueling", origin, destination, date, func(ctx context.Context) providerOutcome {
+			return runVuelingProvider(ctx, client, origin, destination, date, currency, opts)
+		})},
 	}
 	outcomes := runProviderTasks(ctx, tasks, providerConcurrencyLimit, perProviderTimeout)
 	kiwiOut := outcomes[0]
@@ -408,6 +411,7 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	wizzairOut := outcomes[3]
 	transaviaOut := outcomes[4]
 	easyjetOut := outcomes[5]
+	vuelingOut := outcomes[6]
 
 	statuses := []models.ProviderStatus{
 		googleStatus,
@@ -417,6 +421,7 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 		wizzairOut.status,
 		transaviaOut.status,
 		easyjetOut.status,
+		vuelingOut.status,
 	}
 
 	kiwiFlights := kiwiOut.flights
@@ -437,6 +442,9 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	easyjetFlights := easyjetOut.flights
 	easyjetErr := easyjetOut.err
 	easyjetSucceeded := easyjetOut.succeeded
+	vuelingFlights := vuelingOut.flights
+	vuelingErr := vuelingOut.err
+	vuelingSucceeded := vuelingOut.succeeded
 
 	// Normalize all provider prices to the session currency so resolution and
 	// ranking compare like with like (Skiplagged returns USD, Kiwi its own).
@@ -452,8 +460,9 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	normalizeFlightCurrencies(ctx, wizzairFlights, target, destinations.ConvertCurrency)
 	normalizeFlightCurrencies(ctx, transaviaFlights, target, destinations.ConvertCurrency)
 	normalizeFlightCurrencies(ctx, easyjetFlights, target, destinations.ConvertCurrency)
+	normalizeFlightCurrencies(ctx, vuelingFlights, target, destinations.ConvertCurrency)
 
-	mergedFlights := mergeFlightResults(googleFlights, kiwiFlights, skiplaggedFlights, opts, ryanairFlights, wizzairFlights, transaviaFlights, easyjetFlights)
+	mergedFlights := mergeFlightResults(googleFlights, kiwiFlights, skiplaggedFlights, opts, ryanairFlights, wizzairFlights, transaviaFlights, easyjetFlights, vuelingFlights)
 
 	// Cross-shop re-pricing (MIK-4956 Phase C): re-price each segment of a
 	// Kiwi-discovered self-connect itinerary on Google Flights and append a
@@ -469,7 +478,7 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 		}
 	}
 
-	if googleSucceeded || kiwiSucceeded || skiplaggedSucceeded || ryanairSucceeded || wizzairSucceeded || transaviaSucceeded || easyjetSucceeded {
+	if googleSucceeded || kiwiSucceeded || skiplaggedSucceeded || ryanairSucceeded || wizzairSucceeded || transaviaSucceeded || easyjetSucceeded || vuelingSucceeded {
 		annotateFlightConfidence(mergedFlights, time.Now())
 		result := &models.FlightSearchResult{
 			Success:          true,
@@ -507,6 +516,9 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	}
 	if easyjetErr != nil {
 		errs = append(errs, easyjetErr)
+	}
+	if vuelingErr != nil {
+		errs = append(errs, vuelingErr)
 	}
 	if len(errs) > 0 {
 		err := errors.Join(errs...)

--- a/internal/flights/testdata/vueling_availability.json
+++ b/internal/flights/testdata/vueling_availability.json
@@ -1,0 +1,29 @@
+{
+  "flights": [
+    {
+      "flightNumber": "8301",
+      "departureAirport": "AMS",
+      "arrivalAirport": "BCN",
+      "departureDateTime": "2026-07-07T07:15:00",
+      "arrivalDateTime": "2026-07-07T09:25:00",
+      "fare": { "amount": 44.99, "currencyCode": "EUR" }
+    },
+    {
+      "flightNumber": "VY8303",
+      "departureAirport": "AMS",
+      "arrivalAirport": "BCN",
+      "departureDateTime": "2026-07-07T18:40:00",
+      "arrivalDateTime": "2026-07-07T20:50:00",
+      "lowestFare": 59.99,
+      "currencyCode": "EUR"
+    },
+    {
+      "flightNumber": "8305",
+      "departureAirport": "AMS",
+      "arrivalAirport": "BCN",
+      "departureDateTime": "2026-07-08T07:15:00",
+      "arrivalDateTime": "2026-07-08T09:25:00",
+      "fare": { "amount": 47.99, "currencyCode": "EUR" }
+    }
+  ]
+}

--- a/internal/flights/vueling.go
+++ b/internal/flights/vueling.go
@@ -1,0 +1,262 @@
+package flights
+
+// Vueling flight provider (opt-in, endpoint-gated).
+//
+// Vueling (VY) is, like Ryanair, Wizz Air and easyJet, an ultra-LCC that sells
+// almost exclusively through its own channel and is omitted from Google Flights
+// / GDS aggregation — so a meta-search misses its frequently-cheapest
+// short-haul fares (a large Barcelona-hub network) entirely.
+//
+// UNLIKE Ryanair (public Fare Finder JSON) and Wizz Air (public unauthenticated
+// timetable JSON), Vueling has NO clean public unauthenticated JSON availability
+// endpoint reachable from a static Go binary. Its booking funnel is an Akamai
+// Bot Manager-defended SPA:
+//
+//	GET https://tickets.vueling.com/  (the New Skies booking/availability engine)
+//
+// is served by AkamaiGHost and sets the full Akamai Bot Manager cookie suite —
+// _abck (with a ~-1~ unsolved-sensor token), bm_ss, bm_s, bm_so, bm_sz and
+// akacd_dc_tickets — verified 2026-06-25 against an AMS→BCN one-way ~30 days
+// out. The public www.vueling.com host likewise carries x-akamai-transformed
+// and bm_ss. Any availability request lacking a valid Akamai sensor payload
+// (which is generated only by executing Akamai's obfuscated JS in a real
+// browser) is challenged or blocked. There is no clean static-client path.
+//
+// Per the locked repo decisions (no browser/headless deps; honest typed status
+// over fabricated data; "API-first with optional opt-ins") we do NOT ship a
+// fragile scraper that races Akamai Bot Manager. Instead this provider mirrors
+// the easyJet / Transavia opt-in pattern: it is a no-op skip unless the operator
+// supplies a reachable availability base URL via VUELING_API_BASE (e.g. an
+// authorised partner endpoint or a self-hosted reverse proxy that handles the
+// bot challenge). When configured it maps an ASSUMED availability JSON shape to
+// canonical FlightResults tagged provider "vueling" with carrier code "VY".
+//
+// SCHEMA NOT VERIFIED: the public endpoint is Akamai-blocked, so this parser is
+// written against a representative/assumed shape, NOT confirmed against a live
+// response. The field tags below may need adjustment once an operator supplies a
+// reachable endpoint; the parser is intentionally tolerant (two price encodings),
+// matching the easyJet adapter.
+//
+// When UNconfigured, searchFlightsCore surfaces an honest "skipped /
+// not_configured" ProviderStatus carrying the AKAMAI_BLOCK root cause and a fix
+// hint — never a crash, never a fabricated empty "no Vueling flights" result.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"golang.org/x/time/rate"
+)
+
+// vuelingDefaultHost is the canonical Vueling host used to build human booking
+// deep links. Its booking/availability engine is Akamai Bot Manager-defended
+// (challenge for plain clients), so it is never queried for fares by default —
+// the operator must point VUELING_API_BASE at a reachable endpoint for the
+// fare-search path.
+const vuelingDefaultHost = "https" + "://" + "www.vueling.com"
+
+var (
+	vuelingLimiter = rate.NewLimiter(rate.Every(500*time.Millisecond), 1)
+	vuelingClient  = &http.Client{Timeout: 25 * time.Second}
+)
+
+// vuelingAPIBase returns the operator-supplied Vueling availability base URL, or
+// "". When empty the provider is a no-op (honest skip), because the public
+// endpoint is Akamai Bot Manager-defended for static clients.
+func vuelingAPIBase() string {
+	return strings.TrimSpace(os.Getenv("VUELING_API_BASE"))
+}
+
+// vuelingConfigured reports whether an operator has opted in by supplying a
+// reachable availability base URL. Mirrors easyjetConfigured().
+func vuelingConfigured() bool {
+	return vuelingAPIBase() != ""
+}
+
+// vuelingFare is the lead-in price of an availability slice.
+type vuelingFare struct {
+	Amount   float64 `json:"amount"`
+	Currency string  `json:"currencyCode"`
+}
+
+// vuelingFlight is a single bookable flight in the availability response. The
+// shape is an ASSUMED/representative Vueling availability payload — NOT verified
+// against the live API (the endpoint is Akamai-blocked). The parser is
+// intentionally tolerant of the two common price encodings.
+type vuelingFlight struct {
+	FlightNumber  string      `json:"flightNumber"`
+	DepartureIata string      `json:"departureAirport"`
+	ArrivalIata   string      `json:"arrivalAirport"`
+	Departure     string      `json:"departureDateTime"`
+	Arrival       string      `json:"arrivalDateTime"`
+	Fare          vuelingFare `json:"fare"`
+	LowestFare    float64     `json:"lowestFare"`
+	Currency      string      `json:"currencyCode"`
+}
+
+type vuelingAvailabilityResponse struct {
+	Flights []vuelingFlight `json:"flights"`
+}
+
+// SearchVueling queries an operator-configured Vueling availability endpoint for
+// one-way fares on the given route and date, returning canonical FlightResults
+// tagged provider "vueling". It is a no-op (returns nil, nil) when no base URL is
+// configured, mirroring the easyJet opt-in pattern — the public Vueling endpoint
+// is Akamai Bot Manager-defended and unreachable from a static client.
+func SearchVueling(ctx context.Context, origin, destination, date, currency string, opts SearchOptions) ([]models.FlightResult, error) {
+	base := vuelingAPIBase()
+	if base == "" {
+		return nil, nil
+	}
+	if currency == "" {
+		currency = "EUR"
+	}
+	if err := vuelingLimiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("DepartureIata", strings.ToUpper(origin))
+	q.Set("ArrivalIata", strings.ToUpper(destination))
+	q.Set("DepartureDateFrom", date)
+	q.Set("DepartureDateTo", date)
+	q.Set("Currency", currency)
+	q.Set("NumberOfAdults", fmt.Sprintf("%d", max(opts.Adults, 1)))
+	reqURL := strings.TrimRight(base, "/") + "/availability/query?" + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("vueling: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "trvl/1.0")
+
+	resp, err := vuelingClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("vueling: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+		// The default public host is Akamai Bot Manager-defended; a 403 here
+		// means the configured base is still serving a bot challenge, not real
+		// JSON.
+		return nil, fmt.Errorf("vueling: blocked (status %d) — VUELING_API_BASE must reach the JSON availability API, not the Akamai-defended public site", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("vueling: unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, fmt.Errorf("vueling: read body: %w", err)
+	}
+
+	var parsed vuelingAvailabilityResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("vueling: decode: %w", err)
+	}
+
+	results := make([]models.FlightResult, 0, len(parsed.Flights))
+	for _, f := range parsed.Flights {
+		if mapped, ok := mapVuelingFlight(f, date, currency); ok {
+			results = append(results, mapped)
+		}
+	}
+	return results, nil
+}
+
+// vuelingTimeLayout is the local datetime Vueling returns (no zone).
+const vuelingTimeLayout = "2006-01-02T15:04:05"
+
+// mapVuelingFlight converts a single availability flight to a FlightResult,
+// keeping only flights whose local departure day matches wantDate. Returns
+// ok=false for off-date flights or zero-priced placeholders.
+func mapVuelingFlight(f vuelingFlight, wantDate, fallbackCurrency string) (models.FlightResult, bool) {
+	if wantDate != "" && !strings.HasPrefix(f.Departure, wantDate) {
+		return models.FlightResult{}, false
+	}
+	price, cur := vuelingPrice(f, fallbackCurrency)
+	if price <= 0 {
+		return models.FlightResult{}, false
+	}
+	flightNo := strings.TrimSpace(f.FlightNumber)
+	if flightNo != "" && !strings.HasPrefix(strings.ToUpper(flightNo), "VY") {
+		flightNo = "VY" + flightNo
+	}
+	leg := models.FlightLeg{
+		DepartureAirport: models.AirportInfo{Code: strings.ToUpper(f.DepartureIata)},
+		ArrivalAirport:   models.AirportInfo{Code: strings.ToUpper(f.ArrivalIata)},
+		DepartureTime:    vuelingDisplayTime(f.Departure),
+		ArrivalTime:      vuelingDisplayTime(f.Arrival),
+		Duration:         vuelingDuration(f.Departure, f.Arrival),
+		Airline:          "Vueling",
+		AirlineCode:      "VY",
+		FlightNumber:     flightNo,
+	}
+	return models.FlightResult{
+		Price:      price,
+		Currency:   cur,
+		Duration:   leg.Duration,
+		Stops:      0,
+		Provider:   "vueling",
+		Legs:       []models.FlightLeg{leg},
+		BookingURL: vuelingBookingURL(f.DepartureIata, f.ArrivalIata, f.Departure),
+	}, true
+}
+
+func vuelingPrice(f vuelingFlight, fallbackCurrency string) (float64, string) {
+	if f.Fare.Amount > 0 {
+		return f.Fare.Amount, firstNonEmpty(f.Fare.Currency, fallbackCurrency)
+	}
+	return f.LowestFare, firstNonEmpty(f.Currency, fallbackCurrency)
+}
+
+func vuelingDisplayTime(s string) string {
+	if t, err := time.Parse(vuelingTimeLayout, s); err == nil {
+		return t.Format(flightTimeLayout)
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.Format(flightTimeLayout)
+	}
+	return s
+}
+
+func vuelingDuration(dep, arr string) int {
+	dt, derr := vuelingParse(dep)
+	at, aerr := vuelingParse(arr)
+	if derr != nil || aerr != nil {
+		return 0
+	}
+	mins := int(at.Sub(dt).Minutes())
+	if mins < 0 {
+		return 0
+	}
+	return mins
+}
+
+func vuelingParse(s string) (time.Time, error) {
+	if t, err := time.Parse(vuelingTimeLayout, s); err == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC3339, s)
+}
+
+func vuelingBookingURL(origin, destination, departure string) string {
+	day := departure
+	if t, err := vuelingParse(departure); err == nil {
+		day = t.Format("2006-01-02")
+	}
+	q := url.Values{}
+	q.Set("origin", strings.ToUpper(origin))
+	q.Set("destination", strings.ToUpper(destination))
+	q.Set("departureDate", day)
+	q.Set("adults", "1")
+	return vuelingDefaultHost + "/en/book-flights?" + q.Encode()
+}

--- a/internal/flights/vueling_probe_test.go
+++ b/internal/flights/vueling_probe_test.go
@@ -1,0 +1,56 @@
+//go:build proof
+
+package flights
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestSearchVueling_LiveProbe documents the empirically-verified Akamai Bot
+// Manager block on Vueling's public booking/availability engine. It is opt-in
+// (TRVL_TEST_LIVE_PROBES=1) and VUELING_API_BASE-gated: it never runs in the
+// default offline suite.
+//
+// Live probe (2026-06-25, AMS→BCN one-way ~30 days out): the booking engine at
+// tickets.vueling.com is served by AkamaiGHost and returns the full Akamai Bot
+// Manager cookie suite — _abck (with a ~-1~ unsolved-sensor token), bm_ss,
+// bm_s, bm_so, bm_sz and akacd_dc_tickets. The public www.vueling.com host
+// likewise carries x-akamai-transformed and bm_ss. A plain programmatic client
+// cannot obtain a valid Akamai sensor payload (generated only by executing
+// Akamai's obfuscated JS in a real browser), so availability requests are
+// challenged. There is NO clean public unauthenticated JSON endpoint reachable
+// from a static Go binary.
+//
+// Run it ONLY when an operator has configured a reachable endpoint
+// (VUELING_API_BASE) — e.g. an authorised partner endpoint or a self-hosted
+// proxy that handles the bot challenge. Against the raw public host the adapter
+// surfaces a typed error rather than a fabricated empty result.
+func TestSearchVueling_LiveProbe(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("live probe: set TRVL_TEST_LIVE_PROBES=1 to run")
+	}
+	if os.Getenv("VUELING_API_BASE") == "" {
+		t.Skip("Vueling is opt-in: set VUELING_API_BASE to a reachable availability endpoint")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	date := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
+	out, err := SearchVueling(ctx, "AMS", "BCN", date, "EUR", SearchOptions{Adults: 1})
+	if err != nil {
+		// A typed error (e.g. Akamai 403 on a still-blocked base) is an
+		// acceptable, honest outcome — log it rather than fail the probe.
+		t.Logf("Vueling live probe returned a typed error (expected when base is bot-defended): %v", err)
+		return
+	}
+	t.Logf("Vueling live probe returned %d flights", len(out))
+	for _, f := range out {
+		if len(f.Legs) == 0 || f.Legs[0].AirlineCode != "VY" {
+			t.Errorf("unexpected non-VY result from Vueling: %+v", f)
+		}
+	}
+}

--- a/internal/flights/vueling_test.go
+++ b/internal/flights/vueling_test.go
@@ -1,0 +1,186 @@
+package flights
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/batchexec"
+)
+
+// TestSearchVueling_MapsFlight proves the opt-in adapter parses the documented
+// availability JSON shape into canonical FlightResults when an operator points
+// VUELING_API_BASE at a reachable endpoint. Date-scoping drops the off-date
+// flight; both price encodings (fare.amount and lowestFare) are handled.
+func TestSearchVueling_MapsFlight(t *testing.T) {
+	fixture := loadFixture(t, "vueling_availability.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if got := r.URL.Query().Get("DepartureIata"); got != "AMS" {
+			t.Errorf("DepartureIata = %q, want AMS", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer srv.Close()
+
+	t.Setenv("VUELING_API_BASE", srv.URL)
+
+	out, err := SearchVueling(context.Background(), "AMS", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	if err != nil {
+		t.Fatalf("SearchVueling error: %v", err)
+	}
+	// Two 2026-07-07 flights match; the 07-08 flight is date-scoped out.
+	if len(out) != 2 {
+		t.Fatalf("want 2 date-scoped results, got %d", len(out))
+	}
+
+	first := out[0]
+	if first.Provider != "vueling" || first.Currency != "EUR" || first.Stops != 0 {
+		t.Errorf("bad first result: %+v", first)
+	}
+	if first.Price != 44.99 {
+		t.Errorf("first price = %v, want 44.99", first.Price)
+	}
+	if len(first.Legs) != 1 {
+		t.Fatalf("want 1 leg, got %d", len(first.Legs))
+	}
+	leg := first.Legs[0]
+	if leg.AirlineCode != "VY" || leg.Airline != "Vueling" {
+		t.Errorf("bad leg airline: %+v", leg)
+	}
+	// Bare numeric flight number is prefixed with the VY carrier code.
+	if leg.FlightNumber != "VY8301" {
+		t.Errorf("flight number = %q, want VY8301", leg.FlightNumber)
+	}
+	if leg.DepartureAirport.Code != "AMS" || leg.ArrivalAirport.Code != "BCN" {
+		t.Errorf("bad leg airports: %+v", leg)
+	}
+	if leg.DepartureTime != "2026-07-07T07:15" {
+		t.Errorf("departure time = %q, want 2026-07-07T07:15", leg.DepartureTime)
+	}
+	if leg.Duration != 130 {
+		t.Errorf("duration = %d, want 130", leg.Duration)
+	}
+	if first.BookingURL == "" {
+		t.Error("booking URL not set")
+	}
+
+	// Second flight uses the lowestFare encoding and an already-prefixed number.
+	second := out[1]
+	if second.Price != 59.99 {
+		t.Errorf("second price = %v, want 59.99 (lowestFare encoding)", second.Price)
+	}
+	if second.Legs[0].FlightNumber != "VY8303" {
+		t.Errorf("second flight number = %q, want VY8303 (already-prefixed, not doubled)", second.Legs[0].FlightNumber)
+	}
+}
+
+// TestSearchVueling_NoopWhenUnconfigured proves the adapter is a silent no-op
+// (nil, nil) when no opt-in endpoint is configured — never a crash, never a
+// fabricated empty result. This is the honest default given the Akamai block.
+func TestSearchVueling_NoopWhenUnconfigured(t *testing.T) {
+	t.Setenv("VUELING_API_BASE", "")
+	out, err := SearchVueling(context.Background(), "AMS", "BCN", "2026-07-07", "EUR", SearchOptions{})
+	if err != nil {
+		t.Fatalf("unconfigured Vueling should be a no-op, got error: %v", err)
+	}
+	if out != nil {
+		t.Errorf("unconfigured Vueling should return nil results, got %d", len(out))
+	}
+}
+
+// TestSearchVueling_ForbiddenIsTypedError proves a 403 (Akamai Bot Manager
+// challenge served to a configured-but-still-blocked base) yields an honest
+// typed error, not a silent empty — the AKAMAI_BLOCK reality surfaced as a
+// failure, never a lie.
+func TestSearchVueling_ForbiddenIsTypedError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("<html>Access Denied</html>"))
+	}))
+	defer srv.Close()
+	t.Setenv("VUELING_API_BASE", srv.URL)
+
+	_, err := SearchVueling(context.Background(), "AMS", "BCN", "2026-07-07", "EUR", SearchOptions{})
+	if err == nil {
+		t.Fatal("403 from Vueling should surface a typed error, got nil")
+	}
+}
+
+func TestVuelingEligibleOptions(t *testing.T) {
+	if !vuelingEligibleOptions(SearchOptions{}) {
+		t.Error("plain one-way economy should be eligible")
+	}
+	if vuelingEligibleOptions(SearchOptions{ReturnDate: "2026-07-10"}) {
+		t.Error("round-trip should be ineligible")
+	}
+	if vuelingEligibleOptions(SearchOptions{Alliances: []string{"STAR_ALLIANCE"}}) {
+		t.Error("alliance filter should be ineligible (Vueling non-aligned)")
+	}
+	if vuelingEligibleOptions(SearchOptions{Airlines: []string{"BA"}}) {
+		t.Error("non-VY airline filter should be ineligible")
+	}
+	if !vuelingEligibleOptions(SearchOptions{Airlines: []string{"VY"}}) {
+		t.Error("VY airline filter should be eligible")
+	}
+}
+
+func TestVuelingSearchEligible_RequiresSharedClientAndConfig(t *testing.T) {
+	// Injected (non-shared) client: never eligible, regardless of config.
+	injected := batchexec.NewTestClient("http" + "://" + "127.0.0.1:0")
+	t.Setenv("VUELING_API_BASE", "http"+"://"+"example.invalid")
+	if vuelingSearchEligible(injected, SearchOptions{}) {
+		t.Error("injected client must never be eligible (shared-client guard)")
+	}
+
+	// Shared client but unconfigured: opt-in gate keeps it skipped.
+	t.Setenv("VUELING_API_BASE", "")
+	if vuelingSearchEligible(batchexec.SharedClient(), SearchOptions{}) {
+		t.Error("unconfigured Vueling must be ineligible even on the shared client")
+	}
+}
+
+// TestSearchFlightsCore_VuelingHonestStatusWhenUnconfigured is the surfacing
+// proof: a default-merge search (injected Google client, so the LCC providers
+// auto-skip) still emits an HONEST typed Vueling ProviderStatus carrying the
+// AKAMAI_BLOCK root cause and a fix hint — never a fabricated empty result and
+// never a crash. This is the opt-in deliverable: the path is wired and reports
+// its unavailability truthfully.
+func TestSearchFlightsCore_VuelingHonestStatusWhenUnconfigured(t *testing.T) {
+	t.Setenv("VUELING_API_BASE", "")
+	body := makeFlightResponseBody(t)
+	ts := flightsTestServer(t, 200, body)
+	defer ts.Close()
+
+	client := batchexec.NewTestClient(ts.URL)
+	result, err := SearchFlightsWithClient(t.Context(), client, "AMS", "BCN", "2026-07-07", SearchOptions{})
+	if err != nil {
+		t.Fatalf("search error: %v", err)
+	}
+
+	var vy *struct {
+		status, code, fixHint string
+	}
+	for _, s := range result.ProviderStatuses {
+		if s.ID == "vueling" {
+			vy = &struct{ status, code, fixHint string }{s.Status, s.FixHintCode, s.FixHint}
+			break
+		}
+	}
+	if vy == nil {
+		t.Fatal("Vueling provider status not present in default merge — opt-in path not wired")
+	}
+	if vy.status != "skipped" {
+		t.Errorf("Vueling status = %q, want skipped (honest opt-in skip)", vy.status)
+	}
+	if vy.code != "AKAMAI_BLOCK" {
+		t.Errorf("Vueling fix_hint_code = %q, want AKAMAI_BLOCK", vy.code)
+	}
+	if vy.fixHint == "" {
+		t.Error("Vueling skip must carry an actionable fix hint (set VUELING_API_BASE)")
+	}
+}


### PR DESCRIPTION
## Add Vueling (VY) as an opt-in low-cost-carrier flight provider

Vueling is a Barcelona-hub ultra-LCC. Like Ryanair, Wizz Air and easyJet it
sells almost entirely through its own channel. It is largely absent from Google
Flights and GDS aggregation, so a meta-search misses its short-haul fares.

### Which branch and why

Branch B: env-gated opt-in (`VUELING_API_BASE`), mirroring the existing
`easyjet.go` doctrine. A live probe on 2026-06-25 decided it. Route: AMS→BCN,
one-way, roughly 30 days out.

The booking engine at `tickets.vueling.com` is served by `AkamaiGHost`. It hands
back the full Akamai Bot Manager cookie suite: `_abck` carrying a `~-1~`
unsolved-sensor token, plus `bm_ss`, `bm_s`, `bm_so`, `bm_sz` and
`akacd_dc_tickets`. The public `www.vueling.com` host also returns
`x-akamai-transformed` and `bm_ss`. A plain Go client cannot produce a valid
Akamai sensor payload. That payload comes only from running Akamai's obfuscated
JavaScript in a real browser. Path-guessing the availability API just returned
the SPA shell — HTTP 404 HTML with Akamai headers, never JSON.

So there is no clean public unauthenticated JSON endpoint reachable from a static
binary. The locked repo decisions settle it: no browser/headless deps, honest
typed status over fabricated data. A default-on scraper that races Akamai would
be the wrong call. This provider stays a no-op skip unless an operator supplies a
reachable endpoint, exactly as easyJet does.

### Behaviour

- `SearchVueling` shares the `SearchEasyjet` / `SearchRyanair` signature and
  flows through `searchSingleLCC`, so the honest one-way result and the composed
  round-trip (two one-way legs, `FareSplitTickets`) come for free.
- Registered in `lccRegistry` as `"vueling"` plus a `"vy"` alias.
- When `VUELING_API_BASE` is unset, the fan-out emits a `skipped` /
  `AKAMAI_BLOCK` `ProviderStatus` with a fix hint. It never fabricates an empty
  "no Vueling flights" result and never crashes.
- A configured-but-still-blocked base that returns 403 surfaces a typed error
  rather than a silent empty.
- The parser is marked "SCHEMA NOT VERIFIED": the public endpoint is blocked, so
  the field tags follow the representative easyJet shape and the parser tolerates
  two price encodings.

### Tests

- `vueling_test.go` (default tags, offline): registry resolution for `vueling`
  and `vy`, the honest `AKAMAI_BLOCK` skip status in a default merge, the
  fixture-backed parse via an `httptest` server, the unconfigured no-op, the 403
  typed error, and eligibility gating.
- `vueling_probe_test.go` (`//go:build proof`): documents the live Akamai block
  and stays opt-in behind `TRVL_TEST_LIVE_PROBES=1` and `VUELING_API_BASE`.

The default suite stays offline and deterministic. Live calls live only in the
proof-tagged probe.

### Verification

```
gofmt -l internal/flights/   # clean
go vet ./internal/flights/   # clean
go build ./...               # clean
go test ./internal/flights/ -run 'LCC|Vueling|Registry|Provider' -count=1  # ok
go test ./internal/flights/ -count=1   # ok (full package)
go vet -tags proof ./internal/flights/ # proof probe compiles
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
