### PR TITLE
feat(flights): add Norwegian Air (DY) as opt-in LCC provider

### DIFF
--- a/internal/flights/lcc_search.go
+++ b/internal/flights/lcc_search.go
@@ -8,7 +8,7 @@ import (
 )
 
 // lccSearcher is the shared signature of the direct low-cost-carrier one-way
-// search functions (Ryanair, Wizz Air, Transavia, easyJet, Vueling). Each returns a flat
+// search functions (Ryanair, Wizz Air, Transavia, easyJet, Vueling, Norwegian). Each returns a flat
 // slice of one-way FlightResults for a single date.
 type lccSearcher func(ctx context.Context, origin, destination, date, currency string, opts SearchOptions) ([]models.FlightResult, error)
 
@@ -25,6 +25,8 @@ var lccRegistry = map[string]struct {
 	"easyjet":   {"easyJet", SearchEasyjet},
 	"vueling":   {"Vueling", SearchVueling},
 	"vy":        {"Vueling", SearchVueling},
+	"norwegian": {"Norwegian", SearchNorwegian},
+	"dy":        {"Norwegian", SearchNorwegian},
 }
 
 // SearchLowCostCarrier runs a single low-cost carrier as an explicitly

--- a/internal/flights/norwegian.go
+++ b/internal/flights/norwegian.go
@@ -1,0 +1,269 @@
+package flights
+
+// Norwegian Air (DY) flight provider (opt-in, endpoint-gated).
+//
+// Norwegian Air Shuttle (DY) is, like Ryanair, Wizz Air, easyJet and Vueling, a
+// low-cost carrier that sells largely through its own channel and is omitted or
+// under-represented in Google Flights / GDS aggregation — so a meta-search
+// misses its frequently-cheapest Nordic / intra-European short-haul fares.
+//
+// UNLIKE Ryanair (public Fare Finder JSON) and Wizz Air (public unauthenticated
+// timetable JSON), Norwegian Air has NO clean public unauthenticated JSON
+// availability endpoint reachable from a static Go binary. Its site and booking
+// funnel sit behind Cloudflare's bot-management challenge:
+//
+//	GET https://www.norwegian.com/... (and historic fare/availability API paths)
+//
+// is served by `server: cloudflare` and, for any plain programmatic client,
+// returns HTTP 403 with `cf-mitigated: challenge`, an "Are you human? | Norwegian"
+// interstitial HTML body, and a `__cf_bm` bot-management cookie — verified
+// 2026-06-25 against OSL→LGW ~30 days out from a static client. Every probed
+// path (fare-calendar, flydata/availability, booking/search/availability,
+// booking.norwegian.com, and the site root itself) returned the same Cloudflare
+// 403 challenge. A browser-grade fetcher with residential cookies reaches the
+// host, but the repo forbids browser/headless dependencies and the data is NOT
+// reachable from curl / Go's net/http — so there is no clean static-client path.
+//
+// Per the locked repo decisions (no browser/headless deps; honest typed status
+// over fabricated data; "API-first with optional opt-ins") we do NOT ship a
+// fragile scraper that races Cloudflare Bot Management. Instead this provider
+// mirrors the easyJet / Vueling opt-in pattern: it is a no-op skip unless the
+// operator supplies a reachable availability base URL via NORWEGIAN_API_BASE
+// (e.g. an authorised partner endpoint or a self-hosted reverse proxy that
+// handles the bot challenge). When configured it maps an ASSUMED availability
+// JSON shape to canonical FlightResults tagged provider "norwegian" with carrier
+// code "DY".
+//
+// SCHEMA NOT VERIFIED: the public endpoint is Cloudflare-blocked, so this parser
+// is written against a representative/assumed shape, NOT confirmed against a live
+// response. The field tags below may need adjustment once an operator supplies a
+// reachable endpoint; the parser is intentionally tolerant (two price encodings),
+// matching the easyJet / Vueling adapters.
+//
+// When UNconfigured, searchFlightsCore surfaces an honest "skipped /
+// not_configured" ProviderStatus carrying the CLOUDFLARE_BLOCK root cause and a
+// fix hint — never a crash, never a fabricated empty "no Norwegian flights"
+// result.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"golang.org/x/time/rate"
+)
+
+// norwegianDefaultHost is the canonical Norwegian host used to build human
+// booking deep links. Its site/booking funnel is Cloudflare bot-defended (403
+// `cf-mitigated: challenge` for plain clients), so it is never queried for fares
+// by default — the operator must point NORWEGIAN_API_BASE at a reachable
+// endpoint for the fare-search path.
+const norwegianDefaultHost = "https" + "://" + "www.norwegian.com"
+
+var (
+	norwegianLimiter = rate.NewLimiter(rate.Every(500*time.Millisecond), 1)
+	norwegianClient  = &http.Client{Timeout: 25 * time.Second}
+)
+
+// norwegianAPIBase returns the operator-supplied Norwegian availability base
+// URL, or "". When empty the provider is a no-op (honest skip), because the
+// public endpoint is Cloudflare-blocked for static clients.
+func norwegianAPIBase() string {
+	return strings.TrimSpace(os.Getenv("NORWEGIAN_API_BASE"))
+}
+
+// norwegianConfigured reports whether an operator has opted in by supplying a
+// reachable availability base URL. Mirrors easyjetConfigured().
+func norwegianConfigured() bool {
+	return norwegianAPIBase() != ""
+}
+
+// norwegianFare is the lead-in price of an availability slice.
+type norwegianFare struct {
+	Amount   float64 `json:"amount"`
+	Currency string  `json:"currencyCode"`
+}
+
+// norwegianFlight is a single bookable flight in the availability response. The
+// shape is an ASSUMED/representative Norwegian availability payload — NOT
+// verified against the live API (the endpoint is Cloudflare-blocked). The parser
+// is intentionally tolerant of the two common price encodings.
+type norwegianFlight struct {
+	FlightNumber  string        `json:"flightNumber"`
+	DepartureIata string        `json:"departureAirport"`
+	ArrivalIata   string        `json:"arrivalAirport"`
+	Departure     string        `json:"departureDateTime"`
+	Arrival       string        `json:"arrivalDateTime"`
+	Fare          norwegianFare `json:"fare"`
+	LowestFare    float64       `json:"lowestFare"`
+	Currency      string        `json:"currencyCode"`
+}
+
+type norwegianAvailabilityResponse struct {
+	Flights []norwegianFlight `json:"flights"`
+}
+
+// SearchNorwegian queries an operator-configured Norwegian availability endpoint
+// for one-way fares on the given route and date, returning canonical
+// FlightResults tagged provider "norwegian". It is a no-op (returns nil, nil)
+// when no base URL is configured, mirroring the easyJet / Vueling opt-in
+// pattern — the public Norwegian endpoint is Cloudflare bot-defended and
+// unreachable from a static client.
+func SearchNorwegian(ctx context.Context, origin, destination, date, currency string, opts SearchOptions) ([]models.FlightResult, error) {
+	base := norwegianAPIBase()
+	if base == "" {
+		return nil, nil
+	}
+	if currency == "" {
+		currency = "EUR"
+	}
+	if err := norwegianLimiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("DepartureIata", strings.ToUpper(origin))
+	q.Set("ArrivalIata", strings.ToUpper(destination))
+	q.Set("DepartureDateFrom", date)
+	q.Set("DepartureDateTo", date)
+	q.Set("Currency", currency)
+	q.Set("NumberOfAdults", fmt.Sprintf("%d", max(opts.Adults, 1)))
+	reqURL := strings.TrimRight(base, "/") + "/availability/query?" + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("norwegian: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "trvl/1.0")
+
+	resp, err := norwegianClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("norwegian: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+		// The default public host is Cloudflare bot-defended; a 403 here means
+		// the configured base is still serving a bot challenge, not real JSON.
+		return nil, fmt.Errorf("norwegian: blocked (status %d) — NORWEGIAN_API_BASE must reach the JSON availability API, not the Cloudflare-defended public site", resp.StatusCode)
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("norwegian: rate-limited (status %d)", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("norwegian: unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, fmt.Errorf("norwegian: read body: %w", err)
+	}
+
+	var parsed norwegianAvailabilityResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("norwegian: decode: %w", err)
+	}
+
+	results := make([]models.FlightResult, 0, len(parsed.Flights))
+	for _, f := range parsed.Flights {
+		if mapped, ok := mapNorwegianFlight(f, date, currency); ok {
+			results = append(results, mapped)
+		}
+	}
+	return results, nil
+}
+
+// norwegianTimeLayout is the local datetime Norwegian returns (no zone).
+const norwegianTimeLayout = "2006-01-02T15:04:05"
+
+// mapNorwegianFlight converts a single availability flight to a FlightResult,
+// keeping only flights whose local departure day matches wantDate. Returns
+// ok=false for off-date flights or zero-priced placeholders.
+func mapNorwegianFlight(f norwegianFlight, wantDate, fallbackCurrency string) (models.FlightResult, bool) {
+	if wantDate != "" && !strings.HasPrefix(f.Departure, wantDate) {
+		return models.FlightResult{}, false
+	}
+	price, cur := norwegianPrice(f, fallbackCurrency)
+	if price <= 0 {
+		return models.FlightResult{}, false
+	}
+	flightNo := strings.TrimSpace(f.FlightNumber)
+	if flightNo != "" && !strings.HasPrefix(strings.ToUpper(flightNo), "DY") {
+		flightNo = "DY" + flightNo
+	}
+	leg := models.FlightLeg{
+		DepartureAirport: models.AirportInfo{Code: strings.ToUpper(f.DepartureIata)},
+		ArrivalAirport:   models.AirportInfo{Code: strings.ToUpper(f.ArrivalIata)},
+		DepartureTime:    norwegianDisplayTime(f.Departure),
+		ArrivalTime:      norwegianDisplayTime(f.Arrival),
+		Duration:         norwegianDuration(f.Departure, f.Arrival),
+		Airline:          "Norwegian",
+		AirlineCode:      "DY",
+		FlightNumber:     flightNo,
+	}
+	return models.FlightResult{
+		Price:      price,
+		Currency:   cur,
+		Duration:   leg.Duration,
+		Stops:      0,
+		Provider:   "norwegian",
+		Legs:       []models.FlightLeg{leg},
+		BookingURL: norwegianBookingURL(f.DepartureIata, f.ArrivalIata, f.Departure),
+	}, true
+}
+
+func norwegianPrice(f norwegianFlight, fallbackCurrency string) (float64, string) {
+	if f.Fare.Amount > 0 {
+		return f.Fare.Amount, firstNonEmpty(f.Fare.Currency, fallbackCurrency)
+	}
+	return f.LowestFare, firstNonEmpty(f.Currency, fallbackCurrency)
+}
+
+func norwegianDisplayTime(s string) string {
+	if t, err := time.Parse(norwegianTimeLayout, s); err == nil {
+		return t.Format(flightTimeLayout)
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.Format(flightTimeLayout)
+	}
+	return s
+}
+
+func norwegianDuration(dep, arr string) int {
+	dt, derr := norwegianParse(dep)
+	at, aerr := norwegianParse(arr)
+	if derr != nil || aerr != nil {
+		return 0
+	}
+	mins := int(at.Sub(dt).Minutes())
+	if mins < 0 {
+		return 0
+	}
+	return mins
+}
+
+func norwegianParse(s string) (time.Time, error) {
+	if t, err := time.Parse(norwegianTimeLayout, s); err == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC3339, s)
+}
+
+func norwegianBookingURL(origin, destination, departure string) string {
+	day := departure
+	if t, err := norwegianParse(departure); err == nil {
+		day = t.Format("2006-01-02")
+	}
+	q := url.Values{}
+	q.Set("origin", strings.ToUpper(origin))
+	q.Set("destination", strings.ToUpper(destination))
+	q.Set("outboundDate", day)
+	q.Set("adults", "1")
+	return norwegianDefaultHost + "/uk/booking/flight-tickets/?" + q.Encode()
+}

--- a/internal/flights/norwegian_probe_test.go
+++ b/internal/flights/norwegian_probe_test.go
@@ -1,0 +1,64 @@
+//go:build proof
+
+package flights
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestSearchNorwegian_LiveProbe documents the empirically-verified Cloudflare Bot
+// Management block on Norwegian's public site / booking funnel. It is opt-in
+// (TRVL_TEST_LIVE_PROBES=1) and NORWEGIAN_API_BASE-gated: it never runs in the
+// default offline suite.
+//
+// Live probe (2026-06-25, OSL→LGW one-way ~30 days out, 1 adult) from a static
+// client (curl and Go net/http): every probed endpoint shape returned HTTP 403
+// with `server: cloudflare`, `cf-mitigated: challenge`, an "Are you human? |
+// Norwegian" text/html interstitial body, and a `__cf_bm` bot-management cookie.
+// Paths probed (all 403-challenged):
+//
+//	GET https://www.norwegian.com/api/fare-calendar/get?...        -> 403 cf challenge
+//	GET https://www.norwegian.com/api/flydata/availability/v1?...  -> 403 cf challenge
+//	GET https://www.norwegian.com/booking/api/search/availability  -> 403 cf challenge
+//	GET https://booking.norwegian.com/api/availability?...         -> 403 cf challenge
+//	GET https://www.norwegian.com/  (site root)                    -> 403 cf challenge
+//
+// A browser-grade fetcher with residential cookies reaches the host, but the
+// data is NOT reachable from curl / Go's net/http, and the repo forbids
+// browser/headless dependencies — so there is no clean static-client path. This
+// is the canonical Branch-B (bot-walled) outcome: an env-gated opt-in adapter
+// that returns an honest typed status rather than fabricated data.
+//
+// Run it ONLY when an operator has configured a reachable endpoint
+// (NORWEGIAN_API_BASE) — e.g. an authorised partner endpoint or a self-hosted
+// proxy that handles the bot challenge. Against the raw public host the adapter
+// surfaces a typed error rather than a fabricated empty result.
+func TestSearchNorwegian_LiveProbe(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
+		t.Skip("live probe: set TRVL_TEST_LIVE_PROBES=1 to run")
+	}
+	if os.Getenv("NORWEGIAN_API_BASE") == "" {
+		t.Skip("Norwegian is opt-in: set NORWEGIAN_API_BASE to a reachable availability endpoint")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	date := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
+	out, err := SearchNorwegian(ctx, "OSL", "LGW", date, "EUR", SearchOptions{Adults: 1})
+	if err != nil {
+		// A typed error (e.g. Cloudflare 403 on a still-blocked base) is an
+		// acceptable, honest outcome — log it rather than fail the probe.
+		t.Logf("Norwegian live probe returned a typed error (expected when base is bot-defended): %v", err)
+		return
+	}
+	t.Logf("Norwegian live probe returned %d flights", len(out))
+	for _, f := range out {
+		if len(f.Legs) == 0 || f.Legs[0].AirlineCode != "DY" {
+			t.Errorf("unexpected non-DY result from Norwegian: %+v", f)
+		}
+	}
+}

--- a/internal/flights/norwegian_test.go
+++ b/internal/flights/norwegian_test.go
@@ -1,0 +1,272 @@
+package flights
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/batchexec"
+)
+
+// TestSearchNorwegian_MapsFlight proves the opt-in adapter parses the documented
+// availability JSON shape into canonical FlightResults when an operator points
+// NORWEGIAN_API_BASE at a reachable endpoint. Date-scoping drops the off-date
+// flight; both price encodings (fare.amount and lowestFare) are handled.
+func TestSearchNorwegian_MapsFlight(t *testing.T) {
+	fixture := loadFixture(t, "norwegian_availability.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if got := r.URL.Query().Get("DepartureIata"); got != "OSL" {
+			t.Errorf("DepartureIata = %q, want OSL", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer srv.Close()
+
+	t.Setenv("NORWEGIAN_API_BASE", srv.URL)
+
+	out, err := SearchNorwegian(context.Background(), "OSL", "LGW", "2026-07-25", "EUR", SearchOptions{Adults: 1})
+	if err != nil {
+		t.Fatalf("SearchNorwegian error: %v", err)
+	}
+	// Two 2026-07-25 flights match; the 07-26 flight is date-scoped out.
+	if len(out) != 2 {
+		t.Fatalf("want 2 date-scoped results, got %d", len(out))
+	}
+
+	first := out[0]
+	if first.Provider != "norwegian" || first.Currency != "EUR" || first.Stops != 0 {
+		t.Errorf("bad first result: %+v", first)
+	}
+	if first.Price != 39.9 {
+		t.Errorf("first price = %v, want 39.9", first.Price)
+	}
+	if len(first.Legs) != 1 {
+		t.Fatalf("want 1 leg, got %d", len(first.Legs))
+	}
+	leg := first.Legs[0]
+	if leg.AirlineCode != "DY" || leg.Airline != "Norwegian" {
+		t.Errorf("bad leg airline: %+v", leg)
+	}
+	// Bare numeric flight number is prefixed with the DY carrier code.
+	if leg.FlightNumber != "DY744" {
+		t.Errorf("flight number = %q, want DY744", leg.FlightNumber)
+	}
+	if leg.DepartureAirport.Code != "OSL" || leg.ArrivalAirport.Code != "LGW" {
+		t.Errorf("bad leg airports: %+v", leg)
+	}
+	if leg.DepartureTime != "2026-07-25T06:55" {
+		t.Errorf("departure time = %q, want 2026-07-25T06:55", leg.DepartureTime)
+	}
+	if leg.Duration != 85 {
+		t.Errorf("duration = %d, want 85", leg.Duration)
+	}
+	if first.BookingURL == "" {
+		t.Error("booking URL not set")
+	}
+
+	// Second flight uses the lowestFare encoding and an already-prefixed number.
+	second := out[1]
+	if second.Price != 54.9 {
+		t.Errorf("second price = %v, want 54.9 (lowestFare encoding)", second.Price)
+	}
+	if second.Legs[0].FlightNumber != "DY746" {
+		t.Errorf("second flight number = %q, want DY746 (already-prefixed, not doubled)", second.Legs[0].FlightNumber)
+	}
+}
+
+// TestSearchNorwegian_NoopWhenUnconfigured proves the adapter is a silent no-op
+// (nil, nil) when no opt-in endpoint is configured — never a crash, never a
+// fabricated empty result. This is the honest default given the Cloudflare block.
+func TestSearchNorwegian_NoopWhenUnconfigured(t *testing.T) {
+	t.Setenv("NORWEGIAN_API_BASE", "")
+	out, err := SearchNorwegian(context.Background(), "OSL", "LGW", "2026-07-25", "EUR", SearchOptions{})
+	if err != nil {
+		t.Fatalf("unconfigured Norwegian should be a no-op, got error: %v", err)
+	}
+	if out != nil {
+		t.Errorf("unconfigured Norwegian should return nil results, got %d", len(out))
+	}
+}
+
+// TestSearchNorwegian_ForbiddenIsTypedError proves a 403 (Cloudflare challenge
+// served to a configured-but-still-blocked base) yields an honest typed error,
+// not a silent empty — the CLOUDFLARE_BLOCK reality surfaced as a failure, never
+// a lie.
+func TestSearchNorwegian_ForbiddenIsTypedError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("<html>Are you human?</html>"))
+	}))
+	defer srv.Close()
+	t.Setenv("NORWEGIAN_API_BASE", srv.URL)
+
+	_, err := SearchNorwegian(context.Background(), "OSL", "LGW", "2026-07-25", "EUR", SearchOptions{})
+	if err == nil {
+		t.Fatal("403 from Norwegian should surface a typed error, got nil")
+	}
+}
+
+// TestSearchNorwegian_RateLimitedIsTypedError proves a 429 yields a typed,
+// rate-limited error classification rather than a generic failure — so the
+// aggregate can distinguish a transient throttle from a hard block.
+func TestSearchNorwegian_RateLimitedIsTypedError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("rate limited"))
+	}))
+	defer srv.Close()
+	t.Setenv("NORWEGIAN_API_BASE", srv.URL)
+
+	_, err := SearchNorwegian(context.Background(), "OSL", "LGW", "2026-07-25", "EUR", SearchOptions{})
+	if err == nil {
+		t.Fatal("429 from Norwegian should surface a typed error, got nil")
+	}
+}
+
+func TestNorwegianEligibleOptions(t *testing.T) {
+	if !norwegianEligibleOptions(SearchOptions{}) {
+		t.Error("plain one-way economy should be eligible")
+	}
+	if norwegianEligibleOptions(SearchOptions{ReturnDate: "2026-07-30"}) {
+		t.Error("round-trip should be ineligible")
+	}
+	if norwegianEligibleOptions(SearchOptions{Alliances: []string{"STAR_ALLIANCE"}}) {
+		t.Error("alliance filter should be ineligible (Norwegian non-aligned)")
+	}
+	if norwegianEligibleOptions(SearchOptions{Airlines: []string{"BA"}}) {
+		t.Error("non-DY airline filter should be ineligible")
+	}
+	if !norwegianEligibleOptions(SearchOptions{Airlines: []string{"DY"}}) {
+		t.Error("DY airline filter should be eligible")
+	}
+}
+
+func TestNorwegianSearchEligible_RequiresSharedClientAndConfig(t *testing.T) {
+	// Injected (non-shared) client: never eligible, regardless of config.
+	injected := batchexec.NewTestClient("http" + "://" + "127.0.0.1:0")
+	t.Setenv("NORWEGIAN_API_BASE", "http"+"://"+"example.invalid")
+	if norwegianSearchEligible(injected, SearchOptions{}) {
+		t.Error("injected client must never be eligible (shared-client guard)")
+	}
+
+	// Shared client but unconfigured: opt-in gate keeps it skipped.
+	t.Setenv("NORWEGIAN_API_BASE", "")
+	if norwegianSearchEligible(batchexec.SharedClient(), SearchOptions{}) {
+		t.Error("unconfigured Norwegian must be ineligible even on the shared client")
+	}
+}
+
+// TestNorwegianRegistryResolves proves both the "norwegian" name and the "dy"
+// alias resolve to the Norwegian entry in lccRegistry, and that an unconfigured
+// (no NORWEGIAN_API_BASE) explicit provider request returns a clean empty
+// result via the searchSingleLCC path — never a crash.
+func TestNorwegianRegistryResolves(t *testing.T) {
+	t.Setenv("NORWEGIAN_API_BASE", "")
+	for _, name := range []string{"norwegian", "dy"} {
+		entry, ok := lccRegistry[name]
+		if !ok {
+			t.Fatalf("lccRegistry missing %q", name)
+		}
+		if entry.name != "Norwegian" {
+			t.Errorf("%q resolves to %q, want Norwegian", name, entry.name)
+		}
+		res, err := SearchLowCostCarrier(context.Background(), name, "OSL", "LGW", "2026-07-25", SearchOptions{})
+		if err != nil {
+			t.Fatalf("SearchLowCostCarrier(%q) unconfigured should be a clean no-op, got error: %v", name, err)
+		}
+		if res == nil || res.Count != 0 {
+			t.Errorf("SearchLowCostCarrier(%q) unconfigured want 0 results, got %+v", name, res)
+		}
+	}
+}
+
+// TestNorwegianRoundTripComposesViaSearchSingleLCC proves a round-trip request
+// (opts.ReturnDate set) composes a genuine return ticket from two one-way legs
+// via the shared searchSingleLCC split-ticket path — not a bare one-way returned
+// for a round-trip request. The outbound and inbound legs are served from the
+// same configured availability fixture endpoint, direction-swapped per leg.
+func TestNorwegianRoundTripComposesViaSearchSingleLCC(t *testing.T) {
+	out := loadFixture(t, "norwegian_availability.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Echo a date-matched availability payload for whichever leg/date is
+		// requested so both the outbound (OSL->LGW 07-25) and inbound
+		// (LGW->OSL 07-28) one-way searches return a priced flight.
+		dep := r.URL.Query().Get("DepartureIata")
+		arr := r.URL.Query().Get("ArrivalIata")
+		from := r.URL.Query().Get("DepartureDateFrom")
+		body := `{"flights":[{"flightNumber":"700","departureAirport":"` + dep +
+			`","arrivalAirport":"` + arr + `","departureDateTime":"` + from +
+			`T07:00:00","arrivalDateTime":"` + from + `T08:25:00","fare":{"amount":49.9,"currencyCode":"EUR"}}]}`
+		_ = out // fixture retained for shape reference; per-leg body is synthesized
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+	t.Setenv("NORWEGIAN_API_BASE", srv.URL)
+
+	res, err := searchSingleLCC(context.Background(), "Norwegian", SearchNorwegian,
+		"OSL", "LGW", "2026-07-25", SearchOptions{Adults: 1, ReturnDate: "2026-07-28"})
+	if err != nil {
+		t.Fatalf("round-trip searchSingleLCC error: %v", err)
+	}
+	if res.TripType != "round_trip" {
+		t.Fatalf("TripType = %q, want round_trip", res.TripType)
+	}
+	if res.Count == 0 {
+		t.Fatal("round-trip composition returned no itineraries")
+	}
+	// A composed return itinerary carries both legs (outbound + inbound).
+	rt := res.Flights[0]
+	if len(rt.Legs) != 2 {
+		t.Fatalf("composed round-trip want 2 legs, got %d: %+v", len(rt.Legs), rt)
+	}
+	if rt.Legs[0].DepartureAirport.Code != "OSL" || rt.Legs[1].DepartureAirport.Code != "LGW" {
+		t.Errorf("legs not direction-composed OSL->LGW + LGW->OSL: %+v", rt.Legs)
+	}
+}
+
+// TestSearchFlightsCore_NorwegianHonestStatusWhenUnconfigured is the surfacing
+// proof: a default-merge search (injected Google client, so the LCC providers
+// auto-skip) still emits an HONEST typed Norwegian ProviderStatus carrying the
+// CLOUDFLARE_BLOCK root cause and a fix hint — never a fabricated empty result
+// and never a crash. This is the opt-in deliverable: the path is wired and
+// reports its unavailability truthfully.
+func TestSearchFlightsCore_NorwegianHonestStatusWhenUnconfigured(t *testing.T) {
+	t.Setenv("NORWEGIAN_API_BASE", "")
+	body := makeFlightResponseBody(t)
+	ts := flightsTestServer(t, 200, body)
+	defer ts.Close()
+
+	client := batchexec.NewTestClient(ts.URL)
+	result, err := SearchFlightsWithClient(t.Context(), client, "OSL", "LGW", "2026-07-25", SearchOptions{})
+	if err != nil {
+		t.Fatalf("search error: %v", err)
+	}
+
+	var dy *struct {
+		status, code, fixHint string
+	}
+	for _, s := range result.ProviderStatuses {
+		if s.ID == "norwegian" {
+			dy = &struct{ status, code, fixHint string }{s.Status, s.FixHintCode, s.FixHint}
+			break
+		}
+	}
+	if dy == nil {
+		t.Fatal("Norwegian provider status not present in default merge — opt-in path not wired")
+	}
+	if dy.status != "skipped" {
+		t.Errorf("Norwegian status = %q, want skipped (honest opt-in skip)", dy.status)
+	}
+	if dy.code != "CLOUDFLARE_BLOCK" {
+		t.Errorf("Norwegian fix_hint_code = %q, want CLOUDFLARE_BLOCK", dy.code)
+	}
+	if dy.fixHint == "" {
+		t.Error("Norwegian skip must carry an actionable fix hint (set NORWEGIAN_API_BASE)")
+	}
+}

--- a/internal/flights/providers_concurrent.go
+++ b/internal/flights/providers_concurrent.go
@@ -250,3 +250,40 @@ func runVuelingProvider(ctx context.Context, client *batchexec.Client, origin, d
 		Results: len(flights),
 	}}
 }
+
+func runNorwegianProvider(ctx context.Context, client *batchexec.Client, origin, destination, date, currency string, opts SearchOptions) providerOutcome {
+	if !norwegianSearchEligible(client, opts) {
+		fixHint := "search one-way economy; drop the alliance/airline filter"
+		reason := "options not supported by Norwegian direct (round-trip / non-economy cabin / alliance filter / non-DY airline filter)"
+		fixHintCode := ""
+		if !norwegianConfigured() {
+			reason = "Norwegian's public site/booking funnel is Cloudflare Bot Management-defended (HTTP 403 cf-mitigated:challenge); it is opt-in and requires a reachable endpoint"
+			fixHint = "set NORWEGIAN_API_BASE to an authorised partner endpoint or a self-hosted proxy that returns the JSON availability API"
+			fixHintCode = "CLOUDFLARE_BLOCK"
+		}
+		return providerOutcome{status: models.ProviderStatus{
+			ID:          "norwegian",
+			Name:        "Norwegian",
+			Status:      "skipped",
+			Error:       reason,
+			FixHint:     fixHint,
+			FixHintCode: fixHintCode,
+		}}
+	}
+	flights, err := SearchNorwegian(ctx, origin, destination, date, currency, opts)
+	if err != nil {
+		slog.Warn("norwegian flight search failed", "origin", origin, "destination", destination, "date", date, "error", err)
+		return providerOutcome{err: err, status: models.ProviderStatus{
+			ID:     "norwegian",
+			Name:   "Norwegian",
+			Status: models.ClassifyProviderError(err),
+			Error:  err.Error(),
+		}}
+	}
+	return providerOutcome{flights: flights, succeeded: true, status: models.ProviderStatus{
+		ID:      "norwegian",
+		Name:    "Norwegian",
+		Status:  okOrNoHit(len(flights)),
+		Results: len(flights),
+	}}
+}

--- a/internal/flights/results.go
+++ b/internal/flights/results.go
@@ -553,6 +553,50 @@ func vuelingEligibleOptions(opts SearchOptions) bool {
 	return true
 }
 
+// norwegianSearchEligible gates the Norwegian provider. Like easyJet and Vueling
+// it is opt-in: the public site/booking funnel is Cloudflare Bot
+// Management-defended (HTTP 403 `cf-mitigated: challenge`), so it only fires when
+// the operator supplies a reachable endpoint via NORWEGIAN_API_BASE. The
+// shared-client guard keeps it out of injected-client unit tests.
+func norwegianSearchEligible(client *batchexec.Client, opts SearchOptions) bool {
+	if client == nil || client != batchexec.SharedClient() {
+		return false
+	}
+	if !norwegianConfigured() {
+		return false
+	}
+	return norwegianEligibleOptions(opts)
+}
+
+// norwegianEligibleOptions reports whether a search can be served by Norwegian's
+// availability endpoint. Norwegian is non-aligned and the availability search
+// here is one-way nonstop economy; round-trip / non-economy / alliance filters
+// skip it. An airline filter, if present, must include Norwegian (DY).
+func norwegianEligibleOptions(opts SearchOptions) bool {
+	if opts.ReturnDate != "" {
+		return false
+	}
+	if len(opts.Alliances) > 0 {
+		return false
+	}
+	if opts.CabinClass != 0 && opts.CabinClass != models.Economy {
+		return false
+	}
+	if len(opts.Airlines) > 0 {
+		ok := false
+		for _, a := range opts.Airlines {
+			if strings.EqualFold(strings.TrimSpace(a), "DY") {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // okOrNoHit returns StatusCheckedNoHit when a provider succeeded but returned
 // zero results (a definitive "checked, found nothing"), else StatusOK.
 // Distinguishing this from a failure/timeout is the evidence-envelope contract.

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -403,6 +403,9 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 		{name: "vueling", run: withFlightNegCache("vueling", origin, destination, date, func(ctx context.Context) providerOutcome {
 			return runVuelingProvider(ctx, client, origin, destination, date, currency, opts)
 		})},
+		{name: "norwegian", run: withFlightNegCache("norwegian", origin, destination, date, func(ctx context.Context) providerOutcome {
+			return runNorwegianProvider(ctx, client, origin, destination, date, currency, opts)
+		})},
 	}
 	outcomes := runProviderTasks(ctx, tasks, providerConcurrencyLimit, perProviderTimeout)
 	kiwiOut := outcomes[0]
@@ -412,6 +415,7 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	transaviaOut := outcomes[4]
 	easyjetOut := outcomes[5]
 	vuelingOut := outcomes[6]
+	norwegianOut := outcomes[7]
 
 	statuses := []models.ProviderStatus{
 		googleStatus,
@@ -422,6 +426,7 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 		transaviaOut.status,
 		easyjetOut.status,
 		vuelingOut.status,
+		norwegianOut.status,
 	}
 
 	kiwiFlights := kiwiOut.flights
@@ -445,6 +450,9 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	vuelingFlights := vuelingOut.flights
 	vuelingErr := vuelingOut.err
 	vuelingSucceeded := vuelingOut.succeeded
+	norwegianFlights := norwegianOut.flights
+	norwegianErr := norwegianOut.err
+	norwegianSucceeded := norwegianOut.succeeded
 
 	// Normalize all provider prices to the session currency so resolution and
 	// ranking compare like with like (Skiplagged returns USD, Kiwi its own).
@@ -461,8 +469,9 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	normalizeFlightCurrencies(ctx, transaviaFlights, target, destinations.ConvertCurrency)
 	normalizeFlightCurrencies(ctx, easyjetFlights, target, destinations.ConvertCurrency)
 	normalizeFlightCurrencies(ctx, vuelingFlights, target, destinations.ConvertCurrency)
+	normalizeFlightCurrencies(ctx, norwegianFlights, target, destinations.ConvertCurrency)
 
-	mergedFlights := mergeFlightResults(googleFlights, kiwiFlights, skiplaggedFlights, opts, ryanairFlights, wizzairFlights, transaviaFlights, easyjetFlights, vuelingFlights)
+	mergedFlights := mergeFlightResults(googleFlights, kiwiFlights, skiplaggedFlights, opts, ryanairFlights, wizzairFlights, transaviaFlights, easyjetFlights, vuelingFlights, norwegianFlights)
 
 	// Cross-shop re-pricing (MIK-4956 Phase C): re-price each segment of a
 	// Kiwi-discovered self-connect itinerary on Google Flights and append a
@@ -478,7 +487,7 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 		}
 	}
 
-	if googleSucceeded || kiwiSucceeded || skiplaggedSucceeded || ryanairSucceeded || wizzairSucceeded || transaviaSucceeded || easyjetSucceeded || vuelingSucceeded {
+	if googleSucceeded || kiwiSucceeded || skiplaggedSucceeded || ryanairSucceeded || wizzairSucceeded || transaviaSucceeded || easyjetSucceeded || vuelingSucceeded || norwegianSucceeded {
 		annotateFlightConfidence(mergedFlights, time.Now())
 		result := &models.FlightSearchResult{
 			Success:          true,
@@ -519,6 +528,9 @@ func searchFlightsCore(ctx context.Context, client *batchexec.Client, origin, de
 	}
 	if vuelingErr != nil {
 		errs = append(errs, vuelingErr)
+	}
+	if norwegianErr != nil {
+		errs = append(errs, norwegianErr)
 	}
 	if len(errs) > 0 {
 		err := errors.Join(errs...)

--- a/internal/flights/testdata/norwegian_availability.json
+++ b/internal/flights/testdata/norwegian_availability.json
@@ -1,0 +1,29 @@
+{
+  "flights": [
+    {
+      "flightNumber": "744",
+      "departureAirport": "OSL",
+      "arrivalAirport": "LGW",
+      "departureDateTime": "2026-07-25T06:55:00",
+      "arrivalDateTime": "2026-07-25T08:20:00",
+      "fare": { "amount": 39.9, "currencyCode": "EUR" }
+    },
+    {
+      "flightNumber": "DY746",
+      "departureAirport": "OSL",
+      "arrivalAirport": "LGW",
+      "departureDateTime": "2026-07-25T17:40:00",
+      "arrivalDateTime": "2026-07-25T19:05:00",
+      "lowestFare": 54.9,
+      "currencyCode": "EUR"
+    },
+    {
+      "flightNumber": "748",
+      "departureAirport": "OSL",
+      "arrivalAirport": "LGW",
+      "departureDateTime": "2026-07-26T06:55:00",
+      "arrivalDateTime": "2026-07-26T08:20:00",
+      "fare": { "amount": 42.9, "currencyCode": "EUR" }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Norwegian Air (DY) flight coverage as an opt-in, endpoint-gated low-cost-carrier provider, following the same pattern as the existing easyJet and Vueling adapters.

A live probe on 2026-06-25 found Norwegian's public site and booking funnel behind Cloudflare Bot Management. Every endpoint reachable from a static client (curl, Go `net/http`) returns HTTP 403 with `cf-mitigated: challenge`, a `server: cloudflare` header, an "Are you human? | Norwegian" HTML interstitial, and a `__cf_bm` cookie. The repo does not allow browser or headless dependencies, so there is no static-client path to live fares. This provider therefore ships as an opt-in adapter rather than a default-on parser, which keeps the honesty doctrine intact: no fabricated data, and a typed status when the provider cannot run.

## Probe evidence (static client, OSL to LGW, ~30 days out, 1 adult)

Every probed path returned the same Cloudflare challenge:

```
GET https://www.norwegian.com/api/fare-calendar/get?...        -> 403, server: cloudflare, cf-mitigated: challenge, __cf_bm cookie
GET https://www.norwegian.com/api/flydata/availability/v1?...  -> 403, server: cloudflare, __cf_bm cookie
GET https://www.norwegian.com/booking/api/search/availability  -> 403, server: cloudflare, __cf_bm cookie
GET https://booking.norwegian.com/api/availability?...         -> 403, server: cloudflare
GET https://www.norwegian.com/  (site root)                    -> 403, server: cloudflare, cf-mitigated: challenge
```

Response body on each was the `<title>Are you human? | Norwegian</title>` interstitial, not JSON. A browser-grade fetcher with residential cookies reaches the host, but that needs JS execution to clear the challenge, which the static binary cannot do.

## What this adds

- `internal/flights/norwegian.go`: the opt-in adapter. Gated by `NORWEGIAN_API_BASE`; a no-op skip when unset. When configured, maps an availability JSON shape to `models.FlightResult` tagged provider `norwegian`, carrier code `DY`. The schema is marked "SCHEMA NOT VERIFIED" because the public endpoint is Cloudflare-blocked, so the field tags are written against a representative shape and are tolerant of two price encodings.
- Registration of `norwegian` and the `dy` alias in `lccRegistry`, so `--provider norwegian` and `--provider dy` both resolve.
- Wiring into the concurrent LCC fan-out (`search.go`, `providers_concurrent.go`, `results.go`), matching how easyJet and Vueling are wired: eligibility gating, currency normalization, merge, and error aggregation.
- When unconfigured, the search surfaces a typed `skipped` `ProviderStatus` carrying a `CLOUDFLARE_BLOCK` code and a fix hint naming `NORWEGIAN_API_BASE`, rather than a crash or a fabricated empty result.

Round-trip requests compose a genuine return ticket from two one-way legs through the shared `searchSingleLCC` split-ticket path, so a return search returns return data, not a bare one-way.

## Tests

- Offline deterministic tests (run in the default suite): registry resolve for both `norwegian` and `dy`, unconfigured no-op, fixture parse with both price encodings and date scoping, 403 and 429 typed-error classification, eligibility gating, shared-client guard, honest-status surfacing in the default merge, and round-trip composition through `searchSingleLCC`.
- A live probe test behind `//go:build proof` and gated by `TRVL_TEST_LIVE_PROBES=1`, mirroring the Vueling probe. It skips without the env var and never runs in CI.

## Verification

```
gofmt -l internal/flights/                                  -> (empty)
go vet ./internal/flights/ ./internal/...                   -> exit 0
go build ./...                                               -> exit 0
go test ./internal/flights/ -count=1                         -> ok (178.9s)
go vet -tags proof ./internal/flights/                       -> exit 0
go test -tags proof ./internal/flights/ -run TestSearchNorwegian_LiveProbe -v  -> SKIP (no env), exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
