### PR TITLE
flights: wire Vueling and Norwegian into the CLI --provider switch

### DIFF
--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -190,7 +190,7 @@ Examples:
 					return fmt.Errorf("--provider afklm supports exactly one origin and one destination")
 				}
 				result, err = flights.SearchAFKLM(cmd.Context(), origins[0], destinations[0], date, opts)
-			case "ryanair", "wizzair", "wizz", "transavia", "easyjet":
+			case "ryanair", "wizzair", "wizz", "transavia", "easyjet", "vueling", "vy", "norwegian", "dy":
 				if len(origins) != 1 || len(destinations) != 1 {
 					return fmt.Errorf("--provider %s supports exactly one origin and one destination", provider)
 				}
@@ -202,7 +202,7 @@ Examples:
 					result, err = flights.SearchFlights(cmd.Context(), origins[0], destinations[0], date, opts)
 				}
 			default:
-				return fmt.Errorf("unsupported --provider %q (valid: skiplagged, afklm, ryanair, wizzair, transavia, easyjet, or empty for default Google+Kiwi+Skiplagged merge)", provider)
+				return fmt.Errorf("unsupported --provider %q (valid: skiplagged, afklm, ryanair, wizzair, transavia, easyjet, vueling, norwegian, or empty for default Google+Kiwi+Skiplagged merge)", provider)
 			}
 			if err != nil {
 				return err
@@ -317,7 +317,7 @@ Examples:
 	cmd.Flags().BoolVar(&explain, "explain", false, "Show per-factor profile match breakdown for each result")
 	cmd.Flags().BoolVar(&award, "award", false, "Search Flying Blue award availability instead of cash fares")
 	cmd.Flags().StringVar(&awardCookies, "award-cookies", "", "KLM/Flying Blue Cookie header for --award (or set AFKL_KLM_COOKIES)")
-	cmd.Flags().StringVar(&provider, "provider", "", "Flight provider: empty = default (Google Flights + Kiwi + Skiplagged merge), skiplagged = Skiplagged MCP only (hidden-city + virtual-interlining defaults), afklm = Air France-KLM Offers API only (opt-in, native round-trip fares; requires credential), ryanair|wizzair|transavia|easyjet = a single low-cost carrier only (round-trips composed as two one-way tickets; transavia/easyjet are opt-in and require a key)")
+	cmd.Flags().StringVar(&provider, "provider", "", "Flight provider: empty = default (Google Flights + Kiwi + Skiplagged merge), skiplagged = Skiplagged MCP only (hidden-city + virtual-interlining defaults), afklm = Air France-KLM Offers API only (opt-in, native round-trip fares; requires credential), ryanair|wizzair|transavia|easyjet|vueling|norwegian = a single low-cost carrier only (round-trips composed as two one-way tickets; transavia/easyjet/vueling/norwegian are opt-in and require a reachable endpoint)")
 	cmd.Flags().BoolVar(&flightRailFly, "rail-fly", false, "Expand the search to rail-connected origins (KL/AF Air&Rail), surfacing cheaper rail+fly bundles even when the origin is outside the default hub list")
 	cmd.Flags().BoolVar(&deep, "deep", false, "Run a budget-gated counterfactual fan-out (nearby airports, split tickets, hidden city). Issues extra provider calls, capped by a best-effort budget that never delays the primary search")
 	cmd.Flags().BoolVar(&noGeo, "no-geo", false, "Disable geo-IP origin detection (also honored via TRVL_NO_GEO=1). Origin then resolves only from an explicit code or your saved home airport.")

--- a/internal/flights/lcc_search_test.go
+++ b/internal/flights/lcc_search_test.go
@@ -117,6 +117,60 @@ func TestSearchSingleLCC_ErrorSurfacesProviderName(t *testing.T) {
 	}
 }
 
+// TestSearchSingleLCC_RoundTripBothLegsAcrossCarriers proves the round-trip
+// both-legs guarantee holds for EVERY low-cost carrier exposed via the CLI
+// `--provider` switch — including Vueling and Norwegian, which were registered
+// and composition-capable but previously unreachable from the CLI. A round-trip
+// request must return a FareSplitTickets itinerary carrying a real outbound AND
+// a real inbound leg (Direction-tagged), never a bare one-way.
+func TestSearchSingleLCC_RoundTripBothLegsAcrossCarriers(t *testing.T) {
+	for _, name := range []string{"Ryanair", "Wizz Air", "Transavia", "easyJet", "Vueling", "Norwegian"} {
+		t.Run(name, func(t *testing.T) {
+			search := func(_ context.Context, origin, dest, _, _ string, _ SearchOptions) ([]models.FlightResult, error) {
+				return []models.FlightResult{fakeLeg(origin, dest, 60)}, nil
+			}
+			opts := SearchOptions{ReturnDate: "2026-07-08"}
+			res, err := searchSingleLCC(context.Background(), name, search, "BCN", "FCO", "2026-07-01", opts)
+			if err != nil {
+				t.Fatalf("%s round-trip: %v", name, err)
+			}
+			if res.TripType != "round_trip" {
+				t.Fatalf("%s trip type: want round_trip, got %q", name, res.TripType)
+			}
+			if len(res.Flights) == 0 {
+				t.Fatalf("%s: expected a composed round-trip itinerary", name)
+			}
+			rt := res.Flights[0]
+			if rt.FareType != models.FareSplitTickets {
+				t.Errorf("%s fare type: want %q, got %q", name, models.FareSplitTickets, rt.FareType)
+			}
+			if len(rt.Legs) != 2 {
+				t.Fatalf("%s: expected 2 legs (outbound + inbound), got %d", name, len(rt.Legs))
+			}
+			if rt.Legs[0].Direction != "outbound" || rt.Legs[1].Direction != "inbound" {
+				t.Errorf("%s leg directions: want outbound/inbound, got %q/%q", name, rt.Legs[0].Direction, rt.Legs[1].Direction)
+			}
+		})
+	}
+}
+
+// TestSearchLowCostCarrier_VuelingNorwegianRoutable guards that the dispatcher
+// (the public entry the CLI calls) recognises Vueling/Norwegian and their
+// aliases, rather than rejecting them. It asserts routing, not a network result:
+// the real carrier searchers are opt-in and error honestly when unconfigured,
+// so we accept either composed results or a provider-named error — but never the
+// "unrecognised provider" rejection that the missing CLI wiring produced.
+func TestSearchLowCostCarrier_VuelingNorwegianRoutable(t *testing.T) {
+	for _, name := range []string{"vueling", "vy", "norwegian", "dy"} {
+		t.Run(name, func(t *testing.T) {
+			_, err := SearchLowCostCarrier(context.Background(), name, "BCN", "FCO", "2026-07-01", SearchOptions{ReturnDate: "2026-07-08"})
+			if err != nil && strings.Contains(err.Error(), "unrecognised low-cost carrier") {
+				t.Fatalf("%s should be a recognised provider, got: %v", name, err)
+			}
+		})
+	}
+}
+
 // TestSearchLowCostCarrier_UnrecognisedProvider guards the public dispatcher.
 func TestSearchLowCostCarrier_UnrecognisedProvider(t *testing.T) {
 	_, err := SearchLowCostCarrier(context.Background(), "spirit", "JFK", "LAX", "2026-07-01", SearchOptions{})
@@ -129,7 +183,7 @@ func TestSearchLowCostCarrier_UnrecognisedProvider(t *testing.T) {
 // dispatches is registered, so a new CLI case can never reference a missing
 // searcher.
 func TestLCCRegistryCoversCLIProviders(t *testing.T) {
-	for _, name := range []string{"ryanair", "wizzair", "wizz", "transavia", "easyjet", "vueling", "vy"} {
+	for _, name := range []string{"ryanair", "wizzair", "wizz", "transavia", "easyjet", "vueling", "vy", "norwegian", "dy"} {
 		if _, ok := lccRegistry[name]; !ok {
 			t.Errorf("lccRegistry missing CLI provider %q", name)
 		}


### PR DESCRIPTION
## Round-trip return-leg coverage by provider

I audited every flight path in `internal/flights/` plus the aggregation and CLI layers for whether a `round_trip` request actually returns the inbound leg. Here is where each provider stands:

| Provider | Returns both legs on a round-trip request? | How |
|---|---|---|
| Google Flights | Yes | Native round-trip (`tripType=1`) plus composition; inbound legs enriched from real data |
| Kiwi | Yes | Native round-trip with `ReturnDate`; legs date-tagged downstream |
| Skiplagged | Yes | Native round-trip fare, outbound/inbound Direction tags |
| Air France-KLM | Yes (opt-in) | Native round-trip, both bounds materialised; reachable only via `--provider afklm` with a credential |
| Ryanair / Wizz Air / Transavia / easyJet | Yes | One-way searchers by design; round-trip composed into a split-ticket itinerary (two one-way tickets, both legs Direction-tagged, with a warning that they are separate tickets) |
| Vueling / Norwegian | **Was unreachable from the CLI, fixed here** | Same split-ticket composition as the other low-cost carriers |

## The gap

`SearchVueling` and `SearchNorwegian` exist, are registered in `lccRegistry` (`vueling`/`vy`/`norwegian`/`dy`), and compose round-trips correctly through `searchSingleLCC`. But the `--provider` switch in `cmd/trvl/flights.go` only routed ryanair/wizzair/transavia/easyjet. A user asking for a Vueling or Norwegian round-trip hit the default branch and got `unsupported --provider` instead of a composed itinerary, so the return leg was unreachable for those two carriers from the command line.

## The fix

Add `vueling`/`vy`/`norwegian`/`dy` to the existing low-cost-carrier case in the `--provider` switch, and update the error string and flag help to match. That is the whole change to production code. It routes to registry entries that already existed and already composed both legs. No new provider, no new endpoint, no synthesized fares or routes. The carrier searchers stay opt-in and return cleanly when their endpoint environment variable is unset, so the suite stays offline and deterministic.

## Tests

- `TestSearchSingleLCC_RoundTripBothLegsAcrossCarriers` checks the round-trip both-legs guarantee for all six CLI carriers: trip type `round_trip`, `FareSplitTickets`, two legs, Direction `outbound`/`inbound`.
- `TestSearchLowCostCarrier_VuelingNorwegianRoutable` checks the dispatcher recognises `vueling`/`vy`/`norwegian`/`dy` rather than rejecting them as unrecognised.
- `TestLCCRegistryCoversCLIProviders` extended with `norwegian`/`dy`.

## Verification

- `gofmt -l internal/ cmd/`: clean
- `go build ./...`: passes
- `go vet ./internal/... ./cmd/...`: passes; `go vet -tags proof ./internal/...`: passes
- `staticcheck ./internal/... ./cmd/...`: exit 0, zero findings
- `go test ./internal/flights/... ./cmd/...`: passes (all new subtests included)

No fabricated flights, prices, or endpoints; no browser or headless dependencies; bot-walled providers remain env-gated and opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
