### PR TITLE
flights(kiwi): map the dropped round-trip return leg

### DIFF
--- a/internal/flights/kiwi.go
+++ b/internal/flights/kiwi.go
@@ -92,6 +92,38 @@ type kiwiItinerary struct {
 	DeepLink               string        `json:"deepLink"`
 	Currency               string        `json:"currency"`
 	Layovers               []kiwiLayover `json:"layovers"`
+	// Return carries the inbound journey of a native round-trip fare. Kiwi nests
+	// it in a top-level "return" object with the same routing shape as the
+	// outbound (flyFrom/flyTo, departure/arrival, layovers) but WITHOUT its own
+	// price/currency/deepLink — the parent's Price is the full round-trip total.
+	// Nil for a one-way search, so one-way results stay byte-unchanged.
+	Return *kiwiReturnJourney `json:"return,omitempty"`
+}
+
+// kiwiReturnJourney is the inbound half of a Kiwi native round-trip. It mirrors
+// the outbound routing fields of kiwiItinerary; it deliberately has no
+// price/currency/deepLink because the round-trip total lives on the parent.
+type kiwiReturnJourney struct {
+	FlyFrom           string        `json:"flyFrom"`
+	FlyTo             string        `json:"flyTo"`
+	CityFrom          string        `json:"cityFrom"`
+	CityTo            string        `json:"cityTo"`
+	Departure         kiwiDateTime  `json:"departure"`
+	Arrival           kiwiDateTime  `json:"arrival"`
+	DurationInSeconds int           `json:"durationInSeconds"`
+	Layovers          []kiwiLayover `json:"layovers"`
+}
+
+// kiwiJourney is the common routing shape shared by an itinerary's outbound and
+// its nested return, letting one leg-builder serve both halves.
+type kiwiJourney struct {
+	FlyFrom   string
+	FlyTo     string
+	CityFrom  string
+	CityTo    string
+	Departure kiwiDateTime
+	Arrival   kiwiDateTime
+	Layovers  []kiwiLayover
 }
 
 func SearchKiwiFlights(ctx context.Context, origin, destination, date, currency string, opts SearchOptions) ([]models.FlightResult, error) {
@@ -290,22 +322,59 @@ func extractKiwiContent(rpc kiwiRPCResponse) (json.RawMessage, error) {
 }
 
 func mapKiwiItinerary(itinerary kiwiItinerary, fallbackCurrency string) models.FlightResult {
-	legs := buildKiwiLegs(itinerary)
+	legs := buildKiwiLegs(outboundJourney(itinerary))
+	roundTrip := itinerary.Return != nil
+
+	// Tag legs by direction only for a round-trip. A one-way itinerary leaves
+	// Direction empty so single-direction results stay byte-unchanged.
+	if roundTrip {
+		for i := range legs {
+			legs[i].Direction = "outbound"
+		}
+	}
+
+	// SelfConnect means the OUTBOUND has a layover (self-connect risk on the way
+	// there). It is derived from the outbound layovers only; the return's
+	// layovers must not by themselves flag the outbound as self-connect.
 	selfConnect := len(itinerary.Layovers) > 0
-	durationSeconds := itinerary.DurationInSeconds
+	// Outbound stops = outbound legs minus 1; computed before the inbound legs
+	// are appended so the return's airports are never counted as outbound stops.
+	stops := max(len(legs)-1, 0)
+
+	if roundTrip {
+		inbound := buildKiwiLegs(returnJourney(*itinerary.Return))
+		for i := range inbound {
+			inbound[i].Direction = "inbound"
+		}
+		legs = append(legs, inbound...)
+	}
+
+	// Duration: prefer the provider's total (covers both halves for a round-trip);
+	// fall back to the single-journey duration, then to summing all leg durations.
+	durationSeconds := itinerary.TotalDurationInSeconds
 	if durationSeconds <= 0 {
-		durationSeconds = itinerary.TotalDurationInSeconds
+		durationSeconds = itinerary.DurationInSeconds
+	}
+	durationMinutes := durationSeconds / 60
+	if durationMinutes <= 0 {
+		durationMinutes = sumLegDurations(legs)
 	}
 
 	flight := models.FlightResult{
 		Price:       itinerary.Price,
 		Currency:    firstNonEmpty(itinerary.Currency, fallbackCurrency),
-		Duration:    durationSeconds / 60,
-		Stops:       max(len(legs)-1, 0),
+		Duration:    durationMinutes,
+		Stops:       stops,
 		Provider:    "kiwi",
 		SelfConnect: selfConnect,
 		Legs:        legs,
 		BookingURL:  itinerary.DeepLink,
+	}
+	if roundTrip {
+		// FlightResult carries the per-result round-trip marker via FareType
+		// (matching the roundtrip.go composer convention); the "round_trip"
+		// TripType string lives on the enclosing FlightSearchResult, not here.
+		flight.FareType = models.FareRoundTrip
 	}
 	if selfConnect {
 		flight.Warnings = []string{kiwiSelfConnectWarning}
@@ -313,13 +382,50 @@ func mapKiwiItinerary(itinerary kiwiItinerary, fallbackCurrency string) models.F
 	return flight
 }
 
-func buildKiwiLegs(itinerary kiwiItinerary) []models.FlightLeg {
-	legs := make([]models.FlightLeg, 0, len(itinerary.Layovers)+1)
-	currentCode := itinerary.FlyFrom
-	currentName := firstNonEmpty(itinerary.CityFrom, itinerary.FlyFrom)
-	currentDeparture := itinerary.Departure
+// outboundJourney projects the outbound routing of an itinerary into the shared
+// kiwiJourney shape.
+func outboundJourney(it kiwiItinerary) kiwiJourney {
+	return kiwiJourney{
+		FlyFrom:   it.FlyFrom,
+		FlyTo:     it.FlyTo,
+		CityFrom:  it.CityFrom,
+		CityTo:    it.CityTo,
+		Departure: it.Departure,
+		Arrival:   it.Arrival,
+		Layovers:  it.Layovers,
+	}
+}
 
-	for _, layover := range itinerary.Layovers {
+// returnJourney projects a nested return into the shared kiwiJourney shape.
+func returnJourney(r kiwiReturnJourney) kiwiJourney {
+	return kiwiJourney{
+		FlyFrom:   r.FlyFrom,
+		FlyTo:     r.FlyTo,
+		CityFrom:  r.CityFrom,
+		CityTo:    r.CityTo,
+		Departure: r.Departure,
+		Arrival:   r.Arrival,
+		Layovers:  r.Layovers,
+	}
+}
+
+// sumLegDurations totals each leg's per-segment duration (minutes), used as a
+// last-resort fallback when the provider supplies no usable trip total.
+func sumLegDurations(legs []models.FlightLeg) int {
+	total := 0
+	for _, leg := range legs {
+		total += leg.Duration
+	}
+	return total
+}
+
+func buildKiwiLegs(journey kiwiJourney) []models.FlightLeg {
+	legs := make([]models.FlightLeg, 0, len(journey.Layovers)+1)
+	currentCode := journey.FlyFrom
+	currentName := firstNonEmpty(journey.CityFrom, journey.FlyFrom)
+	currentDeparture := journey.Departure
+
+	for _, layover := range journey.Layovers {
 		legs = append(legs, buildKiwiLeg(
 			currentCode,
 			currentName,
@@ -337,10 +443,12 @@ func buildKiwiLegs(itinerary kiwiItinerary) []models.FlightLeg {
 		currentCode,
 		currentName,
 		currentDeparture,
-		itinerary.FlyTo,
-		firstNonEmpty(itinerary.CityTo, itinerary.FlyTo),
-		itinerary.Arrival,
+		journey.FlyTo,
+		firstNonEmpty(journey.CityTo, journey.FlyTo),
+		journey.Arrival,
 	))
+	// Compute per-journey so the inbound's first leg never inherits a spurious
+	// layover from the outbound's final arrival.
 	computeLayovers(legs)
 	return legs
 }

--- a/internal/flights/kiwi_roundtrip_test.go
+++ b/internal/flights/kiwi_roundtrip_test.go
@@ -1,0 +1,122 @@
+package flights
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestMapKiwiItineraryRoundTrip unmarshals a real captured Kiwi round-trip
+// response (testdata/kiwi_roundtrip.json — HEL<->BCN, returnDate 2026-08-01)
+// and asserts mapKiwiItinerary now emits BOTH halves: outbound HEL->AMS->BCN
+// tagged "outbound" and the previously-dropped return BCN->PMI->HEL tagged
+// "inbound", as a single native round-trip fare. This is the regression that
+// the live probe surfaced: the return journey was discarded entirely.
+func TestMapKiwiItineraryRoundTrip(t *testing.T) {
+	raw, err := os.ReadFile("testdata/kiwi_roundtrip.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var itineraries []kiwiItinerary
+	if err := json.Unmarshal(raw, &itineraries); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	if len(itineraries) != 1 {
+		t.Fatalf("itineraries = %d, want 1", len(itineraries))
+	}
+	if itineraries[0].Return == nil {
+		t.Fatal("expected a parsed return journey, got nil")
+	}
+
+	flight := mapKiwiItinerary(itineraries[0], "EUR")
+
+	if got := len(flight.Legs); got != 4 {
+		t.Fatalf("Legs = %d, want 4 (2 outbound + 2 inbound)", got)
+	}
+
+	// Outbound: HEL -> AMS -> BCN, both tagged "outbound".
+	if c := flight.Legs[0].DepartureAirport.Code; c != "HEL" {
+		t.Errorf("leg[0] departure = %q, want HEL", c)
+	}
+	if c := flight.Legs[0].ArrivalAirport.Code; c != "AMS" {
+		t.Errorf("leg[0] arrival = %q, want AMS", c)
+	}
+	if c := flight.Legs[1].DepartureAirport.Code; c != "AMS" {
+		t.Errorf("leg[1] departure = %q, want AMS", c)
+	}
+	if c := flight.Legs[1].ArrivalAirport.Code; c != "BCN" {
+		t.Errorf("leg[1] arrival = %q, want BCN", c)
+	}
+	for i := 0; i < 2; i++ {
+		if d := flight.Legs[i].Direction; d != "outbound" {
+			t.Errorf("leg[%d] direction = %q, want outbound", i, d)
+		}
+	}
+
+	// Inbound (the dropped half): BCN -> PMI -> HEL, both tagged "inbound".
+	if c := flight.Legs[2].DepartureAirport.Code; c != "BCN" {
+		t.Errorf("leg[2] departure = %q, want BCN", c)
+	}
+	if c := flight.Legs[2].ArrivalAirport.Code; c != "PMI" {
+		t.Errorf("leg[2] arrival = %q, want PMI", c)
+	}
+	if c := flight.Legs[3].DepartureAirport.Code; c != "PMI" {
+		t.Errorf("leg[3] departure = %q, want PMI", c)
+	}
+	if c := flight.Legs[3].ArrivalAirport.Code; c != "HEL" {
+		t.Errorf("leg[3] arrival = %q, want HEL", c)
+	}
+	for i := 2; i < 4; i++ {
+		if d := flight.Legs[i].Direction; d != "inbound" {
+			t.Errorf("leg[%d] direction = %q, want inbound", i, d)
+		}
+	}
+
+	if flight.FareType != models.FareRoundTrip {
+		t.Errorf("FareType = %q, want %q", flight.FareType, models.FareRoundTrip)
+	}
+	if flight.Price != 323 {
+		t.Errorf("Price = %v, want 323 (the full round-trip total)", flight.Price)
+	}
+	// Outbound stops only — the inbound airports must not inflate the count.
+	if flight.Stops != 1 {
+		t.Errorf("Stops = %d, want 1 (outbound legs-1, return excluded)", flight.Stops)
+	}
+	// totalDurationInSeconds (47700) / 60 = 795 minutes covers both halves.
+	if flight.Duration != 795 {
+		t.Errorf("Duration = %d, want 795 (totalDurationInSeconds/60)", flight.Duration)
+	}
+}
+
+// TestMapKiwiItineraryOneWayNoDirectionTags is the regression guard for the
+// one-way path: an itinerary with no Return must stay byte-unchanged — no
+// Direction tags and no round-trip FareType (empty, as a one-way result).
+func TestMapKiwiItineraryOneWayNoDirectionTags(t *testing.T) {
+	itinerary := kiwiItinerary{
+		FlyFrom:           "HEL",
+		FlyTo:             "BCN",
+		CityFrom:          "Helsinki",
+		CityTo:            "Barcelona",
+		Departure:         kiwiDateTime{UTC: "2026-07-25T10:55:00.000Z", Local: "2026-07-25T13:55:00.000"},
+		Arrival:           kiwiDateTime{UTC: "2026-07-25T16:50:00.000Z", Local: "2026-07-25T18:50:00.000"},
+		DurationInSeconds: 21300,
+		Price:             102,
+		Currency:          "EUR",
+		DeepLink:          "https://on.kiwi.com/oneway",
+	}
+
+	flight := mapKiwiItinerary(itinerary, "EUR")
+
+	if len(flight.Legs) != 1 {
+		t.Fatalf("Legs = %d, want 1", len(flight.Legs))
+	}
+	if flight.Legs[0].Direction != "" {
+		t.Errorf("one-way leg Direction = %q, want empty", flight.Legs[0].Direction)
+	}
+	if flight.FareType != "" {
+		t.Errorf("one-way FareType = %q, want empty", flight.FareType)
+	}
+}

--- a/internal/flights/testdata/kiwi_roundtrip.json
+++ b/internal/flights/testdata/kiwi_roundtrip.json
@@ -1,0 +1,27 @@
+[
+  {
+    "arrival": { "local": "2026-07-25T18:50:00.000", "utc": "2026-07-25T16:50:00.000Z" },
+    "cityFrom": "Helsinki", "cityTo": "Barcelona", "currency": "EUR",
+    "deepLink": "https://on.kiwi.com/5pkPcZ",
+    "departure": { "local": "2026-07-25T13:55:00.000", "utc": "2026-07-25T10:55:00.000Z" },
+    "durationInSeconds": 21300, "flyFrom": "HEL", "flyTo": "BCN",
+    "layovers": [
+      { "arrival": { "local": "2026-07-25T15:25:00.000", "utc": "2026-07-25T13:25:00.000Z" },
+        "at": "AMS", "city": "Amsterdam", "cityCode": "AMS",
+        "departure": { "local": "2026-07-25T16:45:00.000", "utc": "2026-07-25T14:45:00.000Z" } }
+    ],
+    "price": 323,
+    "return": {
+      "arrival": { "local": "2026-08-01T14:50:00.000", "utc": "2026-08-01T11:50:00.000Z" },
+      "cityFrom": "Barcelona", "cityTo": "Helsinki",
+      "departure": { "local": "2026-08-01T06:30:00.000", "utc": "2026-08-01T04:30:00.000Z" },
+      "durationInSeconds": 26400, "flyFrom": "BCN", "flyTo": "HEL",
+      "layovers": [
+        { "arrival": { "local": "2026-08-01T07:25:00.000", "utc": "2026-08-01T05:25:00.000Z" },
+          "at": "PMI", "city": "Palma, Majorca", "cityCode": "PMI",
+          "departure": { "local": "2026-08-01T09:50:00.000", "utc": "2026-08-01T07:50:00.000Z" } }
+      ]
+    },
+    "totalDurationInSeconds": 47700
+  }
+]


### PR DESCRIPTION
## The bug (live-probe confirmed)

`internal/flights/kiwi.go` requested round-trips correctly (`buildKiwiSearchArgs` sends `returnDate`), but `mapKiwiItinerary` dropped the return leg. A live HEL↔BCN probe (returnDate 2026-08-01) returned 15 results, every one rendered outbound-only (e.g. HEL→AMS→BCN as a self-connect) with the entire return journey discarded.

## Root cause

`kiwiItinerary` had no field for the return journey. Kiwi nests the inbound half in a top-level `"return"` object with the same routing shape as the outbound:

```json
"return": {
  "flyFrom": "BCN", "flyTo": "HEL",
  "cityFrom": "Barcelona", "cityTo": "Helsinki",
  "departure": { "local": "...", "utc": "..." },
  "arrival":   { "local": "...", "utc": "..." },
  "durationInSeconds": 26400,
  "layovers": [ { "at": "PMI", ... } ]
}
```

It carries no `price`/`currency`/`deepLink` — the parent's `price` is the full round-trip total.

## The fix

- Add `kiwiReturnJourney` and a `Return *kiwiReturnJourney` field to `kiwiItinerary`.
- Refactor `buildKiwiLegs` to take a shared `kiwiJourney` so it builds either half; layovers are computed per-journey so the inbound's first leg never inherits a spurious layover from the outbound's arrival.
- `mapKiwiItinerary` tags outbound legs `outbound` and appends the return legs tagged `inbound` (matching the roundtrip.go `Direction` convention), sets `FareType = FareRoundTrip`, and uses `totalDurationInSeconds` for the round-trip duration.
- `SelfConnect` stays derived from the outbound's layovers only; `Stops` counts the outbound legs only — the return's airports never inflate either signal.
- One-way itineraries (`Return == nil`) are byte-unchanged: no `Direction` tags, no `FareType`.

(Note: the per-result round-trip marker is `FareType` on `FlightResult`; the round_trip `TripType` string lives on the enclosing `FlightSearchResult`, consistent with the existing composer in roundtrip.go.)

## Tests

- New fixture `internal/flights/testdata/kiwi_roundtrip.json` from the real captured response.
- New `kiwi_roundtrip_test.go`: asserts 4 legs (HEL→AMS→BCN outbound, BCN→PMI→HEL inbound) with correct `Direction` tags, `FareType == FareRoundTrip`, price 323, outbound-only `Stops == 1`, and round-trip duration; plus a one-way regression guard (no `Direction` tags, empty `FareType`).

Verified: gofmt, vet, build, full `internal/flights` test package, and staticcheck all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)