### PR TITLE
trip: prefer native single-ticket round-trip fares in plan summary

### DIFF
--- a/cmd/trvl/trip.go
+++ b/cmd/trvl/trip.go
@@ -345,6 +345,26 @@ func printTripPlan(ctx context.Context, targetCurrency string, result *trip.Plan
 
 	fTotal := (cheapOut + cheapRet) * float64(result.Guests)
 	hTotal := cheapHotel
+
+	// Prefer the cheaper of {two one-ways, native single-ticket round-trip}. A
+	// native round-trip fare is one bookable ticket whose price is already the
+	// full round-trip per person, so it competes directly against cheapOut+cheapRet.
+	// Surface it (and use it in the total) only when it is genuinely cheaper, so
+	// the existing split display stays the headline whenever it wins.
+	if len(result.RoundTripFares) > 0 {
+		rt := result.RoundTripFares[0]
+		cheapRT := rt.Price
+		if targetCurrency != "" && rt.Currency != targetCurrency && cheapRT > 0 {
+			converted, _ := destinations.ConvertCurrency(ctx, cheapRT, rt.Currency, targetCurrency)
+			cheapRT = math.Round(converted)
+		}
+		if cheapRT > 0 && cheapRT < cheapOut+cheapRet {
+			fmt.Printf("  %s Round-trip fare (1 ticket): %s — %s — %s\n\n",
+				models.Bold("🎫"), formatPrice(cheapRT, cur), rt.Airline, rt.Route)
+			fTotal = cheapRT * float64(result.Guests)
+		}
+	}
+
 	gTotal := fTotal + hTotal
 	var pp, pd float64
 	if result.Guests > 0 {

--- a/internal/trip/plan.go
+++ b/internal/trip/plan.go
@@ -107,21 +107,28 @@ type PlanSummary struct {
 
 // PlanResult is the full trip plan response.
 type PlanResult struct {
-	Success         bool                    `json:"success"`
-	Origin          string                  `json:"origin"`
-	Destination     string                  `json:"destination"`
-	DepartDate      string                  `json:"depart_date"`
-	ReturnDate      string                  `json:"return_date"`
-	Nights          int                     `json:"nights"`
-	Guests          int                     `json:"guests"`
-	OutboundFlights []PlanFlight            `json:"outbound_flights"`
-	ReturnFlights   []PlanFlight            `json:"return_flights"`
-	Hotels          []PlanHotel             `json:"hotels"`
-	Breakfast       []PlanBreakfast         `json:"breakfast,omitempty"`
-	ReviewSnippets  []PlanReviewSnippet     `json:"review_snippets,omitempty"`
-	Context         *PlanDestinationContext `json:"context,omitempty"`
-	Summary         PlanSummary             `json:"summary"`
-	Error           string                  `json:"error,omitempty"`
+	Success         bool         `json:"success"`
+	Origin          string       `json:"origin"`
+	Destination     string       `json:"destination"`
+	DepartDate      string       `json:"depart_date"`
+	ReturnDate      string       `json:"return_date"`
+	Nights          int          `json:"nights"`
+	Guests          int          `json:"guests"`
+	OutboundFlights []PlanFlight `json:"outbound_flights"`
+	ReturnFlights   []PlanFlight `json:"return_flights"`
+	// RoundTripFares carries native single-ticket round-trip fares — one bookable
+	// ticket per entry covering both directions, whose Price is the full round-trip
+	// total per person (often discounted below the sum of two separate one-ways).
+	// Purely additive: the split OutboundFlights/ReturnFlights view stays populated
+	// exactly as before, so this never weakens the existing two-one-way display. A
+	// native fare is preferred in the cost summary only when it is genuinely cheaper.
+	RoundTripFares []PlanFlight            `json:"round_trip_fares,omitempty"`
+	Hotels         []PlanHotel             `json:"hotels"`
+	Breakfast      []PlanBreakfast         `json:"breakfast,omitempty"`
+	ReviewSnippets []PlanReviewSnippet     `json:"review_snippets,omitempty"`
+	Context        *PlanDestinationContext `json:"context,omitempty"`
+	Summary        PlanSummary             `json:"summary"`
+	Error          string                  `json:"error,omitempty"`
 
 	// HotelCoverage / HotelProviders carry the per-provider evidence so the
 	// renderer can be honest about partial accommodation coverage instead of
@@ -205,14 +212,16 @@ func PlanTrip(ctx context.Context, input PlanInput) (*PlanResult, error) {
 	var (
 		outResult   *models.FlightSearchResult
 		retResult   *models.FlightSearchResult
+		rtResult    *models.FlightSearchResult
 		hotelResult *models.HotelSearchResult
 		outErr      error
 		retErr      error
+		rtErr       error
 		hotelErr    error
 		wg          sync.WaitGroup
 	)
 
-	wg.Add(3)
+	wg.Add(4)
 	go func() {
 		defer wg.Done()
 		outResult, outErr = flights.SearchFlightsWithClient(ctx, client, input.Origin, input.Destination, input.DepartDate, flights.SearchOptions{
@@ -225,6 +234,20 @@ func PlanTrip(ctx context.Context, input PlanInput) (*PlanResult, error) {
 		retResult, retErr = flights.SearchFlightsWithClient(ctx, client, input.Destination, input.Origin, input.ReturnDate, flights.SearchOptions{
 			SortBy: models.SortCheapest,
 			Adults: input.Guests,
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		// Native single-ticket round-trip fares. Passing ReturnDate routes this
+		// through searchRoundTripComposed, which queries providers' genuine
+		// round-trip fares (FareRoundTrip) alongside composed one-way pairs. The
+		// leg sub-searches share the same singleflight cache keys as the outbound
+		// and return goroutines above, so only the native-RT passes are net-new
+		// network — no extra fan-out beyond this single call.
+		rtResult, rtErr = flights.SearchFlightsWithClient(ctx, client, input.Origin, input.Destination, input.DepartDate, flights.SearchOptions{
+			SortBy:     models.SortCheapest,
+			Adults:     input.Guests,
+			ReturnDate: input.ReturnDate,
 		})
 	}()
 	go func() {
@@ -248,6 +271,15 @@ func PlanTrip(ctx context.Context, input PlanInput) (*PlanResult, error) {
 	// Extract top return flights (up to 5).
 	if retErr == nil && retResult != nil && retResult.Success {
 		result.ReturnFlights = extractTopFlights(retResult.Flights, 5)
+	}
+
+	// Extract native single-ticket round-trip fares (up to 5). Keep ONLY
+	// FareRoundTrip results — the composed one-way pairs that searchRoundTripComposed
+	// also returns are already represented by the split outbound/return view above,
+	// so including them here would double-count. Each kept fare is one bookable
+	// ticket whose Price is the full round-trip total per person.
+	if rtErr == nil && rtResult != nil && rtResult.Success {
+		result.RoundTripFares = extractTopRoundTripFares(rtResult.Flights, 5)
 	}
 
 	// Extract top hotels (up to 5).
@@ -351,6 +383,7 @@ func PlanTrip(ctx context.Context, input PlanInput) (*PlanResult, error) {
 	if input.Currency != "" {
 		convertPlanFlights(ctx, result.OutboundFlights, input.Currency)
 		convertPlanFlights(ctx, result.ReturnFlights, input.Currency)
+		convertPlanFlights(ctx, result.RoundTripFares, input.Currency)
 		convertPlanHotels(ctx, result.Hotels, input.Currency)
 	}
 
@@ -369,7 +402,17 @@ func PlanTrip(ctx context.Context, input PlanInput) (*PlanResult, error) {
 		cheapHotel = convertedPlanAmount(ctx, result.Hotels[0].Total, result.Hotels[0].Currency, cur)
 	}
 
-	flightsTotal := (cheapOut + cheapRet) * float64(input.Guests)
+	// Prefer the cheaper of {two one-ways, native single-ticket round-trip}. The
+	// native RT price is ALREADY a full round-trip per person, so it competes
+	// directly against cheapOut+cheapRet — no doubling. When no native fare was
+	// found (or it is pricier), this is byte-identical to the two-one-way total.
+	var cheapRT float64
+	if len(result.RoundTripFares) > 0 {
+		cheapRT = convertedPlanAmount(ctx, result.RoundTripFares[0].Price, result.RoundTripFares[0].Currency, cur)
+	}
+	perPersonFlights := cheaperPerPersonFlights(cheapOut+cheapRet, cheapRT)
+
+	flightsTotal := perPersonFlights * float64(input.Guests)
 	grandTotal := flightsTotal + cheapHotel
 
 	result.Summary = PlanSummary{
@@ -458,7 +501,83 @@ func extractTopFlights(flts []models.FlightResult, n int) []PlanFlight {
 	return result
 }
 
-// trimReview cuts a review text to n characters at a word boundary.
+// cheaperPerPersonFlights returns the lower per-person flight cost between the
+// summed two-one-way total and a native single-ticket round-trip total. A native
+// fare wins only when it is present (> 0) AND strictly cheaper; otherwise the
+// two-one-way total is returned unchanged, keeping the summary byte-identical to
+// the pre-native behaviour when no cheaper native fare exists. Pure: no I/O.
+func cheaperPerPersonFlights(twoOneWays, nativeRoundTrip float64) float64 {
+	if nativeRoundTrip > 0 && nativeRoundTrip < twoOneWays {
+		return nativeRoundTrip
+	}
+	return twoOneWays
+}
+
+// extractTopRoundTripFares maps native single-ticket round-trip fares to
+// PlanFlights. Only FareRoundTrip results are kept — a single bookable ticket
+// whose Price is the full round-trip total per person. The Route spans both
+// directions (e.g. "HEL -> BCN -> HEL"), built from the Direction-tagged legs so
+// the inbound leg is never silently dropped. Mirrors extractTopFlights' price
+// sort, zero-price filter, and cap.
+func extractTopRoundTripFares(flts []models.FlightResult, n int) []PlanFlight {
+	native := make([]models.FlightResult, 0, len(flts))
+	for _, f := range flts {
+		if f.FareType == models.FareRoundTrip {
+			native = append(native, f)
+		}
+	}
+
+	sort.Slice(native, func(i, j int) bool {
+		return native[i].Price < native[j].Price
+	})
+
+	if len(native) > n {
+		native = native[:n]
+	}
+
+	var result []PlanFlight
+	for _, f := range native {
+		if f.Price <= 0 {
+			continue
+		}
+		pf := PlanFlight{
+			Price:    f.Price,
+			Currency: f.Currency,
+			Stops:    f.Stops,
+			Duration: f.Duration,
+		}
+		if len(f.Legs) > 0 {
+			pf.Airline = f.Legs[0].Airline
+			pf.Flight = f.Legs[0].FlightNumber
+			pf.Departure = f.Legs[0].DepartureTime
+			pf.Arrival = f.Legs[len(f.Legs)-1].ArrivalTime
+			pf.Route = roundTripRoute(f.Legs)
+		}
+		result = append(result, pf)
+	}
+	return result
+}
+
+// roundTripRoute builds a both-directions route string from a native round-trip
+// fare's legs (e.g. "HEL -> BCN -> HEL"). It walks every leg in order so the
+// inbound (return) legs are represented, deduplicating only consecutive repeats
+// where one leg's arrival equals the next leg's departure (the normal chained
+// case). The inbound leg's distinct airports are always surfaced — the return is
+// never silently dropped.
+func roundTripRoute(legs []models.FlightLeg) string {
+	if len(legs) == 0 {
+		return ""
+	}
+	parts := []string{legs[0].DepartureAirport.Code}
+	for _, leg := range legs {
+		dep := leg.DepartureAirport.Code
+		if dep != "" && dep != parts[len(parts)-1] {
+			parts = append(parts, dep)
+		}
+		parts = append(parts, leg.ArrivalAirport.Code)
+	}
+	return joinRoute(parts)
+}
 func trimReview(s string, n int) string {
 	s = strings.TrimSpace(s)
 	if len(s) <= n {

--- a/internal/trip/roundtrip_fare_test.go
+++ b/internal/trip/roundtrip_fare_test.go
@@ -1,0 +1,160 @@
+package trip
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestCheaperPerPersonFlights proves the summary-preference logic: a native
+// single-ticket round-trip fare is used only when present AND strictly cheaper
+// than the two-one-way total; otherwise the two-one-way total is returned
+// byte-identically (the pre-native behaviour).
+func TestCheaperPerPersonFlights(t *testing.T) {
+	tests := []struct {
+		name            string
+		twoOneWays      float64
+		nativeRoundTrip float64
+		want            float64
+	}{
+		{name: "native cheaper wins", twoOneWays: 300, nativeRoundTrip: 250, want: 250},
+		{name: "native pricier falls back", twoOneWays: 300, nativeRoundTrip: 350, want: 300},
+		{name: "native equal falls back (not strictly cheaper)", twoOneWays: 300, nativeRoundTrip: 300, want: 300},
+		{name: "native absent (zero) falls back", twoOneWays: 300, nativeRoundTrip: 0, want: 300},
+		{name: "native negative ignored", twoOneWays: 300, nativeRoundTrip: -10, want: 300},
+		{name: "both zero", twoOneWays: 0, nativeRoundTrip: 0, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cheaperPerPersonFlights(tt.twoOneWays, tt.nativeRoundTrip)
+			if got != tt.want {
+				t.Errorf("cheaperPerPersonFlights(%v, %v) = %v, want %v",
+					tt.twoOneWays, tt.nativeRoundTrip, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractTopRoundTripFares proves only native FareRoundTrip results are
+// kept (composed split-ticket pairs are excluded — they are already represented
+// by the split outbound/return view), sorted cheapest-first, zero-price filtered,
+// and that the inbound leg is surfaced in a both-directions Route.
+func TestExtractTopRoundTripFares(t *testing.T) {
+	flts := []models.FlightResult{
+		{
+			Price: 280, Currency: "EUR", FareType: models.FareRoundTrip, Stops: 0,
+			Legs: []models.FlightLeg{
+				{Direction: "outbound", Airline: "Vueling", FlightNumber: "VY1001", DepartureTime: "08:00", ArrivalTime: "11:00",
+					DepartureAirport: models.AirportInfo{Code: "HEL"}, ArrivalAirport: models.AirportInfo{Code: "BCN"}},
+				{Direction: "inbound", Airline: "Vueling", FlightNumber: "VY1002", DepartureTime: "18:00", ArrivalTime: "21:00",
+					DepartureAirport: models.AirportInfo{Code: "BCN"}, ArrivalAirport: models.AirportInfo{Code: "HEL"}},
+			},
+		},
+		{
+			Price: 200, Currency: "EUR", FareType: models.FareRoundTrip, Stops: 0,
+			Legs: []models.FlightLeg{
+				{Direction: "outbound", Airline: "Finnair", FlightNumber: "AY100", DepartureTime: "07:00", ArrivalTime: "10:00",
+					DepartureAirport: models.AirportInfo{Code: "HEL"}, ArrivalAirport: models.AirportInfo{Code: "BCN"}},
+				{Direction: "inbound", Airline: "Finnair", FlightNumber: "AY101", DepartureTime: "19:00", ArrivalTime: "22:00",
+					DepartureAirport: models.AirportInfo{Code: "BCN"}, ArrivalAirport: models.AirportInfo{Code: "HEL"}},
+			},
+		},
+		// Composed split-ticket pair — must be excluded.
+		{
+			Price: 150, Currency: "EUR", FareType: models.FareSplitTickets,
+			Legs: []models.FlightLeg{
+				{Direction: "outbound", Airline: "Ryanair", FlightNumber: "FR1", DepartureAirport: models.AirportInfo{Code: "HEL"}, ArrivalAirport: models.AirportInfo{Code: "BCN"}},
+			},
+		},
+		// One-way (no FareType) — must be excluded.
+		{
+			Price: 90, Currency: "EUR",
+			Legs: []models.FlightLeg{
+				{Airline: "Wizz", FlightNumber: "W6", DepartureAirport: models.AirportInfo{Code: "HEL"}, ArrivalAirport: models.AirportInfo{Code: "BCN"}},
+			},
+		},
+	}
+
+	got := extractTopRoundTripFares(flts, 5)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 native round-trip fares, got %d: %#v", len(got), got)
+	}
+	// Cheapest first: Finnair (200), then Vueling (280).
+	if got[0].Price != 200 || got[0].Airline != "Finnair" {
+		t.Errorf("first fare = %v %q, want 200 Finnair", got[0].Price, got[0].Airline)
+	}
+	// Both-directions route — inbound leg back to HEL must be present.
+	if got[0].Route != "HEL -> BCN -> HEL" {
+		t.Errorf("first route = %q, want HEL -> BCN -> HEL", got[0].Route)
+	}
+	if got[1].Price != 280 {
+		t.Errorf("second fare price = %v, want 280", got[1].Price)
+	}
+	// Arrival is taken from the last (inbound) leg.
+	if got[0].Arrival != "22:00" {
+		t.Errorf("first fare arrival = %q, want 22:00 (last/inbound leg)", got[0].Arrival)
+	}
+}
+
+func TestExtractTopRoundTripFares_ZeroPriceFiltered(t *testing.T) {
+	flts := []models.FlightResult{
+		{Price: 0, Currency: "EUR", FareType: models.FareRoundTrip},
+		{Price: 220, Currency: "EUR", FareType: models.FareRoundTrip, Legs: []models.FlightLeg{
+			{DepartureAirport: models.AirportInfo{Code: "HEL"}, ArrivalAirport: models.AirportInfo{Code: "BCN"}},
+			{DepartureAirport: models.AirportInfo{Code: "BCN"}, ArrivalAirport: models.AirportInfo{Code: "HEL"}},
+		}},
+	}
+	got := extractTopRoundTripFares(flts, 5)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 fare (zero price filtered), got %d", len(got))
+	}
+	if got[0].Price != 220 {
+		t.Errorf("kept fare price = %v, want 220", got[0].Price)
+	}
+}
+
+func TestExtractTopRoundTripFares_NoNativeFares(t *testing.T) {
+	flts := []models.FlightResult{
+		{Price: 150, Currency: "EUR", FareType: models.FareSplitTickets},
+		{Price: 90, Currency: "EUR"},
+	}
+	got := extractTopRoundTripFares(flts, 5)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 native fares when none are FareRoundTrip, got %d", len(got))
+	}
+}
+
+func TestRoundTripRoute(t *testing.T) {
+	tests := []struct {
+		name string
+		legs []models.FlightLeg
+		want string
+	}{
+		{name: "empty", legs: nil, want: ""},
+		{
+			name: "direct round trip",
+			legs: []models.FlightLeg{
+				{DepartureAirport: models.AirportInfo{Code: "HEL"}, ArrivalAirport: models.AirportInfo{Code: "BCN"}},
+				{DepartureAirport: models.AirportInfo{Code: "BCN"}, ArrivalAirport: models.AirportInfo{Code: "HEL"}},
+			},
+			want: "HEL -> BCN -> HEL",
+		},
+		{
+			name: "round trip with connection on outbound",
+			legs: []models.FlightLeg{
+				{DepartureAirport: models.AirportInfo{Code: "HEL"}, ArrivalAirport: models.AirportInfo{Code: "AMS"}},
+				{DepartureAirport: models.AirportInfo{Code: "AMS"}, ArrivalAirport: models.AirportInfo{Code: "BCN"}},
+				{DepartureAirport: models.AirportInfo{Code: "BCN"}, ArrivalAirport: models.AirportInfo{Code: "HEL"}},
+			},
+			want: "HEL -> AMS -> BCN -> HEL",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roundTripRoute(tt.legs)
+			if got != tt.want {
+				t.Errorf("roundTripRoute() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

The trip planner composed every round-trip as two independent one-way flight searches and never asked providers for their native single-bookable round-trip fare. Those native fares are frequently discounted below the sum of two one-ways, so the planner could quietly overstate the real cost of a return trip.

This change surfaces native single-ticket round-trip fares and uses the cheaper of {native round-trip total, two-one-ways total} in the cost summary.

## How

- Adds a 4th parallel flight search in `PlanTrip` that passes `ReturnDate`, routing through the existing round-trip composer (`internal/flights/roundtrip.go`) which already queries providers' native round-trip fares (tagged `FareRoundTrip`).
- New additive field `PlanResult.RoundTripFares` — each entry is one bookable ticket whose price is the full round-trip total per person, with a route spanning both directions (e.g. `HEL -> BCN -> HEL`). Only native `FareRoundTrip` results are kept; composed one-way pairs are already represented by the existing split view, so they are excluded to avoid double-counting.
- The per-person flight cost in the summary becomes `min(cheapOut + cheapRet, nativeRoundTrip)`. When no native fare is found, or it is pricier, the total is byte-identical to today.
- The CLI renderer leads with a short "Round-trip fare (1 ticket)" line only when a native fare is genuinely cheaper than the two-one-way total, so the existing split display stays the headline whenever it wins.

## Honesty / compatibility

- Real provider data only — no fabricated fares. A native fare is preferred solely when present and strictly cheaper.
- `RoundTripFares` is purely additive; the existing split view and the `Success` criteria are unchanged.
- The leg sub-searches reuse the existing one-way singleflight cache keys, so only the native round-trip passes are net-new network — no extra fan-out beyond the single added call.

## Tests

- New table-driven tests in `internal/trip/roundtrip_fare_test.go` cover the summary-preference selection (native cheaper wins; native pricier/equal/absent falls back identically), the `FareRoundTrip`-only filtering, zero-price filtering, and the both-directions route (inbound leg never dropped).
- Existing trip tests stay green.

## Verify

- gofmt -l clean
- go vet pass
- go build pass
- go test (trip + flights) pass
- staticcheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
