### PR TITLE
mcp: wire personal travel-graph nudges into the tool surface

### DIFF
--- a/cmd/trvl/public_claims_test.go
+++ b/cmd/trvl/public_claims_test.go
@@ -145,6 +145,7 @@ func registeredMCPCompatibilityAliasCount(t *testing.T) int {
 		"arbitrage_report": true, // unified arbitrage aggregator (innovation #8) — new capability, not a legacy alias
 		"plan_multimodal":  true, // Multimodal composer capability (innovation #2)
 		"coalesce_trip":    true, // unified trip coalescer (innovation #5) — new capability, not a legacy alias
+		"travel_nudges":    true, // personal travel-graph nudges — new capability reachable via the smart router, not a legacy alias
 	}
 	count := 0
 	for _, key := range handlers.MapKeys() {

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -108,6 +108,13 @@ func registerTools(s *Server) {
 	// unchanged.
 	s.toolDefs[nlSupertoolName] = nlSupertoolTool()
 	s.handlers[nlSupertoolName] = s.wrapHandler(nlSupertoolName, handleNLSupertool)
+	// travel_nudges surfaces grounded proactive nudges from the personal travel
+	// graph. Like plan_journey, it is a smart capability reachable via the travel
+	// router intent and by direct tools/call; its schema lives in toolDefs for
+	// discoverability but it is kept out of the advertised legacyTools surface so
+	// the compatibility-alias count is unchanged.
+	s.toolDefs["travel_nudges"] = travelNudgesTool()
+	s.handlers["travel_nudges"] = s.wrapHandler("travel_nudges", handleTravelNudges)
 	s.handlers["search_flights"] = s.wrapHandler("search_flights", handleSearchFlights)
 	s.handlers["plan_flight_bundle"] = s.wrapHandler("plan_flight_bundle", handlePlanFlightBundle)
 	s.handlers["find_interactive"] = s.wrapHandler("find_interactive", handleFindInteractive)

--- a/mcp/tools_nudges.go
+++ b/mcp/tools_nudges.go
@@ -1,0 +1,112 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/travelgraph"
+	"github.com/MikkoParkkola/trvl/internal/trips"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// travelNudgesTool returns the MCP tool definition for travel_nudges. It mirrors
+// the read-only, no-argument shape of get_preferences: the only optional input
+// is a format hint, and the output is the list of grounded nudges.
+//
+// Like plan_journey and plan_natural, travel_nudges is a smart capability that
+// is registered as a handler and reachable via direct tools/call and the travel
+// smart router, but kept OUT of the advertised legacyTools surface so the
+// compact tool list stays a single router (see registerTools in tools.go).
+func travelNudgesTool() ToolDef {
+	return ToolDef{
+		Name:        "travel_nudges",
+		Title:       "Travel Nudges",
+		Description: "Returns grounded proactive nudges from the user's personal travel graph: watches that have crossed their target price, and routes confirmed at a confident historic low. Every nudge cites its source record. When nothing has triggered, an empty list is returned — this tool never speculates.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"format": {
+					Type:        "string",
+					Description: "Optional output hint. \"json\" is the default structured form; ignored otherwise.",
+				},
+			},
+			Required: []string{},
+		},
+		OutputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"nudges": schemaArray(map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"Kind":    schemaString(),
+						"Message": schemaString(),
+						"Sources": schemaStringArray(),
+					},
+				}),
+				"count": schemaInt(),
+			},
+		},
+		Annotations: &ToolAnnotations{
+			Title:          "Travel Nudges",
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+	}
+}
+
+// handleTravelNudges builds the personal travel graph from the same local stores
+// as the `trvl nudges` CLI command (watch store + AllHistory, preferences, trips)
+// and returns its grounded nudges. Missing or unreadable preference/trip stores
+// degrade to defaults/empty rather than failing, matching the CLI's tolerance:
+// quiet stores simply yield zero nudges, not a hard error.
+func handleTravelNudges(_ context.Context, _ map[string]any, _ ElicitFunc, _ SamplingFunc, _ ProgressFunc) ([]ContentBlock, interface{}, error) {
+	store, err := watch.DefaultStore()
+	if err != nil {
+		return nil, nil, fmt.Errorf("open watch store: %w", err)
+	}
+	if err := store.Load(); err != nil {
+		return nil, nil, fmt.Errorf("load watches: %w", err)
+	}
+	ws := store.List()
+
+	// AllHistory returns every price point — both watch-keyed and route-keyed —
+	// so historicLowNudge evaluates the full corpus (matches cmd/trvl/nudges.go).
+	history := store.AllHistory()
+
+	prefs, err := preferences.Load()
+	if err != nil {
+		prefs = preferences.Default()
+	}
+
+	var ts []trips.Trip
+	if tstore, terr := trips.DefaultStore(); terr == nil && tstore.Load() == nil {
+		ts = tstore.List()
+	}
+
+	g := travelgraph.Build(ws, history, prefs, ts)
+	nudges := travelgraph.Nudges(g)
+
+	type nudgeResponse struct {
+		Nudges []travelgraph.Nudge `json:"nudges"`
+		Count  int                 `json:"count"`
+	}
+	resp := nudgeResponse{Nudges: nudges, Count: len(nudges)}
+
+	var summary string
+	if len(nudges) == 0 {
+		summary = "No nudges — watches quiet and no historic lows detected."
+	} else {
+		summary = fmt.Sprintf("%d grounded nudge(s):\n", len(nudges))
+		for _, n := range nudges {
+			summary += fmt.Sprintf("  [%s] %s\n    sources: %s\n", n.Kind, n.Message, strings.Join(n.Sources, ", "))
+		}
+	}
+
+	content, err := buildAnnotatedContentBlocks(summary, resp)
+	if err != nil {
+		return nil, nil, err
+	}
+	return content, resp, nil
+}

--- a/mcp/tools_nudges_test.go
+++ b/mcp/tools_nudges_test.go
@@ -1,0 +1,88 @@
+package mcp
+
+import (
+	"encoding/json"
+	"runtime"
+	"testing"
+)
+
+// TestTravelNudgesRegistered asserts the travel_nudges handler and tool
+// definition are wired into the server, mirroring how plan_journey/plan_natural
+// are registered but kept out of the advertised legacy surface.
+func TestTravelNudgesRegistered(t *testing.T) {
+	s := NewServer()
+
+	if _, ok := s.handlers["travel_nudges"]; !ok {
+		t.Fatal("travel_nudges handler not registered")
+	}
+	if _, ok := s.toolDefs["travel_nudges"]; !ok {
+		t.Fatal("travel_nudges tool definition not registered")
+	}
+}
+
+// TestHandleTravelNudgesEmptyStores verifies the handler returns valid,
+// non-panicking JSON for empty stores. A fresh HOME makes the watch/trip/prefs
+// stores empty, which must degrade to zero nudges rather than erroring.
+func TestHandleTravelNudgesEmptyStores(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", dir)
+	}
+
+	content, structured, err := handleTravelNudges(t.Context(), nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) == 0 {
+		t.Error("expected content blocks")
+	}
+	if structured == nil {
+		t.Fatal("expected structured output")
+	}
+
+	// Structured output must be valid JSON with a nudges array and a count.
+	data, err := json.Marshal(structured)
+	if err != nil {
+		t.Fatalf("marshal structured: %v", err)
+	}
+	var result struct {
+		Nudges []map[string]any `json:"nudges"`
+		Count  int              `json:"count"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal structured: %v", err)
+	}
+	if result.Count != len(result.Nudges) {
+		t.Errorf("count = %d, want %d", result.Count, len(result.Nudges))
+	}
+	if result.Count != 0 {
+		t.Errorf("expected 0 nudges for empty stores, got %d", result.Count)
+	}
+}
+
+// TestTravelNudgesSmartIntent verifies the smart router resolves the "nudges"
+// intent alias to the travel_nudges tool.
+func TestTravelNudgesSmartIntent(t *testing.T) {
+	target, ok := resolveSmartIntentAlias("nudges")
+	if !ok {
+		t.Fatal("smart intent alias 'nudges' did not resolve")
+	}
+	if target != "travel_nudges" {
+		t.Errorf("alias 'nudges' resolved to %q, want travel_nudges", target)
+	}
+}
+
+// TestTravelNudgesToolDef checks the tool definition has the required fields.
+func TestTravelNudgesToolDef(t *testing.T) {
+	tool := travelNudgesTool()
+	if tool.Name != "travel_nudges" {
+		t.Errorf("Name = %q, want travel_nudges", tool.Name)
+	}
+	if tool.Description == "" {
+		t.Error("Description is empty")
+	}
+	if tool.InputSchema.Type != "object" {
+		t.Errorf("InputSchema.Type = %q, want object", tool.InputSchema.Type)
+	}
+}

--- a/mcp/tools_smart.go
+++ b/mcp/tools_smart.go
@@ -253,6 +253,11 @@ var smartIntentAliases = map[string]string{
 	"profile":            "get_preferences",
 	"providers":          "provider_health",
 	"provider":           "provider_health",
+	"nudges":             "travel_nudges",
+	"price_drops":        "travel_nudges",
+	"deals_for_me":       "travel_nudges",
+	"what_should_i_book": "travel_nudges",
+	"proactive":          "travel_nudges",
 }
 
 func inferTravelTarget(text, action string) string {


### PR DESCRIPTION
## What

Wires the personal travel graph (`internal/travelgraph`) into the MCP tool surface so an AI assistant can get grounded proactive nudges, not just the `trvl nudges` CLI command.

## Why

The travel graph joins watches, price history, preferences, and trips and emits grounded nudges — a watch that crossed its target price, or a route confirmed at a confident historic low. That capability existed only behind the CLI (`cmd/trvl/nudges.go`). An MCP client had no path to it. This was a half-wired feature; this PR finishes it.

## How

- New read-only `travel_nudges` handler (`mcp/tools_nudges.go`) loads the same local stores as the CLI (watch store + `AllHistory`, preferences, trips) and returns `travelgraph.Nudges(travelgraph.Build(...))`.
- Missing or unreadable preference/trip stores degrade to defaults/empty rather than failing — quiet stores yield zero nudges, matching the CLI tolerance.
- Registered as a handler reachable via direct `tools/call` and the smart router, but kept out of the advertised `legacyTools` surface so the default tool list stays a single router and the compatibility-alias count is unchanged (same treatment as `plan_journey`).
- Smart-router intents added: `nudges`, `price_drops`, `deals_for_me`, `what_should_i_book`, `proactive` → `travel_nudges`.
- Test (`mcp/tools_nudges_test.go`) covers registration, valid JSON for empty stores (no panic), and smart-router resolution.

## Verification

`gofmt -l` clean, `go vet ./...`, `go build ./...`, `go test ./mcp/... ./internal/travelgraph/...`, and `staticcheck ./...` (0 findings) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
