### PR TITLE
docs: lead with smart-router value, demote alias count to back-compat footnote

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,7 @@ CLI alternative: `trvl prefs init`
 
 ## How To Use (after setup)
 
-You now have one `travel` MCP tool available by default, with 63 legacy tool names still callable as compatibility aliases. Use `travel` for new clients and the aliases when an older workflow names a specific tool:
+You now have one `travel` MCP tool available by default. Older clients that call legacy per-domain tool names still work — 66 of them remain callable as compatibility aliases. Use `travel` for new clients and the aliases when an older workflow names a specific tool:
 
 ### search_flights — Find flights between airports
 ```json

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ trvl hotels "Helsinki" --checkin 2026-09-01 --checkout 2026-09-04 --stealth
 
 | Area | Highlights | Reference |
 |------|-----------|-----------|
-| **MCP tools** | 1 smart `travel` router + 66 compatibility aliases; 98.9% smaller `tools/list` footprint (~378 vs ~33,500 tokens) | [MCP-TOOLS-REFERENCE.md](docs/MCP-TOOLS-REFERENCE.md) |
+| **MCP tools** | 1 smart `travel` router — a natural-language tool that advertises a single tool (~378 tokens) instead of a full per-domain list (~33,500 tokens): ~98.9% smaller `tools/list` footprint. Older clients that call legacy tool names still work (66 compatibility aliases). | [MCP-TOOLS-REFERENCE.md](docs/MCP-TOOLS-REFERENCE.md) |
 | **Flights** | Google Flights + Kiwi + Skiplagged merged; LCC fares, AFKLM award scan, round-trip (both legs) | [PROVIDERS.md](docs/PROVIDERS.md) |
 | **Ground** | 20 train/bus/ferry providers across Europe, API-first | [PROVIDERS.md](docs/PROVIDERS.md) |
 | **Hotels** | 6 sources, discovery → verification trust model | [PROVIDERS.md](docs/PROVIDERS.md) |

--- a/cmd/trvl/share.go
+++ b/cmd/trvl/share.go
@@ -233,7 +233,7 @@ func formatLastSearchMarkdown(ls *LastSearch) string {
 // Tool-surface copy is enforced by share tests so public trip cards do not
 // drift back to stale advertised counts.
 func trvlFooter() string {
-	return "*Found by [trvl](https://github.com/MikkoParkkola/trvl) — 1 smart MCP tool + 66 compatibility aliases, no API keys for core search*\n"
+	return "*Found by [trvl](https://github.com/MikkoParkkola/trvl) — 1 smart `travel` MCP tool, natural language, no API keys for core search*\n"
 }
 
 // extractTripRoute derives origin, destination, dates, and nights from trip legs.

--- a/cmd/trvl/share_test.go
+++ b/cmd/trvl/share_test.go
@@ -101,8 +101,8 @@ func TestFormatTripMarkdown_Basic(t *testing.T) {
 	if !strings.Contains(md, "trvl") {
 		t.Errorf("missing trvl footer in:\n%s", md)
 	}
-	if !strings.Contains(md, "1 smart MCP tool + 66 compatibility aliases") {
-		t.Errorf("missing tool count in footer:\n%s", md)
+	if !strings.Contains(md, "1 smart `travel` MCP tool, natural language") {
+		t.Errorf("missing smart-tool framing in footer:\n%s", md)
 	}
 }
 
@@ -335,8 +335,8 @@ func TestTrvlFooter(t *testing.T) {
 	if !strings.Contains(f, "trvl") {
 		t.Error("footer missing 'trvl'")
 	}
-	if !strings.Contains(f, "1 smart MCP tool + 66 compatibility aliases") {
-		t.Error("footer missing tool count")
+	if !strings.Contains(f, "1 smart `travel` MCP tool, natural language") {
+		t.Error("footer missing smart-tool framing")
 	}
 	if !strings.Contains(f, "no API keys") {
 		t.Error("footer missing 'no API keys'")

--- a/mcp/alias_count_test.go
+++ b/mcp/alias_count_test.go
@@ -1,0 +1,21 @@
+package mcp
+
+import "testing"
+
+// expectedCompatibilityAliasCount is the authoritative compatibility-alias
+// count cited by docs. It is a deliberate tripwire: when the alias surface
+// changes, this test fails and forces a single, intentional update here (and a
+// docs sweep), rather than letting the number drift silently across files.
+const expectedCompatibilityAliasCount = 66
+
+func TestAdvertisedSurfaceIsSingleSmartTool(t *testing.T) {
+	if got := AdvertisedToolCount(); got != 1 {
+		t.Fatalf("AdvertisedToolCount() = %d, want 1 (default tools/list must advertise only the `travel` smart router)", got)
+	}
+}
+
+func TestCompatibilityAliasCountMatchesExpected(t *testing.T) {
+	if got := CompatibilityAliasCount(); got != expectedCompatibilityAliasCount {
+		t.Fatalf("CompatibilityAliasCount() = %d, want %d; if the alias surface changed intentionally, update expectedCompatibilityAliasCount and sweep docs that cite the number", got, expectedCompatibilityAliasCount)
+	}
+}

--- a/mcp/aliases.go
+++ b/mcp/aliases.go
@@ -16,6 +16,7 @@ var nonAliasCapabilities = map[string]bool{
 	"arbitrage_report": true, // unified arbitrage aggregator (innovation #8)
 	"plan_multimodal":  true, // Multimodal composer capability (innovation #2)
 	"coalesce_trip":    true, // unified trip coalescer (innovation #5)
+	"travel_nudges":    true, // personal travel-graph nudges — new capability via the router intent, not a legacy alias
 }
 
 // AdvertisedToolCount returns the number of tools advertised in tools/list by

--- a/mcp/aliases.go
+++ b/mcp/aliases.go
@@ -1,0 +1,41 @@
+package mcp
+
+// Compatibility-alias accounting. This is the single source of truth for the
+// "1 smart tool + N compatibility aliases" numbers cited in docs and tests.
+// Counting from a live server keeps the number honest: it can never drift from
+// the actual registered handler surface.
+
+// nonAliasCapabilities are handlers reachable via the `travel` router intent
+// (or by direct tools/call) that are NOT legacy per-domain compatibility
+// aliases, so they must not inflate the marketed alias count. Keep this in sync
+// with registerTools in tools.go.
+var nonAliasCapabilities = map[string]bool{
+	"travel":           true, // the smart router itself
+	"plan_journey":     true, // Leave-By Scheduler capability (MIK-5734 B)
+	"plan_natural":     true, // NL travel-planner supertool (innovation #7)
+	"arbitrage_report": true, // unified arbitrage aggregator (innovation #8)
+	"plan_multimodal":  true, // Multimodal composer capability (innovation #2)
+	"coalesce_trip":    true, // unified trip coalescer (innovation #5)
+}
+
+// AdvertisedToolCount returns the number of tools advertised in tools/list by
+// default. The smart-router design advertises exactly one tool (`travel`); the
+// legacy surface is opt-in via TRVL_MCP_TOOL_MODE=legacy.
+func AdvertisedToolCount() int {
+	return len(NewServer().tools)
+}
+
+// CompatibilityAliasCount returns the number of legacy per-domain tool names
+// that remain callable as compatibility aliases (via the `travel` router's
+// intent field or direct tools/call), excluding the smart router and the
+// newer non-alias smart capabilities. Docs and marketing copy that need the
+// exact number derive it from this function rather than hand-typing it.
+func CompatibilityAliasCount() int {
+	count := 0
+	for name := range NewServer().handlers {
+		if !nonAliasCapabilities[name] {
+			count++
+		}
+	}
+	return count
+}

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # trvl-mcp
 
-AI travel agent MCP server. **1 smart tool, not 66** — advertises a single `travel` router (~378 tokens of context) instead of 66 separate tools (~33,500 tokens), a **98.9% smaller context footprint**. Covers flights, hotels, ground transport, price alerts, and more, dispatched by natural language. No API keys required for default discovery.
+AI travel agent MCP server. **1 smart `travel` MCP tool** — a natural-language router that advertises a single tool (~378 tokens of context) instead of a full per-domain tool list (~33,500 tokens): a **~98.9% smaller context footprint**. Covers flights, hotels, ground transport, price alerts, and more, dispatched by natural language. No API keys required for core search.
 
 Hotel trust rule: use `search_accommodations` for traveller-facing stay recommendations. Raw `search_hotels` prices are lead-in discovery prices. Before ranking a final trip cost or telling a user what to book, use criteria-matched room/apartment offers from `search_accommodations` or verify shortlisted hotels with room/detail/provider totals (`search_hotels_with_details`, `hotel_rooms`, or `trvl serpapi` when `SERPAPI_KEY` is configured). trvl provides booking handoff links; it does not book, hold, or guarantee hotel rates.
 
@@ -27,7 +27,7 @@ Add to `claude_desktop_config.json`:
 
 ## What's included
 
-- **1 smart `travel` MCP tool** — natural-language router; advertises one tool (~378 tokens) instead of 66 (~33,500), so your AI's context window stays lean. 66 legacy tool names remain callable as compatibility aliases via the `intent` field (set `TRVL_MCP_TOOL_MODE=legacy` to advertise all 66 for clients that require it).
+- **1 smart `travel` MCP tool** — natural-language router; advertises one tool (~378 tokens) instead of a full per-domain list (~33,500), so your AI's context window stays lean. Older clients that call legacy per-domain tool names still work, callable as compatibility aliases via the `intent` field (set `TRVL_MCP_TOOL_MODE=legacy` to advertise the full list for clients that require it).
 - Flight search (Google Flights, Kiwi)
 - Criteria-first accommodation search plus hotel discovery (Google Hotels, Booking.com, Airbnb, Hostelworld, Trivago) and verified room/detail flows for shortlisted candidates
 - Ground transport (buses, trains, ferries — 20 providers)

--- a/npm/package.json
+++ b/npm/package.json
@@ -2,7 +2,7 @@
   "name": "trvl-mcp",
   "mcpName": "io.github.MikkoParkkola/trvl",
   "version": "1.10.0",
-  "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart MCP tool plus 66 compatibility aliases.",
+  "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as compatibility aliases.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What

The "1 smart MCP tool plus N compatibility aliases" framing had drifted — the alias count appeared as 57 (profile README), 63 (AGENTS), and 66 elsewhere, with no single source of truth.

This PR makes the framing consistent and accurate:

- Leads with the real value in docs and marketing prose: one smart `travel` router that advertises a single tool (~378 tokens) instead of a full per-domain tool list (~33,500 tokens) — a ~98.9 percent smaller listing footprint, no API keys for core search.
- Demotes legacy per-domain tools to a back-compat footnote rather than a headline number. External prose no longer leads with a fragile count; clients that need the full list still set the legacy tool mode env var.
- Fixes the stale `63` in AGENTS to the authoritative count.
- Removes the count from the user-facing share-card footer, keeping the value framing; the share tests are updated to match.

## Drift-proofing

Adds a new mcp aliases source file exposing AdvertisedToolCount and CompatibilityAliasCount, computed from the live server — the single source of truth for the number. A new mcp alias-count test asserts the default advertised surface is exactly 1 tool and the alias count equals the expected constant, so the number cannot silently drift across files again. Internal reference docs that cite the exact count track this code value.

## Verification

- gofmt — clean
- go build — exit 0
- go test on the mcp and cmd packages — ok
- staticcheck — 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
