### PR TITLE
ground: add --return flag for round-trip CLI searches

### DIFF
--- a/cmd/trvl/ground.go
+++ b/cmd/trvl/ground.go
@@ -15,6 +15,7 @@ func groundCmd() *cobra.Command {
 	var (
 		currency              string
 		providers             string
+		returnDate            string
 		maxPrice              float64
 		typeFilter            string
 		allowBrowserFallbacks bool
@@ -47,6 +48,7 @@ Examples:
 
 			opts := ground.SearchOptions{
 				Currency:              currency,
+				ReturnDate:            returnDate,
 				MaxPrice:              maxPrice,
 				Type:                  typeFilter,
 				NoCache:               noCache,
@@ -102,7 +104,8 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&currency, "currency", "", "Convert prices to this currency (e.g. EUR). Empty = provider default")
-	cmd.Flags().StringVar(&providers, "provider", "", "Restrict to providers (e.g. flixbus,regiojet,trainline,sncf,transitous)")
+	cmd.Flags().StringVar(&providers, "provider", "", "Restrict to providers (e.g. flixbus,regiojet,trainline,sncf,transitous,db,oebb,ns,vr,tallink,dfds,vikingline,eckeroline,ferryhopper)")
+	cmd.Flags().StringVar(&returnDate, "return", "", "Return date (YYYY-MM-DD) for a round-trip / return leg")
 	cmd.Flags().Float64Var(&maxPrice, "max-price", 0, "Maximum price filter")
 	cmd.Flags().StringVar(&typeFilter, "type", "", "Filter by type (bus, train, ferry)")
 	cmd.Flags().BoolVar(&allowBrowserFallbacks, "allow-browser-fallbacks", false, "Allow browser/curl/cookie-assisted provider fallbacks")

--- a/cmd/trvl/ground_return_test.go
+++ b/cmd/trvl/ground_return_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+// TestGroundCmd_ReturnFlagRegistered proves the ground command exposes a
+// --return flag with the expected default so round-trip / return-leg searches
+// are reachable from the CLI (parity with the MCP search_ground tool).
+func TestGroundCmd_ReturnFlagRegistered(t *testing.T) {
+	cmd := groundCmd()
+	f := cmd.Flags().Lookup("return")
+	if f == nil {
+		t.Fatal("ground missing --return flag")
+	}
+	if f.DefValue != "" {
+		t.Errorf("ground --return default = %q, want empty", f.DefValue)
+	}
+}
+
+// TestGroundCmd_ReturnFlagCapturesValue proves a parsed --return value is
+// captured by the flag binding. If the binding is dropped, GetString returns
+// the empty default and this test fails.
+func TestGroundCmd_ReturnFlagCapturesValue(t *testing.T) {
+	cmd := groundCmd()
+	if err := cmd.ParseFlags([]string{"--return", "2026-07-08"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	got, err := cmd.Flags().GetString("return")
+	if err != nil {
+		t.Fatalf("GetString(return): %v", err)
+	}
+	if got != "2026-07-08" {
+		t.Errorf("--return = %q, want %q", got, "2026-07-08")
+	}
+}


### PR DESCRIPTION
## What

The `trvl ground` CLI command gained a `--return` flag so round-trip ground transport searches work. Previously only the MCP `search_ground` tool and the underlying `internal/ground` library supported return legs; the CLI read `opts.ReturnDate` for arrival enrichment but never registered a flag to populate it, so a return date passed by a user was silently dropped.

## Changes

- `cmd/trvl/ground.go`: register a `--return` string flag and wire it into `ground.SearchOptions.ReturnDate`. Help text: "Return date (YYYY-MM-DD) for a round-trip / return leg". This mirrors the existing `--return` flag on the `flights`, `optimize`, and `watch` commands.
- `cmd/trvl/ground.go`: extend the `--provider` help string to list the full set of accepted providers (adds `db`, `oebb`, `ns`, `vr`, `tallink`, `dfds`, `vikingline`, `eckeroline`, `ferryhopper`). These were already accepted and pass through to `opts.Providers` unchanged; only the help text was out of date. No validation was added.
- `cmd/trvl/ground_return_test.go`: tests that the flag is registered with an empty default and that a parsed `--return` value is captured by the flag binding.

## Validation

Run with `GOTOOLCHAIN=go1.26.4`:

- `gofmt -l .` — empty
- `go vet ./...` — 0
- `go build ./...` — 0
- `staticcheck ./...` — 0 findings
- `go test ./cmd/...` — pass (includes the new ground tests)
- `go test -short ./...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
