### PR TITLE
fix(cli): apply traveller profile budget + time-window to flight search

### DIFF
--- a/cmd/trvl/flights.go
+++ b/cmd/trvl/flights.go
@@ -43,6 +43,7 @@ func flightsCmd() *cobra.Command {
 		flightRailFly  bool
 		deep           bool
 		stealth        bool
+		maxPrice       int
 	)
 
 	cmd := &cobra.Command{
@@ -171,6 +172,7 @@ Examples:
 				Airlines:   airlines,
 				Adults:     adults,
 				Stealth:    stealth,
+				MaxPrice:   maxPrice,
 			}
 
 			// --compare-cabins: search all cabin classes in parallel.
@@ -207,6 +209,17 @@ Examples:
 			if err != nil {
 				return err
 			}
+
+			// Apply the traveller's saved preferences as post-search filters,
+			// matching the MCP surface (mcp/tools_flights.go). The CLI previously
+			// ignored the stored budget cap and preferred departure-time window;
+			// this brings it to parity so the profile is actually used.
+			//
+			// Explicit-flag precedence: when the user passes --max-price on the
+			// command line, that explicit value already flows into opts.MaxPrice
+			// (the server-side cap) and we skip the profile BudgetFlightMax
+			// fallback so a stored preference never overrides an explicit flag.
+			applyFlightProfileFilters(result, prefs, cmd.Flags().Changed("max-price"))
 
 			// MIK-6229/6234: log the search and compute price-position + all
 			// call-free savings via the shared pricefeed (single source shared
@@ -311,6 +324,7 @@ Examples:
 	cmd.Flags().StringVar(&sortBy, "sort", "", "Sort by: cheapest, duration, departure, arrival")
 	cmd.Flags().StringSliceVar(&airlines, "airline", nil, "Filter by airline IATA code (repeatable)")
 	cmd.Flags().IntVar(&adults, "adults", 1, "Number of adult passengers")
+	cmd.Flags().IntVar(&maxPrice, "max-price", 0, "Maximum flight price in whole currency units (0 = no limit). Overrides the saved profile budget cap when set.")
 	cmd.Flags().StringVar(&format, "format", "table", "Output format: table, json")
 	cmd.Flags().StringVar(&targetCurrency, "currency", "", "Convert prices to this currency (e.g. EUR, USD). Empty = show API default")
 	cmd.Flags().BoolVar(&compareCabins, "compare-cabins", false, "Compare prices across all cabin classes (economy, premium, business, first)")
@@ -326,6 +340,31 @@ Examples:
 	cmd.ValidArgsFunction = airportCompletion
 
 	return cmd
+}
+
+// applyFlightProfileFilters applies the traveller's saved preferences as
+// post-search filters, mirroring the MCP surface (mcp/tools_flights.go): the
+// saved budget cap, the preferred departure-time window, and frequent-flyer bag
+// allowance adjustments. It keeps result.Count consistent with the filtered
+// slice, exactly as the MCP path does.
+//
+// budgetFlagSet reports whether the user passed an explicit --max-price flag on
+// the command line. When true, the explicit value has already been applied as a
+// server-side cap (opts.MaxPrice) and the profile BudgetFlightMax fallback is
+// skipped so a stored preference never silently overrides an explicit flag.
+//
+// It is a no-op on a nil/unsuccessful result so callers can invoke it
+// unconditionally after a search.
+func applyFlightProfileFilters(result *models.FlightSearchResult, prefs *preferences.Preferences, budgetFlagSet bool) {
+	if prefs == nil || result == nil || !result.Success {
+		return
+	}
+	if !budgetFlagSet {
+		result.Flights = flights.FilterFlightsByBudget(result.Flights, prefs.BudgetFlightMax)
+	}
+	result.Flights = flights.FilterFlightsByTimePreference(result.Flights, prefs.FlightTimeEarliest, prefs.FlightTimeLatest)
+	result.Flights = flights.AdjustBagAllowance(result.Flights, prefs.FrequentFlyerPrograms)
+	result.Count = len(result.Flights)
 }
 
 // printFlightsTable renders flight results as an ASCII table.

--- a/cmd/trvl/flights_profile_test.go
+++ b/cmd/trvl/flights_profile_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+)
+
+// makeFlight builds a minimal priced one-way FlightResult for filter tests.
+func makeFlight(price float64, departHHMM string) models.FlightResult {
+	return models.FlightResult{
+		Price:    price,
+		Currency: "EUR",
+		Legs: []models.FlightLeg{{
+			DepartureTime: "2026-06-15T" + departHHMM,
+		}},
+	}
+}
+
+// TestApplyFlightProfileFiltersBudget proves the CLI applies the traveller's
+// saved BudgetFlightMax as a post-search filter, dropping over-budget flights —
+// the parity behaviour the CLI previously lacked (the MCP surface already did
+// this in mcp/tools_flights.go).
+func TestApplyFlightProfileFiltersBudget(t *testing.T) {
+	prefs := preferences.Default()
+	prefs.BudgetFlightMax = 500
+
+	result := &models.FlightSearchResult{
+		Success: true,
+		Count:   3,
+		Flights: []models.FlightResult{
+			makeFlight(300, "10:00"), // under budget — kept
+			makeFlight(500, "11:00"), // exactly at budget — kept
+			makeFlight(900, "12:00"), // over budget — filtered
+		},
+	}
+
+	// No explicit --max-price flag, so the profile budget applies.
+	applyFlightProfileFilters(result, prefs, false)
+
+	if result.Count != 2 {
+		t.Fatalf("expected Count 2 after budget filter, got %d", result.Count)
+	}
+	if len(result.Flights) != 2 {
+		t.Fatalf("expected 2 flights after budget filter, got %d", len(result.Flights))
+	}
+	for _, f := range result.Flights {
+		if f.Price > prefs.BudgetFlightMax {
+			t.Errorf("flight priced %.0f exceeds profile budget %.0f and should have been filtered", f.Price, prefs.BudgetFlightMax)
+		}
+	}
+}
+
+// TestApplyFlightProfileFiltersExplicitFlagWins proves an explicit --max-price
+// command-line flag overrides the saved profile budget: when budgetFlagSet is
+// true the profile BudgetFlightMax fallback is skipped, so a stored preference
+// never silently overrides what the user typed.
+func TestApplyFlightProfileFiltersExplicitFlagWins(t *testing.T) {
+	prefs := preferences.Default()
+	prefs.BudgetFlightMax = 500
+
+	result := &models.FlightSearchResult{
+		Success: true,
+		Count:   2,
+		Flights: []models.FlightResult{
+			makeFlight(300, "10:00"),
+			makeFlight(900, "12:00"), // over the profile cap, but the user passed an explicit flag
+		},
+	}
+
+	// Explicit --max-price flag set: the profile budget post-filter is skipped
+	// (the explicit value is already applied server-side via opts.MaxPrice).
+	applyFlightProfileFilters(result, prefs, true)
+
+	if result.Count != 2 {
+		t.Fatalf("expected explicit flag to skip the profile budget filter (Count 2), got %d", result.Count)
+	}
+	if len(result.Flights) != 2 {
+		t.Fatalf("expected both flights retained when explicit flag is set, got %d", len(result.Flights))
+	}
+}
+
+// TestApplyFlightProfileFiltersTimeWindow proves the preferred departure-time
+// window from the profile is applied, matching MCP parity.
+func TestApplyFlightProfileFiltersTimeWindow(t *testing.T) {
+	prefs := preferences.Default()
+	prefs.BudgetFlightMax = 0 // no budget cap, isolate the time-window behaviour
+	prefs.FlightTimeEarliest = "08:00"
+	prefs.FlightTimeLatest = "20:00"
+
+	result := &models.FlightSearchResult{
+		Success: true,
+		Count:   3,
+		Flights: []models.FlightResult{
+			makeFlight(300, "06:00"), // before window — filtered
+			makeFlight(300, "10:00"), // within window — kept
+			makeFlight(300, "22:00"), // after window — filtered
+		},
+	}
+
+	applyFlightProfileFilters(result, prefs, false)
+
+	if result.Count != 1 {
+		t.Fatalf("expected Count 1 after time-window filter, got %d", result.Count)
+	}
+}
+
+// TestApplyFlightProfileFiltersNilSafe verifies the helper is a no-op on a nil
+// or unsuccessful result, so callers can invoke it unconditionally.
+func TestApplyFlightProfileFiltersNilSafe(t *testing.T) {
+	applyFlightProfileFilters(nil, preferences.Default(), false)
+
+	failed := &models.FlightSearchResult{Success: false, Flights: []models.FlightResult{makeFlight(900, "12:00")}}
+	prefs := preferences.Default()
+	prefs.BudgetFlightMax = 500
+	applyFlightProfileFilters(failed, prefs, false)
+	if len(failed.Flights) != 1 {
+		t.Errorf("expected unsuccessful result untouched, got %d flights", len(failed.Flights))
+	}
+}
+
+// TestFlightsMaxPriceFlagRegistered guards the --max-price flag wiring that
+// gives explicit-flag precedence over the saved profile budget.
+func TestFlightsMaxPriceFlagRegistered(t *testing.T) {
+	if flightsCmd().Flags().Lookup("max-price") == nil {
+		t.Error("--max-price flag not registered on flights command")
+	}
+}


### PR DESCRIPTION
## What

CLI flight search now applies the traveller's saved budget cap and preferred departure/arrival time window after a search, matching what the MCP surface already does.

Before this change, `trvl flights ...` loaded the profile only for the baggage all-in display column. It silently ignored the stored `budget_flight_max` and the `flight_time_earliest` / `flight_time_latest` window, so the CLI returned over-budget and out-of-window flights that the MCP path would have filtered out. This brings the two surfaces to parity so the profile is actually used.

## How

After the provider search populates results, the CLI now applies the same post-search filters as `mcp/tools_flights.go`:

- `flights.FilterFlightsByBudget(result.Flights, prefs.BudgetFlightMax)`
- `flights.FilterFlightsByTimePreference(result.Flights, prefs.FlightTimeEarliest, prefs.FlightTimeLatest)`
- `flights.AdjustBagAllowance(result.Flights, prefs.FrequentFlyerPrograms)`
- `result.Count = len(result.Flights)` to keep the count consistent with the filtered slice

The logic lives in a small helper, `applyFlightProfileFilters`, which reuses the preferences value already loaded earlier in the command (no double-load) and is a no-op on a nil or unsuccessful result.

## Explicit flags take precedence over saved preferences

A new `--max-price` flag is added (parity with the MCP `max_price` parameter). When the user passes it on the command line, the value is applied as the server-side cap and the saved-profile budget fallback is skipped, so a stored preference never overrides what the user typed. The preferred time window has no corresponding CLI flag, so it always applies from the profile.

## Tests

Added `cmd/trvl/flights_profile_test.go` (deterministic, offline, no live calls):

- `TestApplyFlightProfileFiltersBudget` — over-budget flights are dropped, at/under-budget kept, `Count` updated
- `TestApplyFlightProfileFiltersExplicitFlagWins` — an explicit `--max-price` flag skips the profile budget filter
- `TestApplyFlightProfileFiltersTimeWindow` — flights outside the preferred window are dropped
- `TestApplyFlightProfileFiltersNilSafe` — no-op on nil / unsuccessful result
- `TestFlightsMaxPriceFlagRegistered` — `--max-price` flag wiring guard

## Validation (GOTOOLCHAIN=go1.26.4)

- `gofmt -l .` — empty
- `go vet ./...` — 0
- `go build ./...` — 0
- `staticcheck ./...` — 0 findings
- `go test ./cmd/... ./internal/flights/...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
