### PR TITLE
Make travelgraph nudges profile-aware (consume g.prefs)

### DIFF
--- a/internal/travelgraph/travelgraph.go
+++ b/internal/travelgraph/travelgraph.go
@@ -12,6 +12,7 @@ package travelgraph
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/MikkoParkkola/trvl/internal/fareintel"
@@ -64,8 +65,9 @@ type routeHistory struct {
 type Graph struct {
 	// byRoute maps "ORIGIN-DESTINATION" to the aggregated history and watches.
 	byRoute map[string]*routeHistory
-	// prefs holds user preferences for contextual filtering (currently stored for
-	// future extension; not used in nudge logic itself).
+	// prefs holds user preferences. They gate and rank emitted nudges:
+	// ExcludedDestinations hard-drops unwanted routes, and home airports +
+	// AirportAffinity reorder the surviving nudges by relevance (see Nudges).
 	prefs *preferences.Preferences
 	// trips holds planned / booked trips indexed by ID.
 	trips map[string]trips.Trip
@@ -189,30 +191,146 @@ func (g *Graph) routeFor(key string) *routeHistory {
 //     and confidence is "high" fires KindHistoricLow. Source: route key.
 //     This check is skipped if the route already fired a KindBelowThreshold to
 //     avoid duplicate nudges for the same route.
+//
+// Profile awareness (uses g.prefs):
+//
+//   - Routes whose destination is in ExcludedDestinations are gated out: the
+//     user never wants those destinations, so a "buy" signal for them is noise.
+//   - Surviving nudges are ordered by profile relevance — routes departing from
+//     a home (or nearby) airport rank first, then by destination AirportAffinity,
+//     so the most personally relevant nudges surface at the top of the list.
+//
+// With nil/empty preferences the gate is a no-op and ordering is stable by
+// route key, so the no-profile baseline is unchanged.
 func Nudges(g *Graph) []Nudge {
-	var out []Nudge
+	var scored []scoredNudge
 	// Track which routes already produced a KindBelowThreshold nudge so the
 	// historic-low check doesn't double-fire on the same route.
 	belowRoutes := make(map[string]bool)
 
 	for key, rh := range g.byRoute {
-		belowNudges := belowThresholdNudges(rh)
-		if len(belowNudges) > 0 {
-			out = append(out, belowNudges...)
-			belowRoutes[key] = true
+		if g.isExcludedRoute(key) {
+			continue
 		}
+		belowNudges := belowThresholdNudges(rh)
+		if len(belowNudges) == 0 {
+			continue
+		}
+		for _, n := range belowNudges {
+			scored = append(scored, scoredNudge{nudge: n, key: key, rank: g.routeRank(key)})
+		}
+		belowRoutes[key] = true
 	}
 
 	for key, rh := range g.byRoute {
-		if belowRoutes[key] {
-			continue // already nudged via threshold crossing
+		if belowRoutes[key] || g.isExcludedRoute(key) {
+			continue // already nudged via threshold crossing, or gated out
 		}
 		if n, ok := historicLowNudge(key, rh); ok {
-			out = append(out, n)
+			scored = append(scored, scoredNudge{nudge: n, key: key, rank: g.routeRank(key)})
 		}
 	}
 
+	return orderByRelevance(scored)
+}
+
+// scoredNudge couples an emitted nudge with the route key it came from and the
+// profile-relevance rank used to order the final slice. Higher rank sorts first.
+type scoredNudge struct {
+	nudge Nudge
+	key   string
+	rank  int
+}
+
+// orderByRelevance returns the nudges sorted by descending profile rank, with
+// route key as a deterministic tiebreaker. When every rank is equal (the
+// no-profile case) the result is simply route-key ordered — stable and
+// reproducible, unlike the bare map iteration it replaces.
+func orderByRelevance(scored []scoredNudge) []Nudge {
+	sort.SliceStable(scored, func(i, j int) bool {
+		if scored[i].rank != scored[j].rank {
+			return scored[i].rank > scored[j].rank
+		}
+		return scored[i].key < scored[j].key
+	})
+	out := make([]Nudge, 0, len(scored))
+	for _, s := range scored {
+		out = append(out, s.nudge)
+	}
 	return out
+}
+
+// splitRouteKey splits a canonical "ORIGIN-DESTINATION" key back into its two
+// airport codes. Returns ("", "", false) for keys that don't contain exactly
+// one separator (defensive — all keys built by routeKey are well-formed).
+func splitRouteKey(key string) (origin, dest string, ok bool) {
+	o, d, found := strings.Cut(key, "-")
+	if !found || o == "" || d == "" {
+		return "", "", false
+	}
+	return o, d, true
+}
+
+// isExcludedRoute reports whether the route's destination is hard-excluded by
+// the user's ExcludedDestinations preference. Matching is case-insensitive on
+// the destination airport code. Returns false when prefs are nil/empty.
+func (g *Graph) isExcludedRoute(key string) bool {
+	if g.prefs == nil || len(g.prefs.ExcludedDestinations) == 0 {
+		return false
+	}
+	_, dest, ok := splitRouteKey(key)
+	if !ok {
+		return false
+	}
+	for _, ex := range g.prefs.ExcludedDestinations {
+		if strings.EqualFold(strings.TrimSpace(ex), dest) {
+			return true
+		}
+	}
+	return false
+}
+
+// homeRankBonus is added to a route's rank when it departs from one of the
+// user's home or nearby airports. It dominates the affinity component (which is
+// at most affinityRankScale) so any home-origin route always outranks a
+// non-home route, regardless of destination affinity.
+const homeRankBonus = 1000
+
+// affinityRankScale maps a destination's AirportAffinity score in [0,1] onto an
+// integer rank contribution in [0,100], keeping ranks comparable as ints.
+const affinityRankScale = 100
+
+// routeRank scores a route for ordering: a large bonus when its origin is a
+// home/nearby airport, plus a destination-affinity component. Higher is more
+// relevant. Returns 0 for nil prefs so the no-profile case orders by key alone.
+func (g *Graph) routeRank(key string) int {
+	if g.prefs == nil {
+		return 0
+	}
+	origin, dest, ok := splitRouteKey(key)
+	if !ok {
+		return 0
+	}
+
+	rank := 0
+	if g.isHomeOrigin(origin) {
+		rank += homeRankBonus
+	}
+	if aff, found := g.prefs.AirportAffinity[strings.ToUpper(dest)]; found {
+		rank += int(aff * affinityRankScale)
+	}
+	return rank
+}
+
+// isHomeOrigin reports whether origin is one of the user's home airports or a
+// configured nearby alternative. Matching is case-insensitive.
+func (g *Graph) isHomeOrigin(origin string) bool {
+	for _, home := range g.prefs.ExpandHomeOrigins() {
+		if strings.EqualFold(home, origin) {
+			return true
+		}
+	}
+	return false
 }
 
 // belowThresholdNudges emits one KindBelowThreshold nudge per watch that has

--- a/internal/travelgraph/travelgraph_profile_test.go
+++ b/internal/travelgraph/travelgraph_profile_test.go
@@ -1,0 +1,206 @@
+package travelgraph_test
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/travelgraph"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// Profile gap (profile-aware nudges): g.prefs now gates and ranks nudges.
+//
+// These tests exercise the below-threshold path because it fires
+// deterministically (no fareintel dependency), letting us assert the exact
+// gating and ordering the profile imposes.
+
+// belowWatch returns a watch already below its target, so it deterministically
+// fires a KindBelowThreshold nudge.
+func belowWatch(id, origin, dest string) watch.Watch {
+	return watch.Watch{
+		ID:          id,
+		Origin:      origin,
+		Destination: dest,
+		BelowPrice:  200.0,
+		LastPrice:   150.0,
+		Currency:    "EUR",
+	}
+}
+
+// firstSource returns the first source ID of the first nudge, or "".
+func firstSource(nudges []travelgraph.Nudge) string {
+	if len(nudges) == 0 || len(nudges[0].Sources) == 0 {
+		return ""
+	}
+	return nudges[0].Sources[0]
+}
+
+// sourcesInOrder flattens the first source of each nudge, preserving order.
+func sourcesInOrder(nudges []travelgraph.Nudge) []string {
+	out := make([]string, 0, len(nudges))
+	for _, n := range nudges {
+		if len(n.Sources) > 0 {
+			out = append(out, n.Sources[0])
+		}
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestProfile_ExcludedDestination_GatesNudge proves a route whose destination
+// is on ExcludedDestinations emits no nudge, while a sibling route still does.
+func TestProfile_ExcludedDestination_GatesNudge(t *testing.T) {
+	cases := []struct {
+		name     string
+		excluded []string
+		wantIDs  []string // expected source IDs, in order
+	}{
+		{
+			name:     "no exclusions: both fire (key order AMS-BCN < AMS-WAW)",
+			excluded: nil,
+			wantIDs:  []string{"w-bcn", "w-waw"},
+		},
+		{
+			name:     "exclude WAW: only BCN fires",
+			excluded: []string{"WAW"},
+			wantIDs:  []string{"w-bcn"},
+		},
+		{
+			name:     "exclude is case-insensitive",
+			excluded: []string{"waw"},
+			wantIDs:  []string{"w-bcn"},
+		},
+		{
+			name:     "exclude both: zero nudges",
+			excluded: []string{"WAW", "BCN"},
+			wantIDs:  []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prefs := preferences.Default()
+			prefs.ExcludedDestinations = tc.excluded
+			ws := []watch.Watch{
+				belowWatch("w-bcn", "AMS", "BCN"),
+				belowWatch("w-waw", "AMS", "WAW"),
+			}
+
+			g := travelgraph.Build(ws, nil, prefs, nil)
+			got := sourcesInOrder(travelgraph.Nudges(g))
+
+			if !equalStrings(got, tc.wantIDs) {
+				t.Errorf("sources = %v, want %v", got, tc.wantIDs)
+			}
+		})
+	}
+}
+
+// TestProfile_HomeAirportRoutesRankFirst proves a home-origin route is ordered
+// ahead of a non-home route, reversing plain key order.
+func TestProfile_HomeAirportRoutesRankFirst(t *testing.T) {
+	// Plain key order would put the alphabetically-first origin first. With HEL
+	// as home, the HEL-origin nudge must jump to the front instead.
+	ws := []watch.Watch{
+		belowWatch("w-far", "ZZZ", "ROM"),  // non-home origin, alphabetically last
+		belowWatch("w-home", "HEL", "ROM"), // home origin
+	}
+
+	prefs := preferences.Default()
+	prefs.HomeAirports = []string{"HEL"}
+
+	g := travelgraph.Build(ws, nil, prefs, nil)
+	got := sourcesInOrder(travelgraph.Nudges(g))
+
+	want := []string{"w-home", "w-far"}
+	if !equalStrings(got, want) {
+		t.Errorf("home-origin route did not rank first: got %v, want %v", got, want)
+	}
+}
+
+// TestProfile_NearbyAirportCountsAsHome proves a configured nearby airport is
+// treated as a home origin for ranking.
+func TestProfile_NearbyAirportCountsAsHome(t *testing.T) {
+	ws := []watch.Watch{
+		belowWatch("w-far", "ZZZ", "ROM"),    // non-home
+		belowWatch("w-nearby", "ARN", "ROM"), // ARN configured as nearby of HEL
+	}
+
+	prefs := preferences.Default()
+	prefs.HomeAirports = []string{"HEL"}
+	prefs.NearbyAirports = map[string][]string{"HEL": {"ARN"}}
+
+	g := travelgraph.Build(ws, nil, prefs, nil)
+	if got := firstSource(travelgraph.Nudges(g)); got != "w-nearby" {
+		t.Errorf("nearby-airport route did not rank first: got %q, want w-nearby", got)
+	}
+}
+
+// TestProfile_AffinityBreaksTieAmongNonHomeRoutes proves destination affinity
+// reorders routes that share the same home status.
+func TestProfile_AffinityBreaksTieAmongNonHomeRoutes(t *testing.T) {
+	// Two non-home routes; key order is AMS-LOW < AMS-TOP. Affinity should lift
+	// the high-affinity destination above the low-affinity one.
+	ws := []watch.Watch{
+		belowWatch("w-low", "AMS", "LOW"),
+		belowWatch("w-top", "AMS", "TOP"),
+	}
+
+	prefs := preferences.Default()
+	prefs.AirportAffinity = map[string]float64{"TOP": 0.9, "LOW": 0.1}
+
+	g := travelgraph.Build(ws, nil, prefs, nil)
+	if got := firstSource(travelgraph.Nudges(g)); got != "w-top" {
+		t.Errorf("high-affinity route did not rank first: got %q, want w-top", got)
+	}
+}
+
+// TestProfile_HomeBonusDominatesAffinity proves a home-origin route outranks a
+// non-home route even when the non-home destination has higher affinity.
+func TestProfile_HomeBonusDominatesAffinity(t *testing.T) {
+	ws := []watch.Watch{
+		belowWatch("w-affinity", "ZZZ", "TOP"), // non-home, high affinity
+		belowWatch("w-home", "HEL", "MEH"),     // home, no affinity
+	}
+
+	prefs := preferences.Default()
+	prefs.HomeAirports = []string{"HEL"}
+	prefs.AirportAffinity = map[string]float64{"TOP": 1.0}
+
+	g := travelgraph.Build(ws, nil, prefs, nil)
+	if got := firstSource(travelgraph.Nudges(g)); got != "w-home" {
+		t.Errorf("home bonus did not dominate affinity: got %q, want w-home", got)
+	}
+}
+
+// TestProfile_NoProfile_StableKeyOrder proves the no-profile baseline still
+// surfaces every grounded nudge and is now deterministically ordered by route
+// key (the pre-fix bare map iteration was order-undefined). nil prefs must not
+// panic.
+func TestProfile_NoProfile_StableKeyOrder(t *testing.T) {
+	ws := []watch.Watch{
+		belowWatch("w-c", "AMS", "CCC"),
+		belowWatch("w-a", "AMS", "AAA"),
+		belowWatch("w-b", "AMS", "BBB"),
+	}
+
+	g := travelgraph.Build(ws, nil, nil, nil)
+	got := sourcesInOrder(travelgraph.Nudges(g))
+
+	// Route keys order: AMS-AAA < AMS-BBB < AMS-CCC.
+	want := []string{"w-a", "w-b", "w-c"}
+	if !equalStrings(got, want) {
+		t.Errorf("no-profile order not stable by key: got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## What

Make the travel graph's nudges read the traveller profile they already store.

## The gap

`internal/travelgraph` stores `Preferences` on the `Graph` but never reads them. The field carried the comment "stored for future extension; not used in nudge logic itself", and the nudge generators (`Nudges`, `belowThresholdNudges`, `historicLowNudge`) never referenced `g.prefs`. Because this graph backs the `travel_nudges` MCP tool, the stored profile had zero effect on what the user saw.

## The fix

`Nudges` now consumes `g.prefs` in two ways:

- **Exclusion gate** — a route whose destination is in `ExcludedDestinations` emits no nudge. A "buy" signal for a destination the user has hard-excluded is noise.
- **Relevance ordering** — surviving nudges are sorted so routes departing from a home or nearby airport (`ExpandHomeOrigins`) rank first, then by destination `AirportAffinity`. This also makes the output deterministic; the previous bare map iteration left ordering undefined.

With `nil`/empty preferences the gate is a no-op and ordering falls back to a stable route-key sort, so the no-profile baseline is unchanged (and now deterministic).

## Tests

Table-driven tests in `travelgraph_profile_test.go` prove the profile changes output:

- exclusion gating, including case-insensitive matching and full exclusion (zero nudges)
- home-airport routes ranking ahead of non-home routes
- a configured nearby airport counting as home
- destination affinity breaking ties among non-home routes
- the home bonus dominating affinity
- the no-profile baseline still surfacing every nudge, in stable key order

## Verification (all exit 0)

- `gofmt -l .` (empty)
- `go vet ./...`
- `go build ./...`
- `staticcheck ./...`
- `go test -race ./internal/travelgraph/... ./mcp/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
