### PR TITLE
Seed award search from saved loyalty profile

### DIFF
--- a/cmd/trvl/awards.go
+++ b/cmd/trvl/awards.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/MikkoParkkola/trvl/internal/awards"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
 	"github.com/spf13/cobra"
 )
 
@@ -26,6 +27,10 @@ func awardsCmd() *cobra.Command {
 Provide pre-fetched seat fixtures via --seat flags (from seats.aero or known
 availability), your point balances via --balance flags, and get ranked redemption
 paths with miles cost, cash equivalent, cents-per-point, and transfer route.
+
+When no --balance flag is given, the program set is seeded from your saved
+loyalty profile (loyalty_airlines + frequent_flyer_programs in
+~/.trvl/preferences.json). Any explicit --balance overrides the profile default.
 
 Supported programs: FB (Flying Blue), BA (Avios), AC (Aeroplan), VS (Virgin),
 AY (Finnair Plus), plus transfer currencies MR (Amex), UR (Chase), Bilt.
@@ -68,6 +73,15 @@ Examples:
 					return fmt.Errorf("invalid --balance %q: %w", b, err)
 				}
 				balances = append(balances, bal)
+			}
+
+			// Seed the program/balance set from the traveller's saved
+			// loyalty profile when no --balance flag was passed. An
+			// explicit --balance always wins over the profile default,
+			// mirroring the flights command's flag-precedence pattern.
+			if !cmd.Flags().Changed("balance") {
+				prefs, _ := preferences.Load() //nolint:errcheck // default prefs on error
+				balances = awards.SeedBalancesFromProfile(balances, awards.ProfileProgramsFrom(prefs.AwardLoyaltyInput()))
 			}
 
 			// Find sweet spots (nil = use default transfer ratios).
@@ -125,7 +139,7 @@ Examples:
 	cmd.Flags().StringArrayVar(&seatFlags, "seat", nil,
 		"Seat fixture: PROGRAM:MILES:CASH_FEES:CASH_EQUIV:DATE:CABIN (e.g. VS:50000:35.00:650.00:2026-08-15:business)")
 	cmd.Flags().StringArrayVar(&balanceFlags, "balance", nil,
-		"Point balance: PROGRAM:AMOUNT (e.g. MR:80000, VS:20000)")
+		"Point balance: PROGRAM:AMOUNT (e.g. MR:80000, VS:20000). Omit to seed from your saved loyalty profile.")
 	cmd.Flags().Float64Var(&minCPP, "min-cpp", 0.5, "Minimum cents-per-point to show")
 	cmd.Flags().StringVar(&cabin, "cabin", "", "Filter by cabin class (economy/premium_economy/business/first)")
 	cmd.Flags().StringVar(&currency, "currency", "EUR", "Display currency for cash amounts")

--- a/cmd/trvl/awards_loyalty_test.go
+++ b/cmd/trvl/awards_loyalty_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeAwardsPrefs writes a preferences.json into a temp HOME and points
+// the process at it. Not parallel-safe (mutates HOME); callers must not
+// run in parallel.
+func writeAwardsPrefs(t *testing.T, prefsJSON string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)        // unix
+	t.Setenv("USERPROFILE", home) // windows
+	dir := filepath.Join(home, ".trvl")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "preferences.json"), []byte(prefsJSON), 0o644); err != nil {
+		t.Fatalf("write prefs: %v", err)
+	}
+}
+
+func runAwards(t *testing.T, args ...string) string {
+	t.Helper()
+	cmd := awardsCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("awards execute: %v", err)
+	}
+	return buf.String()
+}
+
+// TestAwardsCmd_SeedsBalancesFromProfile proves that with no --balance
+// flag, the program set is seeded from the saved loyalty profile: a
+// 60k VS balance makes the 50k VS seat affordable.
+func TestAwardsCmd_SeedsBalancesFromProfile(t *testing.T) {
+	writeAwardsPrefs(t, `{"frequent_flyer_programs":[{"airline_code":"VS","miles_balance":60000}]}`)
+
+	out := runAwards(t, "AMS", "JFK",
+		"--seat", "VS:50000:55.00:600.00:2026-08-01:economy")
+
+	// The VS-native row must appear and be affordable ("yes").
+	if !strings.Contains(out, "VS") {
+		t.Fatalf("expected a VS row seeded from profile, got:\n%s", out)
+	}
+	if !strings.Contains(out, "yes") {
+		t.Fatalf("expected an affordable (yes) row from the 60k VS profile balance, got:\n%s", out)
+	}
+}
+
+// TestAwardsCmd_ExplicitBalanceOverridesProfile proves an explicit
+// --balance always wins: the profile would seed VS:60000 (affordable),
+// but an explicit VS:10000 leaves the 50k seat unaffordable.
+func TestAwardsCmd_ExplicitBalanceOverridesProfile(t *testing.T) {
+	writeAwardsPrefs(t, `{"frequent_flyer_programs":[{"airline_code":"VS","miles_balance":60000}]}`)
+
+	out := runAwards(t, "AMS", "JFK",
+		"--seat", "VS:50000:55.00:600.00:2026-08-01:economy",
+		"--balance", "VS:10000",
+		"--min-cpp", "0", // keep the short row visible
+	)
+
+	// With only 10k VS explicitly, the VS native row must be short ("no");
+	// the profile's 60k must not leak in.
+	if strings.Contains(out, "yes") {
+		t.Fatalf("explicit VS:10000 should leave the 50k seat unaffordable, but found an affordable row:\n%s", out)
+	}
+	if !strings.Contains(out, "no") {
+		t.Fatalf("expected an unaffordable (no) row under the explicit 10k balance, got:\n%s", out)
+	}
+}
+
+// TestAwardsCmd_EmptyProfileNoRegression proves that with no profile and
+// no --balance flag, behaviour is unchanged: every seat still surfaces a
+// short row for guidance (no balances => nothing affordable).
+func TestAwardsCmd_EmptyProfileNoRegression(t *testing.T) {
+	writeAwardsPrefs(t, `{}`)
+
+	out := runAwards(t, "AMS", "JFK",
+		"--seat", "VS:50000:55.00:600.00:2026-08-01:economy",
+		"--min-cpp", "0",
+	)
+
+	if strings.Contains(out, "yes") {
+		t.Fatalf("empty profile + no balances should yield no affordable rows, got:\n%s", out)
+	}
+	// A guidance row should still render (FindSweetSpots keeps short rows).
+	if !strings.Contains(out, "VS") {
+		t.Fatalf("expected a VS guidance row even with no balances, got:\n%s", out)
+	}
+}

--- a/internal/awards/awards.go
+++ b/internal/awards/awards.go
@@ -112,6 +112,100 @@ func DefaultTransferRatios() []TransferRatio {
 	}
 }
 
+// ProfileProgram is one loyalty program seeded from the traveller's
+// saved profile: the program/currency code plus an optional known
+// balance. A balance of 0 means the user redeems with this program but
+// the balance is not recorded; it still surfaces the program as a
+// source option (Affordable=false) so the user sees the redemption path.
+type ProfileProgram struct {
+	Program string // source program / currency IATA code (e.g. "AY", "KL")
+	Balance int    // known balance in whole points; 0 if not recorded
+}
+
+// LoyaltyInput is the plain, dependency-free projection of a traveller's
+// saved loyalty profile that ProfileProgramsFrom consumes. Surfaces
+// (CLI, MCP) translate their own preferences types into this so the
+// program-set construction lives in exactly one place.
+//
+// FrequentFlyer carries the per-program (carrier code, known balance)
+// pairs; Airlines carries bare loyalty-airline IATA codes the user
+// redeems with but for which no balance is recorded.
+type LoyaltyInput struct {
+	FrequentFlyer []ProfileProgram
+	Airlines      []string
+}
+
+// ProfileProgramsFrom flattens a traveller's saved loyalty profile into
+// the ordered ProfileProgram set used to seed an award search. It is the
+// single shared translation point for both surfaces: frequent-flyer
+// programs come first (they may carry a real balance), then any bare
+// loyalty airlines that were not already covered. Blank codes are
+// skipped and duplicates are dropped (first occurrence wins, preserving
+// any balance from the frequent-flyer entry).
+func ProfileProgramsFrom(in LoyaltyInput) []ProfileProgram {
+	out := make([]ProfileProgram, 0, len(in.FrequentFlyer)+len(in.Airlines))
+	seen := make(map[string]struct{}, cap(out))
+	add := func(code string, balance int) {
+		code = strings.ToUpper(strings.TrimSpace(code))
+		if code == "" {
+			return
+		}
+		if _, dup := seen[code]; dup {
+			return
+		}
+		seen[code] = struct{}{}
+		out = append(out, ProfileProgram{Program: code, Balance: balance})
+	}
+	for _, p := range in.FrequentFlyer {
+		add(p.Program, p.Balance)
+	}
+	for _, code := range in.Airlines {
+		add(code, 0)
+	}
+	return out
+}
+
+// SeedBalancesFromProfile builds the PointBalance set for an award
+// search from the traveller's saved loyalty profile when the user did
+// not pass any explicit balances. It is the single seeding entrypoint
+// shared by the CLI and MCP surfaces so both behave identically.
+//
+// explicit takes strict precedence: when the user supplied one or more
+// balances, it is returned unchanged and the profile is ignored, so an
+// explicit value always wins over the profile default.
+//
+// When explicit is empty, balances are seeded from profile. Duplicate
+// program codes are merged (highest known balance wins) and blank codes
+// are skipped, so a malformed profile cannot inject empty programs. An
+// empty profile yields no change (explicit is returned as-is).
+func SeedBalancesFromProfile(explicit []PointBalance, profile []ProfileProgram) []PointBalance {
+	if len(explicit) > 0 {
+		return explicit
+	}
+	merged := make(map[string]int, len(profile))
+	order := make([]string, 0, len(profile))
+	for _, p := range profile {
+		code := strings.ToUpper(strings.TrimSpace(p.Program))
+		if code == "" {
+			continue
+		}
+		if _, seen := merged[code]; !seen {
+			order = append(order, code)
+		}
+		if p.Balance > merged[code] {
+			merged[code] = p.Balance
+		}
+	}
+	if len(order) == 0 {
+		return explicit
+	}
+	out := make([]PointBalance, 0, len(order))
+	for _, code := range order {
+		out = append(out, PointBalance{Program: code, Balance: merged[code]})
+	}
+	return out
+}
+
 // FindSweetSpots scans every AwardSeat against the user's available
 // balances and the transfer table. For each seat, it constructs every
 // (source-program, target-program=seat.Program) path the table allows

--- a/internal/awards/awards_test.go
+++ b/internal/awards/awards_test.go
@@ -241,3 +241,133 @@ func TestDefaultTransferRatios_HasMajorChains(t *testing.T) {
 		}
 	}
 }
+
+func TestSeedBalancesFromProfile(t *testing.T) {
+	cases := []struct {
+		name     string
+		explicit []PointBalance
+		profile  []ProfileProgram
+		want     []PointBalance
+	}{
+		{
+			name:     "profile seeds programs when none specified",
+			explicit: nil,
+			profile:  []ProfileProgram{{Program: "AY", Balance: 40000}, {Program: "KL", Balance: 0}},
+			want:     []PointBalance{{Program: "AY", Balance: 40000}, {Program: "KL", Balance: 0}},
+		},
+		{
+			name:     "explicit value overrides profile",
+			explicit: []PointBalance{{Program: "MR", Balance: 80000}},
+			profile:  []ProfileProgram{{Program: "AY", Balance: 40000}},
+			want:     []PointBalance{{Program: "MR", Balance: 80000}},
+		},
+		{
+			name:     "empty profile is no change",
+			explicit: nil,
+			profile:  nil,
+			want:     nil,
+		},
+		{
+			name:     "blank program codes skipped",
+			explicit: nil,
+			profile:  []ProfileProgram{{Program: "  ", Balance: 10}, {Program: "ay", Balance: 5}},
+			want:     []PointBalance{{Program: "AY", Balance: 5}},
+		},
+		{
+			name:     "duplicate codes merge keeping highest balance",
+			explicit: nil,
+			profile:  []ProfileProgram{{Program: "VS", Balance: 20000}, {Program: "vs", Balance: 50000}},
+			want:     []PointBalance{{Program: "VS", Balance: 50000}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SeedBalancesFromProfile(tc.explicit, tc.profile)
+			if !equalBalances(got, tc.want) {
+				t.Errorf("SeedBalancesFromProfile() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProfileProgramsFrom(t *testing.T) {
+	cases := []struct {
+		name string
+		in   LoyaltyInput
+		want []ProfileProgram
+	}{
+		{
+			name: "frequent-flyer first then bare airlines",
+			in: LoyaltyInput{
+				FrequentFlyer: []ProfileProgram{{Program: "AY", Balance: 40000}},
+				Airlines:      []string{"KL"},
+			},
+			want: []ProfileProgram{{Program: "AY", Balance: 40000}, {Program: "KL", Balance: 0}},
+		},
+		{
+			name: "airline already covered by frequent-flyer is not duplicated",
+			in: LoyaltyInput{
+				FrequentFlyer: []ProfileProgram{{Program: "AY", Balance: 40000}},
+				Airlines:      []string{"ay", "KL"},
+			},
+			want: []ProfileProgram{{Program: "AY", Balance: 40000}, {Program: "KL", Balance: 0}},
+		},
+		{
+			name: "blank codes skipped",
+			in: LoyaltyInput{
+				FrequentFlyer: []ProfileProgram{{Program: "", Balance: 99}},
+				Airlines:      []string{"  ", "vs"},
+			},
+			want: []ProfileProgram{{Program: "VS", Balance: 0}},
+		},
+		{
+			name: "empty input yields empty set",
+			in:   LoyaltyInput{},
+			want: []ProfileProgram{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ProfileProgramsFrom(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("ProfileProgramsFrom() len = %d, want %d (%+v)", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("ProfileProgramsFrom()[%d] = %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSeedBalancesFromProfile_EndToEnd proves a profile-only search
+// produces the same sweet spots as passing the equivalent balances
+// explicitly — the core promise of the gap fix.
+func TestSeedBalancesFromProfile_EndToEnd(t *testing.T) {
+	profile := ProfileProgramsFrom(LoyaltyInput{
+		FrequentFlyer: []ProfileProgram{{Program: "VS", Balance: 60000}},
+	})
+	seeded := SeedBalancesFromProfile(nil, profile)
+	fromProfile := FindSweetSpots([]AwardSeat{sampleSeat()}, seeded, nil)
+	fromExplicit := FindSweetSpots([]AwardSeat{sampleSeat()},
+		[]PointBalance{{Program: "VS", Balance: 60000}}, nil)
+	if len(fromProfile) != len(fromExplicit) || len(fromProfile) == 0 {
+		t.Fatalf("profile-seeded result count %d != explicit %d", len(fromProfile), len(fromExplicit))
+	}
+	if !fromProfile[0].Affordable || fromProfile[0].SourceProgram != "VS" {
+		t.Errorf("profile-seeded top spot = %+v, want affordable native VS", fromProfile[0])
+	}
+}
+
+func equalBalances(a, b []PointBalance) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/preferences/award_loyalty_test.go
+++ b/internal/preferences/award_loyalty_test.go
@@ -1,0 +1,101 @@
+package preferences
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/awards"
+)
+
+// TestAwardLoyaltyInput proves the saved loyalty profile is projected
+// into the dependency-free shape the awards package seeds from:
+// frequent-flyer programs carry their carrier code + balance, loyalty
+// airlines carry bare codes, and a nil receiver is safe.
+func TestAwardLoyaltyInput(t *testing.T) {
+	cases := []struct {
+		name      string
+		prefs     *Preferences
+		wantFF    []awards.ProfileProgram
+		wantAirls []string
+	}{
+		{
+			name: "frequent-flyer programs map to code+balance",
+			prefs: &Preferences{
+				FrequentFlyerPrograms: []FrequentFlyerStatus{
+					{Alliance: "skyteam", Tier: "elite", AirlineCode: "AY", MilesBalance: 40000},
+				},
+				LoyaltyAirlines: []string{"KL"},
+			},
+			wantFF:    []awards.ProfileProgram{{Program: "AY", Balance: 40000}},
+			wantAirls: []string{"KL"},
+		},
+		{
+			name: "frequent-flyer entry without airline code is skipped",
+			prefs: &Preferences{
+				FrequentFlyerPrograms: []FrequentFlyerStatus{
+					{Alliance: "oneworld", Tier: "sapphire", MilesBalance: 5000}, // no AirlineCode
+					{Alliance: "skyteam", Tier: "elite", AirlineCode: "VS", MilesBalance: 10000},
+				},
+			},
+			wantFF:    []awards.ProfileProgram{{Program: "VS", Balance: 10000}},
+			wantAirls: nil,
+		},
+		{
+			name:      "nil receiver returns zero value",
+			prefs:     nil,
+			wantFF:    nil,
+			wantAirls: nil,
+		},
+		{
+			name:      "empty profile yields empty input",
+			prefs:     &Preferences{},
+			wantFF:    nil,
+			wantAirls: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.prefs.AwardLoyaltyInput()
+			if len(got.FrequentFlyer) != len(tc.wantFF) {
+				t.Fatalf("FrequentFlyer len = %d, want %d (%+v)", len(got.FrequentFlyer), len(tc.wantFF), got.FrequentFlyer)
+			}
+			for i := range got.FrequentFlyer {
+				if got.FrequentFlyer[i] != tc.wantFF[i] {
+					t.Errorf("FrequentFlyer[%d] = %+v, want %+v", i, got.FrequentFlyer[i], tc.wantFF[i])
+				}
+			}
+			if len(got.Airlines) != len(tc.wantAirls) {
+				t.Fatalf("Airlines = %v, want %v", got.Airlines, tc.wantAirls)
+			}
+			for i := range got.Airlines {
+				if got.Airlines[i] != tc.wantAirls[i] {
+					t.Errorf("Airlines[%d] = %q, want %q", i, got.Airlines[i], tc.wantAirls[i])
+				}
+			}
+		})
+	}
+}
+
+// TestAwardLoyaltyInput_SeedsEndToEnd proves the profile flows through
+// the awards seeding helpers into a usable balance set without the user
+// specifying anything.
+func TestAwardLoyaltyInput_SeedsEndToEnd(t *testing.T) {
+	prefs := &Preferences{
+		FrequentFlyerPrograms: []FrequentFlyerStatus{
+			{AirlineCode: "AY", MilesBalance: 40000},
+		},
+		LoyaltyAirlines: []string{"KL"},
+	}
+	seeded := awards.SeedBalancesFromProfile(nil, awards.ProfileProgramsFrom(prefs.AwardLoyaltyInput()))
+	want := []awards.PointBalance{
+		{Program: "AY", Balance: 40000},
+		{Program: "KL", Balance: 0},
+	}
+	if len(seeded) != len(want) {
+		t.Fatalf("seeded = %+v, want %+v", seeded, want)
+	}
+	for i := range seeded {
+		if seeded[i] != want[i] {
+			t.Errorf("seeded[%d] = %+v, want %+v", i, seeded[i], want[i])
+		}
+	}
+}

--- a/internal/preferences/preferences.go
+++ b/internal/preferences/preferences.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/MikkoParkkola/trvl/internal/awards"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -143,6 +144,37 @@ type FrequentFlyerStatus struct {
 	AirlineCode  string `json:"airline_code,omitempty"`  // optional specific IATA carrier code
 	MilesBalance int    `json:"miles_balance,omitempty"` // current miles/points balance
 	ProgramName  string `json:"program_name,omitempty"`  // e.g. "Flying Blue", "Royal Plus"
+}
+
+// AwardLoyaltyInput projects the saved loyalty profile into the
+// dependency-free shape the awards package consumes to seed an award
+// search. It is the single translation point shared by the CLI and MCP
+// surfaces so both seed identical program sets.
+//
+// FrequentFlyerPrograms map to (carrier code, miles balance) pairs using
+// AirlineCode — the program's redemption currency. Entries without an
+// AirlineCode are skipped because there is no program code to redeem
+// from. LoyaltyAirlines map to bare codes with no recorded balance.
+// Returns the zero value on a nil receiver so callers can invoke it
+// unconditionally.
+func (p *Preferences) AwardLoyaltyInput() awards.LoyaltyInput {
+	if p == nil {
+		return awards.LoyaltyInput{}
+	}
+	ff := make([]awards.ProfileProgram, 0, len(p.FrequentFlyerPrograms))
+	for _, prog := range p.FrequentFlyerPrograms {
+		if strings.TrimSpace(prog.AirlineCode) == "" {
+			continue
+		}
+		ff = append(ff, awards.ProfileProgram{
+			Program: prog.AirlineCode,
+			Balance: prog.MilesBalance,
+		})
+	}
+	return awards.LoyaltyInput{
+		FrequentFlyer: ff,
+		Airlines:      p.LoyaltyAirlines,
+	}
 }
 
 // PaymentCard captures the per-card metadata internal/cards needs to

--- a/mcp/tools_awards.go
+++ b/mcp/tools_awards.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/MikkoParkkola/trvl/internal/awards"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
 )
 
 // searchAwardsTool returns the MCP tool definition for cross-program award scanning.
@@ -25,7 +26,7 @@ func searchAwardsTool() ToolDef {
 				"balances": {
 					Type:        "array",
 					Items:       &Property{Type: "object"},
-					Description: "User's loyalty point balances. Each entry: program (e.g. VS, AY, MR, UR, Bilt), balance (int).",
+					Description: "User's loyalty point balances. Each entry: program (e.g. VS, AY, MR, UR, Bilt), balance (int). Omit to seed the program set from the traveller's saved loyalty profile (loyalty_airlines + frequent_flyer_programs); any explicit entry overrides the profile default.",
 				},
 				"transfer_ratios": {
 					Type:        "array",
@@ -49,7 +50,7 @@ func searchAwardsTool() ToolDef {
 					Description: "Filter to specific destination IATA.",
 				},
 			},
-			Required: []string{"seats", "balances"},
+			Required: []string{"seats"},
 		},
 		OutputSchema: awardsOutputSchema(),
 		Annotations: &ToolAnnotations{
@@ -127,6 +128,14 @@ func handleSearchAwards(_ context.Context, args map[string]any, _ ElicitFunc, _ 
 			Program: stringField(m, "program"),
 			Balance: intField(m, "balance"),
 		})
+	}
+
+	// Seed the program/balance set from the traveller's saved loyalty
+	// profile when the caller passed no balances. Explicit balances
+	// always win over the profile default — mirrors the CLI surface.
+	if len(balances) == 0 {
+		prefs, _ := preferences.Load() //nolint:errcheck // default prefs on error
+		balances = awards.SeedBalancesFromProfile(balances, awards.ProfileProgramsFrom(prefs.AwardLoyaltyInput()))
 	}
 
 	// Parse optional transfer_ratios.

--- a/mcp/tools_awards_test.go
+++ b/mcp/tools_awards_test.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -145,5 +147,121 @@ func TestHandleSearchAwards_TransferRoute(t *testing.T) {
 	// MR -> VS transfer route should appear in summary.
 	if !strings.Contains(content[0].Text, "MR") {
 		t.Fatalf("expected MR transfer route in summary, got: %q", content[0].Text)
+	}
+}
+
+// TestHandleSearchAwards_SeedsFromProfile proves that when the caller
+// passes no balances, the program set is seeded from the traveller's
+// saved loyalty profile. It points HOME at a temp dir holding a known
+// preferences.json so the assertion is deterministic and filesystem-
+// independent. Not parallel: it mutates process-wide HOME.
+func TestHandleSearchAwards_SeedsFromProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)        // unix
+	t.Setenv("USERPROFILE", home) // windows
+	trvlDir := filepath.Join(home, ".trvl")
+	if err := os.MkdirAll(trvlDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	prefsJSON := `{"frequent_flyer_programs":[{"alliance":"skyteam","tier":"elite","airline_code":"VS","miles_balance":60000}]}`
+	if err := os.WriteFile(filepath.Join(trvlDir, "preferences.json"), []byte(prefsJSON), 0o644); err != nil {
+		t.Fatalf("write prefs: %v", err)
+	}
+
+	args := map[string]any{
+		"seats": []interface{}{
+			map[string]interface{}{
+				"program": "VS", "origin": "AMS", "destination": "JFK",
+				"date": "2026-08-01", "cabin": "economy",
+				"miles_cost": 50000, "cash_fees": 55.0, "cash_equivalent": 600.0,
+				"bookable_segments": 1,
+			},
+		},
+		// No "balances" — must come from the profile.
+	}
+	_, structured, err := handleSearchAwards(context.Background(), args, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b, _ := json.Marshal(structured)
+	var resp struct {
+		Count      int `json:"count"`
+		SweetSpots []struct {
+			SourceProgram string `json:"source_program"`
+			Affordable    bool   `json:"affordable"`
+		} `json:"sweet_spots"`
+	}
+	if err := json.Unmarshal(b, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Count == 0 {
+		t.Fatal("expected profile-seeded VS balance to produce a sweet spot")
+	}
+	gotAffordableVS := false
+	for _, sp := range resp.SweetSpots {
+		if sp.SourceProgram == "VS" && sp.Affordable {
+			gotAffordableVS = true
+		}
+	}
+	if !gotAffordableVS {
+		t.Errorf("want an affordable VS spot seeded from the profile, got %+v", resp.SweetSpots)
+	}
+}
+
+// TestHandleSearchAwards_ExplicitBalanceOverridesProfile proves an
+// explicit balance wins even when the on-disk profile would seed a
+// different program. Not parallel: mutates HOME.
+func TestHandleSearchAwards_ExplicitBalanceOverridesProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	trvlDir := filepath.Join(home, ".trvl")
+	if err := os.MkdirAll(trvlDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Profile would seed AY only; the explicit VS balance must win.
+	prefsJSON := `{"frequent_flyer_programs":[{"airline_code":"AY","miles_balance":1000}]}`
+	if err := os.WriteFile(filepath.Join(trvlDir, "preferences.json"), []byte(prefsJSON), 0o644); err != nil {
+		t.Fatalf("write prefs: %v", err)
+	}
+
+	args := map[string]any{
+		"seats": []interface{}{
+			map[string]interface{}{
+				"program": "VS", "origin": "AMS", "destination": "JFK",
+				"date": "2026-08-01", "cabin": "economy",
+				"miles_cost": 50000, "cash_fees": 55.0, "cash_equivalent": 600.0,
+				"bookable_segments": 1,
+			},
+		},
+		"balances": []interface{}{
+			map[string]interface{}{"program": "VS", "balance": 60000},
+		},
+	}
+	_, structured, err := handleSearchAwards(context.Background(), args, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b, _ := json.Marshal(structured)
+	var resp struct {
+		SweetSpots []struct {
+			SourceProgram string `json:"source_program"`
+			Affordable    bool   `json:"affordable"`
+		} `json:"sweet_spots"`
+	}
+	if err := json.Unmarshal(b, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	gotAffordableVS := false
+	for _, sp := range resp.SweetSpots {
+		if sp.SourceProgram == "VS" && sp.Affordable {
+			gotAffordableVS = true
+		}
+		if sp.SourceProgram == "AY" {
+			t.Errorf("profile AY leaked despite explicit VS balance: %+v", sp)
+		}
+	}
+	if !gotAffordableVS {
+		t.Errorf("explicit VS balance should produce an affordable VS spot, got %+v", resp.SweetSpots)
 	}
 }


### PR DESCRIPTION
## Problem

Award-flight search ignored the traveller's saved loyalty profile on both surfaces: the CLI `awards` command and the MCP `search_awards` tool loaded no preferences, so users had to re-enter their programs and balances on every call. Other commands (for example flights) already read the profile, so the two award surfaces were out of step.

## Change

When the user does not pass explicit balances, the program/balance set is now seeded from the saved profile (LoyaltyAirlines + FrequentFlyerPrograms). An explicit value always wins over the profile default:

- CLI: gated on `cmd.Flags().Changed("balance")`, matching the precedence pattern the flights command uses.
- MCP: gated on whether the `balances` arg was provided; `balances` is now optional in the input schema so the profile can fill it.

The seeding logic lives in one shared place to keep both surfaces aligned:

- `awards.ProfileProgramsFrom` + `awards.SeedBalancesFromProfile` keep the awards package dependency-free (stdlib only) and own program-set construction.
- `preferences.AwardLoyaltyInput` projects the saved profile into the shape both surfaces translate from.

## Behaviour

| Input | Result |
|---|---|
| No explicit balances | Programs + balances seeded from the saved profile |
| Explicit balance flag/arg | Used as-is; profile is ignored |
| Empty profile, no explicit balances | Unchanged from before (guidance rows only) |

## Tests

Table-driven tests cover the seeding helpers, the profile projection, and both surfaces end-to-end: profile seeds programs when none specified; explicit value overrides profile; empty profile is a no-op (no regression); blank and duplicate program codes are handled.

## Verification

`gofmt -l .` (empty), `go vet ./...`, `go build ./...`, `staticcheck ./...`, and `go test -race` on the touched packages (internal/awards, internal/preferences, cmd/trvl, mcp) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
