### PR TITLE
feat(mcp): add airline filter and afklm provider to search_flights

### DIFF
--- a/internal/flights/filter.go
+++ b/internal/flights/filter.go
@@ -56,6 +56,42 @@ func FilterFlightsByBudget(flights []models.FlightResult, maxPrice float64) []mo
 	return out
 }
 
+// FilterByAirline keeps only flights operated (on at least one leg) by one of
+// the requested airline IATA codes. Matching is case-insensitive and trims
+// surrounding whitespace on both the requested codes and the leg codes.
+//
+// An empty (or all-blank) airlines list is a no-op: the input slice is returned
+// unchanged. A flight with no legs, or whose legs carry no matching airline
+// code, is dropped when a filter is active, since it cannot satisfy the
+// restriction.
+//
+// This mirrors the CLI `--airline` semantics (restrict to these carriers) as a
+// deterministic post-search narrowing over whatever the provider returned. The
+// function never mutates the input slice and always returns a valid (possibly
+// empty) slice.
+func FilterByAirline(flights []models.FlightResult, airlines []string) []models.FlightResult {
+	wanted := make(map[string]struct{}, len(airlines))
+	for _, a := range airlines {
+		if code := strings.ToUpper(strings.TrimSpace(a)); code != "" {
+			wanted[code] = struct{}{}
+		}
+	}
+	if len(wanted) == 0 {
+		return flights
+	}
+	out := make([]models.FlightResult, 0, len(flights))
+	for _, f := range flights {
+		for _, leg := range f.Legs {
+			code := strings.ToUpper(strings.TrimSpace(leg.AirlineCode))
+			if _, ok := wanted[code]; ok {
+				out = append(out, f)
+				break
+			}
+		}
+	}
+	return out
+}
+
 // FirstPricedResult returns the first flight with Price > 0 from a pre-sorted slice.
 // Returns nil if no priced flight exists.
 func FirstPricedResult(flights []models.FlightResult) []models.FlightResult {

--- a/internal/flights/filter_airline_test.go
+++ b/internal/flights/filter_airline_test.go
@@ -1,0 +1,100 @@
+package flights
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func TestFilterByAirline(t *testing.T) {
+	ay := models.FlightResult{Price: 100, Legs: []models.FlightLeg{{AirlineCode: "AY"}}}
+	af := models.FlightResult{Price: 200, Legs: []models.FlightLeg{{AirlineCode: "AF"}}}
+	// Multi-leg flight where only a connecting leg matches the requested code.
+	klmConnect := models.FlightResult{Price: 300, Legs: []models.FlightLeg{
+		{AirlineCode: "AY"}, {AirlineCode: "KL"},
+	}}
+	noLegs := models.FlightResult{Price: 400}
+
+	tests := []struct {
+		name     string
+		flights  []models.FlightResult
+		airlines []string
+		want     []float64 // expected prices, in order
+	}{
+		{
+			name:     "empty filter is a no-op",
+			flights:  []models.FlightResult{ay, af},
+			airlines: nil,
+			want:     []float64{100, 200},
+		},
+		{
+			name:     "all-blank filter is a no-op",
+			flights:  []models.FlightResult{ay, af},
+			airlines: []string{"", "  "},
+			want:     []float64{100, 200},
+		},
+		{
+			name:     "single code narrows to matching carrier",
+			flights:  []models.FlightResult{ay, af},
+			airlines: []string{"AF"},
+			want:     []float64{200},
+		},
+		{
+			name:     "match is case-insensitive and whitespace-trimmed",
+			flights:  []models.FlightResult{ay, af},
+			airlines: []string{" af "},
+			want:     []float64{200},
+		},
+		{
+			name:     "multiple codes keep any match",
+			flights:  []models.FlightResult{ay, af, klmConnect},
+			airlines: []string{"AF", "KL"},
+			want:     []float64{200, 300},
+		},
+		{
+			name:     "connecting leg satisfies the restriction",
+			flights:  []models.FlightResult{af, klmConnect},
+			airlines: []string{"KL"},
+			want:     []float64{300},
+		},
+		{
+			name:     "no match yields empty slice",
+			flights:  []models.FlightResult{ay, af},
+			airlines: []string{"LH"},
+			want:     nil,
+		},
+		{
+			name:     "flight without legs is dropped when filter active",
+			flights:  []models.FlightResult{ay, noLegs},
+			airlines: []string{"AY"},
+			want:     []float64{100},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterByAirline(tt.flights, tt.airlines)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d flights, want %d (%v)", len(got), len(tt.want), tt.want)
+			}
+			for i, price := range tt.want {
+				if got[i].Price != price {
+					t.Errorf("flight[%d].Price = %.0f, want %.0f", i, got[i].Price, price)
+				}
+			}
+		})
+	}
+}
+
+// TestFilterByAirline_DoesNotMutateInput guarantees the helper is safe to call
+// on a shared result slice without corrupting the caller's data.
+func TestFilterByAirline_DoesNotMutateInput(t *testing.T) {
+	in := []models.FlightResult{
+		{Price: 100, Legs: []models.FlightLeg{{AirlineCode: "AY"}}},
+		{Price: 200, Legs: []models.FlightLeg{{AirlineCode: "AF"}}},
+	}
+	_ = FilterByAirline(in, []string{"AY"})
+	if len(in) != 2 || in[0].Price != 100 || in[1].Price != 200 {
+		t.Fatalf("input slice was mutated: %+v", in)
+	}
+}

--- a/mcp/tools_flights.go
+++ b/mcp/tools_flights.go
@@ -201,7 +201,8 @@ func searchFlightsTool() ToolDef {
 				"no_early_connection": {Type: "boolean", Description: "Drop flights whose post-overnight leg departs before preferences.early_connection_floor (default 10:00)."},
 				"lounge_required":     {Type: "boolean", Description: "Drop flights where a layover airport lacks lounge coverage from user's cards."},
 				"first_result":        {Type: "boolean", Description: "Return only the first result with a valid price after sorting. Combine with sort_by to get e.g. the shortest priced flight (duration) or cheapest. Default: false."},
-				"provider":            {Type: "string", Description: "Flight provider: empty (default) = Google Flights + Kiwi + Skiplagged merge, 'skiplagged' = Skiplagged MCP only (hidden-city + virtual-interlining defaults). Use the solo provider when you want to cross-validate hidden-city candidates."},
+				"airline":             {Type: "array", Items: &Property{Type: "string"}, Description: "Restrict results to these airline IATA codes (e.g. AY, AF, KL). Accepts a JSON array or a comma-separated string. Empty = no filter. Mirrors the CLI --airline flag: the codes are passed to the provider and the results are also narrowed post-search to flights with at least one matching leg."},
+				"provider":            {Type: "string", Description: "Flight provider: empty (default) = Google Flights + Kiwi + Skiplagged merge, 'skiplagged' = Skiplagged MCP only (hidden-city + virtual-interlining defaults), 'afklm' (aliases: af-klm, airfranceklm) = Air France-KLM Offers API only (opt-in, native round-trip fares; requires a credential). Use a solo provider when you want to cross-validate candidates."},
 			},
 			Required: []string{"destination", "departure_date"},
 		},
@@ -280,6 +281,7 @@ func handleSearchFlights(ctx context.Context, args map[string]any, elicit Elicit
 		MaxDuration:       argInt(args, "max_duration", 0),
 		ExcludeBasic:      argBool(args, "exclude_basic", false),
 		Alliances:         argStringSlice(args, "alliances"),
+		Airlines:          argStringSlice(args, "airline"),
 		DepartAfter:       argString(args, "depart_after"),
 		DepartBefore:      argString(args, "depart_before"),
 		LessEmissions:     argBool(args, "less_emissions", false),
@@ -354,6 +356,14 @@ func handleSearchFlights(ctx context.Context, args map[string]any, elicit Elicit
 	// plan_flight_bundle — lets agents stick with search_flights and still
 	// get the filter stack.
 	if result != nil && result.Success {
+		// Airline restriction (CLI --airline parity). opts.Airlines was already
+		// passed to the provider as a server-side hint; narrow deterministically
+		// here so the response only contains flights with a matching leg, even
+		// when a provider returns near-matches.
+		if len(opts.Airlines) > 0 {
+			result.Flights = flights.FilterByAirline(result.Flights, opts.Airlines)
+			result.Count = len(result.Flights)
+		}
 		if mins := argInt(args, "min_layover_minutes", 0); mins > 0 || len(argStringSlice(args, "layover_at")) > 0 {
 			result.Flights = flights.FilterByLongLayover(result.Flights, mins, argStringSlice(args, "layover_at"))
 			result.Count = len(result.Flights)
@@ -618,10 +628,11 @@ func buildBookingContext(date, origin string, originSource travelctx.Source) *bo
 // provider based on the optional `provider` argument. Empty (or one
 // of the legacy aliases) goes through the default Google Flights +
 // Kiwi merge in `flights.SearchFlights`. `provider="skiplagged"`
-// dispatches to the Skiplagged MCP-backed provider, which is opt-in
-// only and never participates in the default-on path. New providers
-// must explicitly register here so the dispatcher remains the single
-// switchboard.
+// dispatches to the Skiplagged MCP-backed provider and
+// `provider="afklm"` (aliases af-klm, airfranceklm) to the
+// Air France-KLM Offers API; both are opt-in only and never
+// participate in the default-on path. New providers must explicitly
+// register here so the dispatcher remains the single switchboard.
 func dispatchFlightSearch(ctx context.Context, args map[string]any, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
 	provider := strings.ToLower(strings.TrimSpace(argString(args, "provider")))
 	// origin/dest are validated, possibly comma-separated multi-airport lists.
@@ -638,13 +649,18 @@ func dispatchFlightSearch(ctx context.Context, args map[string]any, origin, dest
 			return nil, fmt.Errorf("provider skiplagged supports exactly one origin and one destination")
 		}
 		return flights.SearchSkiplagged(ctx, origins[0], dests[0], date, opts)
+	case "afklm", "af-klm", "airfranceklm":
+		if len(origins) != 1 || len(dests) != 1 {
+			return nil, fmt.Errorf("provider afklm supports exactly one origin and one destination")
+		}
+		return flights.SearchAFKLM(ctx, origins[0], dests[0], date, opts)
 	case "", "default", "google", "google_flights", "kiwi":
 		if multiAirportRoute(origins, dests) {
 			return flights.SearchMultiAirport(ctx, origins, dests, date, opts)
 		}
 		return flights.SearchFlights(ctx, origins[0], dests[0], date, opts)
 	default:
-		return nil, fmt.Errorf("unsupported provider %q (valid: skiplagged, or empty for default Google+Kiwi+Skiplagged merge)", provider)
+		return nil, fmt.Errorf("unsupported provider %q (valid: skiplagged, afklm, or empty for default Google+Kiwi+Skiplagged merge)", provider)
 	}
 }
 

--- a/mcp/tools_flights_airline_test.go
+++ b/mcp/tools_flights_airline_test.go
@@ -1,0 +1,113 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+)
+
+// TestSearchFlightsTool_AirlineArg verifies the search_flights schema advertises
+// the new `airline` filter argument (CLI --airline parity) as a string array.
+func TestSearchFlightsTool_AirlineArg(t *testing.T) {
+	tool := searchFlightsTool()
+	prop, ok := tool.InputSchema.Properties["airline"]
+	if !ok {
+		t.Fatal("search_flights schema is missing the `airline` argument")
+	}
+	if prop.Type != "array" {
+		t.Errorf("airline arg Type = %q, want \"array\"", prop.Type)
+	}
+	if prop.Items == nil || prop.Items.Type != "string" {
+		t.Errorf("airline arg Items = %+v, want string items", prop.Items)
+	}
+}
+
+// TestDispatchFlightSearch_Provider is a table-driven check of the provider
+// switchboard: afklm is dispatchable (CLI parity), the airline filter arg flows
+// without disturbing routing, and an unknown provider is still rejected. All
+// cases stay offline: the afklm route is exercised via its deterministic
+// multi-airport guard, which fires before any network call.
+func TestDispatchFlightSearch_Provider(t *testing.T) {
+	ctx := context.Background()
+	opts := flights.SearchOptions{}
+
+	tests := []struct {
+		name         string
+		args         map[string]any
+		origin, dest string
+		wantErrHas   string // substring the error must contain
+		wantRouted   bool   // true => must NOT be the "unsupported provider" error
+	}{
+		{
+			name:       "afklm is a recognized provider (multi-airport guard proves routing)",
+			args:       map[string]any{"provider": "afklm"},
+			origin:     "AMS,CDG",
+			dest:       "JFK",
+			wantErrHas: "provider afklm supports exactly one origin and one destination",
+			wantRouted: true,
+		},
+		{
+			name:       "afklm alias af-klm routes the same way",
+			args:       map[string]any{"provider": "af-klm"},
+			origin:     "AMS",
+			dest:       "JFK,EWR",
+			wantErrHas: "provider afklm supports exactly one origin and one destination",
+			wantRouted: true,
+		},
+		{
+			name:       "unknown provider is rejected",
+			args:       map[string]any{"provider": "nope"},
+			origin:     "AMS",
+			dest:       "JFK",
+			wantErrHas: "unsupported provider",
+			wantRouted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := dispatchFlightSearch(ctx, tt.args, tt.origin, tt.dest, "2026-06-15", opts)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrHas) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErrHas)
+			}
+			isUnsupported := strings.Contains(err.Error(), "unsupported provider")
+			if tt.wantRouted && isUnsupported {
+				t.Errorf("provider was not routed: %q", err.Error())
+			}
+		})
+	}
+}
+
+// TestHandleSearchFlights_AirlineArgParsed proves the airline arg is parsed into
+// SearchOptions.Airlines exactly as the CLI does, by exercising the same
+// argStringSlice helper the handler uses. Both comma-separated and JSON-array
+// forms are accepted.
+func TestHandleSearchFlights_AirlineArgParsed(t *testing.T) {
+	tests := []struct {
+		name string
+		v    any
+		want []string
+	}{
+		{"comma-separated string", "AY,AF", []string{"AY", "AF"}},
+		{"json array", []any{"AY", "KL"}, []string{"AY", "KL"}},
+		{"empty string yields no filter", "", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := argStringSlice(map[string]any{"airline": tt.v}, "airline")
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Brings two flight-search capabilities that already exist on the CLI to the MCP `search_flights` tool, closing a CLI/MCP parity gap.

### Gap

- The CLI `trvl flights` command has an `--airline` filter and a `--provider afklm` switch for the Air France-KLM native round-trip provider.
- The MCP `search_flights` tool had neither: no airline argument in its schema, and `afklm` was absent from the provider dispatcher (it returned "unsupported provider").

### Fix

- **Airline filter**: adds an `airline` argument to the `search_flights` schema (a JSON array or comma-separated string of IATA codes). The codes flow into `SearchOptions.Airlines` exactly as the CLI `--airline` flag does, and results are additionally narrowed post-search by a new `flights.FilterByAirline` helper so the response only contains flights with at least one matching leg.
- **afklm provider**: wires `afklm` (aliases `af-klm`, `airfranceklm`) into `dispatchFlightSearch`, so MCP can request the Air France-KLM Offers API the same way the CLI does, including the single-origin/destination guard and the opt-in credential behaviour.

Existing MCP flight behaviour is unchanged when the new argument and provider are not used.

## Tests

Table-driven and offline:

- `FilterByAirline` narrows results (case-insensitive, whitespace-trimmed, connecting-leg match, empty filter is a no-op, input not mutated).
- `afklm` and its `af-klm` alias are dispatchable from MCP; an unknown provider is still rejected.
- The `airline` argument parses from both comma-separated and JSON-array forms; the empty/no-arg baseline yields no filter.

## Verification

All exit 0 locally (`GOTOOLCHAIN=go1.26.4`):

- `gofmt -l .` — empty
- `go vet ./...`
- `go build ./...`
- `staticcheck ./...`
- `go test -short ./internal/flights/ ./mcp/`

## Scope

Changes are confined to `mcp/tools_flights.go` and `internal/flights/filter.go` plus two new test files. `mcp/tools.go` was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
