### PR TITLE
mcp: add carry_on_only filter to get_baggage_rules

### DIFF
--- a/mcp/tools_baggage.go
+++ b/mcp/tools_baggage.go
@@ -17,7 +17,8 @@ func getBaggageRulesTool() ToolDef {
 		InputSchema: InputSchema{
 			Type: "object",
 			Properties: map[string]Property{
-				"airline_code": {Type: "string", Description: "IATA airline code (e.g. KL, FR, U2) or \"all\" to list all airlines"},
+				"airline_code":  {Type: "string", Description: "IATA airline code (e.g. KL, FR, U2) or \"all\" to list all airlines"},
+				"carry_on_only": {Type: "boolean", Description: "When listing all airlines, return only carriers that include a full overhead cabin bag in the base fare (excludes low-cost carriers that charge extra for the overhead bag). Ignored for single-airline lookups."},
 			},
 			Required: []string{"airline_code"},
 		},
@@ -61,6 +62,15 @@ func handleGetBaggageRules(_ context.Context, args map[string]any, _ ElicitFunc,
 
 	if code == "ALL" || code == "" {
 		airlines := baggage.All()
+		if argBool(args, "carry_on_only", false) {
+			filtered := make([]baggage.AirlineBaggage, 0, len(airlines))
+			for _, ab := range airlines {
+				if !ab.OverheadOnly {
+					filtered = append(filtered, ab)
+				}
+			}
+			airlines = filtered
+		}
 		summary := buildBaggageSummaryAll(airlines)
 		type response struct {
 			Airlines []baggage.AirlineBaggage `json:"airlines"`

--- a/mcp/tools_baggage_test.go
+++ b/mcp/tools_baggage_test.go
@@ -2,7 +2,10 @@ package mcp
 
 import (
 	"context"
+	"reflect"
 	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/baggage"
 )
 
 func TestGetBaggageRulesTool_Definition(t *testing.T) {
@@ -13,6 +16,9 @@ func TestGetBaggageRulesTool_Definition(t *testing.T) {
 	}
 	if len(tool.InputSchema.Required) == 0 {
 		t.Error("expected required params")
+	}
+	if _, ok := tool.InputSchema.Properties["carry_on_only"]; !ok {
+		t.Error("expected carry_on_only property in input schema")
 	}
 }
 
@@ -45,5 +51,104 @@ func TestHandleGetBaggageRules_ByAirlineCode(t *testing.T) {
 	}
 	if structured == nil {
 		t.Fatal("expected structured result")
+	}
+}
+
+// extractAirlines pulls the "Airlines" field out of the anonymous response
+// struct returned by the list/all path, via reflection.
+func extractAirlines(t *testing.T, structured interface{}) []baggage.AirlineBaggage {
+	t.Helper()
+	v := reflect.ValueOf(structured)
+	field := v.FieldByName("Airlines")
+	if !field.IsValid() {
+		t.Fatalf("structured result has no Airlines field: %#v", structured)
+	}
+	airlines, ok := field.Interface().([]baggage.AirlineBaggage)
+	if !ok {
+		t.Fatalf("Airlines field is not []baggage.AirlineBaggage: %T", field.Interface())
+	}
+	return airlines
+}
+
+func TestHandleGetBaggageRules_CarryOnOnly_ExcludesOverheadOnly(t *testing.T) {
+	t.Parallel()
+
+	// Sanity: the dataset must contain at least one OverheadOnly carrier for
+	// this test to be meaningful.
+	var overheadCount int
+	for _, ab := range baggage.All() {
+		if ab.OverheadOnly {
+			overheadCount++
+		}
+	}
+	if overheadCount == 0 {
+		t.Skip("no OverheadOnly airlines in dataset; filter is a no-op")
+	}
+
+	_, structured, err := handleGetBaggageRules(context.Background(), map[string]any{
+		"airline_code":  "all",
+		"carry_on_only": true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	airlines := extractAirlines(t, structured)
+	for _, ab := range airlines {
+		if ab.OverheadOnly {
+			t.Errorf("carry_on_only=true returned OverheadOnly airline %s (%s)", ab.Code, ab.Name)
+		}
+	}
+
+	wantLen := len(baggage.All()) - overheadCount
+	if len(airlines) != wantLen {
+		t.Errorf("filtered len = %d, want %d (total %d − %d overhead-only)",
+			len(airlines), wantLen, len(baggage.All()), overheadCount)
+	}
+}
+
+func TestHandleGetBaggageRules_CarryOnOnly_DefaultReturnsFullSet(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+	}{
+		{"absent", map[string]any{"airline_code": "all"}},
+		{"false", map[string]any{"airline_code": "all", "carry_on_only": false}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, structured, err := handleGetBaggageRules(context.Background(), tc.args, nil, nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			airlines := extractAirlines(t, structured)
+			if len(airlines) != len(baggage.All()) {
+				t.Errorf("len = %d, want full set %d", len(airlines), len(baggage.All()))
+			}
+		})
+	}
+}
+
+// TestHandleGetBaggageRules_CarryOnOnly_IgnoredForSingleAirline confirms the
+// flag does not alter single-airline lookups, including OverheadOnly carriers.
+func TestHandleGetBaggageRules_CarryOnOnly_IgnoredForSingleAirline(t *testing.T) {
+	t.Parallel()
+
+	// FR (Ryanair) is a low-cost carrier flagged OverheadOnly; carry_on_only
+	// must not suppress a direct lookup of it.
+	_, structured, err := handleGetBaggageRules(context.Background(), map[string]any{
+		"airline_code":  "FR",
+		"carry_on_only": true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	v := reflect.ValueOf(structured)
+	found := v.FieldByName("Found")
+	if !found.IsValid() || !found.Bool() {
+		t.Fatalf("expected single-airline lookup to find FR regardless of carry_on_only")
 	}
 }


### PR DESCRIPTION
## Gap

The CLI `trvl baggage --carry-on-only` filters out low-cost carriers that only include a small under-seat bag in the base fare, so the user sees only airlines whose fare includes a real overhead cabin bag (`cmd/trvl/baggage.go`, predicate `!ab.OverheadOnly`).

The MCP `get_baggage_rules` tool had no equivalent. Its input schema exposed only `airline_code`, and the handler never applied the filter, so an AI assistant calling the tool could not reproduce what the CLI offers.

## Fix

- Add a `carry_on_only` boolean to the `get_baggage_rules` input schema.
- In the list/all path of `handleGetBaggageRules`, when `carry_on_only` is true, drop airlines where `OverheadOnly` is set — the same predicate the CLI uses.
- Single-airline lookups are unchanged: the flag only applies when listing all airlines, so a direct lookup of a low-cost carrier still returns it.

## Tests

`mcp/tools_baggage_test.go` gains cases that:

- confirm `carry_on_only=true` returns no `OverheadOnly` airlines and the expected reduced count,
- confirm absent and `false` both return the full set unchanged,
- confirm a single-airline lookup of a low-cost carrier (FR) still resolves when `carry_on_only=true`.

## Verification

All commands exit 0:

```
gofmt -l mcp/tools_baggage.go mcp/tools_baggage_test.go   # empty
go vet ./mcp/...
go build ./...
staticcheck ./mcp/...
go test ./mcp/...
```
