### PR TITLE
mcp: expose visa country list via check_visa list_countries

### DIFF
--- a/mcp/coverage_push_test.go
+++ b/mcp/coverage_push_test.go
@@ -495,14 +495,16 @@ func TestHandleCheckVisa_SameCountry(t *testing.T) {
 }
 
 func TestHandleCheckVisa_EmptyArgs(t *testing.T) {
+	// Empty args take the lookup path, which now requires passport+destination
+	// and returns a Go error (list_countries is the only argument-free mode).
 	content, structured, err := handleCheckVisa(context.Background(),
 		map[string]any{}, nil, nil, nil)
-	if err != nil {
-		t.Fatalf("expected no error for empty visa lookup, got: %v", err)
+	if err == nil {
+		t.Fatal("expected error for empty visa lookup args")
 	}
-	// visa.Lookup returns an error result, not a Go error
-	_ = content
-	_ = structured
+	if content != nil || structured != nil {
+		t.Fatalf("expected nil content/structured on error, got content=%v structured=%v", content, structured)
+	}
 }
 
 // --- handleGetWeather input defaults (0% coverage) ---

--- a/mcp/tools_visa.go
+++ b/mcp/tools_visa.go
@@ -13,14 +13,14 @@ func checkVisaTool() ToolDef {
 	return ToolDef{
 		Name:        "check_visa",
 		Title:       "Visa Requirements",
-		Description: "Check visa and entry requirements for a passport→destination country pair. Returns visa status (visa-free, visa-required, visa-on-arrival, e-visa, freedom-of-movement), maximum stay duration, and notes. Uses ISO 3166-1 alpha-2 country codes (e.g. FI=Finland, JP=Japan, US=United States).",
+		Description: "Check visa and entry requirements for a passport→destination country pair. Returns visa status (visa-free, visa-required, visa-on-arrival, e-visa, freedom-of-movement), maximum stay duration, and notes. Uses ISO 3166-1 alpha-2 country codes (e.g. FI=Finland, JP=Japan, US=United States). Set list_countries=true to enumerate all supported country codes and names instead of doing a lookup.",
 		InputSchema: InputSchema{
 			Type: "object",
 			Properties: map[string]Property{
-				"passport":    {Type: "string", Description: "Passport country code (ISO 3166-1 alpha-2, e.g. FI, US, GB, JP)"},
-				"destination": {Type: "string", Description: "Destination country code (ISO 3166-1 alpha-2, e.g. JP, TH, US, DE)"},
+				"passport":       {Type: "string", Description: "Passport country code (ISO 3166-1 alpha-2, e.g. FI, US, GB, JP). Required unless list_countries is true."},
+				"destination":    {Type: "string", Description: "Destination country code (ISO 3166-1 alpha-2, e.g. JP, TH, US, DE). Required unless list_countries is true."},
+				"list_countries": {Type: "boolean", Description: "When true, return all supported country codes and names instead of a passport→destination lookup. passport and destination are ignored."},
 			},
-			Required: []string{"passport", "destination"},
 		},
 		OutputSchema: visaOutputSchema(),
 		Annotations: &ToolAnnotations{
@@ -54,8 +54,15 @@ func visaOutputSchema() interface{} {
 }
 
 func handleCheckVisa(_ context.Context, args map[string]any, _ ElicitFunc, _ SamplingFunc, progress ProgressFunc) ([]ContentBlock, interface{}, error) {
+	if argBool(args, "list_countries", false) {
+		return handleListVisaCountries(progress)
+	}
+
 	passport := argString(args, "passport")
 	destination := argString(args, "destination")
+	if passport == "" || destination == "" {
+		return nil, nil, fmt.Errorf("both passport and destination are required (use ISO country codes, e.g. FI, JP), or set list_countries=true")
+	}
 
 	sendProgress(progress, 30, 100, fmt.Sprintf("Looking up %s → %s visa requirements...", strings.ToUpper(passport), strings.ToUpper(destination)))
 
@@ -69,6 +76,48 @@ func handleCheckVisa(_ context.Context, args map[string]any, _ ElicitFunc, _ Sam
 		return nil, nil, err
 	}
 	return content, result, nil
+}
+
+// visaCountry is one entry in the supported-countries list, mirroring the
+// `trvl visa --list` CLI output shape (code + display name).
+type visaCountry struct {
+	Code string `json:"code"`
+	Name string `json:"name"`
+}
+
+// visaCountryList is the structured result for the list_countries path.
+type visaCountryList struct {
+	Success   bool          `json:"success"`
+	Countries []visaCountry `json:"countries"`
+}
+
+func handleListVisaCountries(progress ProgressFunc) ([]ContentBlock, interface{}, error) {
+	sendProgress(progress, 30, 100, "Listing supported countries...")
+
+	codes := visa.ListCountries()
+	countries := make([]visaCountry, 0, len(codes))
+	for _, code := range codes {
+		countries = append(countries, visaCountry{Code: code, Name: visa.CountryName(code)})
+	}
+	result := visaCountryList{Success: true, Countries: countries}
+
+	sendProgress(progress, 100, 100, "Done")
+
+	summary := buildVisaCountryListSummary(countries)
+	content, err := buildAnnotatedContentBlocks(summary, result)
+	if err != nil {
+		return nil, nil, err
+	}
+	return content, result, nil
+}
+
+func buildVisaCountryListSummary(countries []visaCountry) string {
+	var sb strings.Builder
+	_, _ = fmt.Fprintf(&sb, "Supported countries (%d):\n\n", len(countries))
+	for _, c := range countries {
+		_, _ = fmt.Fprintf(&sb, "  %s  %s\n", c.Code, c.Name)
+	}
+	return sb.String()
 }
 
 func buildVisaSummary(result visa.Result) string {

--- a/mcp/tools_visa_test.go
+++ b/mcp/tools_visa_test.go
@@ -11,8 +11,13 @@ func TestCheckVisaTool_Definition(t *testing.T) {
 	if tool.Name != "check_visa" {
 		t.Errorf("Name = %q, want check_visa", tool.Name)
 	}
-	if len(tool.InputSchema.Required) == 0 {
-		t.Error("expected required params")
+	// Dual-mode tool: passport/destination are not hard-required at the schema
+	// level so list_countries can run without them. The lookup-path requirement
+	// is enforced in the handler instead. All three inputs must be advertised.
+	for _, key := range []string{"passport", "destination", "list_countries"} {
+		if _, ok := tool.InputSchema.Properties[key]; !ok {
+			t.Errorf("missing input property %q", key)
+		}
 	}
 }
 
@@ -30,5 +35,57 @@ func TestHandleCheckVisa_Success(t *testing.T) {
 	}
 	if structured == nil {
 		t.Fatal("expected structured result")
+	}
+}
+
+func TestHandleCheckVisa_MissingArgsErrors(t *testing.T) {
+	t.Parallel()
+	if _, _, err := handleCheckVisa(context.Background(), map[string]any{}, nil, nil, nil); err == nil {
+		t.Fatal("expected error when passport and destination are absent")
+	}
+	if _, _, err := handleCheckVisa(context.Background(), map[string]any{"passport": "FI"}, nil, nil, nil); err == nil {
+		t.Fatal("expected error when destination is absent")
+	}
+}
+
+func TestHandleCheckVisa_ListCountries(t *testing.T) {
+	t.Parallel()
+	content, structured, err := handleCheckVisa(context.Background(), map[string]any{
+		"list_countries": true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("expected content")
+	}
+	list, ok := structured.(visaCountryList)
+	if !ok {
+		t.Fatalf("structured result = %T, want visaCountryList", structured)
+	}
+	if !list.Success {
+		t.Error("expected success=true")
+	}
+	if len(list.Countries) == 0 {
+		t.Fatal("expected a non-empty country list")
+	}
+	for i, c := range list.Countries {
+		if c.Code == "" || c.Name == "" {
+			t.Fatalf("country[%d] = %+v, want non-empty code and name", i, c)
+		}
+	}
+}
+
+func TestHandleCheckVisa_ListCountriesIgnoresPassportDestination(t *testing.T) {
+	t.Parallel()
+	// list_countries takes precedence; missing passport/destination must not error.
+	_, structured, err := handleCheckVisa(context.Background(), map[string]any{
+		"list_countries": true,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := structured.(visaCountryList); !ok {
+		t.Fatalf("structured result = %T, want visaCountryList", structured)
 	}
 }


### PR DESCRIPTION
## What

The `check_visa` MCP tool could only do a passport→destination lookup. The CLI already exposes the full list of supported countries via `trvl visa --list`, but MCP clients had no equivalent — the tool schema hard-required both `passport` and `destination`, and the handler only called `visa.Lookup`.

This adds a `list_countries` mode to `check_visa` so MCP clients can enumerate supported countries, matching the CLI.

## Changes

- New optional boolean input `list_countries` on `check_visa`. When `true`, the handler returns the supported country code + name list (sourced from `visa.ListCountries()` and `visa.CountryName()`, the same data the CLI `--list` path uses) and ignores `passport`/`destination`.
- `passport` and `destination` are no longer required at the schema level. The lookup path still requires them — that requirement is now enforced in the handler, which returns a clear error when either is missing. Default lookup behavior is unchanged.
- The list result mirrors the CLI shape exactly: `{code, name}` entries, alphabetically sorted. No new fields are invented.

## Tests

Extended the visa MCP tests:

- `list_countries=true` returns a non-empty list where every entry has a code and a name.
- `list_countries` runs without `passport`/`destination` and does not error.
- The lookup path still succeeds with both codes and now errors when either is missing.
- Updated the pre-existing empty-args test to reflect the new handler-level requirement.

## Verification

All commands exit 0:

- `gofmt -l mcp/tools_visa.go` (no output)
- `go vet ./mcp/...`
- `go build ./...`
- `staticcheck ./mcp/...`
- `go test ./mcp/... ./internal/visa/...`

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
