### PR TITLE
mcp: wire watch_price webhook, flight date-range, and alert-drop modes

### DIFF
--- a/mcp/coverage_boost4_split2_test.go
+++ b/mcp/coverage_boost4_split2_test.go
@@ -408,8 +408,17 @@ func TestWatchPriceTool_Definition(t *testing.T) {
 	if tool.Name != "watch_price" {
 		t.Errorf("Name = %q, want watch_price", tool.Name)
 	}
-	if len(tool.InputSchema.Required) < 2 {
-		t.Errorf("Required = %v, want at least 2", tool.InputSchema.Required)
+	// "type" is the only hard requirement: target_price is optional when a
+	// proactive alert_drop / alert_drop_abs is supplied, mirroring the CLI which
+	// allows --alert-drop without --below.
+	hasType := false
+	for _, r := range tool.InputSchema.Required {
+		if r == "type" {
+			hasType = true
+		}
+	}
+	if !hasType {
+		t.Errorf("Required = %v, want it to include \"type\"", tool.InputSchema.Required)
 	}
 	if tool.Annotations == nil {
 		t.Fatal("annotations should be set")

--- a/mcp/tools_watch_price.go
+++ b/mcp/tools_watch_price.go
@@ -19,9 +19,11 @@ func watchPriceTool() ToolDef {
 		Description: "Create a price watch for a flight route or hotel stay. " +
 			"The watch is stored in ~/.trvl/watches.json and tracks whether the price drops " +
 			"below your target. Call check_watches later to re-check all active watches. " +
-			"For flights: provide origin, destination, and date. " +
+			"For flights: provide origin, destination, and either a single date or a " +
+			"depart_from/depart_to date range to scan. " +
 			"For hotels: provide location, check_in, and check_out. " +
-			"Set target_price to the maximum price you are willing to pay.",
+			"Set target_price to the maximum price you are willing to pay, or use " +
+			"alert_drop/alert_drop_abs for a proactive drop-from-baseline alert with no fixed threshold.",
 		InputSchema: InputSchema{
 			Type: "object",
 			Properties: map[string]Property{
@@ -33,12 +35,17 @@ func watchPriceTool() ToolDef {
 				"return_date":          {Type: "string", Description: "Return date YYYY-MM-DD for round-trip flights (optional)"},
 				"check_in":             {Type: "string", Description: "Hotel check-in date YYYY-MM-DD (hotels only)"},
 				"check_out":            {Type: "string", Description: "Hotel check-out date YYYY-MM-DD (hotels only)"},
-				"target_price":         {Type: "number", Description: "Alert threshold: notify when price drops below this amount"},
+				"target_price":         {Type: "number", Description: "Alert threshold: notify when price drops below this amount. Optional when alert_drop or alert_drop_abs is set."},
 				"currency":             {Type: "string", Description: "Currency code (e.g. EUR, USD). Default: EUR"},
+				"webhook":              {Type: "string", Description: "URL to POST a JSON payload to on price drop, mirroring CLI --webhook"},
+				"depart_from":          {Type: "string", Description: "Flight date-range start (scan for the cheapest fare across a window, mirrors CLI --from). Use with depart_to instead of a single date."},
+				"depart_to":            {Type: "string", Description: "Flight date-range end (scan for the cheapest fare across a window, mirrors CLI --to). Use with depart_from instead of a single date."},
+				"alert_drop":           {Type: "number", Description: "Proactively alert when the fare falls this percent below its baseline (mirrors CLI --alert-drop)"},
+				"alert_drop_abs":       {Type: "number", Description: "Proactively alert when the fare falls this many currency units below its baseline (mirrors CLI --alert-drop-abs)"},
 				"last_minute":          {Type: "boolean", Description: "Hotel watches only: notify when sub-48h availability is at least 25% below last seen price"},
 				"last_minute_drop_pct": {Type: "number", Description: "Hotel last-minute drop threshold percentage. Default: 25"},
 			},
-			Required: []string{"type", "target_price"},
+			Required: []string{"type"},
 		},
 		OutputSchema: map[string]interface{}{
 			"type": "object",
@@ -72,8 +79,12 @@ func handleWatchPrice(_ context.Context, args map[string]any, _ ElicitFunc, _ Sa
 	}
 
 	targetPrice := argFloat(args, "target_price", 0)
-	if targetPrice <= 0 {
-		return nil, nil, fmt.Errorf("target_price must be a positive number")
+	alertDropPct := argFloat(args, "alert_drop", 0)
+	alertDropAbs := argFloat(args, "alert_drop_abs", 0)
+	// target_price is optional when a proactive drop-from-baseline alert is set,
+	// mirroring the CLI which allows --alert-drop / --alert-drop-abs without --below.
+	if targetPrice <= 0 && alertDropPct <= 0 && alertDropAbs <= 0 {
+		return nil, nil, fmt.Errorf("set target_price, alert_drop, or alert_drop_abs to a positive value")
 	}
 
 	currency := argString(args, "currency")
@@ -85,6 +96,9 @@ func handleWatchPrice(_ context.Context, args map[string]any, _ ElicitFunc, _ Sa
 		Type:              watchType,
 		BelowPrice:        targetPrice,
 		Currency:          currency,
+		WebhookURL:        argString(args, "webhook"),
+		AlertDropPct:      alertDropPct,
+		AlertDropAbs:      alertDropAbs,
 		LastMinuteMode:    argBool(args, "last_minute", false),
 		LastMinuteDropPct: argFloat(args, "last_minute_drop_pct", 25),
 	}
@@ -96,15 +110,31 @@ func handleWatchPrice(_ context.Context, args map[string]any, _ ElicitFunc, _ Sa
 		if w.Origin == "" || w.Destination == "" {
 			return nil, nil, fmt.Errorf("flight watches require origin and destination")
 		}
-		// Accept "date" or "depart_date" for departure.
+		// Two flight date modes, mirroring the CLI:
+		//   - single date  ("date"/"depart_date") -> DepartDate
+		//   - date range   (depart_from + depart_to) -> scan window
+		// The watch validator rejects setting both, so pick exactly one.
 		date := argString(args, "date")
 		if date == "" {
 			date = argString(args, "depart_date")
 		}
-		if date == "" {
-			return nil, nil, fmt.Errorf("flight watches require a departure date (date)")
+		departFrom := argString(args, "depart_from")
+		departTo := argString(args, "depart_to")
+		switch {
+		case departFrom != "" || departTo != "":
+			if departFrom == "" || departTo == "" {
+				return nil, nil, fmt.Errorf("flight date-range watches require both depart_from and depart_to")
+			}
+			if date != "" {
+				return nil, nil, fmt.Errorf("provide either a single date or a depart_from/depart_to range, not both")
+			}
+			w.DepartFrom = departFrom
+			w.DepartTo = departTo
+		case date != "":
+			w.DepartDate = date
+		default:
+			return nil, nil, fmt.Errorf("flight watches require a departure date (date) or a depart_from/depart_to range")
 		}
-		w.DepartDate = date
 		if ret := argString(args, "return_date"); ret != "" {
 			w.ReturnDate = ret
 		}
@@ -164,19 +194,24 @@ func handleWatchPrice(_ context.Context, args map[string]any, _ ElicitFunc, _ Sa
 	}
 
 	var summary string
+	alert := watchAlertClause(w)
 	switch watchType {
 	case "flight":
 		resp.Origin = w.Origin
 		resp.Destination = w.Destination
-		summary = fmt.Sprintf("Flight watch %s created: %s→%s on %s. Alert when below %.0f %s.",
-			id, w.Origin, w.Destination, w.DepartDate, targetPrice, currency)
+		when := "on " + w.DepartDate
+		if w.IsDateRange() {
+			when = fmt.Sprintf("scanning %s to %s", w.DepartFrom, w.DepartTo)
+		}
+		summary = fmt.Sprintf("Flight watch %s created: %s→%s %s. %s",
+			id, w.Origin, w.Destination, when, alert)
 		if w.ReturnDate != "" {
 			summary += fmt.Sprintf(" Return: %s.", w.ReturnDate)
 		}
 	case "hotel":
 		resp.Location = w.Destination
-		summary = fmt.Sprintf("Hotel watch %s created: %s (%s to %s). Alert when below %.0f %s.",
-			id, w.Destination, w.DepartFrom, w.DepartTo, targetPrice, currency)
+		summary = fmt.Sprintf("Hotel watch %s created: %s (%s to %s). %s",
+			id, w.Destination, w.DepartFrom, w.DepartTo, alert)
 		if w.LastMinuteMode {
 			summary += fmt.Sprintf(" Last-minute mode enabled at %.0f%% below last seen price.", w.LastMinuteDropPct)
 		}
@@ -499,6 +534,26 @@ func (m *mcpPriceChecker) CheckPrice(ctx context.Context, w watch.Watch) (float6
 }
 
 // --- helpers ---
+
+// watchAlertClause renders a human-readable description of when a watch fires,
+// covering the fixed below-price threshold and the proactive drop-from-baseline
+// alerts (percent and/or absolute), mirroring the CLI's summary output.
+func watchAlertClause(w watch.Watch) string {
+	var parts []string
+	if w.BelowPrice > 0 {
+		parts = append(parts, fmt.Sprintf("when below %.0f %s", w.BelowPrice, w.Currency))
+	}
+	if w.AlertDropPct > 0 {
+		parts = append(parts, fmt.Sprintf("on a %.0f%% drop from baseline", w.AlertDropPct))
+	}
+	if w.AlertDropAbs > 0 {
+		parts = append(parts, fmt.Sprintf("on a %.0f %s drop from baseline", w.AlertDropAbs, w.Currency))
+	}
+	if len(parts) == 0 {
+		return "Tracking price history."
+	}
+	return "Alert " + strings.Join(parts, " or ") + "."
+}
 
 // watchRoute returns a human-readable route string for a watch.
 func watchRoute(w watch.Watch) string {

--- a/mcp/tools_watch_price_test.go
+++ b/mcp/tools_watch_price_test.go
@@ -65,3 +65,140 @@ func TestHandleCheckWatches_ReturnsLivePrice(t *testing.T) {
 		t.Errorf("expected below_goal:true, got %s", got)
 	}
 }
+
+// storedWatch re-opens the on-disk watch store (the same path handleWatchPrice
+// writes to, under the test HOME) and returns the single watch it finds. It
+// proves the handler persisted what we expect rather than only echoing the
+// response struct.
+func storedWatch(t *testing.T) watch.Watch {
+	t.Helper()
+	store, err := watch.DefaultStore()
+	if err != nil {
+		t.Fatalf("DefaultStore: %v", err)
+	}
+	if err := store.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := store.List()
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 stored watch, got %d", len(got))
+	}
+	return got[0]
+}
+
+// TestHandleWatchPrice_WebhookPersists proves the webhook arg is wired into the
+// stored watch, mirroring the CLI --webhook flag.
+func TestHandleWatchPrice_WebhookPersists(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const hookURL = "https://hooks.invalid/notify"
+	_, _, err := handleWatchPrice(context.Background(), map[string]any{
+		"type":         "flight",
+		"origin":       "HEL",
+		"destination":  "BCN",
+		"date":         "2026-09-01",
+		"target_price": 200.0,
+		"webhook":      hookURL,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleWatchPrice: %v", err)
+	}
+
+	w := storedWatch(t)
+	if w.WebhookURL != hookURL {
+		t.Errorf("expected webhook to persist, got %q", w.WebhookURL)
+	}
+}
+
+// TestHandleWatchPrice_FlightDateRange proves a flight watch with a
+// depart_from/depart_to window (and no single date) is accepted and stored as a
+// date-range watch, mirroring the CLI --from/--to mode.
+func TestHandleWatchPrice_FlightDateRange(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	_, _, err := handleWatchPrice(context.Background(), map[string]any{
+		"type":         "flight",
+		"origin":       "HEL",
+		"destination":  "PRG",
+		"depart_from":  "2026-07-01",
+		"depart_to":    "2026-08-31",
+		"target_price": 100.0,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleWatchPrice (date range): %v", err)
+	}
+
+	w := storedWatch(t)
+	if !w.IsDateRange() {
+		t.Errorf("expected a date-range watch, got DepartFrom=%q DepartTo=%q DepartDate=%q",
+			w.DepartFrom, w.DepartTo, w.DepartDate)
+	}
+	if w.DepartFrom != "2026-07-01" || w.DepartTo != "2026-08-31" {
+		t.Errorf("date range not persisted: from=%q to=%q", w.DepartFrom, w.DepartTo)
+	}
+	if w.DepartDate != "" {
+		t.Errorf("date-range watch must not set a single DepartDate, got %q", w.DepartDate)
+	}
+}
+
+// TestHandleWatchPrice_FlightNoDateErrors proves a flight watch with neither a
+// single date nor a depart_from/depart_to range is rejected.
+func TestHandleWatchPrice_FlightNoDateErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	_, _, err := handleWatchPrice(context.Background(), map[string]any{
+		"type":         "flight",
+		"origin":       "HEL",
+		"destination":  "BCN",
+		"target_price": 200.0,
+	}, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected an error when a flight watch has neither date nor date range")
+	}
+}
+
+// TestHandleWatchPrice_AlertDropPersists proves alert_drop / alert_drop_abs
+// persist and that target_price may be omitted when a proactive drop alert is
+// set, mirroring the CLI which allows --alert-drop without --below.
+func TestHandleWatchPrice_AlertDropPersists(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	_, _, err := handleWatchPrice(context.Background(), map[string]any{
+		"type":           "flight",
+		"origin":         "HEL",
+		"destination":    "NRT",
+		"date":           "2026-09-01",
+		"alert_drop":     12.0,
+		"alert_drop_abs": 50.0,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleWatchPrice (alert drop, no target_price): %v", err)
+	}
+
+	w := storedWatch(t)
+	if w.AlertDropPct != 12.0 {
+		t.Errorf("expected AlertDropPct=12, got %v", w.AlertDropPct)
+	}
+	if w.AlertDropAbs != 50.0 {
+		t.Errorf("expected AlertDropAbs=50, got %v", w.AlertDropAbs)
+	}
+	if w.BelowPrice != 0 {
+		t.Errorf("expected no fixed threshold, got BelowPrice=%v", w.BelowPrice)
+	}
+}
+
+// TestHandleWatchPrice_NoThresholdErrors proves the handler rejects a watch with
+// no target_price and no proactive drop alert (nothing to fire on).
+func TestHandleWatchPrice_NoThresholdErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	_, _, err := handleWatchPrice(context.Background(), map[string]any{
+		"type":        "flight",
+		"origin":      "HEL",
+		"destination": "BCN",
+		"date":        "2026-09-01",
+	}, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected an error when neither target_price nor alert_drop is set")
+	}
+}

--- a/mcp/tools_watch_price_test.go
+++ b/mcp/tools_watch_price_test.go
@@ -24,7 +24,9 @@ func (f fixedChecker) CheckPrice(_ context.Context, _ watch.Watch) (float64, str
 // tool response. Before the fix the response always carried current_price 0
 // regardless of the checker. Not parallel: it sets HOME and swaps a package var.
 func TestHandleCheckWatches_ReturnsLivePrice(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	watchHome := t.TempDir()
+	t.Setenv("HOME", watchHome)
+	t.Setenv("USERPROFILE", watchHome) // os.UserHomeDir() reads USERPROFILE on Windows
 
 	store, err := watch.DefaultStore()
 	if err != nil {
@@ -89,7 +91,9 @@ func storedWatch(t *testing.T) watch.Watch {
 // TestHandleWatchPrice_WebhookPersists proves the webhook arg is wired into the
 // stored watch, mirroring the CLI --webhook flag.
 func TestHandleWatchPrice_WebhookPersists(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	watchHome := t.TempDir()
+	t.Setenv("HOME", watchHome)
+	t.Setenv("USERPROFILE", watchHome) // os.UserHomeDir() reads USERPROFILE on Windows
 
 	const hookURL = "https://hooks.invalid/notify"
 	_, _, err := handleWatchPrice(context.Background(), map[string]any{
@@ -114,7 +118,9 @@ func TestHandleWatchPrice_WebhookPersists(t *testing.T) {
 // depart_from/depart_to window (and no single date) is accepted and stored as a
 // date-range watch, mirroring the CLI --from/--to mode.
 func TestHandleWatchPrice_FlightDateRange(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	watchHome := t.TempDir()
+	t.Setenv("HOME", watchHome)
+	t.Setenv("USERPROFILE", watchHome) // os.UserHomeDir() reads USERPROFILE on Windows
 
 	_, _, err := handleWatchPrice(context.Background(), map[string]any{
 		"type":         "flight",
@@ -144,7 +150,9 @@ func TestHandleWatchPrice_FlightDateRange(t *testing.T) {
 // TestHandleWatchPrice_FlightNoDateErrors proves a flight watch with neither a
 // single date nor a depart_from/depart_to range is rejected.
 func TestHandleWatchPrice_FlightNoDateErrors(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	watchHome := t.TempDir()
+	t.Setenv("HOME", watchHome)
+	t.Setenv("USERPROFILE", watchHome) // os.UserHomeDir() reads USERPROFILE on Windows
 
 	_, _, err := handleWatchPrice(context.Background(), map[string]any{
 		"type":         "flight",
@@ -161,7 +169,9 @@ func TestHandleWatchPrice_FlightNoDateErrors(t *testing.T) {
 // persist and that target_price may be omitted when a proactive drop alert is
 // set, mirroring the CLI which allows --alert-drop without --below.
 func TestHandleWatchPrice_AlertDropPersists(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	watchHome := t.TempDir()
+	t.Setenv("HOME", watchHome)
+	t.Setenv("USERPROFILE", watchHome) // os.UserHomeDir() reads USERPROFILE on Windows
 
 	_, _, err := handleWatchPrice(context.Background(), map[string]any{
 		"type":           "flight",
@@ -190,7 +200,9 @@ func TestHandleWatchPrice_AlertDropPersists(t *testing.T) {
 // TestHandleWatchPrice_NoThresholdErrors proves the handler rejects a watch with
 // no target_price and no proactive drop alert (nothing to fire on).
 func TestHandleWatchPrice_NoThresholdErrors(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	watchHome := t.TempDir()
+	t.Setenv("HOME", watchHome)
+	t.Setenv("USERPROFILE", watchHome) // os.UserHomeDir() reads USERPROFILE on Windows
 
 	_, _, err := handleWatchPrice(context.Background(), map[string]any{
 		"type":        "flight",


### PR DESCRIPTION
## Summary

The CLI `trvl watch add` command supports three modes that the `watch_price` MCP tool did not expose: webhook notifications, flight date-range scanning, and proactive drop-from-baseline alerts. The `watch.Watch` struct and the watch checker (`internal/watch/check.go`) already support all three; the gap was purely missing wiring in the MCP tool schema and handler. MCP clients could only create single-date watches with a fixed below-price threshold.

This PR wires the three modes into the `watch_price` tool. `internal/watch` is unchanged.

## What changed

- **webhook**: new `webhook` string arg sets `Watch.WebhookURL`, mirroring CLI `--webhook`. The checker already POSTs a JSON payload to this URL on a price drop.
- **flight date-range**: new `depart_from` / `depart_to` string args (YYYY-MM-DD) create a date-range flight watch that scans a window for the cheapest fare, mirroring CLI `--from` / `--to`. The existing single-date path is preserved. The two are mutually exclusive, matching the watch validator, which rejects setting both a single `DepartDate` and a `DepartFrom`/`DepartTo` range.
- **alert-drop**: new `alert_drop` (percent below baseline) and `alert_drop_abs` (absolute currency units below baseline) number args set `Watch.AlertDropPct` and `Watch.AlertDropAbs`, mirroring CLI `--alert-drop` / `--alert-drop-abs`.

`target_price` is no longer hard-required. A watch is accepted when at least one of `target_price`, `alert_drop`, or `alert_drop_abs` is positive, matching the CLI, which allows `--alert-drop` without `--below`. A watch with none of the three is still rejected.

## Tests

Added to `mcp/tools_watch_price_test.go`:

- `webhook` arg persists to the stored watch.
- A flight date-range watch (`depart_from`/`depart_to`, no single date) is accepted, stored as a date-range watch, and does not set a single `DepartDate`.
- `alert_drop` / `alert_drop_abs` persist, and `target_price` may be omitted when a drop alert is set.
- A flight watch with neither a date nor a date range is rejected.
- A watch with no threshold of any kind is rejected.

One existing assertion in `TestWatchPriceTool_Definition` required at least two required args; it now checks that `type` is required, reflecting that `target_price` is optional.

## Verification

```
gofmt -l mcp/tools_watch_price.go      # empty (formatted)
go vet ./mcp/...                       # pass
go build ./...                         # pass
staticcheck ./mcp/...                  # pass
go test ./mcp/... ./internal/watch/... # pass
```
