### PR TITLE
mcp: expose multi-program points arbitrage in calculate_points_value

### DIFF
--- a/mcp/tools_points.go
+++ b/mcp/tools_points.go
@@ -4,15 +4,20 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/MikkoParkkola/trvl/internal/hotelarb"
 	"github.com/MikkoParkkola/trvl/internal/points"
 )
 
 // --- Output schema ---
 
+// calculatePointsValueOutputSchema describes both result shapes: the
+// single-program recommendation (default) and the multi-program arbitrage
+// comparison returned when `offers` is supplied.
 func calculatePointsValueOutputSchema() interface{} {
 	return map[string]interface{}{
 		"type": "object",
 		"properties": map[string]interface{}{
+			// Single-program recommendation fields.
 			"program_slug":    schemaString(),
 			"program_name":    schemaString(),
 			"cash_price":      schemaNum(),
@@ -22,8 +27,35 @@ func calculatePointsValueOutputSchema() interface{} {
 			"ceiling_cpp":     schemaNumDesc("Sweet-spot CPP for this program"),
 			"verdict":         map[string]interface{}{"type": "string", "enum": []string{"use points", "pay cash", "borderline"}},
 			"explanation":     schemaString(),
+			// Multi-program arbitrage fields (present when `offers` is supplied).
+			"currency":       schemaStringDesc("Currency label for the arbitrage comparison"),
+			"recommendation": map[string]interface{}{"type": "string", "enum": []string{"use_points", "pay_cash"}},
+			"reason":         schemaStringDesc("Plain-English summary of the arbitrage recommendation"),
+			"best_offer":     pointsOfferValueSchema(),
+			"offers":         schemaArrayDesc("Every evaluated points offer in the arbitrage comparison", pointsOfferValueSchema()),
 		},
-		"required": []string{"program_slug", "program_name", "cpp", "floor_cpp", "ceiling_cpp", "verdict", "explanation"},
+		"required": []string{},
+	}
+}
+
+// pointsOfferValueSchema describes one evaluated hotel points offer in an
+// arbitrage comparison, mirroring hotelarb.PointsOfferValue.
+func pointsOfferValueSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"program_slug":     schemaString(),
+			"program_name":     schemaString(),
+			"points_required":  schemaInt(),
+			"cash_fees":        schemaNum(),
+			"cents_per_point":  schemaNumDesc("Effective cents per point for this offer"),
+			"floor_cpp":        schemaNumDesc("Conservative baseline CPP for this program"),
+			"ceiling_cpp":      schemaNumDesc("Sweet-spot CPP for this program"),
+			"opportunity_cost": schemaNumDesc("Cash-equivalent cost of redeeming at floor value"),
+			"savings_vs_cash":  schemaNumDesc("Cash saved versus paying outright (negative means cash wins)"),
+			"verdict":          map[string]interface{}{"type": "string", "enum": []string{"use points", "pay cash"}},
+			"reason":           schemaString(),
+		},
 	}
 }
 
@@ -36,6 +68,7 @@ func calculatePointsValueTool() ToolDef {
 		Description: "Calculate whether redeeming loyalty points or paying cash is better for a specific redemption. " +
 			"Returns the effective cents-per-point (cpp), program floor/ceiling valuations, a verdict, and a plain-English explanation. " +
 			"Supports 20+ airline/hotel programs and 4 transferable currencies (Amex MR, Chase UR, Citi TYP, Capital One). " +
+			"Pass `offers` (2+ programs) to compare hotel point redemptions side-by-side and get a ranked arbitrage recommendation. " +
 			"No API keys required — uses published valuation data.",
 		InputSchema: InputSchema{
 			Type: "object",
@@ -46,14 +79,26 @@ func calculatePointsValueTool() ToolDef {
 				},
 				"points_required": {
 					Type:        "integer",
-					Description: "Number of points or miles required for the redemption (e.g. 60000)",
+					Description: "Number of points or miles required for the redemption (e.g. 60000). Used by the single-program path; ignored when `offers` is supplied.",
 				},
 				"program": {
 					Type:        "string",
-					Description: "Loyalty program slug. Examples: finnair-plus, ana-mileage-club, world-of-hyatt, amex-mr, chase-ur.",
+					Description: "Loyalty program slug. Examples: finnair-plus, ana-mileage-club, world-of-hyatt, amex-mr, chase-ur. Used by the single-program path; ignored when `offers` is supplied.",
+				},
+				"offers": {
+					Type:        "array",
+					Description: "Compare hotel points redemptions across programs. Each element is an object with `program` (slug, string), `points` (number), and optional `cash_fees` (number). Supply 2+ to rank programs side-by-side; when present, the single-program `program`/`points_required` fields are ignored.",
+					Items: &Property{
+						Type:        "object",
+						Description: "program (slug), points (number), optional cash_fees (number)",
+					},
+				},
+				"currency": {
+					Type:        "string",
+					Description: "Currency label for the arbitrage comparison output (default USD). Only used when `offers` is supplied.",
 				},
 			},
-			Required: []string{"cash_price", "points_required", "program"},
+			Required: []string{"cash_price"},
 		},
 		OutputSchema: calculatePointsValueOutputSchema(),
 		Annotations: &ToolAnnotations{
@@ -69,6 +114,11 @@ func calculatePointsValueTool() ToolDef {
 
 func handleCalculatePointsValue(_ context.Context, args map[string]any, _ ElicitFunc, _ SamplingFunc, _ ProgressFunc) ([]ContentBlock, interface{}, error) {
 	cashPrice := argFloat(args, "cash_price", 0)
+
+	if offers := parsePointsOfferArgs(args); len(offers) > 0 {
+		return handlePointsArbitrage(cashPrice, argString(args, "currency"), offers)
+	}
+
 	pointsRequired := argInt(args, "points_required", 0)
 	programSlug := argString(args, "program")
 
@@ -98,4 +148,75 @@ func handleCalculatePointsValue(_ context.Context, args map[string]any, _ Elicit
 	}
 
 	return content, rec, nil
+}
+
+// handlePointsArbitrage compares hotel points redemptions across programs and
+// returns a ranked recommendation. It mirrors the CLI `--offer` path.
+func handlePointsArbitrage(cashPrice float64, currency string, offers []hotelarb.PointsOffer) ([]ContentBlock, interface{}, error) {
+	if cashPrice <= 0 {
+		return nil, nil, fmt.Errorf("cash_price must be greater than 0")
+	}
+
+	result, err := hotelarb.ComparePointsArbitrage(hotelarb.PointsArbitrageInput{
+		CashPrice: cashPrice,
+		Currency:  currency,
+		Offers:    offers,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	summary := fmt.Sprintf(
+		"Arbitrage across %d programs: %s — best is %s. %s",
+		len(result.Offers),
+		recommendationLabel(result.Recommendation),
+		result.BestOffer.ProgramName,
+		result.Reason,
+	)
+
+	content, err := buildAnnotatedContentBlocks(summary, result)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return content, result, nil
+}
+
+// recommendationLabel renders the arbitrage recommendation as plain words.
+func recommendationLabel(r hotelarb.PointsRecommendation) string {
+	switch r {
+	case hotelarb.RecommendUsePoints:
+		return "use points"
+	case hotelarb.RecommendPayCash:
+		return "pay cash"
+	default:
+		return string(r)
+	}
+}
+
+// parsePointsOfferArgs reads the `offers` argument into hotelarb.PointsOffer
+// values. Each element must be an object carrying `program` (slug), `points`,
+// and optional `cash_fees`, matching the CLI `program:points[:cash_fees]`
+// semantics. Returns nil when `offers` is absent or empty.
+func parsePointsOfferArgs(args map[string]any) []hotelarb.PointsOffer {
+	if args == nil {
+		return nil
+	}
+	raw, ok := args["offers"].([]any)
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	offers := make([]hotelarb.PointsOffer, 0, len(raw))
+	for _, elem := range raw {
+		obj, ok := elem.(map[string]any)
+		if !ok {
+			continue
+		}
+		offers = append(offers, hotelarb.PointsOffer{
+			Program:        argString(obj, "program"),
+			PointsRequired: argInt(obj, "points", 0),
+			CashFees:       argFloat(obj, "cash_fees", 0),
+		})
+	}
+	return offers
 }

--- a/mcp/tools_points_arbitrage_test.go
+++ b/mcp/tools_points_arbitrage_test.go
@@ -1,0 +1,171 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/hotelarb"
+)
+
+func TestHandleCalculatePointsValue_OffersArbitrage(t *testing.T) {
+	t.Parallel()
+	content, structured, err := handleCalculatePointsValue(context.Background(), map[string]any{
+		"cash_price": 300.0,
+		"offers": []any{
+			map[string]any{"program": "world-of-hyatt", "points": 12000.0},
+			map[string]any{"program": "hilton-honors", "points": 80000.0},
+		},
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) != 2 {
+		t.Fatalf("content len = %d, want 2", len(content))
+	}
+
+	result, ok := structured.(*hotelarb.PointsArbitrageResult)
+	if !ok {
+		t.Fatalf("structured type = %T, want *hotelarb.PointsArbitrageResult", structured)
+	}
+	if len(result.Offers) != 2 {
+		t.Fatalf("offers len = %d, want 2", len(result.Offers))
+	}
+	// The leaner 12k-point Hyatt redemption should rank ahead of the 80k Hilton stay.
+	if result.BestOffer.ProgramSlug != "world-of-hyatt" {
+		t.Fatalf("best offer = %q, want world-of-hyatt", result.BestOffer.ProgramSlug)
+	}
+	// The best offer must rank at least as high as every evaluated offer.
+	for _, offer := range result.Offers {
+		if offer.SavingsVsCash > result.BestOffer.SavingsVsCash {
+			t.Fatalf("offer %q savings %.2f beats best %.2f", offer.ProgramSlug, offer.SavingsVsCash, result.BestOffer.SavingsVsCash)
+		}
+	}
+	if !strings.Contains(content[0].Text, "Arbitrage across 2 programs") {
+		t.Fatalf("summary = %q, want arbitrage text", content[0].Text)
+	}
+}
+
+func TestHandleCalculatePointsValue_OffersWithCashFees(t *testing.T) {
+	t.Parallel()
+	_, structured, err := handleCalculatePointsValue(context.Background(), map[string]any{
+		"cash_price": 300.0,
+		"currency":   "eur",
+		"offers": []any{
+			map[string]any{"program": "world-of-hyatt", "points": 12000.0, "cash_fees": 25.0},
+		},
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result, ok := structured.(*hotelarb.PointsArbitrageResult)
+	if !ok {
+		t.Fatalf("structured type = %T, want *hotelarb.PointsArbitrageResult", structured)
+	}
+	if result.Currency != "EUR" {
+		t.Fatalf("currency = %q, want EUR", result.Currency)
+	}
+	if got := result.Offers[0].CashFees; got != 25.0 {
+		t.Fatalf("cash_fees = %.2f, want 25.00", got)
+	}
+}
+
+func TestHandleCalculatePointsValue_OffersBadProgram(t *testing.T) {
+	t.Parallel()
+	_, _, err := handleCalculatePointsValue(context.Background(), map[string]any{
+		"cash_price": 300.0,
+		"offers": []any{
+			map[string]any{"program": "no-such-program", "points": 12000.0},
+		},
+	}, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for an unrecognized program")
+	}
+	if !strings.Contains(err.Error(), "unknown program") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleCalculatePointsValue_OffersInvalidCashPrice(t *testing.T) {
+	t.Parallel()
+	_, _, err := handleCalculatePointsValue(context.Background(), map[string]any{
+		"cash_price": 0.0,
+		"offers": []any{
+			map[string]any{"program": "world-of-hyatt", "points": 12000.0},
+		},
+	}, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected invalid cash price error")
+	}
+	if got := err.Error(); got != "cash_price must be greater than 0" {
+		t.Fatalf("error = %q, want %q", got, "cash_price must be greater than 0")
+	}
+}
+
+func TestHandleCalculatePointsValue_EmptyOffersUsesSingleProgram(t *testing.T) {
+	t.Parallel()
+	// An empty offers array falls through to the single-program path,
+	// which then requires program.
+	_, _, err := handleCalculatePointsValue(context.Background(), map[string]any{
+		"cash_price": 450.0,
+		"offers":     []any{},
+	}, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected single-program path to require program")
+	}
+	if got := err.Error(); got != "program is required" {
+		t.Fatalf("error = %q, want %q", got, "program is required")
+	}
+}
+
+func TestToolsCallCalculatePointsValueArbitrage(t *testing.T) {
+	t.Parallel()
+	s := NewServer()
+	resp := sendRequest(t, s, "tools/call", 43, ToolCallParams{
+		Name: "calculate_points_value",
+		Arguments: map[string]any{
+			"cash_price": 300.0,
+			"offers": []any{
+				map[string]any{"program": "world-of-hyatt", "points": 12000.0},
+				map[string]any{"program": "hilton-honors", "points": 80000.0},
+			},
+		},
+	})
+	if resp == nil {
+		t.Fatal("expected response")
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected top-level error: %+v", resp.Error)
+	}
+
+	resultJSON, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	var result ToolCallResult
+	if err := json.Unmarshal(resultJSON, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.IsError {
+		t.Fatal("expected isError=false")
+	}
+	if result.StructuredContent == nil {
+		t.Fatal("expected structuredContent")
+	}
+
+	structuredJSON, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		t.Fatalf("marshal structuredContent: %v", err)
+	}
+	var arb hotelarb.PointsArbitrageResult
+	if err := json.Unmarshal(structuredJSON, &arb); err != nil {
+		t.Fatalf("unmarshal structuredContent: %v", err)
+	}
+	if len(arb.Offers) != 2 {
+		t.Fatalf("offers len = %d, want 2", len(arb.Offers))
+	}
+	if arb.BestOffer.ProgramSlug != "world-of-hyatt" {
+		t.Fatalf("best offer = %q, want world-of-hyatt", arb.BestOffer.ProgramSlug)
+	}
+}


### PR DESCRIPTION
## Gap

The CLI already compares hotel point redemptions across programs:

```
trvl points-value --cash 300 --offer world-of-hyatt:12000 --offer hilton-honors:80000
```

That path parses `program:points[:cash_fees]` entries and calls
`hotelarb.ComparePointsArbitrage` to rank programs side by side.

The MCP `calculate_points_value` tool had no equivalent. Its input schema only
accepted a single `program` + `points_required`, and the handler only called
single-program `points.CalculateValue`. An AI assistant using the MCP server
could not get the side-by-side comparison the CLI offers.

## Fix

- Add an `offers` array to the tool input schema. Each element is an object with
  `program` (slug), `points`, and optional `cash_fees`, matching the CLI
  `program:points[:cash_fees]` semantics. An optional `currency` field labels
  the comparison output.
- In `handleCalculatePointsValue`, when `offers` is populated, dispatch to
  `hotelarb.ComparePointsArbitrage` and return the ranked comparison result.
  When `offers` is absent or empty, the existing single-program path runs
  unchanged.
- Extend the output schema with the arbitrage fields (`recommendation`,
  `best_offer`, per-offer `offers`, `currency`, `reason`), mirroring
  `PointsArbitrageResult`.

The single-program behavior is untouched: same required fields semantics, same
result type, same summary text.

## Tests

`mcp/tools_points_arbitrage_test.go` covers:

- Two-or-more programs returns a ranked `PointsArbitrageResult` with the
  expected best offer.
- `cash_fees` and `currency` flow through.
- Unknown program and non-positive cash price return errors.
- An empty `offers` array falls through to the single-program path.
- End-to-end `tools/call` returns the arbitrage result as structured content.

## Verification

All exit 0:

```
gofmt -l mcp/tools_points.go        # empty
go vet ./mcp/...
go build ./...
staticcheck ./mcp/...
go test ./mcp/...                    # ok
go test -race ./mcp/                 # ok
```
