### PR TITLE
flights: typed rate-limit classification for Kiwi and Ryanair

### DIFF
--- a/internal/flights/kiwi.go
+++ b/internal/flights/kiwi.go
@@ -238,6 +238,13 @@ func kiwiRPCWithHeaders(ctx context.Context, sessionID string, payload kiwiRPCRe
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		// Classify rate-limit / block / overload as a typed, retryable error so
+		// the merge layer reports an honest `rate_limited` status instead of a
+		// generic failure (mirrors googleUpstreamStatusError in search.go).
+		switch resp.StatusCode {
+		case http.StatusTooManyRequests, http.StatusForbidden, http.StatusServiceUnavailable:
+			return resp.Header, kiwiRPCResponse{}, fmt.Errorf("kiwi: HTTP %d: %s: %w", resp.StatusCode, bytes.TrimSpace(body), models.ErrRateLimited)
+		}
 		return resp.Header, kiwiRPCResponse{}, fmt.Errorf("kiwi: HTTP %d: %s", resp.StatusCode, bytes.TrimSpace(body))
 	}
 

--- a/internal/flights/ryanair.go
+++ b/internal/flights/ryanair.go
@@ -95,6 +95,13 @@ func SearchRyanair(ctx context.Context, origin, destination, date, currency stri
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
+		// Typed, retryable classification for rate-limit / block / overload so
+		// the merge layer surfaces an honest `rate_limited` status instead of a
+		// generic failure (mirrors googleUpstreamStatusError in search.go).
+		switch resp.StatusCode {
+		case http.StatusTooManyRequests, http.StatusForbidden, http.StatusServiceUnavailable:
+			return nil, fmt.Errorf("ryanair: unexpected status %d: %w", resp.StatusCode, models.ErrRateLimited)
+		}
 		return nil, fmt.Errorf("ryanair: unexpected status %d", resp.StatusCode)
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))

--- a/internal/flights/ryanair_test.go
+++ b/internal/flights/ryanair_test.go
@@ -2,9 +2,12 @@ package flights
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
 const ryanairFixture = `{"fares":[{"outbound":{
@@ -55,6 +58,25 @@ func TestSearchRyanair_MapsFare(t *testing.T) {
 	}
 	if f.BookingURL == "" {
 		t.Error("booking URL not set")
+	}
+}
+
+func TestSearchRyanair_RateLimitTyped(t *testing.T) {
+	for _, code := range []int{http.StatusTooManyRequests, http.StatusForbidden, http.StatusServiceUnavailable} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(code)
+		}))
+		orig := ryanairBaseURL
+		ryanairBaseURL = srv.URL
+		_, err := SearchRyanair(context.Background(), "STN", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+		ryanairBaseURL = orig
+		srv.Close()
+		if err == nil {
+			t.Fatalf("status %d: want error, got nil", code)
+		}
+		if !errors.Is(err, models.ErrRateLimited) {
+			t.Errorf("status %d: err = %v, want models.ErrRateLimited", code, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Kiwi and Ryanair call their carrier APIs directly rather than through an aggregator. Until now both wrapped every non-200 response in a generic HTTP-status error, so the merge layer could not tell an upstream throttle (429/403/503) apart from a hard failure. A rate-limited provider looked the same as a broken one, and callers had no signal to retry.

Both providers now wrap 429, 403, and 503 with `models.ErrRateLimited`, matching the `googleUpstreamStatusError` path already used in `internal/flights/search.go`. The merge layer reports an honest `rate_limited` status; other status codes keep their generic error.

## Changes
- `internal/flights/kiwi.go`: typed classification in `kiwiRPCWithHeaders`
- `internal/flights/ryanair.go`: typed classification in `SearchRyanair`
- `internal/flights/ryanair_test.go`: `TestSearchRyanair_RateLimitTyped` covers all three codes

## Validation
- gofmt clean, go vet clean
- flights package tests pass
- full build passes
