### PR TITLE
feat(ground): partial-failure honesty envelope + round-trip carry

### DIFF
--- a/internal/ground/ground_partial_failure_test.go
+++ b/internal/ground/ground_partial_failure_test.go
@@ -1,0 +1,79 @@
+package ground
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"golang.org/x/time/rate"
+)
+
+// TestSearchByName_PartialFailureEnvelope proves gap1: when a ground provider
+// fails, its outcome is recorded in ProviderStatuses + Completeness instead of
+// being silently dropped. Before the fix a provider error left no trace unless
+// EVERY provider produced zero routes (the legacy Error-only-on-total-wipeout
+// behaviour), so "no routes found" could not be distinguished from "the only
+// provider we asked timed out".
+func TestSearchByName_PartialFailureEnvelope(t *testing.T) {
+	origClient := httpClient
+	origLimiter := flixbusLimiter
+	t.Cleanup(func() {
+		httpClient = origClient
+		flixbusLimiter = origLimiter
+	})
+	flixbusLimiter = rate.NewLimiter(rate.Limit(1000), 1)
+
+	// Every upstream call fails hard.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	httpClient = &http.Client{
+		Transport: &urlRewriter{base: srv.URL},
+		Timeout:   5 * time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Isolate to flixbus so the assertion is deterministic and offline.
+	result, err := SearchByName(ctx, "city-berlin", "city-munich", "2026-07-01", SearchOptions{
+		Currency:  "EUR",
+		Providers: []string{"flixbus"},
+		NoCache:   true,
+	})
+	if err != nil {
+		t.Fatalf("SearchByName returned transport error: %v", err)
+	}
+
+	// The failure must be visible per-provider, not dropped.
+	if len(result.ProviderStatuses) != 1 {
+		t.Fatalf("ProviderStatuses = %#v, want exactly 1 (flixbus)", result.ProviderStatuses)
+	}
+	ps := result.ProviderStatuses[0]
+	if ps.ID != "flixbus" {
+		t.Errorf("status ID = %q, want flixbus", ps.ID)
+	}
+	if ps.Status == models.StatusOK {
+		t.Errorf("status = %q, want a non-ok failure classification", ps.Status)
+	}
+	if ps.Error == "" {
+		t.Error("failed provider status carries no error message")
+	}
+
+	// With the only queried provider down, absence is unproven: callers must NOT
+	// be allowed to claim an exhaustive "no routes found".
+	if result.Completeness.MayClaimExhaustive() {
+		t.Errorf("Completeness=%+v claims exhaustive after a total provider failure", result.Completeness)
+	}
+	if result.Completeness.State != models.CompletenessBlocked {
+		t.Errorf("Completeness.State = %q, want %q", result.Completeness.State, models.CompletenessBlocked)
+	}
+	if result.Success {
+		t.Error("Success = true despite zero routes and a failed provider")
+	}
+}

--- a/internal/ground/search.go
+++ b/internal/ground/search.go
@@ -202,12 +202,21 @@ func searchRoundTripByName(ctx context.Context, from, to, date, returnDate strin
 		if res.HackSaving != nil && combined.HackSaving == nil {
 			combined.HackSaving = res.HackSaving
 		}
+		// Carry each direction's provider outcomes into the combined envelope so a
+		// round-trip is as honest about partial failures as a one-way (otherwise a
+		// timed-out inbound provider would vanish). Direction-prefix the id to keep
+		// outbound/inbound entries distinct.
+		for _, ps := range res.ProviderStatuses {
+			ps.ID = dir + ":" + ps.ID
+			combined.ProviderStatuses = append(combined.ProviderStatuses, ps)
+		}
 	}
 	tagDirection(outbound, "outbound")
 	tagDirection(inbound, "inbound")
 
 	combined.Count = len(combined.Routes)
 	combined.Success = combined.Count > 0
+	combined.Completeness = models.ComputeCompleteness(combined.ProviderStatuses)
 	return combined, nil
 }
 
@@ -483,18 +492,41 @@ func searchByNameCore(ctx context.Context, from, to, date string, opts SearchOpt
 
 	var allRoutes []models.GroundRoute
 	var errors []string
+	var statuses []models.ProviderStatus
 	for r := range results {
 		if r.err != nil {
 			if isProviderNotApplicable(r.err) {
 				slog.Debug("ground provider not applicable", "provider", r.name, "reason", r.err)
+				// Attempted but no applicable route for this origin/destination —
+				// not a failure, so it must not drag Completeness toward "partial".
+				statuses = append(statuses, models.ProviderStatus{
+					ID:     r.name,
+					Name:   r.name,
+					Status: models.StatusSkipped,
+				})
 			} else {
 				slog.Warn("ground provider error", "provider", r.name, "error", r.err)
 				errors = append(errors, fmt.Sprintf("%s: %v", r.name, r.err))
+				statuses = append(statuses, models.ProviderStatus{
+					ID:     r.name,
+					Name:   r.name,
+					Status: models.ClassifyProviderError(r.err),
+					Error:  r.err.Error(),
+				})
 			}
 			continue
 		}
 		allRoutes = append(allRoutes, r.routes...)
+		statuses = append(statuses, models.ProviderStatus{
+			ID:      r.name,
+			Name:    r.name,
+			Status:  models.StatusOK,
+			Results: len(r.routes),
+		})
 	}
+	// Deterministic order: the channel drains concurrently, so sort by id for
+	// stable JSON output (and stable tests).
+	sort.Slice(statuses, func(i, j int) bool { return statuses[i].ID < statuses[j].ID })
 
 	// Filter/deduplicate in one pass while preserving the current semantics:
 	// unavailable routes are removed first, then duplicate routes are suppressed
@@ -513,9 +545,11 @@ func searchByNameCore(ctx context.Context, from, to, date string, opts SearchOpt
 	annotateGroundConfidence(allRoutes, time.Now())
 
 	result := &models.GroundSearchResult{
-		Success: len(allRoutes) > 0,
-		Count:   len(allRoutes),
-		Routes:  allRoutes,
+		Success:          len(allRoutes) > 0,
+		Count:            len(allRoutes),
+		Routes:           allRoutes,
+		ProviderStatuses: statuses,
+		Completeness:     models.ComputeCompleteness(statuses),
 	}
 	if len(allRoutes) == 0 && len(errors) > 0 {
 		result.Error = strings.Join(errors, "; ")

--- a/internal/models/ground.go
+++ b/internal/models/ground.go
@@ -16,7 +16,19 @@ type GroundSearchResult struct {
 	// location. Additive and silently degrading — absent when the lookup fails
 	// or no destination is known; never blocks the core route search.
 	Destination *DestinationInfo `json:"destination,omitempty"`
-	Error       string           `json:"error,omitempty"`
+	// ProviderStatuses reports the outcome of each ground provider (bus / train
+	// / ferry) that was attempted, mirroring flight and hotel search. It makes
+	// PARTIAL failures honest: when one provider rate-limits or times out but
+	// others return routes, the failure is recorded here instead of being
+	// silently dropped (the legacy Error field is only populated on a total
+	// wipeout). When a provider returns 0 routes without an error its status is
+	// "ok" with Results=0 — distinct from "failed"/"timeout"/"skipped".
+	ProviderStatuses []ProviderStatus `json:"provider_statuses,omitempty"`
+	// Completeness is the composite evidence summary derived from
+	// ProviderStatuses. When State != "complete", callers MUST NOT claim
+	// "no routes found" — some providers timed out or failed.
+	Completeness Completeness `json:"completeness,omitempty"`
+	Error        string       `json:"error,omitempty"`
 }
 
 // GroundRoute represents a single bus or train connection.

--- a/mcp/tools_ground.go
+++ b/mcp/tools_ground.go
@@ -164,7 +164,14 @@ func handleSearchGround(ctx context.Context, args map[string]any, elicit ElicitF
 		if result.Error != "" {
 			return nil, nil, toolResultError("Ground transport search", result.Error)
 		}
+		// Evidence guard: only claim a definitive "no routes" when every relevant
+		// provider was actually reached. If some timed out / rate-limited / failed,
+		// absence is not established — say so instead of lying (mirrors flights).
 		msg := fmt.Sprintf("No ground routes found from %s to %s on %s", from, to, date)
+		if !result.Completeness.MayClaimExhaustive() {
+			msg = fmt.Sprintf("No ground routes returned from %s to %s on %s yet. %s",
+				from, to, date, result.Completeness.IncompleteNote())
+		}
 		return []ContentBlock{{Type: "text", Text: msg}}, result, nil
 	}
 
@@ -181,6 +188,12 @@ func handleSearchGround(ctx context.Context, args map[string]any, elicit ElicitF
 		fmt.Sprintf("Found %d ground routes from %s to %s on %s", result.Count, from, to, date),
 		result.Routes,
 	)
+	// Partial-failure caveat: some providers returned routes but others timed
+	// out / failed, so this set is not exhaustive — say so rather than imply the
+	// cheapest shown is the cheapest available.
+	if note := result.Completeness.IncompleteNote(); note != "" {
+		summary += "\n\n" + note
+	}
 
 	content, err := buildAnnotatedContentBlocks(summary, result)
 	if err != nil {


### PR DESCRIPTION
## What

Ground transport search now carries a partial-failure honesty envelope, matching the pattern already used by flight and hotel search.

- `GroundSearchResult` gains `ProviderStatuses` (per-provider outcome) and `Completeness` (aggregate state).
- The drain loop records each provider as ok / skipped / classified-failure instead of discarding errors.
- The MCP ground handler stops claiming an exhaustive "no routes found" when completeness is unproven; it appends the incomplete-note instead.
- Round-trip searches merge both directions' provider outcomes (direction-prefixed ids) and recompute completeness over the combined set.

## Why

Previously a provider error left no trace unless *every* provider returned zero routes (legacy `Error`-only-on-total-wipeout). A caller could not distinguish "no service on this route" from "the only provider we asked timed out" — the search looked authoritative when it was blind. That is the kind of silent gap that makes downstream itinerary decisions wrong.

## Scope discipline

Additive only. Reuses existing `models.ClassifyProviderError` / `ComputeCompleteness` / `MayClaimExhaustive` / `IncompleteNote`. Legacy `result.Error` and the negative-result cache gate are untouched.

## Test

`TestSearchByName_PartialFailureEnvelope` drives a provider to HTTP 500 and asserts the failure surfaces in `ProviderStatuses`, `Completeness.State == blocked`, and that exhaustive-absence cannot be claimed.

## Gate

- `gofmt -l` clean
- `go vet ./internal/ground/... ./internal/models/... ./mcp/...` clean
- `go test ./internal/ground/... ./internal/models/...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
