### PR TITLE
feat(ground): distribusion honours 429 Retry-After with one bounded retry (#357)

### DIFF
--- a/internal/ground/distribusion.go
+++ b/internal/ground/distribusion.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/providers"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -44,6 +45,50 @@ var distribusionTitleCaser = cases.Title(language.English)
 // distribusionHTTPClient is a shared HTTP client for Distribusion API calls.
 var distribusionHTTPClient = &http.Client{
 	Timeout: 30 * time.Second,
+}
+
+// distribusionMaxRetryDelay caps how long a single 429 backoff may sleep
+// inside one search call (#357 TRVL-RETRY.2). The shared parser already caps
+// at 60s for the longer hotel/runtime deadline; ground fan-out wants a tighter
+// bound so one rate-limited provider can't stall the whole search.
+const distribusionMaxRetryDelay = 30 * time.Second
+
+// distribusionAfter is the sleep seam for the retry loop, overridable in tests
+// so 429-backoff paths run instantly instead of sleeping the real Retry-After.
+// ponytail: test seam, not configuration — production always uses time.After.
+var distribusionAfter = time.After
+
+// distribusionDoWithRetry performs req, retrying ONCE on HTTP 429 while
+// honouring the Retry-After header (capped at distribusionMaxRetryDelay).
+// The request is a bodyless GET so it is safely replayable. The final
+// response is returned for the caller to classify (a still-429 response on
+// the last attempt surfaces as a rate-limit error upstream).
+func distribusionDoWithRetry(ctx context.Context, req *http.Request) (*http.Response, error) {
+	const maxAttempts = 2
+	var resp *http.Response
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		resp, err = distribusionHTTPClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusTooManyRequests || attempt == maxAttempts {
+			return resp, nil
+		}
+		delay := providers.RetryAfterOrDefault(resp.Header.Get("Retry-After"), time.Now())
+		if delay > distribusionMaxRetryDelay {
+			delay = distribusionMaxRetryDelay
+		}
+		// Drain and close before replaying so the connection can be reused.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+		_ = resp.Body.Close()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-distribusionAfter(delay):
+		}
+	}
+	return resp, nil
 }
 
 // distribusionStationCodes maps lowercase city name / alias to Distribusion
@@ -299,7 +344,7 @@ func SearchDistribusion(ctx context.Context, from, to, date, currency string) ([
 	slog.Debug("distribusion search", "from", from, "to", to, "date", date,
 		"fromCode", fromCode, "toCode", toCode)
 
-	resp, err := distribusionHTTPClient.Do(req)
+	resp, err := distribusionDoWithRetry(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("distribusion: HTTP request: %w", err)
 	}

--- a/internal/ground/distribusion_retry_test.go
+++ b/internal/ground/distribusion_retry_test.go
@@ -1,0 +1,112 @@
+package ground
+
+// #357 TRVL-RETRY.2/.3: distribusion honours a single bounded retry on HTTP
+// 429, replaying the bodyless GET after the Retry-After backoff. These tests
+// drive the path entirely offline via a scripted RoundTripper and an instant
+// sleep seam, so no live origin is contacted and the suite stays fast.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// scriptedRT returns a canned response per call index, counting invocations.
+type scriptedRT struct {
+	calls atomic.Int32
+	fn    func(n int32) *http.Response
+}
+
+func (s *scriptedRT) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return s.fn(s.calls.Add(1)), nil
+}
+
+func resp429() *http.Response {
+	h := http.Header{}
+	h.Set("Retry-After", "1")
+	return &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(`{"err":"rate limited"}`)),
+	}
+}
+
+func resp200(body string) *http.Response {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// installRetryStub swaps the shared client transport, the sleep seam and the
+// limiter for deterministic offline behaviour, restoring them on cleanup.
+func installRetryStub(t *testing.T, rt http.RoundTripper) {
+	t.Helper()
+	t.Setenv("DISTRIBUSION_API_KEY", "test-key")
+
+	origTransport := distribusionHTTPClient.Transport
+	origAfter := distribusionAfter
+	origLimiter := distribusionLimiter
+	t.Cleanup(func() {
+		distribusionHTTPClient.Transport = origTransport
+		distribusionAfter = origAfter
+		distribusionLimiter = origLimiter
+	})
+
+	distribusionHTTPClient.Transport = rt
+	distribusionAfter = func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Time{}
+		return ch
+	}
+	distribusionLimiter = rate.NewLimiter(rate.Limit(1000), 1)
+}
+
+func TestSearchDistribusion_429RetriesThenSucceeds(t *testing.T) {
+	stub := &scriptedRT{fn: func(n int32) *http.Response {
+		if n == 1 {
+			return resp429()
+		}
+		return resp200(`{"data":[],"included":[]}`)
+	}}
+	installRetryStub(t, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := SearchDistribusion(ctx, "helsinki", "tallinn", "2026-07-01", "EUR")
+	if err != nil {
+		t.Fatalf("SearchDistribusion after one 429 retry: unexpected error %v", err)
+	}
+	if got := stub.calls.Load(); got != 2 {
+		t.Errorf("upstream calls = %d, want 2 (one 429 + one successful retry)", got)
+	}
+}
+
+func TestSearchDistribusion_429ExhaustsRetries(t *testing.T) {
+	stub := &scriptedRT{fn: func(int32) *http.Response { return resp429() }}
+	installRetryStub(t, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := SearchDistribusion(ctx, "helsinki", "tallinn", "2026-07-01", "EUR")
+	if err == nil {
+		t.Fatal("SearchDistribusion with persistent 429: want rate-limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "429") {
+		t.Errorf("error = %v, want it to surface the 429 rate limit", err)
+	}
+	if got := stub.calls.Load(); got != 2 {
+		t.Errorf("upstream calls = %d, want 2 (initial + one bounded retry, then give up)", got)
+	}
+}

--- a/internal/providers/retry_after.go
+++ b/internal/providers/retry_after.go
@@ -43,9 +43,13 @@ const (
 	rateLimitFloorRPS = 0.05
 )
 
-// parseRetryAfter inspects the value of an HTTP Retry-After header and
+// ParseRetryAfter inspects the value of an HTTP Retry-After header and
 // returns the duration the caller should sleep before retrying. `now` is
 // injected for deterministic testing of the HTTP-date form.
+//
+// This is the single shared Retry-After parser for the codebase (MIK-3071,
+// #357 TRVL-RETRY.1); providers honour 429 backoff through it rather than
+// re-implementing RFC 7231 §7.1.3 parsing per provider.
 //
 // Behaviour:
 //   - empty or whitespace-only → 0 (caller falls back to default)
@@ -53,7 +57,7 @@ const (
 //   - HTTP-date in the future → time until that date, capped
 //   - HTTP-date in the past → 0
 //   - any other input → 0
-func parseRetryAfter(value string, now time.Time) time.Duration {
+func ParseRetryAfter(value string, now time.Time) time.Duration {
 	v := strings.TrimSpace(value)
 	if v == "" {
 		return 0
@@ -87,11 +91,11 @@ func parseRetryAfter(value string, now time.Time) time.Duration {
 	return d
 }
 
-// retryAfterOrDefault returns parseRetryAfter's result if non-zero,
+// RetryAfterOrDefault returns ParseRetryAfter's result if non-zero,
 // otherwise retryAfterDefaultDelay. Convenience wrapper for the retry
 // loop in the search request path.
-func retryAfterOrDefault(value string, now time.Time) time.Duration {
-	d := parseRetryAfter(value, now)
+func RetryAfterOrDefault(value string, now time.Time) time.Duration {
+	d := ParseRetryAfter(value, now)
 	if d <= 0 {
 		return retryAfterDefaultDelay
 	}

--- a/internal/providers/retry_after_test.go
+++ b/internal/providers/retry_after_test.go
@@ -33,8 +33,8 @@ func TestParseRetryAfter_DeltaSeconds(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.in, func(t *testing.T) {
-			if got := parseRetryAfter(tc.in, now); got != tc.want {
-				t.Errorf("parseRetryAfter(%q) = %v, want %v", tc.in, got, tc.want)
+			if got := ParseRetryAfter(tc.in, now); got != tc.want {
+				t.Errorf("ParseRetryAfter(%q) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
 	}
@@ -44,18 +44,18 @@ func TestParseRetryAfter_HTTPDate(t *testing.T) {
 	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
 
 	future := now.Add(30 * time.Second).UTC().Format(http.TimeFormat)
-	if got := parseRetryAfter(future, now); got <= 0 || got > 31*time.Second {
+	if got := ParseRetryAfter(future, now); got <= 0 || got > 31*time.Second {
 		t.Errorf("future date: got %v, want ~30s", got)
 	}
 
 	past := now.Add(-30 * time.Second).UTC().Format(http.TimeFormat)
-	if got := parseRetryAfter(past, now); got != 0 {
+	if got := ParseRetryAfter(past, now); got != 0 {
 		t.Errorf("past date: got %v, want 0", got)
 	}
 
 	// Far-future dates are capped.
 	farFuture := now.Add(2 * time.Hour).UTC().Format(http.TimeFormat)
-	if got := parseRetryAfter(farFuture, now); got != retryAfterMaxDelay {
+	if got := ParseRetryAfter(farFuture, now); got != retryAfterMaxDelay {
 		t.Errorf("far-future date: got %v, want cap %v", got, retryAfterMaxDelay)
 	}
 }
@@ -63,7 +63,7 @@ func TestParseRetryAfter_HTTPDate(t *testing.T) {
 func TestParseRetryAfter_Invalid(t *testing.T) {
 	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
 	for _, in := range []string{"", "   ", "not-a-number", "abc", "1.5"} {
-		if got := parseRetryAfter(in, now); got != 0 {
+		if got := ParseRetryAfter(in, now); got != 0 {
 			t.Errorf("invalid %q: got %v, want 0", in, got)
 		}
 	}
@@ -71,10 +71,10 @@ func TestParseRetryAfter_Invalid(t *testing.T) {
 
 func TestRetryAfterOrDefault(t *testing.T) {
 	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
-	if got := retryAfterOrDefault("", now); got != retryAfterDefaultDelay {
+	if got := RetryAfterOrDefault("", now); got != retryAfterDefaultDelay {
 		t.Errorf("empty header: got %v, want default %v", got, retryAfterDefaultDelay)
 	}
-	if got := retryAfterOrDefault("5", now); got != 5*time.Second {
+	if got := RetryAfterOrDefault("5", now); got != 5*time.Second {
 		t.Errorf("5s header: got %v, want 5s", got)
 	}
 }

--- a/internal/providers/runtime_provider.go
+++ b/internal/providers/runtime_provider.go
@@ -381,7 +381,7 @@ func (rt *Runtime) searchProvider(ctx context.Context, cfg *ProviderConfig, loca
 	// Retry on HTTP 429 honouring the Retry-After header (MIK-3071).
 	const maxRetries429 = 2
 	for attempt := 0; attempt < maxRetries429 && resp.StatusCode == http.StatusTooManyRequests; attempt++ {
-		delay := retryAfterOrDefault(resp.Header.Get("Retry-After"), time.Now())
+		delay := RetryAfterOrDefault(resp.Header.Get("Retry-After"), time.Now())
 		select {
 		case <-time.After(delay):
 		case <-ctx.Done():


### PR DESCRIPTION
## What

distribusion previously failed fast on HTTP 429, turning a transient rate limit into a silently dropped provider in the ground fan-out. It now retries **once**, honouring the `Retry-After` header (capped at 30s), before surfacing a rate-limit error.

First vertical slice of #357. Establishes the shared-parser + bounded-retry pattern the other fail-fast ground providers replicate next.

## Acceptance criteria

- **TRVL-RETRY.1** — promote the Retry-After parser to `providers.ParseRetryAfter` / `providers.RetryAfterOrDefault` (was package-private, MIK-3071). One RFC 7231 parser shared by ground + runtime providers; the in-package caller and tests now use the exported names.
- **TRVL-RETRY.2** — distribusion replays the bodyless GET once on 429, sleeping the capped `Retry-After`; a persistent 429 still surfaces as `rate limited (HTTP 429)`.
- **TRVL-RETRY.3** — offline fake-transport tests: `429+Retry-After -> 200` succeeds (2 upstream calls), and `429,429 -> rate_limited` surfaced (2 calls, then give up). A sleep seam keeps the tests instant — no real backoff waits, no live origin.
- **TRVL-RETRY.4** — expedia unchanged (its 429/403 is an Akamai bot wall, not a rate limit; retrying would just hammer it).

## Scope notes

- Remaining #357 providers (norwegian, trivago, rome2rio, trainline) follow this pattern on subsequent changes.
- skiplagged keeps its own 30s-capped parser for now; folding it into the shared one is a deliberate cap reconciliation (60s vs 30s), not a mechanical merge, so it is left for a focused follow-up.

## Validation

```
gofmt -l   : clean (5 files)
go vet     : clean (ground + providers)
go build ./... : ok
go test ./internal/ground/... ./internal/providers/... ./internal/flights/... : all ok
  - TestSearchDistribusion_429RetriesThenSucceeds  PASS (0.00s)
  - TestSearchDistribusion_429ExhaustsRetries       PASS (0.00s)
```

Closes #357 partially (RETRY.1 + distribusion adoption); remaining providers tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
