### PR TITLE
feat(flights): norwegian honours 429 Retry-After with one bounded retry (#357)

### DIFF
--- a/internal/flights/norwegian.go
+++ b/internal/flights/norwegian.go
@@ -57,6 +57,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/providers"
 	"golang.org/x/time/rate"
 )
 
@@ -71,6 +72,45 @@ var (
 	norwegianLimiter = rate.NewLimiter(rate.Every(500*time.Millisecond), 1)
 	norwegianClient  = &http.Client{Timeout: 25 * time.Second}
 )
+
+// norwegianMaxRetryDelay bounds how long a single 429 backoff may sleep inside
+// one search call, so a hostile Retry-After can't stall the request past the
+// MCP client deadline.
+const norwegianMaxRetryDelay = 30 * time.Second
+
+// norwegianAfter is the sleep seam for the bounded 429 retry. Tests override it
+// to fire instantly. ponytail: test seam, not configuration.
+var norwegianAfter = time.After
+
+// norwegianDoWithRetry issues req and retries ONCE on HTTP 429, honouring the
+// Retry-After header (bounded by norwegianMaxRetryDelay) before replaying the
+// bodyless GET. A persistent 429 is returned to the caller for its existing
+// rate-limit classification. 403/401 bot-challenge responses are NOT retried —
+// they are returned on the first attempt for the caller to classify.
+func norwegianDoWithRetry(ctx context.Context, req *http.Request) (*http.Response, error) {
+	const maxAttempts = 2
+	for attempt := 1; ; attempt++ {
+		resp, err := norwegianClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusTooManyRequests || attempt == maxAttempts {
+			return resp, nil
+		}
+		delay := providers.RetryAfterOrDefault(resp.Header.Get("Retry-After"), time.Now())
+		if delay > norwegianMaxRetryDelay {
+			delay = norwegianMaxRetryDelay
+		}
+		// Drain and close before replaying the connection.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+		_ = resp.Body.Close()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-norwegianAfter(delay):
+		}
+	}
+}
 
 // norwegianAPIBase returns the operator-supplied Norwegian availability base
 // URL, or "". When empty the provider is a no-op (honest skip), because the
@@ -144,7 +184,7 @@ func SearchNorwegian(ctx context.Context, origin, destination, date, currency st
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "trvl/1.0")
 
-	resp, err := norwegianClient.Do(req)
+	resp, err := norwegianDoWithRetry(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("norwegian: request: %w", err)
 	}

--- a/internal/flights/norwegian_retry_test.go
+++ b/internal/flights/norwegian_retry_test.go
@@ -1,0 +1,130 @@
+package flights
+
+// #357 TRVL-RETRY.2/.3: Norwegian honours a single bounded retry on HTTP 429,
+// replaying the bodyless GET after the Retry-After backoff. These tests drive
+// the path entirely offline via a scripted RoundTripper and an instant sleep
+// seam, so no live origin is contacted and the suite stays fast. A persistent
+// 429 must surface the rate-limit error (one retry, then give up); a 403
+// bot-challenge must NOT be retried.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// norwegianScriptedRT returns a canned response per call index, counting calls.
+type norwegianScriptedRT struct {
+	calls atomic.Int32
+	fn    func(n int32) *http.Response
+}
+
+func (s *norwegianScriptedRT) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return s.fn(s.calls.Add(1)), nil
+}
+
+func norwegianResp(status int, retryAfter, body string) *http.Response {
+	h := http.Header{}
+	if retryAfter != "" {
+		h.Set("Retry-After", retryAfter)
+	}
+	h.Set("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: status,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// installNorwegianRetryStub swaps the client transport, the sleep seam and the
+// limiter for deterministic offline behaviour, restoring them on cleanup.
+func installNorwegianRetryStub(t *testing.T, rt http.RoundTripper) {
+	t.Helper()
+	t.Setenv("NORWEGIAN_API_BASE", "https://norwegian.test")
+
+	origTransport := norwegianClient.Transport
+	origAfter := norwegianAfter
+	origLimiter := norwegianLimiter
+	t.Cleanup(func() {
+		norwegianClient.Transport = origTransport
+		norwegianAfter = origAfter
+		norwegianLimiter = origLimiter
+	})
+
+	norwegianClient.Transport = rt
+	norwegianAfter = func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Time{}
+		return ch
+	}
+	norwegianLimiter = rate.NewLimiter(rate.Limit(1000), 1)
+}
+
+func TestSearchNorwegian_429RetriesThenSucceeds(t *testing.T) {
+	stub := &norwegianScriptedRT{fn: func(n int32) *http.Response {
+		if n == 1 {
+			return norwegianResp(http.StatusTooManyRequests, "1", `{"err":"rate limited"}`)
+		}
+		return norwegianResp(http.StatusOK, "", `{"flights":[]}`)
+	}}
+	installNorwegianRetryStub(t, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := SearchNorwegian(ctx, "OSL", "LGW", "2026-07-01", "EUR", SearchOptions{})
+	if err != nil {
+		t.Fatalf("SearchNorwegian after one 429 retry: unexpected error %v", err)
+	}
+	if got := stub.calls.Load(); got != 2 {
+		t.Errorf("upstream calls = %d, want 2 (one 429 + one successful retry)", got)
+	}
+}
+
+func TestSearchNorwegian_429ExhaustsRetries(t *testing.T) {
+	stub := &norwegianScriptedRT{fn: func(int32) *http.Response {
+		return norwegianResp(http.StatusTooManyRequests, "1", `{"err":"rate limited"}`)
+	}}
+	installNorwegianRetryStub(t, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := SearchNorwegian(ctx, "OSL", "LGW", "2026-07-01", "EUR", SearchOptions{})
+	if err == nil {
+		t.Fatal("SearchNorwegian with persistent 429: want rate-limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "rate-limited") {
+		t.Errorf("error = %v, want it to surface the rate limit", err)
+	}
+	if got := stub.calls.Load(); got != 2 {
+		t.Errorf("upstream calls = %d, want 2 (initial + one bounded retry, then give up)", got)
+	}
+}
+
+// TestSearchNorwegian_403NotRetried guards the bot-challenge path: a 403 is a
+// Cloudflare challenge, not a transient throttle, so it must fail on the first
+// attempt with NO retry.
+func TestSearchNorwegian_403NotRetried(t *testing.T) {
+	stub := &norwegianScriptedRT{fn: func(int32) *http.Response {
+		return norwegianResp(http.StatusForbidden, "", `<html>Are you human?</html>`)
+	}}
+	installNorwegianRetryStub(t, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := SearchNorwegian(ctx, "OSL", "LGW", "2026-07-01", "EUR", SearchOptions{})
+	if err == nil {
+		t.Fatal("SearchNorwegian on 403: want blocked error, got nil")
+	}
+	if got := stub.calls.Load(); got != 1 {
+		t.Errorf("upstream calls = %d, want 1 (403 must NOT be retried)", got)
+	}
+}


### PR DESCRIPTION
## What
Norwegian flight provider now honours HTTP 429 Retry-After with a single bounded retry, the second slice of #357 after the merged distribusion change (#358).

## Why
On a transient 429 the provider returned an error immediately, dropping itself from the fan-out with no second chance, the same fail-fast gap closed for distribusion. A throttled provider should back off once and retry, not vanish from results.

## Changes
- norwegianDoWithRetry wraps the availability GET: retries once on 429, honouring Retry-After via the shared providers.RetryAfterOrDefault (capped at 30s), draining and closing the body before replaying the bodyless request, context-aware sleep via a test seam.
- Persistent 429 still surfaces the existing rate-limited error.
- 403 and 401 Cloudflare bot challenges are NOT retried, returned on the first attempt, unchanged. Retrying a bot wall is exactly the wrong move.

## Tests (offline, deterministic)
Scripted RoundTripper plus instant sleep seam, no live origin:
- 429 then 200 succeeds in 2 calls
- two consecutive 429s give up with a rate-limit error after one retry
- 403 challenge is never retried (1 call)

## Gate
gofmt clean; go vet clean; go build ok; full flights package test suite green (no regression)

## Scope
AC items 2 and 3 of #357 for norwegian. Remaining providers trivago, rome2rio, trainline follow in their own PRs. expedia stays fail-fast (Akamai bot wall, out of scope).

Generated with Claude Code
