### PR TITLE
rome2rio: bounded retry on 429, fail fast on 403 bot wall

### DIFF
--- a/internal/ground/rome2rio.go
+++ b/internal/ground/rome2rio.go
@@ -2,6 +2,7 @@ package ground
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"golang.org/x/net/html"
 
@@ -46,6 +48,50 @@ const rome2rioThinRenderRetries = 2
 // as a typed error rather than a silently-empty success.
 const rome2rioMarker = "ways to get from"
 
+// rome2rioMaxRetryDelay caps how long a single 429 backoff waits, even when the
+// server's Retry-After asks for longer. #357 TRVL-RETRY.2.
+const rome2rioMaxRetryDelay = 30 * time.Second
+
+// rome2rioAfter is the sleep seam for the bounded 429 retry; tests swap it for an
+// instant channel so the suite never actually waits out a backoff.
+var rome2rioAfter = time.After
+
+// errRome2RioBlocked marks a server-side refusal — a Cloudflare 403 bot wall or a
+// 429 that persists past the one bounded retry. The outer thin-render retry loop
+// must NOT re-attempt these: a 403 is a bot wall (re-fetching only hammers it) and
+// a 429 has already been honoured once. Thin-render and parse errors stay retryable.
+var errRome2RioBlocked = errors.New("rome2rio: blocked")
+
+// rome2rioDoWithRetry issues req via doer, honouring a SINGLE bounded retry on
+// HTTP 429: it reads Retry-After (capped at rome2rioMaxRetryDelay), drains and
+// closes the throttled response, then replays the request once. The request is a
+// bodyless GET, so the replay simply re-issues it. A 403 is a Cloudflare bot
+// wall, not a transient throttle, so it is returned immediately — never retried.
+// The sleep is context-aware so a cancelled search aborts the backoff.
+func rome2rioDoWithRetry(ctx context.Context, doer func(*http.Request) (*http.Response, error), req *http.Request) (*http.Response, error) {
+	const maxAttempts = 2
+	for attempt := 1; ; attempt++ {
+		resp, err := doer(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusTooManyRequests || attempt >= maxAttempts {
+			return resp, nil
+		}
+		delay := providers.RetryAfterOrDefault(resp.Header.Get("Retry-After"), time.Now())
+		if delay > rome2rioMaxRetryDelay {
+			delay = rome2rioMaxRetryDelay
+		}
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+		_ = resp.Body.Close()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-rome2rioAfter(delay):
+		}
+	}
+}
+
 var (
 	// matches "2h 28m", "23h 28m", "4h 2m"
 	r2rHourMin = regexp.MustCompile(`(\d+)\s*h\s*(\d+)\s*m`)
@@ -81,6 +127,12 @@ func SearchRome2Rio(ctx context.Context, from, to string, allowBrowser bool) ([]
 		body, err := fetchRome2Rio(ctx, from, to, allowBrowser)
 		if err != nil {
 			lastErr = err
+			// A bot wall (403) or persistent 429 won't be cured by re-fetching —
+			// the inner retry already honoured Retry-After once. Fail fast rather
+			// than spend the thin-render retries hammering a server saying no.
+			if errors.Is(err, errRome2RioBlocked) {
+				break
+			}
 			continue
 		}
 		if !strings.Contains(body, rome2rioMarker) {
@@ -147,14 +199,17 @@ func fetchRome2Rio(ctx context.Context, from, to string, allowBrowser bool) (str
 		req.Header.Set("User-Agent", rome2rioChromeUA)
 	}
 
-	resp, err := doer(req)
+	resp, err := rome2rioDoWithRetry(ctx, doer, req)
 	if err != nil {
 		return "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
-		return "", fmt.Errorf("rome2rio: bot wall / rate limited (HTTP %d)", resp.StatusCode)
+	if resp.StatusCode == http.StatusForbidden {
+		return "", fmt.Errorf("%w: bot wall (HTTP 403)", errRome2RioBlocked)
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return "", fmt.Errorf("%w: rate limited after retry (HTTP 429)", errRome2RioBlocked)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("rome2rio: unexpected status HTTP %d", resp.StatusCode)

--- a/internal/ground/rome2rio_retry_test.go
+++ b/internal/ground/rome2rio_retry_test.go
@@ -1,0 +1,134 @@
+package ground
+
+// #357 TRVL-RETRY.2/.3: rome2rio honours a single bounded retry on HTTP 429
+// (replaying the bodyless GET after the Retry-After backoff) and fails fast on a
+// 403 Cloudflare bot wall. A persistent 429 or a 403 must also break the outer
+// thin-render retry loop rather than hammer a server already refusing. These
+// tests drive the path entirely offline via the shared scriptedRT/resp* helpers
+// (declared in distribusion_retry_test.go) plus an instant sleep seam.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func resp403() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(`<html>Are you human?</html>`)),
+	}
+}
+
+// installRome2RioInstantBackoff swaps the 429 sleep seam for an instant channel,
+// restoring it on cleanup, so a retry never actually waits out the backoff.
+func installRome2RioInstantBackoff(t *testing.T) {
+	t.Helper()
+	orig := rome2rioAfter
+	t.Cleanup(func() { rome2rioAfter = orig })
+	rome2rioAfter = func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Time{}
+		return ch
+	}
+}
+
+func newRome2RioReq(t *testing.T, ctx context.Context) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://rome2rio.test/s/Helsinki/Tallinn", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	return req
+}
+
+func TestRome2RioDoWithRetry_429ThenSuccess(t *testing.T) {
+	installRome2RioInstantBackoff(t)
+	stub := &scriptedRT{fn: func(n int32) *http.Response {
+		if n == 1 {
+			return resp429()
+		}
+		return resp200("ok")
+	}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := rome2rioDoWithRetry(ctx, stub.RoundTrip, newRome2RioReq(t, ctx))
+	if err != nil {
+		t.Fatalf("rome2rioDoWithRetry after one 429 retry: unexpected error %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 after the retry succeeded", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 2 {
+		t.Errorf("upstream calls = %d, want 2 (one 429 + one successful retry)", got)
+	}
+}
+
+func TestRome2RioDoWithRetry_429Persists(t *testing.T) {
+	installRome2RioInstantBackoff(t)
+	stub := &scriptedRT{fn: func(int32) *http.Response { return resp429() }}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := rome2rioDoWithRetry(ctx, stub.RoundTrip, newRome2RioReq(t, ctx))
+	if err != nil {
+		t.Fatalf("rome2rioDoWithRetry persistent 429: unexpected transport error %v", err)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429 surfaced to the caller", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 2 {
+		t.Errorf("upstream calls = %d, want 2 (initial + one bounded retry, then give up)", got)
+	}
+}
+
+func TestRome2RioDoWithRetry_403NotRetried(t *testing.T) {
+	stub := &scriptedRT{fn: func(int32) *http.Response { return resp403() }}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := rome2rioDoWithRetry(ctx, stub.RoundTrip, newRome2RioReq(t, ctx))
+	if err != nil {
+		t.Fatalf("rome2rioDoWithRetry on 403: unexpected transport error %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 returned immediately", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 1 {
+		t.Errorf("upstream calls = %d, want 1 (403 bot wall must NOT be retried)", got)
+	}
+}
+
+// TestSearchRome2Rio_403FailsFastNoOuterRetry proves the bot-wall sentinel breaks
+// the outer thin-render retry loop: a 403 must hit the transport exactly once,
+// not rome2rioThinRenderRetries+1 times.
+func TestSearchRome2Rio_403FailsFastNoOuterRetry(t *testing.T) {
+	stub := &scriptedRT{fn: func(int32) *http.Response { return resp403() }}
+
+	origTransport := httpClient.Transport
+	t.Cleanup(func() { httpClient.Transport = origTransport })
+	httpClient.Transport = stub
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := SearchRome2Rio(ctx, "Helsinki", "Tallinn", false)
+	if err == nil {
+		t.Fatal("SearchRome2Rio on 403: want blocked error, got nil")
+	}
+	if !errors.Is(err, errRome2RioBlocked) {
+		t.Errorf("error = %v, want it to wrap errRome2RioBlocked", err)
+	}
+	if got := stub.calls.Load(); got != 1 {
+		t.Errorf("transport calls = %d, want 1 (403 must fail fast, not spend outer thin-render retries)", got)
+	}
+}


### PR DESCRIPTION
## What

Adds a single bounded retry on HTTP 429 to the rome2rio ground provider, honouring Retry-After (capped at 30s), and makes a 403 Cloudflare bot wall fail fast.

Part of issue 357 (provider rate-limit reliability), acceptance items 2 and 3.

## Why

rome2rio previously folded a 403 and a 429 into one error that the outer thin-render retry loop retried indiscriminately. A 429 was retried immediately with no Retry-After respect; a 403 bot wall was pointlessly re-fetched. Re-fetching a server that is already refusing only hammers it.

## How

- rome2rioDoWithRetry issues the request, and on a 429 reads Retry-After (capped at 30s), drains and closes the throttled response, waits on a context-aware backoff, then replays the bodyless GET once.
- A 403 is returned immediately and never retried.
- A shared sentinel error marks both a 403 bot wall and a persistent 429 so the outer thin-render loop breaks instead of retrying. Thin-render and parse errors stay retryable.
- The shared Retry-After parser from the providers package is reused.

## Tests

Offline fake-transport tests in the ground package:
- 429 then success replays once and returns 200 (two upstream calls).
- Persistent 429 stops after one retry (two upstream calls).
- 403 is not retried (one upstream call).
- End to end, a 403 fails fast without spending the outer retries (one transport call).

Gate: gofmt clean, go vet clean, go build clean, full ground package suite green.

Generated with Claude Code
