### PR TITLE
trainline: bounded single retry on HTTP 429 honouring Retry-After

### DIFF
--- a/internal/ground/distribusion_retry_test.go
+++ b/internal/ground/distribusion_retry_test.go
@@ -47,15 +47,6 @@ func resp200(body string) *http.Response {
 	}
 }
 
-func resp403() *http.Response {
-	h := http.Header{}
-	return &http.Response{
-		StatusCode: http.StatusForbidden,
-		Header:     h,
-		Body:       io.NopCloser(strings.NewReader(`{"err":"forbidden"}`)),
-	}
-}
-
 // installRetryStub swaps the shared client transport, the sleep seam and the
 // limiter for deterministic offline behaviour, restoring them on cleanup.
 func installRetryStub(t *testing.T, rt http.RoundTripper) {

--- a/internal/ground/distribusion_retry_test.go
+++ b/internal/ground/distribusion_retry_test.go
@@ -47,6 +47,15 @@ func resp200(body string) *http.Response {
 	}
 }
 
+func resp403() *http.Response {
+	h := http.Header{}
+	return &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(`{"err":"forbidden"}`)),
+	}
+}
+
 // installRetryStub swaps the shared client transport, the sleep seam and the
 // limiter for deterministic offline behaviour, restoring them on cleanup.
 func installRetryStub(t *testing.T, rt http.RoundTripper) {

--- a/internal/ground/trainline.go
+++ b/internal/ground/trainline.go
@@ -43,6 +43,13 @@ var trainlineLimiter = newProviderLimiter(12 * time.Second)
 // trainlineClient uses Chrome TLS fingerprint to bypass Datadome bot detection.
 var trainlineClient = batchexec.ChromeHTTPClient()
 
+// trainlineMaxRetryDelay caps how long we wait on a 429 Retry-After before
+// giving up; a throttled origin must not stall the whole search.
+const trainlineMaxRetryDelay = 30 * time.Second
+
+// trainlineAfter is the 429 backoff sleep seam (swapped to instant in tests).
+var trainlineAfter = time.After
+
 var (
 	trainlineDo             = func(req *http.Request) (*http.Response, error) { return trainlineClient.Do(req) }
 	trainlineFetchViaNab    = fetchTrainlineViaNab
@@ -338,6 +345,45 @@ func trainlineViaCurl(ctx context.Context, fromID, toID, date, currency string) 
 	return readAndParseTrainlineResponse(strings.NewReader(trimmed), "", "", date, currency)
 }
 
+// trainlineDoWithRetry issues the request and, on a single HTTP 429, honours the
+// Retry-After header (capped at trainlineMaxRetryDelay) and replays the request
+// exactly once. makeReq rebuilds a fresh request per attempt so the POST body is
+// re-read cleanly. A 403 bot wall is never retried here — SearchTrainline's own
+// fallback ladder handles it; any non-429 response is returned to the caller as-is.
+func trainlineDoWithRetry(ctx context.Context, makeReq func() (*http.Request, error)) (*http.Response, error) {
+	req, err := makeReq()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := trainlineDo(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		return resp, nil
+	}
+
+	delay := providers.RetryAfterOrDefault(resp.Header.Get("Retry-After"), time.Now())
+	if delay > trainlineMaxRetryDelay {
+		delay = trainlineMaxRetryDelay
+	}
+	// Drain + close the 429 body before replaying so the connection can be reused.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	_ = resp.Body.Close()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-trainlineAfter(delay):
+	}
+
+	req2, err := makeReq()
+	if err != nil {
+		return nil, err
+	}
+	return trainlineDo(req2)
+}
+
 // SearchTrainline searches thetrainline.com for train connections between two cities.
 // By default it uses the public journey-search API only. Browser/curl-assisted
 // fallbacks are opt-in via allowBrowserFallbacks.
@@ -406,12 +452,9 @@ func SearchTrainline(ctx context.Context, from, to, date, currency string, allow
 
 	slog.Debug("trainline search", "from", from, "to", to, "date", date)
 
-	req, err := newTrainlineRequest("")
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := trainlineDo(req)
+	resp, err := trainlineDoWithRetry(ctx, func() (*http.Request, error) {
+		return newTrainlineRequest("")
+	})
 	if err != nil {
 		return nil, fmt.Errorf("trainline search: %w", err)
 	}

--- a/internal/ground/trainline_retry_test.go
+++ b/internal/ground/trainline_retry_test.go
@@ -1,0 +1,118 @@
+package ground
+
+// #357 TRVL-RETRY.2/.3: the Trainline journey-search POST honours a single
+// bounded retry on HTTP 429, replaying the request (rebuilding its body) after
+// the Retry-After backoff. A persistent 429 surfaces after exactly one retry; a
+// 403 bot wall is NOT retried by this helper (SearchTrainline's own fallback
+// ladder owns the 403 path). These tests drive the seam entirely offline via the
+// shared scriptedRT/resp* helpers (declared in distribusion_retry_test.go /
+// rome2rio_retry_test.go) plus an instant sleep seam.
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// installTrainlineInstantBackoff swaps the 429 sleep seam for an instant channel,
+// restoring it on cleanup, so a retry never actually waits out the backoff.
+func installTrainlineInstantBackoff(t *testing.T) {
+	t.Helper()
+	orig := trainlineAfter
+	t.Cleanup(func() { trainlineAfter = orig })
+	trainlineAfter = func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Time{}
+		return ch
+	}
+}
+
+// stubTrainlineDo points the trainlineDo seam at a scripted RoundTripper,
+// restoring the original on cleanup.
+func stubTrainlineDo(t *testing.T, stub *scriptedRT) {
+	t.Helper()
+	orig := trainlineDo
+	t.Cleanup(func() { trainlineDo = orig })
+	trainlineDo = func(req *http.Request) (*http.Response, error) { return stub.RoundTrip(req) }
+}
+
+// makeTrainlineReq builds a fresh POST request (with body) per attempt, matching
+// the production newTrainlineRequest closure shape.
+func makeTrainlineReq(ctx context.Context) func() (*http.Request, error) {
+	return func() (*http.Request, error) {
+		return http.NewRequestWithContext(
+			ctx, http.MethodPost,
+			"https://trainline.test/api/journey-search/",
+			strings.NewReader(`{"q":"x"}`),
+		)
+	}
+}
+
+func TestTrainlineDoWithRetry_429ThenSuccess(t *testing.T) {
+	installTrainlineInstantBackoff(t)
+	stub := &scriptedRT{fn: func(n int32) *http.Response {
+		if n == 1 {
+			return resp429()
+		}
+		return resp200("ok")
+	}}
+	stubTrainlineDo(t, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := trainlineDoWithRetry(ctx, makeTrainlineReq(ctx))
+	if err != nil {
+		t.Fatalf("trainlineDoWithRetry after one 429 retry: unexpected error %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 after the retry succeeded", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 2 {
+		t.Errorf("upstream calls = %d, want 2 (one 429 + one successful retry)", got)
+	}
+}
+
+func TestTrainlineDoWithRetry_429Persists(t *testing.T) {
+	installTrainlineInstantBackoff(t)
+	stub := &scriptedRT{fn: func(int32) *http.Response { return resp429() }}
+	stubTrainlineDo(t, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := trainlineDoWithRetry(ctx, makeTrainlineReq(ctx))
+	if err != nil {
+		t.Fatalf("trainlineDoWithRetry persistent 429: unexpected transport error %v", err)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429 surfaced to the caller", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 2 {
+		t.Errorf("upstream calls = %d, want 2 (initial + one bounded retry, then give up)", got)
+	}
+}
+
+// TestTrainlineDoWithRetry_403NotRetried guards the bot-wall path: a 403 is a
+// Datadome challenge, not a transient throttle, so the helper must return it on
+// the first attempt with NO retry and let the caller's fallback ladder run.
+func TestTrainlineDoWithRetry_403NotRetried(t *testing.T) {
+	stub := &scriptedRT{fn: func(int32) *http.Response { return resp403() }}
+	stubTrainlineDo(t, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := trainlineDoWithRetry(ctx, makeTrainlineReq(ctx))
+	if err != nil {
+		t.Fatalf("trainlineDoWithRetry on 403: unexpected transport error %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 returned immediately", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 1 {
+		t.Errorf("upstream calls = %d, want 1 (403 bot wall must NOT be retried)", got)
+	}
+}


### PR DESCRIPTION
## What

The Trainline journey-search POST had no rate-limit handling. A 429 on the primary request fell straight through to the non-200 branch and errored out with zero retry.

This adds `trainlineDoWithRetry`, which honours the Retry-After header (capped at 30 seconds) and replays the request exactly once, rebuilding the POST body per attempt via the existing request builder.

## Why this shape

- A 403 Datadome bot wall is never retried by the helper. SearchTrainline keeps its existing fallback ladder for the 403 path, and the tier1 bypass already fails fast on both 403 and 429.
- Only the primary request gains the bounded retry. There is no outer render-retry loop here, so a persistent 429 surfaces as an error after exactly one retry.

## Tests

Three new offline tests drive the seam with a scripted transport and an instant backoff, no live origin:
- 429 then success: two calls, status 200.
- persistent 429: two calls, 429 surfaced.
- 403 not retried: one call, 403 returned immediately.

Full ground-package suite passes locally. Closes the trainline slice of issue 357 (acceptance items 2 and 3).

Generated with Claude Code
