### PR TITLE
trivago: bounded single retry on HTTP 429 honouring Retry-After

### DIFF
--- a/internal/hotels/trivago.go
+++ b/internal/hotels/trivago.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/providers"
 	"golang.org/x/time/rate"
 )
 
@@ -46,6 +47,52 @@ var trivagoLimiter = rate.NewLimiter(rate.Every(500*time.Millisecond), 1)
 // trivagoHTTPClient is a dedicated HTTP client for Trivago MCP calls.
 var trivagoHTTPClient = &http.Client{
 	Timeout: 30 * time.Second,
+}
+
+// trivagoMaxRetryDelay caps how long we wait on a 429 Retry-After before giving
+// up; a throttled origin must not stall the whole hotel search.
+const trivagoMaxRetryDelay = 30 * time.Second
+
+// trivagoAfter is the 429 backoff sleep seam (swapped to instant in tests).
+var trivagoAfter = time.After
+
+// trivagoDoWithRetry issues the request and, on a single HTTP 429, honours the
+// Retry-After header (capped at trivagoMaxRetryDelay) and replays the request
+// exactly once. makeReq rebuilds a fresh request per attempt so the JSON-RPC
+// POST body is re-read cleanly. Any non-429 response is returned to the caller
+// as-is.
+func trivagoDoWithRetry(ctx context.Context, makeReq func() (*http.Request, error)) (*http.Response, error) {
+	req, err := makeReq()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := trivagoHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		return resp, nil
+	}
+
+	delay := providers.RetryAfterOrDefault(resp.Header.Get("Retry-After"), time.Now())
+	if delay > trivagoMaxRetryDelay {
+		delay = trivagoMaxRetryDelay
+	}
+	// Drain + close the 429 body before replaying so the connection can be reused.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	_ = resp.Body.Close()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-trivagoAfter(delay):
+	}
+
+	req2, err := makeReq()
+	if err != nil {
+		return nil, err
+	}
+	return trivagoHTTPClient.Do(req2)
 }
 
 // ---- JSON-RPC request/response types ----
@@ -291,17 +338,18 @@ func trivagoMCPCall(ctx context.Context, sessionID string, toolName string, args
 		return nil, fmt.Errorf("trivago: marshal request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, trivagoMCPEndpoint, bytes.NewReader(reqBytes))
-	if err != nil {
-		return nil, fmt.Errorf("trivago: build request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json, text/event-stream")
-	if sessionID != "" {
-		req.Header.Set("Mcp-Session-Id", sessionID)
-	}
-
-	resp, err := trivagoHTTPClient.Do(req)
+	resp, err := trivagoDoWithRetry(ctx, func() (*http.Request, error) {
+		r, err := http.NewRequestWithContext(ctx, http.MethodPost, trivagoMCPEndpoint, bytes.NewReader(reqBytes))
+		if err != nil {
+			return nil, err
+		}
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set("Accept", "application/json, text/event-stream")
+		if sessionID != "" {
+			r.Header.Set("Mcp-Session-Id", sessionID)
+		}
+		return r, nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("trivago: HTTP request: %w", err)
 	}

--- a/internal/hotels/trivago_retry_test.go
+++ b/internal/hotels/trivago_retry_test.go
@@ -1,0 +1,136 @@
+package hotels
+
+// #357 TRVL-RETRY.2/.3: the Trivago MCP tools-call POST honours a single bounded
+// retry on HTTP 429, replaying the request (rebuilding its JSON-RPC body) after
+// the Retry-After backoff. A persistent 429 surfaces after exactly one retry; a
+// non-429 response is never retried. These tests drive the seam entirely offline
+// via a scripted RoundTripper on the dedicated trivago client plus an instant
+// sleep seam, so no live MCP endpoint is contacted.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// trivagoScriptedRT returns a canned response per call index, counting calls.
+type trivagoScriptedRT struct {
+	calls atomic.Int32
+	fn    func(n int32) *http.Response
+}
+
+func (s *trivagoScriptedRT) RoundTrip(*http.Request) (*http.Response, error) {
+	return s.fn(s.calls.Add(1)), nil
+}
+
+func trivagoResp(status int, retryAfter, body string) *http.Response {
+	h := http.Header{}
+	if retryAfter != "" {
+		h.Set("Retry-After", retryAfter)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// installTrivagoRetryStub swaps the client transport and the sleep seam for
+// deterministic offline behaviour, restoring them on cleanup.
+func installTrivagoRetryStub(t *testing.T, rt http.RoundTripper) {
+	t.Helper()
+	origTransport := trivagoHTTPClient.Transport
+	origAfter := trivagoAfter
+	t.Cleanup(func() {
+		trivagoHTTPClient.Transport = origTransport
+		trivagoAfter = origAfter
+	})
+	trivagoHTTPClient.Transport = rt
+	trivagoAfter = func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Time{}
+		return ch
+	}
+}
+
+func makeTrivagoTestReq(ctx context.Context) func() (*http.Request, error) {
+	return func() (*http.Request, error) {
+		return http.NewRequestWithContext(
+			ctx, http.MethodPost,
+			"https://trivago.test/mcp",
+			strings.NewReader(`{"jsonrpc":"2.0","method":"tools/call"}`),
+		)
+	}
+}
+
+func TestTrivagoDoWithRetry_429ThenSuccess(t *testing.T) {
+	stub := &trivagoScriptedRT{fn: func(n int32) *http.Response {
+		if n == 1 {
+			return trivagoResp(http.StatusTooManyRequests, "1", `{"err":"rate limited"}`)
+		}
+		return trivagoResp(http.StatusOK, "", `{"ok":true}`)
+	}}
+	installTrivagoRetryStub(t, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := trivagoDoWithRetry(ctx, makeTrivagoTestReq(ctx))
+	if err != nil {
+		t.Fatalf("trivagoDoWithRetry after one 429 retry: unexpected error %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 after the retry succeeded", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 2 {
+		t.Errorf("upstream calls = %d, want 2 (one 429 + one successful retry)", got)
+	}
+}
+
+func TestTrivagoDoWithRetry_429Persists(t *testing.T) {
+	stub := &trivagoScriptedRT{fn: func(int32) *http.Response {
+		return trivagoResp(http.StatusTooManyRequests, "1", `{"err":"rate limited"}`)
+	}}
+	installTrivagoRetryStub(t, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := trivagoDoWithRetry(ctx, makeTrivagoTestReq(ctx))
+	if err != nil {
+		t.Fatalf("trivagoDoWithRetry persistent 429: unexpected transport error %v", err)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429 surfaced to the caller", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 2 {
+		t.Errorf("upstream calls = %d, want 2 (initial + one bounded retry, then give up)", got)
+	}
+}
+
+// TestTrivagoDoWithRetry_200NotRetried proves a healthy response is returned on
+// the first attempt with no spurious replay.
+func TestTrivagoDoWithRetry_200NotRetried(t *testing.T) {
+	stub := &trivagoScriptedRT{fn: func(int32) *http.Response {
+		return trivagoResp(http.StatusOK, "", `{"ok":true}`)
+	}}
+	installTrivagoRetryStub(t, stub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := trivagoDoWithRetry(ctx, makeTrivagoTestReq(ctx))
+	if err != nil {
+		t.Fatalf("trivagoDoWithRetry on 200: unexpected error %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := stub.calls.Load(); got != 1 {
+		t.Errorf("upstream calls = %d, want 1 (a healthy response must not be retried)", got)
+	}
+}


### PR DESCRIPTION
Closes part of issue 357 (provider 429 bounded retry sweep).

The Trivago MCP tools-call POST previously bailed immediately on an
HTTP 429, returning a rate-limited error with no retry. This adds
trivagoDoWithRetry, which honours the Retry-After header (capped at 30
seconds) and replays the request exactly once.

Because this is a Streamable HTTP MCP call (a POST carrying a JSON-RPC
body), the replay rebuilds a fresh request per attempt via a builder
closure so the body is re-read cleanly. The 429 body is drained and
closed before the retry so the connection can be reused. The backoff
sleep and the HTTP transport are seam-injected, so three offline tests
cover 429-then-success, persistent 429, and 200-not-retried with no
live MCP endpoint.

Mirrors the proven pattern already shipped for distribusion,
norwegian, rome2rio, and trainline.

Generated with Claude Code
