### PR TITLE
Add opt-in room-level price enrichment to core hotel search

### DIFF
--- a/internal/hotels/room_enrichment.go
+++ b/internal/hotels/room_enrichment.go
@@ -1,0 +1,165 @@
+package hotels
+
+import (
+	"context"
+	"sync"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// fetchRoomAvailability is the seam used to drill into a single hotel's
+// room-level inventory. Tests set it to a deterministic offline stub. It is
+// declared nil (not initialized to GetRoomAvailabilityWithOpts) to avoid a
+// package-level initialization cycle: the drill-down transitively references
+// core search, which references this enrichment. enrichHotelRooms falls back to
+// GetRoomAvailabilityWithOpts when the seam is unset.
+var fetchRoomAvailability func(ctx context.Context, opts RoomSearchOptions) (*RoomAvailability, error)
+
+// bookingSourceURL returns the Booking.com hotel URL from a result's price
+// sources, if one is present. It deliberately ignores HotelResult.BookingURL,
+// which is a city-level link backfilled for display and not a per-hotel detail
+// page suitable for room drill-down.
+func bookingSourceURL(h models.HotelResult) string {
+	for _, s := range h.Sources {
+		if s.Provider == "booking" && s.BookingURL != "" {
+			return s.BookingURL
+		}
+	}
+	return ""
+}
+
+// roomTypeToModelRoom converts an internal RoomType (the drill-down shape) into
+// the models.Room carried on a HotelResult. It maps the price-trust fields so a
+// tax-inclusive room is surfaced as a verified all-in rate, and a pre-tax room
+// stays room-level.
+func roomTypeToModelRoom(rt RoomType) models.Room {
+	inclusive := rt.TaxesFeesIncluded != nil && *rt.TaxesFeesIncluded
+
+	priceConfidence := models.PriceConfidenceRoomLevel
+	priceBasis := models.PriceBasisRoomNightly
+	if inclusive {
+		priceConfidence = models.PriceConfidenceVerified
+		priceBasis = models.PriceBasisTaxInclusiveTotal
+	}
+
+	return models.Room{
+		Name:               rt.Name,
+		Price:              rt.Price,
+		NightlyPrice:       rt.NightlyPrice,
+		TotalPrice:         rt.TotalPrice,
+		TaxesAndFees:       rt.TaxesAndFees,
+		TaxesFeesIncluded:  rt.TaxesFeesIncluded,
+		Currency:           rt.Currency,
+		Provider:           rt.Provider,
+		ProviderURL:        rt.ProviderURL,
+		RateID:             rt.RateID,
+		RatePlanName:       rt.RatePlanName,
+		MatchConfidence:    rt.MatchConfidence,
+		PriceBasis:         priceBasis,
+		PriceConfidence:    priceConfidence,
+		SizeM2:             rt.SizeM2,
+		MaxGuests:          rt.MaxGuests,
+		BedType:            rt.BedType,
+		Amenities:          rt.Amenities,
+		FreeCancellation:   rt.FreeCancellation != nil && *rt.FreeCancellation,
+		Refundable:         rt.Refundable,
+		CancellationPolicy: rt.CancellationPolicy,
+		BreakfastIncluded:  rt.BreakfastIncluded != nil && *rt.BreakfastIncluded,
+		Board:              rt.Board,
+		Description:        rt.Description,
+	}
+}
+
+// hotelHasVerifiedRoom reports whether a hotel already carries a verified
+// (tax-inclusive) room-level price — e.g. from Agoda's city search — so room
+// enrichment never clobbers a stronger existing price.
+func hotelHasVerifiedRoom(h models.HotelResult) bool {
+	return len(h.RoomTypes) > 0 && h.RoomTypes[0].PriceConfidence == models.PriceConfidenceVerified
+}
+
+// enrichHotelRooms drills into the top-N ranked hotels to attach real
+// room-level pricing, mirroring enrichHotelAmenities. It is opt-in
+// (opts.EnrichRooms) and rate-limit aware: it skips a fetch when the room
+// provider is throttled rather than provoking a persistent 429 block. Hotels
+// that already carry a verified room price are left untouched.
+func enrichHotelRooms(ctx context.Context, hotels []models.HotelResult, opts HotelSearchOptions) []models.HotelResult {
+	limit := opts.EnrichRoomsLimit
+	if limit <= 0 {
+		limit = 5
+	}
+	if limit > 10 {
+		limit = 10
+	}
+
+	var indices []int
+	for i := range hotels {
+		if hotels[i].HotelID != "" && !hotelHasVerifiedRoom(hotels[i]) && len(indices) < limit {
+			indices = append(indices, i)
+		}
+	}
+	if len(indices) == 0 {
+		return hotels
+	}
+
+	const concurrency = 3
+	type result struct {
+		index int
+		rooms []models.Room
+	}
+
+	fetch := fetchRoomAvailability
+	if fetch == nil {
+		fetch = GetRoomAvailabilityWithOpts
+	}
+
+	results := make(chan result, len(indices))
+	sem := make(chan struct{}, concurrency)
+
+	var wg sync.WaitGroup
+	for _, idx := range indices {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			// Respect the shared rate limiter: a throttled provider stays
+			// throttled, so skip rather than deepen the block.
+			if HotelRateManager.IsThrottled("google") {
+				return
+			}
+			HotelRateManager.RecordRequest("google")
+
+			av, err := fetch(ctx, RoomSearchOptions{
+				HotelID:      hotels[i].HotelID,
+				CheckIn:      opts.CheckIn,
+				CheckOut:     opts.CheckOut,
+				Currency:     opts.Currency,
+				Guests:       opts.Guests,
+				ChildrenAges: opts.ChildrenAges,
+				Rooms:        opts.Rooms,
+				BookingURL:   bookingSourceURL(hotels[i]),
+			})
+			if err != nil || av == nil || len(av.Rooms) == 0 {
+				return
+			}
+
+			rooms := make([]models.Room, 0, len(av.Rooms))
+			for _, rt := range av.Rooms {
+				rooms = append(rooms, roomTypeToModelRoom(rt))
+			}
+			results <- result{index: i, rooms: rooms}
+		}(idx)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	for r := range results {
+		hotels[r.index].RoomTypes = r.rooms
+	}
+
+	return hotels
+}

--- a/internal/hotels/room_enrichment_test.go
+++ b/internal/hotels/room_enrichment_test.go
@@ -1,0 +1,82 @@
+package hotels
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestEnrichHotelRooms_AttachesRoomLevelPricing proves the core search room
+// enrichment drills into a hotel with a HotelID and attaches the drilled-down
+// room as verified (tax-inclusive) inventory, via the offline seam.
+func TestEnrichHotelRooms_AttachesRoomLevelPricing(t *testing.T) {
+	orig := fetchRoomAvailability
+	t.Cleanup(func() { fetchRoomAvailability = orig })
+
+	// The rate manager is a package-level singleton; other tests may have
+	// throttled "google". Reset it so enrichment is not skipped here.
+	origRM := HotelRateManager
+	t.Cleanup(func() { HotelRateManager = origRM })
+	HotelRateManager = NewRateManager()
+
+	tt := true
+	fetchRoomAvailability = func(_ context.Context, _ RoomSearchOptions) (*RoomAvailability, error) {
+		return &RoomAvailability{
+			Success: true,
+			Rooms: []RoomType{{
+				Name:              "Deluxe Double Room",
+				Price:             120,
+				NightlyPrice:      120,
+				TotalPrice:        240,
+				Currency:          "EUR",
+				TaxesFeesIncluded: &tt,
+			}},
+		}, nil
+	}
+
+	hotels := []models.HotelResult{{HotelID: "/g/abc", Name: "Hotel X"}}
+	out := enrichHotelRooms(context.Background(), hotels, HotelSearchOptions{
+		EnrichRooms: true,
+		CheckIn:     "2026-07-10",
+		CheckOut:    "2026-07-11",
+		Currency:    "EUR",
+	})
+
+	if len(out[0].RoomTypes) != 1 {
+		t.Fatalf("RoomTypes len = %d, want 1", len(out[0].RoomTypes))
+	}
+	rt := out[0].RoomTypes[0]
+	if rt.Name != "Deluxe Double Room" {
+		t.Errorf("room name = %q, want Deluxe Double Room", rt.Name)
+	}
+	if rt.PriceConfidence != models.PriceConfidenceVerified {
+		t.Errorf("PriceConfidence = %q, want verified", rt.PriceConfidence)
+	}
+	if rt.PriceBasis != models.PriceBasisTaxInclusiveTotal {
+		t.Errorf("PriceBasis = %q, want tax_inclusive_total", rt.PriceBasis)
+	}
+}
+
+// TestEnrichHotelRooms_SkipsWithoutHotelID proves a hotel lacking a HotelID is
+// left untouched and the drill-down seam is never invoked for it.
+func TestEnrichHotelRooms_SkipsWithoutHotelID(t *testing.T) {
+	orig := fetchRoomAvailability
+	t.Cleanup(func() { fetchRoomAvailability = orig })
+
+	called := false
+	fetchRoomAvailability = func(_ context.Context, _ RoomSearchOptions) (*RoomAvailability, error) {
+		called = true
+		return &RoomAvailability{Success: true, Rooms: []RoomType{{Name: "x"}}}, nil
+	}
+
+	hotels := []models.HotelResult{{Name: "No ID Hotel"}}
+	out := enrichHotelRooms(context.Background(), hotels, HotelSearchOptions{EnrichRooms: true})
+
+	if called {
+		t.Error("fetchRoomAvailability was called for a hotel without a HotelID")
+	}
+	if len(out[0].RoomTypes) != 0 {
+		t.Errorf("RoomTypes len = %d, want 0 (untouched)", len(out[0].RoomTypes))
+	}
+}

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -98,6 +98,11 @@ type HotelSearchOptions struct {
 	EnrichAmenities bool // fetch detail pages for top hotels to get full amenity lists
 	EnrichLimit     int  // max hotels to enrich (default: 5, max: 10)
 
+	// EnrichRooms drills into the top-N ranked hotels for real room-level
+	// pricing (Google/Booking/SerpAPI/Agoda). Opt-in and rate-limit aware.
+	EnrichRooms      bool
+	EnrichRoomsLimit int // max hotels to room-enrich (default: 5, max: 10)
+
 	// MaxPages overrides the default pagination depth (maxPages).
 	// Compound commands (trip-cost, weekend, multi-city) set this to 1
 	// because they only need the cheapest result, not 75 hotels.
@@ -744,6 +749,13 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	// Enrich top hotels with full amenity data from detail pages.
 	if opts.EnrichAmenities {
 		hotels = enrichHotelAmenities(ctx, hotels, opts.EnrichLimit)
+	}
+
+	// Enrich top hotels with real room-level pricing via the unified
+	// drill-down (Google/Booking/SerpAPI/Agoda). Runs before confidence
+	// annotation so the verified room price is scored.
+	if opts.EnrichRooms {
+		hotels = enrichHotelRooms(ctx, hotels, opts)
 	}
 
 	// When the eco-certified filter is active, all returned hotels have


### PR DESCRIPTION
Wires the existing unified room drill-down into the core hotel search so the
main accommodation list can carry real room-level prices for the top-ranked
results, instead of only city-level lead-in prices.

## What
- New opt-in option EnrichRooms (with EnrichRoomsLimit, default 5, cap 10) on
  the hotels search options. Default off, so latency and provider cost are
  unchanged unless a caller asks for it.
- enrichHotelRooms drills into the top-N ranked hotels via the existing
  GetRoomAvailabilityWithOpts, which already fans into Google, Booking,
  SerpAPI and Agoda. No per-provider code added.
- Mirrors the enrichHotelAmenities pattern: concurrency 3, silent per-hotel
  failure, runs before confidence annotation so the verified room price is
  scored.

## Safety
- Rate-limit aware: skips a hotel when the room provider is throttled rather
  than provoking a persistent block.
- Never clobbers a stronger existing price (skips hotels that already carry a
  verified tax-inclusive room, e.g. from Agoda city search).
- Converter maps a tax-inclusive room to verified confidence and a pre-tax
  room to room-level, matching the Agoda price-trust mapping.

## Tests
- Offline via a stubbed fetch seam: one test asserts a drilled room is
  attached as verified inventory; one asserts a hotel with no HotelID is left
  untouched and the seam is never called.
- Full hotels package suite green.

Generated with Claude Code
