### PR TITLE
feat(hotels): verified prices lead the headline

### DIFF
--- a/internal/hotels/room_enrichment.go
+++ b/internal/hotels/room_enrichment.go
@@ -3,6 +3,7 @@ package hotels
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -159,7 +160,60 @@ func enrichHotelRooms(ctx context.Context, hotels []models.HotelResult, opts Hot
 
 	for r := range results {
 		hotels[r.index].RoomTypes = r.rooms
+		// Feed the strongest drilled room into the price sources so the
+		// verified room price can win the headline when the caller re-runs
+		// FinalizeHotelPriceTrust (the "verified leads" rule).
+		if src, ok := bestRoomSource(r.rooms); ok {
+			hotels[r.index].Sources = append(hotels[r.index].Sources, src)
+		}
 	}
 
 	return hotels
+}
+
+// bestRoomSource builds a PriceSource from the strongest drilled room (highest
+// price-confidence tier, then cheapest nightly within tier) so a verified,
+// all-in room price can become the headline. Returns false when no room carries
+// a usable price.
+func bestRoomSource(rooms []models.Room) (models.PriceSource, bool) {
+	var best models.Room
+	bestRank := 0
+	found := false
+	for _, rm := range rooms {
+		price := roomHeadlinePrice(rm)
+		if price <= 0 {
+			continue
+		}
+		rank := priceConfidenceRank(rm.PriceConfidence)
+		if !found || rank > bestRank || (rank == bestRank && price < roomHeadlinePrice(best)) {
+			best = rm
+			bestRank = rank
+			found = true
+		}
+	}
+	if !found {
+		return models.PriceSource{}, false
+	}
+	provider := best.Provider
+	if provider == "" {
+		provider = "google"
+	}
+	return models.PriceSource{
+		Provider:        provider,
+		Price:           roomHeadlinePrice(best),
+		Currency:        best.Currency,
+		BookingURL:      best.ProviderURL,
+		PriceBasis:      best.PriceBasis,
+		PriceConfidence: best.PriceConfidence,
+		RetrievedAt:     time.Now(),
+	}, true
+}
+
+// roomHeadlinePrice is the per-night price a room contributes to the headline:
+// the nightly rate when present, otherwise the room's single price field.
+func roomHeadlinePrice(rm models.Room) float64 {
+	if rm.NightlyPrice > 0 {
+		return rm.NightlyPrice
+	}
+	return rm.Price
 }

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -756,6 +756,11 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	// annotation so the verified room price is scored.
 	if opts.EnrichRooms {
 		hotels = enrichHotelRooms(ctx, hotels, opts)
+		// Enrichment appends verified room prices as new sources after the
+		// initial finalize+sort, so re-run both: the verified room price wins
+		// the headline (verified leads) and re-ranks ahead of cheaper teasers.
+		models.FinalizeHotelPriceTrust(hotels, opts.Currency, time.Now())
+		sortHotels(hotels, opts.Sort, opts.CenterLat, opts.CenterLon)
 	}
 
 	// When the eco-certified filter is active, all returned hotels have

--- a/internal/models/hotel_price_trust.go
+++ b/internal/models/hotel_price_trust.go
@@ -98,36 +98,62 @@ func finalizePriceSources(sources []PriceSource, now time.Time) []PriceSource {
 	return out
 }
 
+// priceConfidenceRank orders price-confidence tiers so the highest-trust price
+// wins the headline: verified > room_level > unverified. It mirrors the
+// sort-side ranking in internal/hotels/search_filter.go so headline selection
+// and result ordering agree — a verified, all-in room price leads even when a
+// cheaper unverified lead-in teaser exists for the same hotel.
+func priceConfidenceRank(confidence string) int {
+	switch confidence {
+	case PriceConfidenceVerified:
+		return 3
+	case PriceConfidenceRoomLevel:
+		return 2
+	default:
+		return 1
+	}
+}
+
 func selectPrimaryHotelSource(sources []PriceSource, preferredCurrency, currentCurrency string) (PriceSource, bool) {
 	preferredCurrency = strings.ToUpper(strings.TrimSpace(preferredCurrency))
 	currentCurrency = strings.ToUpper(strings.TrimSpace(currentCurrency))
-	if selected, ok := cheapestSourceInCurrency(sources, preferredCurrency); ok {
+	if selected, ok := bestSourceInCurrency(sources, preferredCurrency); ok {
 		return selected, true
 	}
-	if selected, ok := cheapestSourceInCurrency(sources, currentCurrency); ok {
+	if selected, ok := bestSourceInCurrency(sources, currentCurrency); ok {
 		return selected, true
 	}
 	bestCurrency := mostRepresentedSourceCurrency(sources)
-	if selected, ok := cheapestSourceInCurrency(sources, bestCurrency); ok {
+	if selected, ok := bestSourceInCurrency(sources, bestCurrency); ok {
 		return selected, true
 	}
 	return PriceSource{}, false
 }
 
-func cheapestSourceInCurrency(sources []PriceSource, currency string) (PriceSource, bool) {
+// bestSourceInCurrency picks the headline source within a single currency by
+// highest price-confidence tier first, then cheapest within that tier. This is
+// the "verified leads" rule: an honest, tax-inclusive verified price beats a
+// cheaper-but-unverified teaser, but among equally-trusted prices the cheapest
+// still wins.
+func bestSourceInCurrency(sources []PriceSource, currency string) (PriceSource, bool) {
 	if currency == "" {
 		return PriceSource{}, false
 	}
 	var selected PriceSource
+	selectedRank := 0
+	found := false
 	for _, s := range sources {
 		if s.Price <= 0 || strings.ToUpper(s.Currency) != currency {
 			continue
 		}
-		if selected.Price == 0 || s.Price < selected.Price {
+		rank := priceConfidenceRank(s.PriceConfidence)
+		if !found || rank > selectedRank || (rank == selectedRank && s.Price < selected.Price) {
 			selected = s
+			selectedRank = rank
+			found = true
 		}
 	}
-	return selected, selected.Price > 0
+	return selected, found
 }
 
 func mostRepresentedSourceCurrency(sources []PriceSource) string {

--- a/internal/models/verified_leads_test.go
+++ b/internal/models/verified_leads_test.go
@@ -1,0 +1,62 @@
+package models
+
+import (
+	"testing"
+	"time"
+)
+
+// TestVerifiedSourceLeadsHeadline proves the "verified leads" rule: a verified,
+// tax-inclusive room price becomes the headline even when a cheaper unverified
+// lead-in teaser exists for the same hotel.
+func TestVerifiedSourceLeadsHeadline(t *testing.T) {
+	h := &HotelResult{
+		Currency: "EUR",
+		Sources: []PriceSource{
+			{Provider: "google", Price: 98, Currency: "EUR", PriceBasis: PriceBasisLeadIn, PriceConfidence: PriceConfidenceUnverified},
+			{Provider: "agoda", Price: 142, Currency: "EUR", PriceBasis: PriceBasisTaxInclusiveTotal, PriceConfidence: PriceConfidenceVerified},
+		},
+	}
+	FinalizeHotelResultPriceTrust(h, "EUR", time.Now())
+	if h.PriceConfidence != PriceConfidenceVerified {
+		t.Fatalf("headline confidence = %q, want verified (verified must lead over cheaper teaser)", h.PriceConfidence)
+	}
+	if h.Price != 142 {
+		t.Errorf("headline price = %v, want 142 (the verified all-in rate, not the cheaper teaser)", h.Price)
+	}
+	if h.PriceBasis != PriceBasisTaxInclusiveTotal {
+		t.Errorf("headline basis = %q, want tax_inclusive_total", h.PriceBasis)
+	}
+}
+
+// TestWithinTierCheapestWins proves that among equally-trusted prices the
+// cheapest still wins — confidence is the primary key, price the tiebreaker.
+func TestWithinTierCheapestWins(t *testing.T) {
+	h := &HotelResult{
+		Currency: "EUR",
+		Sources: []PriceSource{
+			{Provider: "a", Price: 120, Currency: "EUR", PriceConfidence: PriceConfidenceVerified},
+			{Provider: "b", Price: 99, Currency: "EUR", PriceConfidence: PriceConfidenceVerified},
+		},
+	}
+	FinalizeHotelResultPriceTrust(h, "EUR", time.Now())
+	if h.Price != 99 {
+		t.Errorf("headline price = %v, want 99 (cheapest within the same confidence tier)", h.Price)
+	}
+}
+
+// TestRoomLevelBeatsUnverifiedButLosesToVerified proves the full tier ordering
+// verified > room_level > unverified for the headline.
+func TestRoomLevelBeatsUnverifiedButLosesToVerified(t *testing.T) {
+	h := &HotelResult{
+		Currency: "EUR",
+		Sources: []PriceSource{
+			{Provider: "google", Price: 80, Currency: "EUR", PriceConfidence: PriceConfidenceUnverified},
+			{Provider: "booking", Price: 110, Currency: "EUR", PriceConfidence: PriceConfidenceRoomLevel},
+			{Provider: "agoda", Price: 130, Currency: "EUR", PriceConfidence: PriceConfidenceVerified},
+		},
+	}
+	FinalizeHotelResultPriceTrust(h, "EUR", time.Now())
+	if h.Price != 130 || h.PriceConfidence != PriceConfidenceVerified {
+		t.Errorf("headline = %v/%q, want 130/verified (top tier leads)", h.Price, h.PriceConfidence)
+	}
+}


### PR DESCRIPTION
## Verified prices lead the headline

Hotel headline price selection used to pick the cheapest source in the
preferred currency, full stop. That meant an honest, tax-inclusive verified
room rate could lose the headline to a cheaper unverified lead-in teaser for
the same property, even though the verified number is the one a traveller can
actually book at.

This changes headline selection to a two-key rule: highest price-confidence
tier first (verified > room_level > unverified), cheapest within the tier as
the tiebreaker. The sort side already ranked by confidence tier, so finalize
and sort now agree instead of contradicting each other.

### What changed

- `internal/models/hotel_price_trust.go`: `selectPrimaryHotelSource` now calls
  a new `bestSourceInCurrency` (confidence tier, then cheapest within tier)
  across the preferred, current, and most-represented currency cascade. Adds a
  models-level `priceConfidenceRank` mirroring the sort-side ranking so the two
  paths can never drift.
- `internal/hotels/room_enrichment.go`: when room enrichment drills a verified
  all-in room price, it now appends that price as a source so it can win the
  headline. New `bestRoomSource` / `roomHeadlinePrice` helpers.
- `internal/hotels/search.go`: the opt-in `EnrichRooms` path re-runs finalize
  and sort after enrichment, so a newly drilled verified price re-ranks the
  result instead of being attached too late to matter.

### Tests

- New `internal/models/verified_leads_test.go`: a verified-but-pricier source
  beats a cheaper unverified one for the headline; cheapest still wins within a
  tier; the full verified > room_level > unverified ordering holds.
- Full `go test ./...` green; `go vet ./...` clean.

The existing confidence-aware sort test stays green untouched; this aligns
headline selection with that already-correct ordering.

Generated with Claude Code
