### PR TITLE
feat(breaker): in-memory circuit breaker primitive for scraper fan-outs

### DIFF
--- a/internal/breaker/breaker.go
+++ b/internal/breaker/breaker.go
@@ -1,0 +1,104 @@
+// Package breaker provides an in-memory circuit breaker for the hand-rolled
+// scraper fan-outs (hotels, flights, ground). Those fan-outs bypass the
+// registry-backed breaker in internal/providers/runtime_search.go, so a
+// persistently-failing scraper (dead cookie, blocked endpoint, hard 429) gets
+// retried on every search with zero back-off. This primitive gives them the
+// same protection without the YAML provider registry's persistence layer, which
+// the in-process scrapers don't have.
+//
+// Semantics mirror internal/providers exactly: trip after N consecutive
+// failures, stay open for a fixed cooldown measured from the last failure, then
+// allow a single half-open probe. A successful probe closes the breaker; a
+// failed probe re-arms the cooldown.
+package breaker
+
+import (
+	"sync"
+	"time"
+)
+
+// Defaults mirror internal/providers/runtime_core.go circuitBreakerThreshold
+// and circuitBreakerCooldown so scraper and registry breakers behave alike.
+const (
+	DefaultThreshold = 5
+	DefaultCooldown  = 5 * time.Minute
+)
+
+type state struct {
+	errorCount  int
+	lastErrorAt time.Time
+}
+
+// Breaker is a per-key in-memory circuit breaker, safe for concurrent use by
+// the goroutine fan-outs. Key is the provider name (e.g. "google", "booking").
+type Breaker struct {
+	threshold int
+	cooldown  time.Duration
+	now       func() time.Time // overridable in tests
+
+	mu     sync.Mutex
+	states map[string]*state
+}
+
+// New returns a breaker with the default threshold and cooldown.
+func New() *Breaker { return NewWithConfig(DefaultThreshold, DefaultCooldown) }
+
+// NewWithConfig returns a breaker with a custom threshold and cooldown.
+// Non-positive values fall back to the defaults.
+func NewWithConfig(threshold int, cooldown time.Duration) *Breaker {
+	if threshold <= 0 {
+		threshold = DefaultThreshold
+	}
+	if cooldown <= 0 {
+		cooldown = DefaultCooldown
+	}
+	return &Breaker{
+		threshold: threshold,
+		cooldown:  cooldown,
+		now:       time.Now,
+		states:    make(map[string]*state),
+	}
+}
+
+// Allow reports whether a call for key may proceed. It returns false only while
+// the breaker is tripped (>= threshold consecutive failures) and still inside
+// the cooldown window. Once cooldown elapses it allows a single half-open probe
+// through; the next RecordFailure re-arms the cooldown and RecordSuccess closes
+// the breaker.
+func (b *Breaker) Allow(key string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := b.states[key]
+	if s == nil || s.errorCount < b.threshold {
+		return true
+	}
+	return b.now().Sub(s.lastErrorAt) >= b.cooldown
+}
+
+// Tripped reports whether key is currently open (tripped and within cooldown).
+// It is the inverse of Allow.
+func (b *Breaker) Tripped(key string) bool { return !b.Allow(key) }
+
+// RecordSuccess closes the breaker for key, clearing its failure count.
+func (b *Breaker) RecordSuccess(key string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if s := b.states[key]; s != nil {
+		s.errorCount = 0
+		s.lastErrorAt = time.Time{}
+	}
+}
+
+// RecordFailure registers a consecutive failure for key, tripping the breaker
+// once the count reaches the threshold and re-arming the cooldown window.
+func (b *Breaker) RecordFailure(key string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := b.states[key]
+	if s == nil {
+		s = &state{}
+		b.states[key] = s
+	}
+	s.errorCount++
+	s.lastErrorAt = b.now()
+}

--- a/internal/breaker/breaker_test.go
+++ b/internal/breaker/breaker_test.go
@@ -1,0 +1,123 @@
+package breaker
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// fixedClock lets a test drive the breaker's notion of "now".
+type fixedClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fixedClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fixedClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+func newTestBreaker(threshold int, cooldown time.Duration) (*Breaker, *fixedClock) {
+	clk := &fixedClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	b := NewWithConfig(threshold, cooldown)
+	b.now = clk.now
+	return b, clk
+}
+
+func TestAllowsUntilThreshold(t *testing.T) {
+	b, _ := newTestBreaker(3, time.Minute)
+	for i := 0; i < 2; i++ {
+		b.RecordFailure("google")
+		if !b.Allow("google") {
+			t.Fatalf("breaker tripped after %d failures, want open only at threshold 3", i+1)
+		}
+	}
+	b.RecordFailure("google") // 3rd → trips
+	if b.Allow("google") {
+		t.Fatal("breaker should be tripped after 3 consecutive failures within cooldown")
+	}
+}
+
+func TestCooldownAllowsHalfOpenProbe(t *testing.T) {
+	b, clk := newTestBreaker(2, time.Minute)
+	b.RecordFailure("booking")
+	b.RecordFailure("booking") // tripped
+	if b.Allow("booking") {
+		t.Fatal("breaker should be open immediately after tripping")
+	}
+	clk.advance(59 * time.Second)
+	if b.Allow("booking") {
+		t.Fatal("breaker should stay open before cooldown elapses")
+	}
+	clk.advance(time.Second) // now exactly at cooldown
+	if !b.Allow("booking") {
+		t.Fatal("breaker should allow a half-open probe once cooldown elapses")
+	}
+}
+
+func TestSuccessClosesBreaker(t *testing.T) {
+	b, clk := newTestBreaker(2, time.Minute)
+	b.RecordFailure("agoda")
+	b.RecordFailure("agoda") // tripped
+	clk.advance(time.Minute) // half-open
+	b.RecordSuccess("agoda") // probe succeeds → closed
+	if !b.Allow("agoda") {
+		t.Fatal("breaker should be closed after a successful probe")
+	}
+	// A fresh failure must not instantly re-trip a closed breaker.
+	b.RecordFailure("agoda")
+	if !b.Allow("agoda") {
+		t.Fatal("single failure after recovery should not trip a threshold-2 breaker")
+	}
+}
+
+func TestFailedProbeReArmsCooldown(t *testing.T) {
+	b, clk := newTestBreaker(2, time.Minute)
+	b.RecordFailure("trivago")
+	b.RecordFailure("trivago") // tripped
+	clk.advance(time.Minute)   // half-open
+	if !b.Allow("trivago") {
+		t.Fatal("expected half-open probe")
+	}
+	b.RecordFailure("trivago") // probe fails → re-arm cooldown
+	if b.Allow("trivago") {
+		t.Fatal("failed probe should re-arm the cooldown and re-open the breaker")
+	}
+	clk.advance(time.Minute)
+	if !b.Allow("trivago") {
+		t.Fatal("breaker should allow another probe after the re-armed cooldown elapses")
+	}
+}
+
+func TestKeysAreIndependent(t *testing.T) {
+	b, _ := newTestBreaker(1, time.Minute)
+	b.RecordFailure("google") // trips google only
+	if b.Allow("google") {
+		t.Fatal("google should be tripped")
+	}
+	if !b.Allow("booking") {
+		t.Fatal("booking must be unaffected by google's failures")
+	}
+}
+
+func TestConcurrentAccessIsRaceFree(t *testing.T) {
+	b := New()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			b.RecordFailure("p")
+			_ = b.Allow("p")
+			b.RecordSuccess("p")
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## What

Adds `internal/breaker`, a dependency-free in-memory circuit breaker for the hand-rolled scraper fan-outs (hotels, flights, ground).

## Why

The registry-backed breaker in `internal/providers/runtime_search.go` only governs the YAML-configured providers. The hand-rolled scrapers bypass that runtime, so a persistently-failing scraper (dead cookie, blocked endpoint, hard 429) is retried on every search with no back-off. This primitive gives them the same protection, without the provider registry persistence layer the in-process fan-outs do not have.

## Semantics

Mirrors `internal/providers` exactly: trip after N consecutive failures (default 5), stay open for a fixed cooldown measured from the last failure (default 5m), then allow a single half-open probe. A successful probe closes the breaker; a failed probe re-arms the cooldown.

## Scope

Leaf package, no importers yet, so zero blast radius on existing behaviour. Wiring into the hotel fan-out follows in a separate PR; flights and ground after that.

## Tests

`go test -race ./internal/breaker/` green: threshold trip, cooldown half-open probe, success-closes, failed-probe-re-arms, key independence, concurrent race-free.

Generated with Claude Code
