### PR TITLE
feat(flights): circuit-breaker on the secondary-provider fan-out

### DIFF
--- a/internal/flights/breaker_wire_test.go
+++ b/internal/flights/breaker_wire_test.go
@@ -1,0 +1,67 @@
+package flights
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/breaker"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestFlightBreakerTripsAtThreshold proves the package-level flightBreaker the
+// secondary-provider fan-out shares trips after DefaultThreshold consecutive
+// failures, so a persistently-failing provider is skipped on the next search
+// instead of being retried. It exercises the same Breaker instance
+// runProviderTasks consults via Tripped/RecordFailure/RecordSuccess.
+func TestFlightBreakerTripsAtThreshold(t *testing.T) {
+	const key = "flight-breaker-wire-test-provider"
+	// Start from a clean slate in case another test touched this key.
+	flightBreaker.RecordSuccess(key)
+
+	for i := 0; i < breaker.DefaultThreshold-1; i++ {
+		flightBreaker.RecordFailure(key)
+		if flightBreaker.Tripped(key) {
+			t.Fatalf("breaker tripped after %d failures, want open only at threshold %d", i+1, breaker.DefaultThreshold)
+		}
+	}
+	flightBreaker.RecordFailure(key) // threshold-th failure trips it
+	if !flightBreaker.Tripped(key) {
+		t.Fatalf("breaker should be tripped after %d consecutive failures", breaker.DefaultThreshold)
+	}
+
+	// A success closes it again so the provider is retried.
+	flightBreaker.RecordSuccess(key)
+	if flightBreaker.Tripped(key) {
+		t.Fatal("breaker should be closed after a successful probe")
+	}
+}
+
+// TestOutcomeFailed pins the breaker's failure discriminator: errors and
+// failure-class statuses count as failures; empty-but-healthy and
+// not-configured responses do not, so a provider with no flights is not
+// penalised.
+func TestOutcomeFailed(t *testing.T) {
+	cases := []struct {
+		name string
+		out  providerOutcome
+		want bool
+	}{
+		{"healthy with flights", providerOutcome{succeeded: true, status: models.ProviderStatus{Status: models.StatusOK}}, false},
+		{"healthy but empty", providerOutcome{status: models.ProviderStatus{Status: models.StatusOK}}, false},
+		{"not configured", providerOutcome{status: models.ProviderStatus{Status: models.StatusNotConfigured}}, false},
+		{"explicit error", providerOutcome{err: errTest, status: models.ProviderStatus{Status: models.StatusFailed}}, true},
+		{"failed status no err", providerOutcome{status: models.ProviderStatus{Status: models.StatusFailed}}, true},
+		{"timeout status no err", providerOutcome{status: models.ProviderStatus{Status: models.StatusTimeout}}, true},
+		{"rate limited", providerOutcome{status: models.ProviderStatus{Status: models.StatusRateLimited}}, true},
+	}
+	for _, c := range cases {
+		if got := outcomeFailed(c.out); got != c.want {
+			t.Errorf("%s: outcomeFailed = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+var errTest = errProbe("boom")
+
+type errProbe string
+
+func (e errProbe) Error() string { return string(e) }

--- a/internal/flights/concurrency.go
+++ b/internal/flights/concurrency.go
@@ -4,9 +4,32 @@ import (
 	"context"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/breaker"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"golang.org/x/sync/errgroup"
 )
+
+// flightBreaker protects the secondary-provider fan-out: a provider that fails
+// (errors, timeouts, rate-limits) DefaultThreshold times in a row is skipped
+// for the cooldown instead of being retried on every search, then probed again
+// once the cooldown elapses. It is keyed by providerTask.name. Shared across
+// searches by design — a provider's recent health carries between requests.
+var flightBreaker = breaker.New()
+
+// outcomeFailed reports whether a provider outcome counts as a breaker failure.
+// An explicit error (including the harness-recorded timeout) or a failure-class
+// status trips it; an empty-but-healthy or not-configured response does not, so
+// a provider that simply has no flights is never penalised.
+func outcomeFailed(out providerOutcome) bool {
+	if out.err != nil {
+		return true
+	}
+	switch out.status.Status {
+	case models.StatusFailed, models.StatusError, models.StatusTimeout, models.StatusRateLimited:
+		return true
+	}
+	return false
+}
 
 // perProviderTimeout bounds how long any single secondary provider may run
 // inside the concurrent fan-out. It is shorter than sharedFlightSearchTimeout
@@ -63,6 +86,20 @@ func runProviderTasks(ctx context.Context, tasks []providerTask, limit int, perT
 
 	for i, task := range tasks {
 		i, task := i, task
+		if flightBreaker.Tripped(task.name) {
+			// Recent failures tripped the breaker; skip the call and report it
+			// honestly rather than hammering a provider that keeps failing.
+			outcomes[i] = providerOutcome{
+				status: models.ProviderStatus{
+					ID:      task.name,
+					Name:    task.name,
+					Status:  models.StatusCircuitBroken,
+					Error:   "skipped: recent failures tripped the circuit breaker",
+					FixHint: "wait for the cooldown to elapse, then it retries automatically",
+				},
+			}
+			continue
+		}
 		g.Go(func() error {
 			tctx, cancel := context.WithTimeout(ctx, perTaskTimeout)
 			defer cancel()
@@ -87,6 +124,14 @@ func runProviderTasks(ctx context.Context, tasks []providerTask, limit int, perT
 					},
 					err: tctx.Err(),
 				}
+			}
+			// Feed the outcome back to the breaker: a failure (error, timeout,
+			// rate-limit) advances it toward tripping; any healthy response
+			// closes it so the provider is retried normally.
+			if outcomeFailed(outcomes[i]) {
+				flightBreaker.RecordFailure(task.name)
+			} else {
+				flightBreaker.RecordSuccess(task.name)
 			}
 			return nil
 		})


### PR DESCRIPTION
## What

Wire the circuit breaker (added in #365, applied to hotels in #366) into the secondary-provider fan-out in `internal/flights/concurrency.go`.

The flight search fans every secondary provider out through one function, `runProviderTasks`. Before this change, a provider that kept erroring, timing out, or returning rate-limit responses was retried on every search with no back-off. The registry-backed providers had breaker protection; this hand-rolled fan-out did not.

## How

The breaker wires into the single choke point rather than each provider, so coverage is automatic for current and future tasks:

- Each `providerTask` already carries a `name`, which is the breaker key.
- Before a task runs, if its breaker is tripped the call is skipped and the outcome reports an honest `circuit_broken` status instead of being made.
- After a task runs, the outcome feeds back: a failure (error, timeout, or a failure-class status) advances the breaker toward tripping; any healthy response closes it. An empty-but-healthy or not-configured response is not a failure, so a provider with no flights is never penalised.
- After `DefaultThreshold` (5) consecutive failures the breaker opens for `DefaultCooldown` (5 min), then a half-open probe retries the provider automatically.

A small `outcomeFailed` helper holds the failure decision so the rule is testable in isolation.

## Scope

- This covers the secondary-provider fan-out (`runProviderTasks`), which is the provider-keyed concurrency path. The date-grid and multi-airport fan-outs (`dates.go`, `multi.go`, `hidden_city.go`) fan out over dates and airports, not providers, so a provider-keyed breaker does not map to them and they are left alone.
- Ground fan-out gets the same treatment in a follow-up PR.

## Tests

- `internal/flights/breaker_wire_test.go`: `TestFlightBreakerTripsAtThreshold` proves the shared `flightBreaker` trips at the threshold and closes on a successful probe; `TestOutcomeFailed` pins the failure discriminator (errors and failure-class statuses fail; empty-but-healthy and not-configured do not).
- `go vet`, `go build ./...`, and the full `internal/flights` + `internal/breaker` suites pass locally (flights 33.3s, breaker 0.9s).

Generated with Claude Code
