### PR TITLE
feat(ground): circuit-breaker on the provider fan-out

### DIFF
--- a/internal/flights/breaker_wire_test.go
+++ b/internal/flights/breaker_wire_test.go
@@ -1,0 +1,67 @@
+package flights
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/breaker"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestFlightBreakerTripsAtThreshold proves the package-level flightBreaker the
+// secondary-provider fan-out shares trips after DefaultThreshold consecutive
+// failures, so a persistently-failing provider is skipped on the next search
+// instead of being retried. It exercises the same Breaker instance
+// runProviderTasks consults via Tripped/RecordFailure/RecordSuccess.
+func TestFlightBreakerTripsAtThreshold(t *testing.T) {
+	const key = "flight-breaker-wire-test-provider"
+	// Start from a clean slate in case another test touched this key.
+	flightBreaker.RecordSuccess(key)
+
+	for i := 0; i < breaker.DefaultThreshold-1; i++ {
+		flightBreaker.RecordFailure(key)
+		if flightBreaker.Tripped(key) {
+			t.Fatalf("breaker tripped after %d failures, want open only at threshold %d", i+1, breaker.DefaultThreshold)
+		}
+	}
+	flightBreaker.RecordFailure(key) // threshold-th failure trips it
+	if !flightBreaker.Tripped(key) {
+		t.Fatalf("breaker should be tripped after %d consecutive failures", breaker.DefaultThreshold)
+	}
+
+	// A success closes it again so the provider is retried.
+	flightBreaker.RecordSuccess(key)
+	if flightBreaker.Tripped(key) {
+		t.Fatal("breaker should be closed after a successful probe")
+	}
+}
+
+// TestOutcomeFailed pins the breaker's failure discriminator: errors and
+// failure-class statuses count as failures; empty-but-healthy and
+// not-configured responses do not, so a provider with no flights is not
+// penalised.
+func TestOutcomeFailed(t *testing.T) {
+	cases := []struct {
+		name string
+		out  providerOutcome
+		want bool
+	}{
+		{"healthy with flights", providerOutcome{succeeded: true, status: models.ProviderStatus{Status: models.StatusOK}}, false},
+		{"healthy but empty", providerOutcome{status: models.ProviderStatus{Status: models.StatusOK}}, false},
+		{"not configured", providerOutcome{status: models.ProviderStatus{Status: models.StatusNotConfigured}}, false},
+		{"explicit error", providerOutcome{err: errTest, status: models.ProviderStatus{Status: models.StatusFailed}}, true},
+		{"failed status no err", providerOutcome{status: models.ProviderStatus{Status: models.StatusFailed}}, true},
+		{"timeout status no err", providerOutcome{status: models.ProviderStatus{Status: models.StatusTimeout}}, true},
+		{"rate limited", providerOutcome{status: models.ProviderStatus{Status: models.StatusRateLimited}}, true},
+	}
+	for _, c := range cases {
+		if got := outcomeFailed(c.out); got != c.want {
+			t.Errorf("%s: outcomeFailed = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+var errTest = errProbe("boom")
+
+type errProbe string
+
+func (e errProbe) Error() string { return string(e) }

--- a/internal/flights/concurrency.go
+++ b/internal/flights/concurrency.go
@@ -4,9 +4,32 @@ import (
 	"context"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/breaker"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"golang.org/x/sync/errgroup"
 )
+
+// flightBreaker protects the secondary-provider fan-out: a provider that fails
+// (errors, timeouts, rate-limits) DefaultThreshold times in a row is skipped
+// for the cooldown instead of being retried on every search, then probed again
+// once the cooldown elapses. It is keyed by providerTask.name. Shared across
+// searches by design — a provider's recent health carries between requests.
+var flightBreaker = breaker.New()
+
+// outcomeFailed reports whether a provider outcome counts as a breaker failure.
+// An explicit error (including the harness-recorded timeout) or a failure-class
+// status trips it; an empty-but-healthy or not-configured response does not, so
+// a provider that simply has no flights is never penalised.
+func outcomeFailed(out providerOutcome) bool {
+	if out.err != nil {
+		return true
+	}
+	switch out.status.Status {
+	case models.StatusFailed, models.StatusError, models.StatusTimeout, models.StatusRateLimited:
+		return true
+	}
+	return false
+}
 
 // perProviderTimeout bounds how long any single secondary provider may run
 // inside the concurrent fan-out. It is shorter than sharedFlightSearchTimeout
@@ -63,6 +86,20 @@ func runProviderTasks(ctx context.Context, tasks []providerTask, limit int, perT
 
 	for i, task := range tasks {
 		i, task := i, task
+		if flightBreaker.Tripped(task.name) {
+			// Recent failures tripped the breaker; skip the call and report it
+			// honestly rather than hammering a provider that keeps failing.
+			outcomes[i] = providerOutcome{
+				status: models.ProviderStatus{
+					ID:      task.name,
+					Name:    task.name,
+					Status:  models.StatusCircuitBroken,
+					Error:   "skipped: recent failures tripped the circuit breaker",
+					FixHint: "wait for the cooldown to elapse, then it retries automatically",
+				},
+			}
+			continue
+		}
 		g.Go(func() error {
 			tctx, cancel := context.WithTimeout(ctx, perTaskTimeout)
 			defer cancel()
@@ -87,6 +124,14 @@ func runProviderTasks(ctx context.Context, tasks []providerTask, limit int, perT
 					},
 					err: tctx.Err(),
 				}
+			}
+			// Feed the outcome back to the breaker: a failure (error, timeout,
+			// rate-limit) advances it toward tripping; any healthy response
+			// closes it so the provider is retried normally.
+			if outcomeFailed(outcomes[i]) {
+				flightBreaker.RecordFailure(task.name)
+			} else {
+				flightBreaker.RecordSuccess(task.name)
 			}
 			return nil
 		})

--- a/internal/ground/breaker_wire_test.go
+++ b/internal/ground/breaker_wire_test.go
@@ -1,0 +1,52 @@
+package ground
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/breaker"
+)
+
+// TestGroundBreakerTripsAtThreshold proves the package-level groundBreaker the
+// provider fan-out shares trips after DefaultThreshold consecutive failures, so
+// a persistently-failing provider is skipped on the next search instead of
+// being retried. It exercises the same Breaker instance launchProvider consults
+// via Tripped/RecordFailure/RecordSuccess.
+func TestGroundBreakerTripsAtThreshold(t *testing.T) {
+	const key = "ground-breaker-wire-test-provider"
+	// Start from a clean slate in case another test touched this key.
+	groundBreaker.RecordSuccess(key)
+
+	for i := 0; i < breaker.DefaultThreshold-1; i++ {
+		groundBreaker.RecordFailure(key)
+		if groundBreaker.Tripped(key) {
+			t.Fatalf("breaker tripped after %d failures, want open only at threshold %d", i+1, breaker.DefaultThreshold)
+		}
+	}
+	groundBreaker.RecordFailure(key) // threshold-th failure trips it
+	if !groundBreaker.Tripped(key) {
+		t.Fatalf("breaker should be tripped after %d consecutive failures", breaker.DefaultThreshold)
+	}
+
+	// A success closes it again so the provider is retried.
+	groundBreaker.RecordSuccess(key)
+	if groundBreaker.Tripped(key) {
+		t.Fatal("breaker should be closed after a successful probe")
+	}
+}
+
+// TestErrCircuitBrokenIsDistinct guards the sentinel the aggregator matches with
+// errors.Is: it must be its own error, not collide with the not-applicable
+// classification, so a breaker skip is reported as circuit_broken rather than a
+// silent "no route" skip.
+func TestErrCircuitBrokenIsDistinct(t *testing.T) {
+	if errCircuitBroken == nil {
+		t.Fatal("errCircuitBroken sentinel must be non-nil")
+	}
+	if isProviderNotApplicable(errCircuitBroken) {
+		t.Fatal("a circuit-broken skip must not be classified as not-applicable")
+	}
+	if !errors.Is(errCircuitBroken, errCircuitBroken) {
+		t.Fatal("errors.Is must match the sentinel against itself")
+	}
+}

--- a/internal/ground/search.go
+++ b/internal/ground/search.go
@@ -3,6 +3,7 @@ package ground
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/breaker"
 	"github.com/MikkoParkkola/trvl/internal/cache"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/searchctx"
@@ -58,13 +60,42 @@ type providerResult struct {
 	name   string
 }
 
+// groundBreaker protects the provider fan-out: a provider that fails (network
+// error, timeout, rate-limit) DefaultThreshold times in a row is skipped for
+// the cooldown instead of being retried on every search, then probed again once
+// the cooldown elapses. It is keyed by provider name and shared across searches
+// by design — a provider's recent health carries between requests. A
+// "not applicable for this route" answer is healthy, not a failure, so it never
+// trips the breaker.
+var groundBreaker = breaker.New()
+
+// errCircuitBroken marks a provider call skipped because its breaker is open.
+// It is a deliberate skip, not a fresh failure, so the result aggregator
+// reports it as a circuit_broken status without counting it as an error.
+var errCircuitBroken = errors.New("skipped: recent failures tripped the circuit breaker")
+
 // launchProvider starts a provider search in a new goroutine, sending the
-// result to the results channel when done.
+// result to the results channel when done. The shared groundBreaker gates the
+// call: a tripped provider is skipped without touching the network, and each
+// real outcome feeds the breaker (a genuine failure advances it toward
+// tripping; a healthy or not-applicable response closes it).
 func launchProvider(wg *sync.WaitGroup, results chan<- providerResult, name string, fn func() ([]models.GroundRoute, error)) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		if groundBreaker.Tripped(name) {
+			results <- providerResult{name: name, err: errCircuitBroken}
+			return
+		}
 		routes, err := fn()
+		// A not-applicable answer (no route for this origin/destination) is a
+		// healthy "nothing to sell" response, not a provider failure, so it must
+		// not push the breaker toward tripping.
+		if err != nil && !isProviderNotApplicable(err) {
+			groundBreaker.RecordFailure(name)
+		} else {
+			groundBreaker.RecordSuccess(name)
+		}
 		results <- providerResult{routes: routes, err: err, name: name}
 	}()
 }
@@ -495,6 +526,20 @@ func searchByNameCore(ctx context.Context, from, to, date string, opts SearchOpt
 	var statuses []models.ProviderStatus
 	for r := range results {
 		if r.err != nil {
+			if r.err == errCircuitBroken {
+				// Deliberately skipped: the provider has been failing and its
+				// breaker is open. Report it honestly, but it is not a fresh
+				// error so it does not drag the search toward "partial".
+				slog.Debug("ground provider circuit-broken", "provider", r.name)
+				statuses = append(statuses, models.ProviderStatus{
+					ID:      r.name,
+					Name:    r.name,
+					Status:  models.StatusCircuitBroken,
+					Error:   "skipped: recent failures tripped the circuit breaker",
+					FixHint: "wait for the cooldown to elapse, then it retries automatically",
+				})
+				continue
+			}
 			if isProviderNotApplicable(r.err) {
 				slog.Debug("ground provider not applicable", "provider", r.name, "reason", r.err)
 				// Attempted but no applicable route for this origin/destination —


### PR DESCRIPTION
## What

Wire the circuit breaker (added in #365, applied to hotels in #366 and flights in #367) into the ground-transport provider fan-out in `internal/ground/search.go`.

Every ground provider — FlixBus, RegioJet, Deutsche Bahn, Eurostar, the ferry lines, Rome2Rio, and the rest — launches through one helper, `launchProvider`. Before this change a provider that kept failing (a blocked endpoint, a dead key, a hard 429) was retried on every search with no back-off. The registry-backed providers had breaker protection; this fan-out did not.

## How

The breaker wires into `launchProvider`, the single choke point, so coverage is automatic for every current and future provider:

- Each provider already has a stable `name`, which is the breaker key.
- If a provider's breaker is open, its goroutine skips the network call and returns an honest `circuit_broken` status instead.
- After a real call, the outcome feeds the breaker. A genuine failure advances it toward tripping; a healthy response closes it.
- A "not applicable for this route" answer (no service between these two cities) is a healthy "nothing to sell" response, not a failure, so it never trips the breaker. This mirrors the empty-but-healthy rule used for hotels and flights.
- After `DefaultThreshold` (5) consecutive failures the breaker opens for `DefaultCooldown` (5 min), then a half-open probe retries the provider automatically.

The result aggregator already classified each provider outcome into a `ProviderStatus`; a circuit-broken skip slots in as its own `StatusCircuitBroken` entry and is not counted as a fresh error, so one cooling-down provider does not drag the search toward "partial".

## Tests

- `internal/ground/breaker_wire_test.go`: `TestGroundBreakerTripsAtThreshold` proves the shared `groundBreaker` trips at the threshold and closes on a successful probe; `TestErrCircuitBrokenIsDistinct` pins that the skip sentinel is distinct from the not-applicable classification, so a breaker skip is reported as `circuit_broken` rather than a silent "no route".
- `go vet`, `go build ./...`, and the full `internal/ground` + `internal/breaker` suites pass locally (ground 28.5s, breaker 0.9s).

Generated with Claude Code
