### PR TITLE
flights: typed error when Google Flights parses 0 of N entries

### DIFF
--- a/internal/flights/parse.go
+++ b/internal/flights/parse.go
@@ -65,6 +65,20 @@ func parseFlights(rawFlights []any) []models.FlightResult {
 	return results
 }
 
+// parseFailureIfAllDropped reports a typed parse failure when the upstream handed
+// us flight entries but parseFlights decoded none of them — the positional array
+// shape rotated underneath us. It returns nil when there were no raw entries (a
+// genuine empty result, an honest no-hit) or when at least one entry parsed. The
+// returned error wraps models.ErrParseFailed so the caller classifies it as
+// StatusFailed and the circuit breaker counts it, instead of mistaking a broken
+// parser for a route with no flights.
+func parseFailureIfAllDropped(parsed, rawEntries int) error {
+	if rawEntries > 0 && parsed == 0 {
+		return fmt.Errorf("google flights: parsed 0 of %d entries: %w", rawEntries, models.ErrParseFailed)
+	}
+	return nil
+}
+
 // parseOneFlight parses a single flight entry into a FlightResult.
 func parseOneFlight(entry []any) (models.FlightResult, error) {
 	var fr models.FlightResult

--- a/internal/flights/parse_failure_test.go
+++ b/internal/flights/parse_failure_test.go
@@ -1,0 +1,45 @@
+package flights
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestParseFailureIfAllDropped pins the discriminator that distinguishes a
+// rotated/undecodable Google Flights response (entries present, none parsed)
+// from a genuine empty result (no entries) and a normal partial parse.
+func TestParseFailureIfAllDropped(t *testing.T) {
+	cases := []struct {
+		name      string
+		parsed    int
+		rawCount  int
+		wantParse bool
+	}{
+		{"no entries is a healthy empty result", 0, 0, false},
+		{"all entries parsed", 5, 5, false},
+		{"some entries dropped but not all", 3, 5, false},
+		{"entries present but none parsed is a parse failure", 0, 5, true},
+		{"single unparseable entry is a parse failure", 0, 1, true},
+	}
+	for _, c := range cases {
+		err := parseFailureIfAllDropped(c.parsed, c.rawCount)
+		if c.wantParse {
+			if err == nil {
+				t.Errorf("%s: want parse failure, got nil", c.name)
+				continue
+			}
+			if !errors.Is(err, models.ErrParseFailed) {
+				t.Errorf("%s: error %q does not wrap ErrParseFailed", c.name, err)
+			}
+			// A clean message routes through ClassifyProviderError to StatusFailed,
+			// not a rate-limit/timeout misclassification.
+			if got := models.ClassifyProviderError(err); got != models.StatusFailed {
+				t.Errorf("%s: ClassifyProviderError = %q, want %q", c.name, got, models.StatusFailed)
+			}
+		} else if err != nil {
+			t.Errorf("%s: want nil, got %q", c.name, err)
+		}
+	}
+}

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -711,6 +711,15 @@ func searchGoogleFlightsWithClient(ctx context.Context, client *batchexec.Client
 
 	flights := parseFlights(rawFlights)
 
+	// Google returned flight entries but the positional parser decoded none of
+	// them — the array shape rotated. That is a parser failure, not a route with
+	// no flights; surface it as a typed error (StatusFailed) so the breaker and
+	// the aggregator treat the provider as unreliable rather than empty-but-healthy.
+	if perr := parseFailureIfAllDropped(len(flights), len(rawFlights)); perr != nil {
+		slog.Debug("google flights: all entries unparseable", "entries", len(rawFlights))
+		return &models.FlightSearchResult{Error: perr.Error()}, perr
+	}
+
 	// Add booking URLs. Prices are in the API's native currency (IP-based).
 	// Currency conversion, if needed, happens in the CLI display layer.
 	for i := range flights {

--- a/internal/models/evidence.go
+++ b/internal/models/evidence.go
@@ -39,6 +39,16 @@ const (
 // letting errors.Is(err, ErrRateLimited) classify the outcome as rate_limited.
 var ErrRateLimited = errors.New("upstream provider rate-limited or temporarily unavailable")
 
+// ErrParseFailed marks a provider response the parser could not decode: a 200 OK
+// body whose shape rotated underneath the positional/HTML decoder so that NO
+// entries parsed even though the upstream returned some. Wrap it with %w to keep
+// a clean message while letting errors.Is(err, ErrParseFailed) and
+// ClassifyProviderError (-> StatusFailed) distinguish "parser broke" from a
+// genuine empty result (StatusCheckedNoHit). The difference is load-bearing: a
+// parse failure means the provider is unreliable this attempt and should count
+// toward the circuit breaker, whereas an honest empty result must not.
+var ErrParseFailed = errors.New("provider response could not be parsed (response shape changed)")
+
 // ClassifyProviderError maps an error to a provider status. A typed rate-limit
 // (ErrRateLimited) wins first so a 429/challenge never renders as a hard parse
 // failure; deadlines map to StatusTimeout; retryable upstream signatures (rate


### PR DESCRIPTION
## What

Google Flights: distinguish a parser failure from a genuine empty result.

When Google returns flight entries but the positional array parser decodes none
of them (the response shape rotated underneath the decoder), the search used to
return `Success: true, Count: 0` — indistinguishable from a route that simply has
no flights. The provider looked healthy while it was actually broken.

This adds a typed sentinel, `models.ErrParseFailed`, and a small pure
discriminator. When entries are present but none parse, the search now returns a
typed error. `ClassifyProviderError` maps it to `StatusFailed`, so the result
aggregator reports the provider as unreliable and the circuit breaker counts the
attempt. A genuine empty response (no entries) still returns an honest no-hit and
is never penalized.

## Why

The circuit breaker added in the prior reliability work keys off the provider
status and error. A parse failure that masquerades as an empty result hides a
broken provider from both the breaker and the user. Making the failure honest is
what lets the rest of the reliability machinery do its job.

## Changes

- `internal/models/evidence.go`: add `ErrParseFailed` sentinel (mirrors the
  existing `ErrRateLimited` pattern). No new status constant — reuses
  `StatusFailed` via the existing `ClassifyProviderError` default.
- `internal/flights/parse.go`: add `parseFailureIfAllDropped`, a pure helper that
  returns the typed error only when entries were present but none parsed.
- `internal/flights/search.go`: wire the helper into
  `searchGoogleFlightsWithClient` after `parseFlights`.
- `internal/flights/parse_failure_test.go`: table test covering the empty,
  partial, full, and all-dropped cases, asserting the sentinel and the
  `StatusFailed` classification.

## Test

`gofmt`, `go vet`, `go build ./...`, and
`go test ./internal/flights/ ./internal/models/ ./internal/breaker/` all green.

Generated with Claude Code
