### PR TITLE
hotels: distinguish Google Hotels parse failure from genuine empty result

### DIFF
--- a/internal/hotels/parse.go
+++ b/internal/hotels/parse.go
@@ -57,6 +57,20 @@ func parseHotelsFromPage(page string, currency string) ([]models.HotelResult, er
 	return pr.Hotels, nil
 }
 
+// hotelParseFailure reports a typed parse failure when the upstream page claims
+// hotels exist (totalAvailable > 0) yet the decoder extracted none — the entry
+// shape rotated underneath the positional parser. It returns nil when zero
+// parsed is consistent with an honest empty result (totalAvailable == 0), so a
+// genuinely empty search is never misreported as a provider failure. Wrapping
+// models.ErrParseFailed lets ClassifyProviderError map the failure to
+// StatusFailed and the circuit breaker count it.
+func hotelParseFailure(parsed, totalAvailable int) error {
+	if totalAvailable > 0 && parsed == 0 {
+		return fmt.Errorf("google hotels: parsed 0 of %d available hotels: %w", totalAvailable, models.ErrParseFailed)
+	}
+	return nil
+}
+
 // parseHotelsFromPageFull extracts hotels and metadata from a Google Travel
 // Hotels HTML page. Unlike parseHotelsFromPage, it returns the full parseResult
 // including total available count.

--- a/internal/hotels/parse_failure_test.go
+++ b/internal/hotels/parse_failure_test.go
@@ -1,0 +1,49 @@
+package hotels
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestHotelParseFailure pins the discriminator that distinguishes a
+// rotated/undecodable Google Hotels response (Google's metadata claims hotels
+// exist, none decoded) from a genuine empty result (no hotels available) and a
+// normal partial parse. The genuine-empty case must NOT be reported as a
+// failure, or an honest no-hit gets misrendered as a broken provider.
+func TestHotelParseFailure(t *testing.T) {
+	cases := []struct {
+		name           string
+		parsed         int
+		totalAvailable int
+		wantParse      bool
+	}{
+		{"no hotels and none available is a healthy empty result", 0, 0, false},
+		{"all available hotels parsed", 5, 5, false},
+		{"some hotels parsed of many available", 3, 5, false},
+		{"hotels available but none decoded is a parse failure", 0, 5, true},
+		{"single available hotel undecoded is a parse failure", 0, 1, true},
+	}
+	for _, c := range cases {
+		err := hotelParseFailure(c.parsed, c.totalAvailable)
+		if c.wantParse {
+			if err == nil {
+				t.Errorf("%s: want parse failure, got nil", c.name)
+				continue
+			}
+			if !errors.Is(err, models.ErrParseFailed) {
+				t.Errorf("%s: error %q does not wrap ErrParseFailed", c.name, err)
+			}
+			// A clean message routes through ClassifyProviderError to StatusFailed,
+			// not a rate-limit/timeout misclassification.
+			if got := models.ClassifyProviderError(err); got != models.StatusFailed {
+				t.Errorf("%s: ClassifyProviderError = %q, want %q", c.name, got, models.StatusFailed)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: want nil, got %q", c.name, err)
+		}
+	}
+}

--- a/internal/hotels/search_fetch.go
+++ b/internal/hotels/search_fetch.go
@@ -243,10 +243,20 @@ func fetchHotelPageFull(ctx context.Context, client *batchexec.Client, location 
 	}
 
 	pr := parseHotelsFromPageFull(string(body), opts.Currency)
-	if len(pr.Hotels) == 0 {
-		return parseResult{}, fmt.Errorf("parse hotel results: no hotels found in response payload")
+	if perr := hotelParseFailure(len(pr.Hotels), pr.TotalAvailable); perr != nil {
+		// Google's own metadata claims hotels exist but the decoder produced
+		// none — the entry shape rotated. Surface a typed parse failure so
+		// ClassifyProviderError maps it to StatusFailed and the breaker counts
+		// it, instead of a lie that masquerades as a healthy empty result.
+		return parseResult{}, perr
 	}
 
+	// An empty result with TotalAvailable == 0 is an honest no-hit: return it as
+	// a successful empty parseResult so the caller maps the zero count to
+	// StatusCheckedNoHit rather than a false provider failure.
+	// ponytail: TotalAvailable == 0 cannot distinguish a genuinely empty page
+	// from a total page-shape loss; acceptable because partial rotations (the
+	// common case) keep TotalAvailable > 0 and are caught above.
 	return pr, nil
 }
 


### PR DESCRIPTION
# hotels: distinguish a Google Hotels parse failure from a genuine empty result

## Problem

`fetchHotelPageFull` returned an error for **any** zero-hotel response from
Google Hotels:

```go
pr := parseHotelsFromPageFull(string(body), opts.Currency)
if len(pr.Hotels) == 0 {
    return parseResult{}, fmt.Errorf("parse hotel results: no hotels found in response payload")
}
```

That error flows through `hotelProviderStatusFromError` →
`ClassifyProviderError`, which has no rate-limit substring to match, so it
lands on `StatusFailed`. The effect: a search that honestly finds zero hotels
for a location is reported as a hard provider failure. Google Hotels could
never return `StatusCheckedNoHit`, so the completeness model treated a healthy
empty answer as missing coverage.

This is the mirror of the Google Flights parse-failure fix (#369): there an
all-unparseable response masqueraded as empty success; here a genuine empty
masquerades as failure.

## Fix

Use `parseResult.TotalAvailable` — Google's own claimed hotel count — as the
discriminator, via a pure helper that mirrors the flights one:

```go
func hotelParseFailure(parsed, totalAvailable int) error {
    if totalAvailable > 0 && parsed == 0 {
        return fmt.Errorf("google hotels: parsed 0 of %d available hotels: %w", totalAvailable, models.ErrParseFailed)
    }
    return nil
}
```

- `TotalAvailable > 0` and zero parsed → the entry shape rotated under the
  positional decoder → typed error wrapping `models.ErrParseFailed` →
  `ClassifyProviderError` → `StatusFailed`, and the circuit breaker counts it.
- `TotalAvailable == 0` and zero parsed → an honest no-hit → return the empty
  `parseResult` with no error, so the caller maps the zero count to
  `StatusCheckedNoHit`.

`models.ErrParseFailed` is reused, not redefined. The pagination loop already
breaks on an empty page, so the healthy-empty path does not loop.

There is one bounded simplification, marked with a `ponytail:` comment:
`TotalAvailable == 0` cannot separate a genuinely empty page from a page whose
shape rotated so completely that even the total count was lost. That is
acceptable because partial rotations — the common case — keep
`TotalAvailable > 0` and are caught as failures above.

## Tests

`TestHotelParseFailure` is a table test on the pure helper, with no network and
no fabricated provider HTML: it asserts `(0, 5)` and `(0, 1)` wrap
`ErrParseFailed` and classify as `StatusFailed`, while `(0, 0)`, `(5, 5)`, and
`(3, 5)` return nil. The existing `parseHotelsFromPage` wrapper tests are
untouched and stay green.

```
go test ./internal/hotels/ ./internal/models/ ./internal/breaker/  # ok
go vet ./internal/hotels/ ./internal/models/                       # clean
```

Generated with Claude Code
