### PR TITLE
hotels: surface Booking.com Apollo parse failure instead of false empty result

### DIFF
--- a/internal/hotels/booking_capture_test.go
+++ b/internal/hotels/booking_capture_test.go
@@ -56,7 +56,10 @@ func TestCaptureBookingFixture(t *testing.T) {
 	}
 	t.Logf("wrote apollo fixture, len=%d", len(blob))
 
-	hotels := parseBookingApollo(blob, "EUR")
+	hotels, err := parseBookingApollo(blob, "EUR")
+	if err != nil {
+		t.Fatalf("parse captured apollo: %v", err)
+	}
 	priced := 0
 	for _, h := range hotels {
 		if h.Price > 0 {

--- a/internal/hotels/booking_parse_failure_test.go
+++ b/internal/hotels/booking_parse_failure_test.go
@@ -1,0 +1,49 @@
+package hotels
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestBookingParseFailure pins the discriminator that distinguishes a
+// rotated/undecodable Booking.com Apollo response (result entries present, none
+// decoded) from a genuine empty result (no entries) and a normal partial parse.
+// The genuine-empty case must NOT be reported as a failure, or an honest no-hit
+// gets misrendered as a broken provider.
+func TestBookingParseFailure(t *testing.T) {
+	cases := []struct {
+		name       string
+		parsed     int
+		rawResults int
+		wantParse  bool
+	}{
+		{"no result entries is a healthy empty result", 0, 0, false},
+		{"all entries decoded", 5, 5, false},
+		{"some entries dropped but not all", 3, 5, false},
+		{"entries present but none decoded is a parse failure", 0, 5, true},
+		{"single undecodable entry is a parse failure", 0, 1, true},
+	}
+	for _, c := range cases {
+		err := bookingParseFailure(c.parsed, c.rawResults)
+		if c.wantParse {
+			if err == nil {
+				t.Errorf("%s: want parse failure, got nil", c.name)
+				continue
+			}
+			if !errors.Is(err, models.ErrParseFailed) {
+				t.Errorf("%s: error %q does not wrap ErrParseFailed", c.name, err)
+			}
+			// A clean message routes through ClassifyProviderError to StatusFailed,
+			// not a rate-limit/timeout misclassification.
+			if got := models.ClassifyProviderError(err); got != models.StatusFailed {
+				t.Errorf("%s: ClassifyProviderError = %q, want %q", c.name, got, models.StatusFailed)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: want nil, got %q", c.name, err)
+		}
+	}
+}

--- a/internal/hotels/booking_search.go
+++ b/internal/hotels/booking_search.go
@@ -50,7 +50,10 @@ func defaultSearchBooking(ctx context.Context, location string, opts HotelSearch
 	if blob == "" {
 		return nil, fmt.Errorf("booking search: apollo store not found in page")
 	}
-	hotels := parseBookingApollo(blob, opts.Currency)
+	hotels, perr := parseBookingApollo(blob, opts.Currency)
+	if perr != nil {
+		return nil, perr
+	}
 
 	// Apply client-side filters.
 	var filtered []models.HotelResult
@@ -228,18 +231,28 @@ func extractBookingApolloBlob(page string) string {
 // parseBookingApollo parses the Apollo store JSON and returns hotel results.
 // It walks ROOT_QUERY → searchQueries → search(<input>) → results[], resolving
 // Apollo normalized __ref pointers against the top-level cache as needed.
-func parseBookingApollo(blob, currency string) []models.HotelResult {
+func parseBookingApollo(blob, currency string) ([]models.HotelResult, error) {
 	var cache map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(blob), &cache); err != nil {
+		// The apollo store <script> was present but its JSON did not parse — the
+		// page shape rotated underneath us. Surface a typed parse failure so the
+		// caller records it against the circuit breaker instead of a false
+		// healthy-empty result.
 		slog.Debug("booking apollo: top-level unmarshal failed", "error", err)
-		return nil
+		return nil, fmt.Errorf("booking apollo: store JSON could not be parsed: %w", models.ErrParseFailed)
 	}
 
 	resolver := apolloResolver{cache: cache}
 
 	results := resolver.findSearchResults()
 	if len(results) == 0 {
-		return nil
+		// No results array anywhere in the cache. This is ambiguous between a
+		// genuinely empty search and a rotated apollo path, and Booking exposes
+		// no claimed-total to disambiguate, so treat it as an honest no-hit.
+		// ponytail: a total page-shape loss is already caught upstream by the
+		// empty-apollo-blob guard in defaultSearchBooking; only a vanished
+		// results array within an otherwise-valid store reaches here.
+		return nil, nil
 	}
 
 	out := make([]models.HotelResult, 0, len(results))
@@ -260,7 +273,23 @@ func parseBookingApollo(blob, currency string) []models.HotelResult {
 		seen[key] = true
 		out = append(out, h)
 	}
-	return out
+	if perr := bookingParseFailure(len(out), len(results)); perr != nil {
+		return nil, perr
+	}
+	return out, nil
+}
+
+// bookingParseFailure reports a typed parse failure when Booking's Apollo store
+// carried result entries but none decoded into a usable hotel — the per-result
+// node shape rotated underneath bookingResultToHotel. It mirrors the flights
+// parseFailureIfAllDropped discriminator: entries present and zero parsed is a
+// provider-unreliable signal that must count toward the breaker, never a
+// healthy empty result.
+func bookingParseFailure(parsed, rawResults int) error {
+	if rawResults > 0 && parsed == 0 {
+		return fmt.Errorf("booking apollo: decoded 0 of %d result entries: %w", rawResults, models.ErrParseFailed)
+	}
+	return nil
 }
 
 // apolloResolver resolves Apollo normalized references against the flat cache.

--- a/internal/hotels/booking_search_test.go
+++ b/internal/hotels/booking_search_test.go
@@ -32,7 +32,10 @@ func TestParseBookingApollo_Fixture(t *testing.T) {
 		t.Fatalf("read fixture: %v", err)
 	}
 
-	hotels := parseBookingApollo(string(blob), "EUR")
+	hotels, err := parseBookingApollo(string(blob), "EUR")
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
 	if len(hotels) == 0 {
 		t.Fatal("expected >=1 hotel from fixture")
 	}


### PR DESCRIPTION
# hotels: surface a Booking.com Apollo parse failure instead of a false empty result

## Problem

`parseBookingApollo` returned a bare `nil` slice for two very different outcomes:

1. The Apollo store `<script>` was present but its JSON did not parse.
2. The `results[]` array carried entries, but every one dropped to an empty
   `Name` so none decoded.

Both flow back through `defaultSearchBooking` as a successful empty result, and
`runAux` (internal/hotels/search.go:394-396) then records a **success** and maps
the zero count to `StatusCheckedNoHit`. So a Booking response whose shape rotated
underneath the decoder was reported as "checked, found nothing" — a healthy
no-hit — when the provider was actually broken for that attempt. The circuit
breaker never counted it, and the completeness model treated missing coverage as
a definitive empty answer.

This is the same latent bug fixed for Google Flights (#369) and Google Hotels
(#370), in Booking's Apollo decoder.

## Fix

Booking exposes no claimed-total field — the `search(...)` node holds only
`__typename` and `results`, and the `total`/`count` keys in a captured store are
per-property review metadata, not a result count. So the discriminator is the
same one Flights uses: **raw entries vs decoded entries**.

`parseBookingApollo` now returns `([]models.HotelResult, error)`:

- Top-level JSON unmarshal failure → typed `models.ErrParseFailed` (the store
  was present but unreadable).
- `results[]` present but zero decoded → `bookingParseFailure(parsed, rawResults)`
  → `models.ErrParseFailed`.
- No `results[]` anywhere → `nil, nil`, an honest no-hit.
- Otherwise → the decoded hotels, no error.

```go
func bookingParseFailure(parsed, rawResults int) error {
    if rawResults > 0 && parsed == 0 {
        return fmt.Errorf("booking apollo: decoded 0 of %d result entries: %w", rawResults, models.ErrParseFailed)
    }
    return nil
}
```

`ClassifyProviderError` maps the typed error to `StatusFailed`, so the breaker
counts it; the genuine no-hit still maps to `StatusCheckedNoHit`. `models.ErrParseFailed`
is reused, not redefined.

There is one bounded simplification, marked with a `ponytail:` comment: when no
`results[]` array exists at all, a genuinely empty search and a fully rotated
apollo path are indistinguishable without a total field. That case stays a
no-hit, because a total page-shape loss is already caught upstream by the
empty-apollo-blob guard in `defaultSearchBooking`.

## Tests

`TestBookingParseFailure` is a fixture-free table test on the pure helper: it
asserts `(0, 5)` and `(0, 1)` wrap `ErrParseFailed` and classify as
`StatusFailed`, while `(0, 0)`, `(5, 5)`, and `(3, 5)` return nil. The existing
`TestParseBookingApollo_Fixture` (real captured Apollo store) is updated to the
new signature and asserts no error, pinning that the happy path stays clean.

```
go test ./internal/hotels/ ./internal/models/ ./internal/breaker/  # ok
go vet ./internal/hotels/                                          # clean
```

Generated with Claude Code
