### PR TITLE
fix(ground): type Rome2Rio zero-route renders to stop false breaker trips

### DIFF
--- a/internal/ground/rome2rio.go
+++ b/internal/ground/rome2rio.go
@@ -139,13 +139,13 @@ func SearchRome2Rio(ctx context.Context, from, to string, allowBrowser bool) ([]
 			lastErr = fmt.Errorf("rome2rio: thin/partial render (no route data); attempt %d", attempt+1)
 			continue
 		}
-		routes, perr := parseRome2Rio(body, from, to)
+		routes, matched, perr := parseRome2Rio(body, from, to)
 		if perr != nil {
 			lastErr = perr
 			continue
 		}
 		if len(routes) == 0 {
-			lastErr = fmt.Errorf("rome2rio: page rendered but no route options parsed")
+			lastErr = rome2rioParseFailure(0, matched, from, to)
 			continue
 		}
 		return routes, nil
@@ -225,13 +225,18 @@ func fetchRome2Rio(ctx context.Context, from, to string, allowBrowser bool) (str
 // pure (no network) so it is exercised by offline fixture tests. Each option is
 // an anchor to /map/{O}/{D}?route=<name>; the anchor's text content carries the
 // title, leg descriptions, duration and price range.
-func parseRome2Rio(body, from, to string) ([]models.GroundRoute, error) {
+// parseRome2Rio extracts route options from an SSR body. It also reports how
+// many distinct route-card anchors the selector matched (`matched`), which lets
+// the caller tell a genuine "no route for this pair" (zero anchors) apart from a
+// decode failure (anchors present but none built into a route). It stays a pure
+// extractor — the failure judgment lives in SearchRome2Rio where the page-marker
+// context is known.
+func parseRome2Rio(body, from, to string) (routes []models.GroundRoute, matched int, err error) {
 	doc, err := html.Parse(strings.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("rome2rio: parse html: %w", err)
+		return nil, 0, fmt.Errorf("rome2rio: parse html: %w", err)
 	}
 
-	var routes []models.GroundRoute
 	seen := make(map[string]bool)
 
 	var walk func(*html.Node)
@@ -242,6 +247,7 @@ func parseRome2Rio(body, from, to string) ([]models.GroundRoute, error) {
 				routeName := m[1]
 				if !seen[routeName] {
 					seen[routeName] = true
+					matched++
 					text := normalizeWS(textOf(n))
 					if route, ok := buildRome2RioRoute(routeName, text, href, from, to); ok {
 						routes = append(routes, route)
@@ -254,7 +260,23 @@ func parseRome2Rio(body, from, to string) ([]models.GroundRoute, error) {
 		}
 	}
 	walk(doc)
-	return routes, nil
+	return routes, matched, nil
+}
+
+// rome2rioParseFailure classifies a zero-route render. A genuine "no route for
+// this pair" (the page rendered but the selector matched no route-card anchors)
+// is a healthy not-applicable answer — its message matches isProviderNotApplicable
+// so the breaker treats it as success. Anchors present but none decoded means the
+// route-card markup rotated: a real parse failure, typed with models.ErrParseFailed
+// so ClassifyProviderError maps it to StatusFailed and the breaker counts it.
+func rome2rioParseFailure(decoded, matched int, from, to string) error {
+	if decoded > 0 {
+		return nil
+	}
+	if matched > 0 {
+		return fmt.Errorf("rome2rio: matched %d route anchors but decoded 0: %w", matched, models.ErrParseFailed)
+	}
+	return fmt.Errorf("rome2rio: no route for %s to %s", from, to)
 }
 
 // buildRome2RioRoute turns one route anchor (its encoded name + visible text)

--- a/internal/ground/rome2rio_failure_test.go
+++ b/internal/ground/rome2rio_failure_test.go
@@ -1,0 +1,42 @@
+package ground
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestRome2RioParseFailure pins the zero-route discriminator end-to-end through
+// the provider status mapping, fixture-free:
+//   - decoded>0           -> nil (healthy, real routes)
+//   - matched>0,decoded==0 -> typed ErrParseFailed -> StatusFailed (breaker counts it)
+//   - matched==0,decoded==0 -> "no route" -> isProviderNotApplicable -> StatusSkipped
+//
+// The last two cases are the reliability fix: before, every zero-route render
+// returned a generic untyped error that classified as StatusFailed, so a city
+// pair Rome2Rio genuinely does not cover would false-trip the circuit breaker.
+func TestRome2RioParseFailure(t *testing.T) {
+	if err := rome2rioParseFailure(3, 5, "London", "Paris"); err != nil {
+		t.Errorf("decoded>0 should be nil, got %v", err)
+	}
+
+	parseFail := rome2rioParseFailure(0, 4, "London", "Paris")
+	if !errors.Is(parseFail, models.ErrParseFailed) {
+		t.Errorf("matched>0,decoded==0 should wrap ErrParseFailed, got %v", parseFail)
+	}
+	if got := models.ClassifyProviderError(parseFail); got != models.StatusFailed {
+		t.Errorf("parse failure should classify as StatusFailed, got %v", got)
+	}
+	if isProviderNotApplicable(parseFail) {
+		t.Errorf("parse failure must NOT read as provider-not-applicable: %v", parseFail)
+	}
+
+	noRoute := rome2rioParseFailure(0, 0, "Helsinki", "Tromso")
+	if errors.Is(noRoute, models.ErrParseFailed) {
+		t.Errorf("genuine empty should NOT wrap ErrParseFailed, got %v", noRoute)
+	}
+	if !isProviderNotApplicable(noRoute) {
+		t.Errorf("genuine no-route should be provider-not-applicable (StatusSkipped path), got %v", noRoute)
+	}
+}

--- a/internal/ground/rome2rio_test.go
+++ b/internal/ground/rome2rio_test.go
@@ -22,7 +22,7 @@ func loadR2RFixture(t *testing.T, name string) string {
 // ranges, and that single-mode options are typed by their mode.
 func TestParseRome2Rio_LondonParis(t *testing.T) {
 	body := loadR2RFixture(t, "rome2rio_london_paris.html")
-	routes, err := parseRome2Rio(body, "London", "Paris")
+	routes, _, err := parseRome2Rio(body, "London", "Paris")
 	if err != nil {
 		t.Fatalf("parseRome2Rio: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestParseRome2Rio_LondonParis(t *testing.T) {
 // genuinely multimodal (ferry+fly, train+night train+bus).
 func TestParseRome2Rio_HelsinkiTromso(t *testing.T) {
 	body := loadR2RFixture(t, "rome2rio_helsinki_tromso.html")
-	routes, err := parseRome2Rio(body, "Helsinki", "Tromso")
+	routes, _, err := parseRome2Rio(body, "Helsinki", "Tromso")
 	if err != nil {
 		t.Fatalf("parseRome2Rio: %v", err)
 	}
@@ -107,12 +107,15 @@ func TestParseRome2Rio_HelsinkiTromso(t *testing.T) {
 // this is what SearchRome2Rio's retry loop keys off.
 func TestParseRome2Rio_ThinRenderHasNoRoutes(t *testing.T) {
 	thin := "<html><body><h1>Loading…</h1></body></html>"
-	routes, err := parseRome2Rio(thin, "London", "Paris")
+	routes, matched, err := parseRome2Rio(thin, "London", "Paris")
 	if err != nil {
 		t.Fatalf("parseRome2Rio(thin): %v", err)
 	}
 	if len(routes) != 0 {
 		t.Errorf("thin render should yield 0 routes, got %d", len(routes))
+	}
+	if matched != 0 {
+		t.Errorf("thin render should match 0 route anchors, got %d", matched)
 	}
 }
 


### PR DESCRIPTION
## What
`SearchRome2Rio` returned a single generic error for every zero-route render. That untyped error classified as `StatusFailed`, so a city pair Rome2Rio genuinely does not cover trips the circuit breaker as a false failure — the same class of provider misreport the breaker work targets, in its inverse form.

## Change
Thread a `matched` count (distinct route-card anchors the selector found) out of `parseRome2Rio`, and split the zero-route case via a pure `rome2rioParseFailure` helper:

- anchors matched but none decoded -> typed `models.ErrParseFailed` -> `StatusFailed` (a real decode failure; the route-card markup rotated, so the breaker should count it)
- zero anchors matched -> `no route for X to Y`, which `isProviderNotApplicable` recognizes -> `StatusSkipped` (healthy not-applicable answer; no false breaker trip)

`parseRome2Rio` stays a pure extractor — the failure judgment lives in `SearchRome2Rio` where the page-marker context is known, preserving the retry-loop contract the thin-render path depends on.

## Tests
- New fixture-free `TestRome2RioParseFailure` pins both paths end-to-end through `ClassifyProviderError` and `isProviderNotApplicable`.
- Existing London/Paris and Helsinki/Tromso fixture tests still pass with the new signature; thin-render test strengthened to assert `matched == 0`.
- `gofmt` + `go vet` + `go build ./...` + `go test ./internal/ground/ ./internal/models/ ./internal/breaker/` all green.

Generated with Claude Code
