### PR TITLE
fix(flights): type Kiwi all-dropped decode so the breaker counts it

### DIFF
--- a/internal/flights/kiwi.go
+++ b/internal/flights/kiwi.go
@@ -167,10 +167,30 @@ func SearchKiwiFlights(ctx context.Context, origin, destination, date, currency 
 	}
 
 	results := make([]models.FlightResult, 0, len(itineraries))
+	usable := 0
 	for _, itinerary := range itineraries {
+		if itinerary.FlyFrom != "" && itinerary.FlyTo != "" {
+			usable++
+		}
 		results = append(results, mapKiwiItinerary(itinerary, currency))
 	}
+	if perr := kiwiParseFailureIfAllDropped(usable, len(itineraries)); perr != nil {
+		return nil, perr
+	}
 	return results, nil
+}
+
+// kiwiParseFailureIfAllDropped mirrors parseFailureIfAllDropped for the Kiwi MCP
+// path: when the upstream returned itinerary entries but none carried a usable
+// route, the response shape rotated underneath us. It wraps models.ErrParseFailed
+// so the caller classifies it as StatusFailed and the circuit breaker counts it,
+// instead of mistaking a broken decoder for a route with no flights. Returns nil
+// for a genuine empty result (no entries) or when at least one itinerary parsed.
+func kiwiParseFailureIfAllDropped(usable, rawEntries int) error {
+	if rawEntries > 0 && usable == 0 {
+		return fmt.Errorf("kiwi: decoded 0 of %d itineraries: %w", rawEntries, models.ErrParseFailed)
+	}
+	return nil
 }
 
 func kiwiInitializeSession(ctx context.Context) (string, error) {

--- a/internal/flights/kiwi_parse_failure_test.go
+++ b/internal/flights/kiwi_parse_failure_test.go
@@ -1,0 +1,45 @@
+package flights
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestKiwiParseFailureIfAllDropped pins the discriminator that distinguishes a
+// rotated/undecodable Kiwi response (itinerary entries present, none carried a
+// usable route) from a genuine empty result (no entries) and a normal partial
+// parse. The all-dropped case must wrap ErrParseFailed so the circuit breaker
+// counts a broken decoder instead of treating it as a route with no flights.
+func TestKiwiParseFailureIfAllDropped(t *testing.T) {
+	cases := []struct {
+		name      string
+		usable    int
+		rawCount  int
+		wantParse bool
+	}{
+		{"no entries is a healthy empty result", 0, 0, false},
+		{"all entries usable", 5, 5, false},
+		{"some entries dropped but not all", 3, 5, false},
+		{"entries present but none usable is a parse failure", 0, 5, true},
+		{"single unusable entry is a parse failure", 0, 1, true},
+	}
+	for _, c := range cases {
+		err := kiwiParseFailureIfAllDropped(c.usable, c.rawCount)
+		if c.wantParse {
+			if err == nil {
+				t.Errorf("%s: want parse failure, got nil", c.name)
+				continue
+			}
+			if !errors.Is(err, models.ErrParseFailed) {
+				t.Errorf("%s: error %q does not wrap ErrParseFailed", c.name, err)
+			}
+			if got := models.ClassifyProviderError(err); got != models.StatusFailed {
+				t.Errorf("%s: ClassifyProviderError = %q, want %q", c.name, got, models.StatusFailed)
+			}
+		} else if err != nil {
+			t.Errorf("%s: want nil, got %q", c.name, err)
+		}
+	}
+}


### PR DESCRIPTION
## What
The Kiwi MCP decode path classified a rotated response shape as success. When the upstream itinerary array changes field names, `json.Unmarshal` into `[]kiwiItinerary` still succeeds — Go ignores unrecognized fields — leaving every struct zero-valued. The old loop mapped those into empty results and returned them as a healthy hit, so a broken decoder recorded as success and the circuit breaker never counted it. Google flights already guards this case with `parseFailureIfAllDropped`; the Kiwi path did not.

## Change
Count itineraries that carry a route (`flyFrom` and `flyTo` both set) while mapping. A new `kiwiParseFailureIfAllDropped` helper, modeled on the Google one, returns a typed `models.ErrParseFailed` when entries were present but none were usable. That classifies as `StatusFailed`, so the breaker counts a real decode failure. A genuinely empty response (no entries) and a normal partial parse both still return cleanly.

## Tests
- New fixture-free `TestKiwiParseFailureIfAllDropped` table-tests the discriminator end to end through `ClassifyProviderError` (empty / all-usable / partial / all-dropped).
- The existing `TestMapKiwiItineraryRoundTrip` golden test (real HEL<->BCN round-trip capture) still passes: its one itinerary is usable, so no false failure.
- `gofmt` + `go vet` + `go build ./...` + `go test ./internal/flights/ ./internal/models/ ./internal/breaker/` all green.

Generated with Claude Code
