### PR TITLE
hotels: lead with priced listings across all sort modes

### DIFF
--- a/internal/hotels/hotel_price_confidence_sort_test.go
+++ b/internal/hotels/hotel_price_confidence_sort_test.go
@@ -42,6 +42,71 @@ func TestSortHotelsLeadsWithRoomLevelPriceConfidence(t *testing.T) {
 	}
 }
 
+// TestSortHotelsPricedFirstAcrossSortModes asserts the operator rule "lead with
+// the ones that have proper price available" holds for every sort mode, not just
+// "cheapest". A listing with no bookable price must never lead a priced one, even
+// when it scores higher on the chosen key (rating/stars/distance). Within each
+// price-presence group the chosen key still orders the results.
+func TestSortHotelsPricedFirstAcrossSortModes(t *testing.T) {
+	cases := []struct {
+		sort   string
+		hotels []models.HotelResult
+		// wantLead is the name expected first: a priced listing, even though the
+		// unpriced one wins the raw key.
+		wantLead     string
+		wantUnpriced string // expected last
+	}{
+		{
+			sort: "rating",
+			hotels: []models.HotelResult{
+				{Name: "Unpriced top-rated", Price: 0, Rating: 9.8},
+				{Name: "Priced decent", Price: 120, Rating: 8.1, PriceConfidence: models.PriceConfidenceRoomLevel},
+			},
+			wantLead: "Priced decent", wantUnpriced: "Unpriced top-rated",
+		},
+		{
+			sort: "stars",
+			hotels: []models.HotelResult{
+				{Name: "Unpriced 5star", Price: 0, Stars: 5},
+				{Name: "Priced 3star", Price: 90, Stars: 3, PriceConfidence: models.PriceConfidenceRoomLevel},
+			},
+			wantLead: "Priced 3star", wantUnpriced: "Unpriced 5star",
+		},
+		{
+			sort: "distance",
+			hotels: []models.HotelResult{
+				{Name: "Unpriced near", Price: 0, Lat: 60.18, Lon: 24.94},
+				{Name: "Priced far", Price: 100, Lat: 61.0, Lon: 25.0, PriceConfidence: models.PriceConfidenceRoomLevel},
+			},
+			wantLead: "Priced far", wantUnpriced: "Unpriced near",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.sort, func(t *testing.T) {
+			sortHotels(c.hotels, c.sort, 60.17, 24.93)
+			if c.hotels[0].Name != c.wantLead {
+				t.Errorf("%s sort: lead = %q, want priced %q", c.sort, c.hotels[0].Name, c.wantLead)
+			}
+			if c.hotels[len(c.hotels)-1].Name != c.wantUnpriced {
+				t.Errorf("%s sort: last = %q, want unpriced %q", c.sort, c.hotels[len(c.hotels)-1].Name, c.wantUnpriced)
+			}
+		})
+	}
+}
+
+// TestSortHotelsKeySortWithinPricedGroup confirms the chosen key still orders
+// listings that all have prices (the priced-first rule must not flatten the key).
+func TestSortHotelsKeySortWithinPricedGroup(t *testing.T) {
+	hotels := []models.HotelResult{
+		{Name: "Low rating", Price: 100, Rating: 7.0, PriceConfidence: models.PriceConfidenceRoomLevel},
+		{Name: "High rating", Price: 100, Rating: 9.0, PriceConfidence: models.PriceConfidenceRoomLevel},
+	}
+	sortHotels(hotels, "rating", 0, 0)
+	if hotels[0].Name != "High rating" {
+		t.Errorf("rating sort within priced group: lead = %q, want High rating", hotels[0].Name)
+	}
+}
+
 // TestLessPriceConfidenceTiers checks the comparator directly across tiers.
 func TestLessPriceConfidenceTiers(t *testing.T) {
 	roomLevel := models.HotelResult{Price: 110, PriceConfidence: models.PriceConfidenceRoomLevel}

--- a/internal/hotels/search_filter.go
+++ b/internal/hotels/search_filter.go
@@ -93,25 +93,47 @@ func sortHotels(hotels []models.HotelResult, sortBy string, centerLat, centerLon
 			return lessPrice(hotels[i], hotels[j])
 		})
 	case "rating":
-		// Sort by rating descending.
+		// Sort by rating descending; priced listings always lead unpriced ones.
 		sort.Slice(hotels, func(i, j int) bool {
+			if lead, decided := pricedLead(hotels[i], hotels[j]); decided {
+				return lead
+			}
 			return hotels[i].Rating > hotels[j].Rating
 		})
 	case "stars":
-		// Sort by star rating descending.
+		// Sort by star rating descending; priced listings always lead.
 		sort.Slice(hotels, func(i, j int) bool {
+			if lead, decided := pricedLead(hotels[i], hotels[j]); decided {
+				return lead
+			}
 			return hotels[i].Stars > hotels[j].Stars
 		})
 	case "distance":
-		// Sort by distance from city center ascending.
+		// Sort by distance from city center ascending; priced listings always lead.
 		if centerLat != 0 || centerLon != 0 {
 			sort.Slice(hotels, func(i, j int) bool {
+				if lead, decided := pricedLead(hotels[i], hotels[j]); decided {
+					return lead
+				}
 				di := Haversine(centerLat, centerLon, hotels[i].Lat, hotels[i].Lon)
 				dj := Haversine(centerLat, centerLon, hotels[j].Lat, hotels[j].Lon)
 				return di < dj
 			})
 		}
 	}
+}
+
+// pricedLead enforces the operator rule "lead with the ones that have proper
+// price available" for the non-price sort modes (rating/stars/distance). When
+// exactly one of a,b carries a bookable price it leads; decided=false when both
+// are priced or both unpriced, so the caller falls through to the chosen sort
+// key. The "cheapest" sort already handles zero-price demotion in lessPrice.
+func pricedLead(a, b models.HotelResult) (lead, decided bool) {
+	ap, bp := a.Price > 0, b.Price > 0
+	if ap != bp {
+		return ap, true
+	}
+	return false, false
 }
 
 // medianHotelCoords computes the median lat/lon from hotels that have


### PR DESCRIPTION
## What

The hotel search ranking now leads with listings that have a real bookable price in **every** sort mode, not just the default cheapest sort.

## Why

The cheapest/price sort already demotes zero-price listings to the tail and ranks real per-night room prices (room_level/verified) ahead of headline teasers (lessPrice). The rating, stars, and distance sorts did not consider price presence at all, so a listing with no bookable price could lead a priced one whenever it scored higher on the raw key. That contradicts the intended behaviour: keep results that have a proper price available at the top, with unpriced listings after them.

## How

A small pricedLead secondary key: when exactly one of two listings carries a price, the priced one leads; otherwise the comparator falls through to the chosen sort key (rating/stars/distance). Within each price-presence group the chosen key still orders results, so the sort semantics are preserved for the priced set.

Room-level price extraction itself is unchanged: Agoda and Google already emit room_level/verified confidence. This PR only fixes ranking so those priced results surface first regardless of sort mode.

## Tests

- TestSortHotelsPricedFirstAcrossSortModes: priced listing leads, unpriced sinks, for rating/stars/distance (was RED before the fix).
- TestSortHotelsKeySortWithinPricedGroup: the key still orders an all-priced set.
- Existing TestSortHotelsLeadsWithRoomLevelPriceConfidence and the rating/stars/distance coverage tests still pass (both-unpriced ties fall through to the key).

Gate: gofmt clean, go vet, go build, go test on the hotels and models packages all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
