### PR TITLE
feat(explore): budget + cabin-class filters for destination search

### DIFF
--- a/internal/explore/budget_cabin_test.go
+++ b/internal/explore/budget_cabin_test.go
@@ -1,0 +1,68 @@
+package explore
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestEncodeExplorePayload_CabinClass asserts the cabin class is encoded into
+// the payload's class slot (business=3) instead of the hardcoded economy.
+func TestEncodeExplorePayload_CabinClass(t *testing.T) {
+	business := EncodeExplorePayload("HEL", ExploreOptions{
+		DepartureDate: "2026-06-15",
+		CabinClass:    models.Business, // 3
+	})
+	economy := EncodeExplorePayload("HEL", ExploreOptions{
+		DepartureDate: "2026-06-15", // CabinClass unset -> economy (1)
+	})
+	if business == economy {
+		t.Fatal("business-class payload should differ from economy payload")
+	}
+	// Decode the URL-escaped payload; the class slot sits between "[]," and the
+	// traveller tuple "[1,0,0,0]".
+	bizRaw, err := url.QueryUnescape(business)
+	if err != nil {
+		t.Fatalf("unescape business: %v", err)
+	}
+	ecoRaw, err := url.QueryUnescape(economy)
+	if err != nil {
+		t.Fatalf("unescape economy: %v", err)
+	}
+	if !strings.Contains(bizRaw, `[],3,[1,0,0,0]`) {
+		t.Errorf("business payload should encode class 3 in the class slot")
+	}
+	if !strings.Contains(ecoRaw, `[],1,[1,0,0,0]`) {
+		t.Errorf("economy payload should encode class 1 by default")
+	}
+}
+
+// TestFilterByBudget asserts the client-side budget cap is authoritative:
+// over-budget and zero-price destinations are dropped, the cap is inclusive,
+// and a zero cap is a no-op.
+func TestFilterByBudget(t *testing.T) {
+	dests := []models.ExploreDestination{
+		{CityName: "Lisbon", Price: 120},
+		{CityName: "Rome", Price: 200}, // exactly at cap -> kept
+		{CityName: "Tokyo", Price: 900},
+		{CityName: "Nameless", Price: 0}, // no price -> dropped under a cap
+	}
+
+	capped := filterByBudget(dests, 200)
+	if len(capped) != 2 {
+		t.Fatalf("expected 2 destinations <= 200, got %d", len(capped))
+	}
+	for _, d := range capped {
+		if d.Price <= 0 || d.Price > 200 {
+			t.Errorf("kept out-of-range destination %s @ %.0f", d.CityName, d.Price)
+		}
+	}
+
+	// No cap -> no-op.
+	all := []models.ExploreDestination{{Price: 50}, {Price: 5000}}
+	if got := filterByBudget(all, 0); len(got) != 2 {
+		t.Errorf("zero cap should be a no-op, got %d of 2", len(got))
+	}
+}

--- a/internal/explore/encode.go
+++ b/internal/explore/encode.go
@@ -34,8 +34,15 @@ func EncodeExplorePayload(srcAirport string, opts ExploreOptions) string {
 	// Travelers: [adults, children, infants_on_lap, infants_in_seat]
 	serTravelers := fmt.Sprintf(`[%d,0,0,0]`, adults)
 
+	// Cabin class slot: 1=economy, 2=premium economy, 3=business, 4=first
+	// (matches models.CabinClass). Zero/unset defaults to economy.
+	cabin := int(opts.CabinClass)
+	if cabin <= 0 {
+		cabin = 1
+	}
+
 	rawData := fmt.Sprintf(`%s,null,[null,null,%d,null,[],%d,%s,null,null,null,null,null,null,`,
-		serCoords, tripType, 1, serTravelers) // class=1 (economy)
+		serCoords, tripType, cabin, serTravelers)
 
 	// Outbound leg
 	rawData += fmt.Sprintf(`[[[[%s]],[],null,0,null,null,\"%s\"]`, serSrc, opts.DepartureDate)

--- a/internal/explore/search.go
+++ b/internal/explore/search.go
@@ -47,10 +47,14 @@ func SearchExplore(ctx context.Context, client *batchexec.Client, origin string,
 		}
 	}
 
+	// Enforce the budget cap client-side. This is the authoritative price
+	// filter (see ExploreOptions.MaxPrice); it stays correct even if a future
+	// server-side payload slot drifts or is absent.
+	result.Destinations = filterByBudget(result.Destinations, opts.MaxPrice)
+	result.Count = len(result.Destinations)
+
 	return result, nil
 }
-
-// doExploreRequest performs a single explore API call.
 func doExploreRequest(ctx context.Context, client *batchexec.Client, encoded string) (*models.ExploreResult, error) {
 	status, body, err := client.PostExplore(ctx, encoded)
 	if err != nil {
@@ -95,4 +99,34 @@ type ExploreOptions struct {
 	SouthLat      float64
 	EastLng       float64
 	WestLng       float64
+
+	// CabinClass is encoded server-side into the explore payload's known
+	// class slot (1=economy..4=first). Zero defaults to economy.
+	CabinClass models.CabinClass
+
+	// MaxPrice caps the per-traveller indicative price. Zero = no cap.
+	//
+	// Enforced client-side (filterByBudget) as the correctness layer. Google's
+	// explore payload has a server-side max-price slot, but its positional
+	// offset is not reverse-engineered here, so we do NOT encode it — guessing
+	// the offset would corrupt the whole payload. The client-side filter is
+	// authoritative; a server-side slot would be pure optimisation.
+	// ponytail: client-side cap is correctness; server-side encoding is a
+	// follow-up needing the gflights offset reference.
+	MaxPrice float64
+}
+
+// filterByBudget drops destinations whose indicative price exceeds maxPrice.
+// maxPrice <= 0 is a no-op (returns the slice unchanged).
+func filterByBudget(dests []models.ExploreDestination, maxPrice float64) []models.ExploreDestination {
+	if maxPrice <= 0 {
+		return dests
+	}
+	kept := dests[:0]
+	for _, d := range dests {
+		if d.Price > 0 && d.Price <= maxPrice {
+			kept = append(kept, d)
+		}
+	}
+	return kept
 }


### PR DESCRIPTION
## What

First brick of the budget-fit trip planner (MIK-6487): make Google Flights Explore filterable by the planner's constraints.

- `ExploreOptions.CabinClass` — encoded into the payload's known class slot (economy..first), replacing the previously hardcoded economy class.
- `ExploreOptions.MaxPrice` — a per-traveller budget cap. Enforced client-side (`filterByBudget`), which is the authoritative price filter.

## Why client-side for the price cap

Google's explore payload has a server-side max-price slot, but its positional offset is not reverse-engineered in this repo. Encoding a guessed offset into a reverse-engineered payload risks corrupting the whole request. The client-side filter is correct regardless; a server-side slot would only reduce the candidate set returned over the wire, which is an optimisation we can add later once the offset is confirmed.

## Tests

- Cabin class lands in the class slot (business=3 differs from default economy=1).
- Budget cap is inclusive, drops over-budget and price-missing destinations, and a zero cap is a no-op.

Offline-deterministic; no live calls. Existing callers are unaffected (`MaxPrice=0` no-op, class defaults to economy).
