### PR TITLE
test(travelgraph): lock MIK-6233 acceptance criteria

### DIFF
--- a/cmd/trvl/nudges.go
+++ b/cmd/trvl/nudges.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
@@ -53,7 +54,7 @@ nothing is shown.`,
 			}
 
 			g := travelgraph.Build(ws, history, prefs, ts)
-			nudges := travelgraph.Nudges(g)
+			nudges := travelgraph.Nudges(g, time.Now())
 
 			if format == "json" {
 				return models.FormatJSON(os.Stdout, nudges)
@@ -63,9 +64,19 @@ nothing is shown.`,
 				return nil
 			}
 			for _, n := range nudges {
-				fmt.Printf("[%s] %s\n  sources: %s\n", n.Kind, n.Message, strings.Join(n.Sources, ", "))
+				fmt.Printf("[%s] %s\n  sources: %s\n", n.Kind, n.Message, formatSources(n.Sources))
 			}
 			return nil
 		},
 	}
+}
+
+// formatSources renders nudge source references as "kind:id" tokens joined by
+// commas, for the human-readable CLI output.
+func formatSources(srcs []travelgraph.SourceRef) string {
+	parts := make([]string, len(srcs))
+	for i, s := range srcs {
+		parts[i] = fmt.Sprintf("%s:%s", s.Kind, s.ID)
+	}
+	return strings.Join(parts, ", ")
 }

--- a/internal/travelgraph/travelgraph.go
+++ b/internal/travelgraph/travelgraph.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/fareintel"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
@@ -41,17 +42,36 @@ const (
 	KindHistoricLow NudgeKind = "historic_low"
 )
 
-// Nudge is a single proactive message grounded in one or more source records.
+// SourceKind classifies the kind of record a SourceRef points at.
+type SourceKind string
+
+const (
+	// SourceWatch references a watch.Watch by its ID.
+	SourceWatch SourceKind = "watch"
+	// SourceRoute references a route bucket by its canonical
+	// "ORIGIN-DESTINATION" key.
+	SourceRoute SourceKind = "route"
+)
+
+// SourceRef is a reference back to the concrete data record that grounds a
+// nudge. Kind distinguishes the record type; ID is its identifier (a watch ID
+// or a route key), so a caller can always trace a nudge to its origin record.
+type SourceRef struct {
+	Kind SourceKind
+	ID   string
+}
+
+// Nudge is a single proactive message grounded in one source record at minimum.
 //
-// Every Nudge carries at least one Source identifier so the caller can trace it
-// back to the underlying watch, route key, or trip that triggered it. Nudges
-// with an empty Sources slice are not produced by this package.
+// Every Nudge carries at least one SourceRef so the caller can trace it back to
+// the underlying watch or route that triggered it. Nudges with an empty Sources
+// slice are not produced by this package.
 type Nudge struct {
 	Kind    NudgeKind
 	Message string
-	// Sources holds the identifiers (watch ID, route key, trip ID) that ground
-	// this nudge. len(Sources) >= 1 is an invariant for all emitted nudges.
-	Sources []string
+	// Sources holds the source-record references that ground this nudge.
+	// len(Sources) >= 1 is an invariant for all emitted nudges.
+	Sources []SourceRef
 }
 
 // routeHistory groups price points by route key (for multi-watch aggregation).
@@ -178,6 +198,26 @@ func (g *Graph) routeFor(key string) *routeHistory {
 	return rh
 }
 
+// RouteEntry is the read-only view of a single route bucket: the watches
+// covering the route and the price points observed for it. Each element retains
+// its source-record reference (watch.Watch / watch.PricePoint) so callers can
+// trace any joined entry back to its origin.
+type RouteEntry struct {
+	Watches []watch.Watch
+	Points  []watch.PricePoint
+}
+
+// ByRoute returns the RouteEntry indexed under a canonical "ORIGIN-DESTINATION"
+// route key (e.g. "HEL-NYC"), and whether that route exists in the graph. The
+// key is normalised (upper-cased, trimmed) to match how Build indexes routes.
+func (g *Graph) ByRoute(key string) (RouteEntry, bool) {
+	rh, ok := g.byRoute[strings.ToUpper(strings.TrimSpace(key))]
+	if !ok {
+		return RouteEntry{}, false
+	}
+	return RouteEntry{Watches: rh.watches, Points: rh.points}, true
+}
+
 // Nudges evaluates the graph and returns all grounded nudges. It emits at most
 // one nudge per watch (below-threshold check) and at most one nudge per route
 // (historic-low check). If there are no grounded triggers, the slice is empty.
@@ -202,7 +242,11 @@ func (g *Graph) routeFor(key string) *routeHistory {
 //
 // With nil/empty preferences the gate is a no-op and ordering is stable by
 // route key, so the no-profile baseline is unchanged.
-func Nudges(g *Graph) []Nudge {
+//
+// now is the evaluation reference time. Price points dated after now are not yet
+// observed and therefore cannot ground a nudge, so they are excluded from the
+// historic-low corpus. Pass time.Now() in production.
+func Nudges(g *Graph, now time.Time) []Nudge {
 	var scored []scoredNudge
 	// Track which routes already produced a KindBelowThreshold nudge so the
 	// historic-low check doesn't double-fire on the same route.
@@ -226,7 +270,7 @@ func Nudges(g *Graph) []Nudge {
 		if belowRoutes[key] || g.isExcludedRoute(key) {
 			continue // already nudged via threshold crossing, or gated out
 		}
-		if n, ok := historicLowNudge(key, rh); ok {
+		if n, ok := historicLowNudge(key, rh, now); ok {
 			scored = append(scored, scoredNudge{nudge: n, key: key, rank: g.routeRank(key)})
 		}
 	}
@@ -352,7 +396,7 @@ func belowThresholdNudges(rh *routeHistory) []Nudge {
 				w.LastPrice, w.Currency,
 				w.BelowPrice, w.Currency,
 			),
-			Sources: []string{w.ID},
+			Sources: []SourceRef{{Kind: SourceWatch, ID: w.ID}},
 		})
 	}
 	return out
@@ -366,19 +410,21 @@ func isThresholdCrossed(w watch.Watch) bool {
 
 // historicLowNudge returns a KindHistoricLow nudge for a route when fareintel
 // rates it as a "buy" with "high" confidence. The current price is derived from
-// the most recent price point in history. Returns (Nudge, true) when a nudge
-// fires, (Nudge{}, false) otherwise.
-func historicLowNudge(key string, rh *routeHistory) (Nudge, bool) {
-	if len(rh.points) < 3 {
+// the most recent price point in history. Points dated after now are excluded
+// (not yet observed). Returns (Nudge, true) when a nudge fires, (Nudge{}, false)
+// otherwise.
+func historicLowNudge(key string, rh *routeHistory, now time.Time) (Nudge, bool) {
+	points := observedPoints(rh.points, now)
+	if len(points) < 3 {
 		return Nudge{}, false
 	}
 
-	latest := latestPoint(rh.points)
+	latest := latestPoint(points)
 	if latest.Price <= 0 {
 		return Nudge{}, false
 	}
 
-	res := fareintel.Analyze(latest.Price, latest.Currency, rh.points)
+	res := fareintel.Analyze(latest.Price, latest.Currency, points)
 	if res.Verdict != fareintel.VerdictBuy || res.Confidence != "high" {
 		return Nudge{}, false
 	}
@@ -391,8 +437,25 @@ func historicLowNudge(key string, rh *routeHistory) (Nudge, bool) {
 			latest.Price, latest.Currency,
 			-res.PercentVsMedian, res.MedianPrice, latest.Currency,
 		),
-		Sources: []string{key},
+		Sources: []SourceRef{{Kind: SourceRoute, ID: key}},
 	}, true
+}
+
+// observedPoints returns the price points that are at or before now (already
+// observed). A point dated after now is in the future and cannot ground a
+// nudge. When now is the zero time, all points are treated as observed so
+// callers that do not care about temporal filtering keep the full corpus.
+func observedPoints(points []watch.PricePoint, now time.Time) []watch.PricePoint {
+	if now.IsZero() {
+		return points
+	}
+	out := make([]watch.PricePoint, 0, len(points))
+	for _, p := range points {
+		if !p.Timestamp.After(now) {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // latestPoint returns the price point with the most recent Timestamp.

--- a/internal/travelgraph/travelgraph_profile_test.go
+++ b/internal/travelgraph/travelgraph_profile_test.go
@@ -32,7 +32,7 @@ func firstSource(nudges []travelgraph.Nudge) string {
 	if len(nudges) == 0 || len(nudges[0].Sources) == 0 {
 		return ""
 	}
-	return nudges[0].Sources[0]
+	return nudges[0].Sources[0].ID
 }
 
 // sourcesInOrder flattens the first source of each nudge, preserving order.
@@ -40,7 +40,7 @@ func sourcesInOrder(nudges []travelgraph.Nudge) []string {
 	out := make([]string, 0, len(nudges))
 	for _, n := range nudges {
 		if len(n.Sources) > 0 {
-			out = append(out, n.Sources[0])
+			out = append(out, n.Sources[0].ID)
 		}
 	}
 	return out
@@ -98,7 +98,7 @@ func TestProfile_ExcludedDestination_GatesNudge(t *testing.T) {
 			}
 
 			g := travelgraph.Build(ws, nil, prefs, nil)
-			got := sourcesInOrder(travelgraph.Nudges(g))
+			got := sourcesInOrder(travelgraph.Nudges(g, now))
 
 			if !equalStrings(got, tc.wantIDs) {
 				t.Errorf("sources = %v, want %v", got, tc.wantIDs)
@@ -121,7 +121,7 @@ func TestProfile_HomeAirportRoutesRankFirst(t *testing.T) {
 	prefs.HomeAirports = []string{"HEL"}
 
 	g := travelgraph.Build(ws, nil, prefs, nil)
-	got := sourcesInOrder(travelgraph.Nudges(g))
+	got := sourcesInOrder(travelgraph.Nudges(g, now))
 
 	want := []string{"w-home", "w-far"}
 	if !equalStrings(got, want) {
@@ -142,7 +142,7 @@ func TestProfile_NearbyAirportCountsAsHome(t *testing.T) {
 	prefs.NearbyAirports = map[string][]string{"HEL": {"ARN"}}
 
 	g := travelgraph.Build(ws, nil, prefs, nil)
-	if got := firstSource(travelgraph.Nudges(g)); got != "w-nearby" {
+	if got := firstSource(travelgraph.Nudges(g, now)); got != "w-nearby" {
 		t.Errorf("nearby-airport route did not rank first: got %q, want w-nearby", got)
 	}
 }
@@ -161,7 +161,7 @@ func TestProfile_AffinityBreaksTieAmongNonHomeRoutes(t *testing.T) {
 	prefs.AirportAffinity = map[string]float64{"TOP": 0.9, "LOW": 0.1}
 
 	g := travelgraph.Build(ws, nil, prefs, nil)
-	if got := firstSource(travelgraph.Nudges(g)); got != "w-top" {
+	if got := firstSource(travelgraph.Nudges(g, now)); got != "w-top" {
 		t.Errorf("high-affinity route did not rank first: got %q, want w-top", got)
 	}
 }
@@ -179,7 +179,7 @@ func TestProfile_HomeBonusDominatesAffinity(t *testing.T) {
 	prefs.AirportAffinity = map[string]float64{"TOP": 1.0}
 
 	g := travelgraph.Build(ws, nil, prefs, nil)
-	if got := firstSource(travelgraph.Nudges(g)); got != "w-home" {
+	if got := firstSource(travelgraph.Nudges(g, now)); got != "w-home" {
 		t.Errorf("home bonus did not dominate affinity: got %q, want w-home", got)
 	}
 }
@@ -196,7 +196,7 @@ func TestProfile_NoProfile_StableKeyOrder(t *testing.T) {
 	}
 
 	g := travelgraph.Build(ws, nil, nil, nil)
-	got := sourcesInOrder(travelgraph.Nudges(g))
+	got := sourcesInOrder(travelgraph.Nudges(g, now))
 
 	// Route keys order: AMS-AAA < AMS-BBB < AMS-CCC.
 	want := []string{"w-a", "w-b", "w-c"}

--- a/internal/travelgraph/travelgraph_test.go
+++ b/internal/travelgraph/travelgraph_test.go
@@ -53,7 +53,7 @@ func TestBelowThreshold_OneNudgeWithWatchIDInSources(t *testing.T) {
 
 	// WHEN
 	g := travelgraph.Build([]watch.Watch{w}, history, nil, nil)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 
 	// THEN: exactly one nudge, cites the watch ID
 	if len(nudges) != 1 {
@@ -81,7 +81,7 @@ func TestBelowThreshold_AtExactThreshold_Fires(t *testing.T) {
 	}
 
 	g := travelgraph.Build([]watch.Watch{w}, nil, nil, nil)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 
 	if len(nudges) != 1 {
 		t.Fatalf("expected 1 nudge at exact threshold, got %d", len(nudges))
@@ -111,7 +111,7 @@ func TestNoGroundedTrigger_ZeroNudges(t *testing.T) {
 
 	// WHEN
 	g := travelgraph.Build([]watch.Watch{w}, history, nil, nil)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 
 	// THEN: no nudges
 	if len(nudges) != 0 {
@@ -132,7 +132,7 @@ func TestWatchAboveThresholdNoHistory_ZeroNudges(t *testing.T) {
 	}
 
 	g := travelgraph.Build([]watch.Watch{w}, nil, nil, nil)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 
 	if len(nudges) != 0 {
 		t.Errorf("expected 0 nudges, got %d", len(nudges))
@@ -157,7 +157,7 @@ func TestHistoricLow_ConfidentAndLowBand_FiresNudge(t *testing.T) {
 
 	// WHEN
 	g := travelgraph.Build([]watch.Watch{w}, history, nil, nil)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 
 	// THEN: exactly one KindHistoricLow nudge citing the route key
 	lowNudges := filterKind(nudges, travelgraph.KindHistoricLow)
@@ -191,7 +191,7 @@ func TestAllNudgesHaveAtLeastOneSource(t *testing.T) {
 		append([]watch.PricePoint{pt("wb1", 75.0, "EUR", 2)}, histHist...),
 		nil, nil,
 	)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 
 	if len(nudges) == 0 {
 		t.Fatal("expected at least one nudge")
@@ -207,9 +207,76 @@ func TestAllNudgesHaveAtLeastOneSource(t *testing.T) {
 
 func TestEmptyInputs_NoPanicZeroNudges(t *testing.T) {
 	g := travelgraph.Build(nil, nil, nil, nil)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 	if len(nudges) != 0 {
 		t.Errorf("expected 0 nudges on empty graph, got %d", len(nudges))
+	}
+}
+
+// --- MIK-6233.AC.2 (TRVL.PTG.2): every emitted nudge carries >=1 SourceRef ---
+
+// TestNudgesCarrySources asserts the core grounding invariant: every nudge that
+// Nudges emits carries a non-empty Sources slice, so a caller can always trace
+// a nudge back to the source record that produced it. The graph mixes a
+// below-threshold watch and a historic-low route to exercise both producers.
+func TestNudgesCarrySources(t *testing.T) {
+	wBelow := watch.Watch{
+		ID: "carry-below", Origin: "AMS", Destination: "BCN",
+		BelowPrice: 80.0, LastPrice: 75.0, Currency: "EUR",
+	}
+	wHist := watch.Watch{
+		ID: "carry-hist", Origin: "HEL", Destination: "DXB",
+		BelowPrice: 0, LastPrice: 400.0, Currency: "EUR",
+	}
+	histHist := historyWithSpread("carry-hist", "EUR", 11, 600.0, 80.0)
+	histHist = append(histHist, pt("carry-hist", 400.0, "EUR", 1))
+
+	g := travelgraph.Build(
+		[]watch.Watch{wBelow, wHist},
+		append([]watch.PricePoint{pt("carry-below", 75.0, "EUR", 2)}, histHist...),
+		nil, nil,
+	)
+	nudges := travelgraph.Nudges(g, now)
+
+	if len(nudges) == 0 {
+		t.Fatal("expected at least one nudge to assert the Sources invariant against")
+	}
+	for i, n := range nudges {
+		if len(n.Sources) == 0 {
+			t.Errorf("nudge[%d] (%s) has empty Sources: %+v", i, n.Kind, n)
+			continue
+		}
+		for j, s := range n.Sources {
+			if s.ID == "" {
+				t.Errorf("nudge[%d].Sources[%d] has empty ID: %+v", i, j, s)
+			}
+		}
+	}
+}
+
+// --- MIK-6233.AC.3 (TRVL.PTG.3): nudges fire ONLY on grounded triggers ---
+
+// TestNudgesGroundedOnly asserts the anti-speculation guarantee: a graph with no
+// grounded trigger (a watch above its target and flat price history that
+// fareintel does not rate as a confident "buy") yields zero nudges.
+func TestNudgesGroundedOnly(t *testing.T) {
+	w := watch.Watch{
+		ID:          "no-trigger",
+		Origin:      "HEL",
+		Destination: "LHR",
+		BelowPrice:  200.0, // target far below current — not crossed
+		LastPrice:   250.0,
+		Currency:    "EUR",
+	}
+	// Flat history near the current price → fareintel verdict is "watch", not a
+	// confident "buy", so no historic-low trigger either.
+	history := historyWithSpread("no-trigger", "EUR", 11, 250.0, 5.0)
+	history = append(history, pt("no-trigger", 250.0, "EUR", 0.5))
+
+	graphWithNoTrigger := travelgraph.Build([]watch.Watch{w}, history, nil, nil)
+
+	if got := travelgraph.Nudges(graphWithNoTrigger, now); len(got) != 0 {
+		t.Errorf("expected 0 nudges from a graph with no grounded trigger, got %d: %v", len(got), got)
 	}
 }
 
@@ -226,7 +293,7 @@ func TestNoBelowPrice_NeverFiresThreshold(t *testing.T) {
 	}
 
 	g := travelgraph.Build([]watch.Watch{w}, nil, nil, nil)
-	nudges := filterKind(travelgraph.Nudges(g), travelgraph.KindBelowThreshold)
+	nudges := filterKind(travelgraph.Nudges(g, now), travelgraph.KindBelowThreshold)
 
 	if len(nudges) != 0 {
 		t.Errorf("expected no threshold nudges when BelowPrice=0, got %d", len(nudges))
@@ -246,7 +313,7 @@ func TestOrphanPricePoint_Ignored(t *testing.T) {
 
 	// WHEN
 	g := travelgraph.Build(nil, []watch.PricePoint{orphan}, nil, nil)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 
 	// THEN: no panic, no nudges
 	if len(nudges) != 0 {
@@ -266,7 +333,7 @@ func TestHistoricLow_TooFewPoints_NoNudge(t *testing.T) {
 		pt("w-few", 120.0, "EUR", 1),
 	}
 	g := travelgraph.Build([]watch.Watch{w}, history, nil, nil)
-	nudges := filterKind(travelgraph.Nudges(g), travelgraph.KindHistoricLow)
+	nudges := filterKind(travelgraph.Nudges(g, now), travelgraph.KindHistoricLow)
 	if len(nudges) != 0 {
 		t.Errorf("expected 0 historic-low nudges with only 2 points, got %d", len(nudges))
 	}
@@ -274,9 +341,9 @@ func TestHistoricLow_TooFewPoints_NoNudge(t *testing.T) {
 
 // --- helpers ---
 
-func containsSource(sources []string, id string) bool {
+func containsSource(sources []travelgraph.SourceRef, id string) bool {
 	for _, s := range sources {
-		if s == id {
+		if s.ID == id {
 			return true
 		}
 	}
@@ -338,7 +405,7 @@ func TestRouteKeyedCorpus_FiresHistoricLowWithNoWatch(t *testing.T) {
 
 	// WHEN: no watches at all — the route corpus is the only input
 	g := travelgraph.Build(nil, history, nil, nil)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 
 	// THEN: exactly one KindHistoricLow nudge citing the route key "AMS-VLC"
 	lowNudges := filterKind(nudges, travelgraph.KindHistoricLow)
@@ -362,7 +429,7 @@ func TestRouteKeyedCorpus_MalformedKey_Skipped(t *testing.T) {
 		{RouteKey: "", Price: 0, Currency: "EUR", Timestamp: now},
 	}
 	g := travelgraph.Build(nil, history, nil, nil)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 	if len(nudges) != 0 {
 		t.Errorf("expected 0 nudges for malformed route keys, got %d: %v", len(nudges), nudges)
 	}
@@ -376,7 +443,7 @@ func TestRouteKeyedCorpus_HotelKey_Skipped(t *testing.T) {
 		{RouteKey: "HOTEL|AMS|MARRIOTT|2026-07-15", Price: 250.0, Currency: "EUR", Timestamp: now},
 	}
 	g := travelgraph.Build(nil, history, nil, nil)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 	if len(nudges) != 0 {
 		t.Errorf("expected 0 nudges for hotel-kind route key, got %d: %v", len(nudges), nudges)
 	}
@@ -405,7 +472,7 @@ func TestRouteKeyedCorpus_MergesWithWatchHistory(t *testing.T) {
 
 	// WHEN
 	g := travelgraph.Build([]watch.Watch{w}, history, nil, nil)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 
 	// THEN: merged corpus reaches high-confidence → historic-low nudge fires
 	lowNudges := filterKind(nudges, travelgraph.KindHistoricLow)
@@ -425,7 +492,7 @@ func TestNoGroundedTrigger_RouteKeyed_ZeroNudges(t *testing.T) {
 	history = append(history, ptRoute(rk, 300.0, "EUR", 0.5))
 
 	g := travelgraph.Build(nil, history, nil, nil)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, now)
 
 	if len(nudges) != 0 {
 		t.Errorf("expected 0 nudges (flat route-keyed history), got %d: %v", len(nudges), nudges)

--- a/mcp/tools_nudges.go
+++ b/mcp/tools_nudges.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/preferences"
 	"github.com/MikkoParkkola/trvl/internal/travelgraph"
@@ -42,7 +43,13 @@ func travelNudgesTool() ToolDef {
 					"properties": map[string]interface{}{
 						"Kind":    schemaString(),
 						"Message": schemaString(),
-						"Sources": schemaStringArray(),
+						"Sources": schemaArray(map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"Kind": schemaString(),
+								"ID":   schemaString(),
+							},
+						}),
 					},
 				}),
 				"count": schemaInt(),
@@ -86,7 +93,7 @@ func handleTravelNudges(_ context.Context, _ map[string]any, _ ElicitFunc, _ Sam
 	}
 
 	g := travelgraph.Build(ws, history, prefs, ts)
-	nudges := travelgraph.Nudges(g)
+	nudges := travelgraph.Nudges(g, time.Now())
 
 	type nudgeResponse struct {
 		Nudges []travelgraph.Nudge `json:"nudges"`
@@ -100,7 +107,7 @@ func handleTravelNudges(_ context.Context, _ map[string]any, _ ElicitFunc, _ Sam
 	} else {
 		summary = fmt.Sprintf("%d grounded nudge(s):\n", len(nudges))
 		for _, n := range nudges {
-			summary += fmt.Sprintf("  [%s] %s\n    sources: %s\n", n.Kind, n.Message, strings.Join(n.Sources, ", "))
+			summary += fmt.Sprintf("  [%s] %s\n    sources: %s\n", n.Kind, n.Message, formatNudgeSources(n.Sources))
 		}
 	}
 
@@ -109,4 +116,14 @@ func handleTravelNudges(_ context.Context, _ map[string]any, _ ElicitFunc, _ Sam
 		return nil, nil, err
 	}
 	return content, resp, nil
+}
+
+// formatNudgeSources renders nudge source references as "kind:id" tokens joined
+// by commas for the human-readable summary block.
+func formatNudgeSources(srcs []travelgraph.SourceRef) string {
+	parts := make([]string, len(srcs))
+	for i, s := range srcs {
+		parts[i] = fmt.Sprintf("%s:%s", s.Kind, s.ID)
+	}
+	return strings.Join(parts, ", ")
 }


### PR DESCRIPTION
## What

Aligns the `internal/travelgraph` personal travel-graph package with the MIK-6233 acceptance criteria and adds the exact named tests each AC requires. The package already shipped (PRs #341/#345) but used a simpler shape; this locks the AC-specified surface.

## Acceptance criteria

- **MIK-6233.AC.1 (TRVL.PTG.1)** — `Build(...)` joins watches, price history, trips, and preferences indexed by route keys. Added `Graph.ByRoute(key) (RouteEntry, bool)` returning the joined per-route entry (watches + price points), each retaining its source record. `func Build(` and `func (g *Graph) ByRoute(` present; `go test ./internal/travelgraph/` passes.
- **MIK-6233.AC.2 (TRVL.PTG.2)** — `Nudge.Sources` is now `[]SourceRef` (typed `Kind` + `ID`) instead of `[]string`, so every nudge carries traceable source-record references. `TestNudgesCarrySources` asserts `len(n.Sources) > 0` for every emitted nudge.
- **MIK-6233.AC.3 (TRVL.PTG.3)** — `Nudges(g, now)` evaluation-time signature; `TestNudgesGroundedOnly` asserts a graph with no grounded trigger yields zero nudges. `now` excludes not-yet-observed (future-dated) points from the historic-low corpus.
- **AC.4+ (CLI + MCP surface)** — `cmd/trvl/nudges.go` and `mcp/tools_nudges.go` updated for the new signature and `SourceRef` rendering; MCP output schema reflects the object-array `Sources` shape.

## Grounding unchanged

Trigger semantics are untouched: nudges fire ONLY on below-threshold watch crossings or confident `fareintel` historic lows. `pricealert`/`fareintel` remains the single grounding engine — no duplication, no new deps, no `internal/models` reverse imports.

## Verification

- `gofmt -l .` empty · `go vet ./...` clean · `go build ./...` clean · staticcheck clean
- `go test ./internal/travelgraph/... ./cmd/trvl/... ./mcp/...` all pass
- `TestNudgesCarrySources` and `TestNudgesGroundedOnly` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DqVXekuAxWnf2JNoPLsgX
