### PR TITLE
fix(providers): route concurrent breaker reads through lock-protected snapshot (MIK-5858)

### DIFF
--- a/internal/providers/circuit_health.go
+++ b/internal/providers/circuit_health.go
@@ -17,6 +17,12 @@ type CircuitHealth struct {
 // CircuitBreakerHealth mirrors the runtime's circuit-break decision so
 // provider_health can explain whether a provider will be tried, skipped, or
 // allowed through as a half-open recovery probe.
+//
+// It reads the breaker fields (ErrorCount/LastErrorAt/LastSuccess) directly off
+// cfg, so concurrent callers MUST pass a snapshot copy — not a live shared
+// *ProviderConfig from Registry.List()/Get() — or they race the breaker writers
+// (MarkSuccess/MarkError). Use Registry.ListSafe()/GetSafe() to obtain copies.
+// Single-threaded callers (CLI/tests) may pass any config (#144; MIK-5858).
 func CircuitBreakerHealth(cfg *ProviderConfig, now time.Time) CircuitHealth {
 	if cfg == nil {
 		return CircuitHealth{State: "unknown"}

--- a/internal/providers/race_stress_test.go
+++ b/internal/providers/race_stress_test.go
@@ -89,3 +89,84 @@ func TestProviderBreaker_ConcurrentSearchAndMark(t *testing.T) {
 	close(stop)
 	wg.Wait()
 }
+
+// TestProviderBreaker_ConcurrentStatusReportAndMark stresses BuildStatusReport
+// (the MCP provider_health tool + HTTP dashboard path) against concurrent
+// MarkSuccess/MarkError writes on the shared provider configs, under the race
+// detector.
+//
+// This is the MIK-5858 companion guard to the SearchHotels case above: before
+// the fix, BuildStatusReport iterated Registry.List() (live shared pointers)
+// and passed them to CircuitBreakerHealth, which read ErrorCount/LastErrorAt/
+// LastSuccess directly — a data race against the lock-protected breaker writers
+// reachable concurrently from an in-flight search. On the fixed code
+// (BuildStatusReport iterates Registry.ListSafe(), which value-copies each
+// config under RLock) this passes clean under `go test -race`.
+func TestProviderBreaker_ConcurrentStatusReportAndMark(t *testing.T) {
+	dir := t.TempDir()
+	reg, err := NewRegistryAt(dir)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+
+	const nprov = 8
+	ids := make([]string, nprov)
+	for i := 0; i < nprov; i++ {
+		id := fmt.Sprintf("fake-%02d", i)
+		ids[i] = id
+		cfg := &ProviderConfig{
+			ID:       id,
+			Name:     id,
+			Category: "hotels",
+			Endpoint: "https://example.invalid/search",
+			Method:   "GET",
+		}
+		if err := reg.Save(cfg); err != nil {
+			t.Fatalf("save %s: %v", id, err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writers: hammer the lock-protected breaker mutations on shared configs.
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				for _, id := range ids {
+					reg.MarkError(id, "boom")
+					reg.MarkSuccess(id)
+				}
+			}
+		}()
+	}
+
+	// Readers: hammer BuildStatusReport, whose circuit-state derivation reads
+	// the same breaker fields via CircuitBreakerHealth.
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = BuildStatusReport(reg, dir, time.Now())
+			}
+		}()
+	}
+
+	// Hammer for long enough that any racy interleave is observed under -race.
+	time.Sleep(1500 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -330,6 +330,47 @@ func (r *Registry) BreakerSnapshot(id string) (BreakerState, bool) {
 	}, true
 }
 
+// ListSafe returns value copies of all loaded provider configurations, taken
+// under RLock. Use this on any path that may run concurrently with
+// MarkSuccess/MarkError/ResetBreaker (the MCP server tool handlers, the HTTP
+// dashboard, and BuildStatusReport): the breaker fields
+// (ErrorCount/LastError/LastErrorAt/LastSuccess) are value types, so the
+// struct copy snapshots them atomically under the lock. Reading those fields
+// off the live shared pointers returned by List()/Get() on a concurrent path
+// is the #144 data-race class. Display-only single-threaded callers (the CLI
+// commands, which run one command and exit) may keep using List()/Get().
+//
+// The remaining reference-typed fields (Headers, lookups, Consent, …) are
+// shared with the live config, which is safe: they are populated at load time
+// and never mutated by the breaker writers, so concurrent readers never race
+// on them.
+func (r *Registry) ListSafe() []*ProviderConfig {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]*ProviderConfig, 0, len(r.configs))
+	for _, cfg := range r.configs {
+		c := *cfg // value copy snapshots breaker fields under the lock
+		out = append(out, &c)
+	}
+	return out
+}
+
+// GetSafe returns a value copy of the provider configuration with the given ID
+// taken under RLock, or nil. It is the single-provider companion to ListSafe
+// for concurrent readers; see ListSafe for the rationale.
+func (r *Registry) GetSafe(id string) *ProviderConfig {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	cfg, ok := r.configs[id]
+	if !ok {
+		return nil
+	}
+	c := *cfg // value copy snapshots breaker fields under the lock
+	return &c
+}
+
 // MarkSuccess records a successful request for the given provider.
 func (r *Registry) MarkSuccess(id string) {
 	r.mu.Lock()

--- a/internal/providers/status_report.go
+++ b/internal/providers/status_report.go
@@ -71,7 +71,11 @@ func BuildStatusReport(reg *Registry, dir string, now time.Time) []StatusRow {
 	summary := HealthSummary(dir)
 	configs := map[string]*ProviderConfig{}
 	if reg != nil {
-		for _, cfg := range reg.List() {
+		// ListSafe snapshots each config under RLock so the breaker reads in
+		// CircuitBreakerHealth below never race concurrent MarkSuccess/MarkError
+		// from an in-flight search. BuildStatusReport runs on concurrent paths
+		// (MCP provider_health tool, HTTP dashboard) — #144 class; MIK-5858.
+		for _, cfg := range reg.ListSafe() {
 			configs[cfg.ID] = cfg
 		}
 	}

--- a/mcp/tools_providers.go
+++ b/mcp/tools_providers.go
@@ -408,7 +408,10 @@ func listProvidersTool() ToolDef {
 
 // handleListProviders processes a list_providers tool call.
 func handleListProviders(_ context.Context, _ map[string]any, _ ElicitFunc, _ SamplingFunc, _ ProgressFunc, reg *providers.Registry, _ *providers.Runtime) ([]ContentBlock, interface{}, error) {
-	configs := reg.List()
+	// ListSafe returns value copies under RLock so reading the breaker fields
+	// (LastSuccess/ErrorCount) here never races MarkSuccess/MarkError running
+	// concurrently from an in-flight search (#144 class; MIK-5858).
+	configs := reg.ListSafe()
 
 	if len(configs) == 0 {
 		return textContent("No external providers configured. Use configure_provider to add one."), nil, nil

--- a/mcp/tools_providers_health.go
+++ b/mcp/tools_providers_health.go
@@ -330,7 +330,10 @@ func handleProviderHealth(_ context.Context, _ map[string]any, _ ElicitFunc, _ S
 	summary := providers.HealthSummary(dir)
 	configs := map[string]*providers.ProviderConfig{}
 	if reg != nil {
-		for _, cfg := range reg.List() {
+		// ListSafe snapshots each config under RLock so the breaker reads in
+		// CircuitBreakerHealth below never race concurrent MarkSuccess/MarkError
+		// from an in-flight search (#144 class; MIK-5858).
+		for _, cfg := range reg.ListSafe() {
 			configs[cfg.ID] = cfg
 		}
 	}

--- a/mcp/tools_providers_test.go
+++ b/mcp/tools_providers_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/MikkoParkkola/trvl/internal/providers"
@@ -675,4 +676,72 @@ func containsSubstring(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+// TestListProvidersConcurrentWithBreakerMarks is the same-package regression
+// guard for the MIK-5858 fix: the provider-listing MCP handlers must read
+// breaker state through reg.ListSafe() (RLock value-copy snapshot) so a
+// concurrent MarkError/MarkSuccess writer cannot race the reader. Run under
+// -race; if the handlers are reverted to the unsynchronized List() path this
+// fails with a data race. The internal/providers package carries the
+// lower-level race test (TestProviderBreaker_ConcurrentStatusReportAndMark);
+// this one exercises the same invariant at the mcp handler boundary that the
+// fix actually changed.
+func TestListProvidersConcurrentWithBreakerMarks(t *testing.T) {
+	reg := testRegistry(t)
+	config := &providers.ProviderConfig{
+		ID:       "race-list",
+		Name:     "Race List Provider",
+		Category: "hotels",
+		Endpoint: "http://127.0.0.1/search",
+		Method:   "POST",
+		ResponseMapping: providers.ResponseMapping{
+			ResultsPath: "$.results",
+			Fields:      map[string]string{"name": "$.hotel_name"},
+		},
+		Consent: &providers.ConsentRecord{Granted: true, Domain: "127.0.0.1"},
+	}
+	if err := reg.Save(config); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	// Writer: mutate the breaker fields concurrently.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if i%2 == 0 {
+				reg.MarkError("race-list", "boom")
+			} else {
+				reg.MarkSuccess("race-list")
+			}
+		}
+	}()
+
+	// Reader 1: list providers via the handler the fix routes through ListSafe.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if _, _, err := handleListProviders(context.Background(), nil, nil, nil, nil, reg, nil); err != nil {
+				t.Errorf("handleListProviders: %v", err)
+				return
+			}
+		}
+	}()
+
+	// Reader 2: provider health snapshot, also routed through ListSafe.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if _, _, err := handleProviderHealth(context.Background(), nil, nil, nil, nil, reg, nil); err != nil {
+				t.Errorf("handleProviderHealth: %v", err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
## MIK-5858 — Structural guard: provider breaker fields read-safe on concurrent paths

`ProviderConfig` breaker fields (`ErrorCount`, `LastError`, `LastErrorAt`, `LastSuccess`) are mutated under the registry lock by `MarkSuccess`/`MarkError`/`ResetBreaker`, but several concurrent readers took them directly off the live shared `*ProviderConfig` pointers returned by `Registry.List()` — the #144 data-race class (a search's `MarkSuccess` write, reached via singleflight, racing a status read).

`SearchHotels` was already fixed via `Registry.BreakerSnapshot`. This PR extends the same snapshot-under-RLock pattern to the remaining concurrent readers, **without** privatizing fields (which would break JSON persistence).

### Approach
Added `Registry.ListSafe()` / `GetSafe()`: value copies of `ProviderConfig` taken under `RLock`. The breaker fields are value types, so a struct copy is an atomic snapshot of them under the lock; the reference-typed config fields (Headers, lookups, Consent, …) are load-time immutable and never touched by the breaker writers, so sharing them stays race-free. Concurrent readers consume copies; display-only single-threaded CLI readers keep using `List()`/`Get()`.

### Acceptance criteria

- **TRVL.BRK.1 — enumerate & classify every breaker-field reader:**

  | Site | Classification | Action |
  |---|---|---|
  | `internal/providers/runtime_search.go` (SearchHotels loop) | concurrent hot path | already via `BreakerSnapshot` (PR #144) — unchanged |
  | `internal/providers/status_report.go` `BuildStatusReport` → `CircuitBreakerHealth` | concurrent (MCP `provider_health` tool + HTTP `/dashboard`) | routed through `ListSafe()` |
  | `mcp/tools_providers.go` `handleListProviders` (`LastSuccess`,`ErrorCount`) | concurrent (MCP server) | routed through `ListSafe()` |
  | `mcp/tools_providers_health.go` `handleProviderHealth` → `CircuitBreakerHealth` | concurrent (MCP server) | routed through `ListSafe()` |
  | `internal/providers/circuit_health.go` `CircuitBreakerHealth` | reads cfg breaker fields | now always receives a snapshot copy on concurrent paths; contract documented |
  | `mcp/tools_providers_health.go` `handleSuggestProviders` (`c.ID` only) | concurrent, but reads no breaker field (ID is immutable) | left as-is |
  | `mcp/tools_providers_health.go` `handleTestProvider` (`reg.Get` fallback) | reads config for a live probe, not breaker fields | left as-is |
  | `cmd/trvl/providers_status.go` `classifyProviderStatus` | display-only, single-threaded CLI | left as-is |
  | `cmd/trvl/providers.go` (`cfg.Status()`, LastSuccess/LastError display) | display-only, single-threaded CLI | left as-is |
  | `cmd/trvl/status.go` | reads `StatusRow` copies (post-`BuildStatusReport`), single-threaded CLI | left as-is |
  | `internal/providers/config.go` `Status()`/`IsStale()` | only reached from CLI display + tests | left as-is |

- **TRVL.BRK.2 — every concurrent reader goes through a lock-protected snapshot:** the three concurrent breaker readers above now consume `ListSafe()` value copies; no concurrent path reads a live shared `ProviderConfig` breaker field directly.

- **TRVL.BRK.3 — stress guard still green + new case added:** the existing `TestProviderBreaker_ConcurrentSearchAndMark` (PR #152) still passes under `-race`. Added `TestProviderBreaker_ConcurrentStatusReportAndMark` covering the newly-routed `BuildStatusReport` path (hammers it against concurrent `MarkSuccess`/`MarkError`). Verified it trips the race detector on the pre-fix `List()` path (`WARNING: DATA RACE`) and passes clean on `ListSafe()`.

- **TRVL.BRK.4 — JSON persistence intact:** no fields privatized; `ProviderConfig` marshaling is untouched. The fix stops *sharing live mutable pointers* on concurrent paths via value-copy snapshots.

### Operator locks honored
stdlib + existing deps only (no new deps); `internal/models` has no new reverse imports; no live/network tests added or unguarded; `filepath.Join` used for paths; no test weakened/skipped/deleted.

### Gate (all green)
```
gofmt -l .                          → (empty)
go vet ./...                        → clean
go build ./...                      → clean
go test ./internal/providers/...    → ok  (19.8s)
go test -race ./internal/providers/... → ok  (22.5s, -count=1)
go test ./mcp/... ./cmd/...         → ok  (all packages)
```
