### PR TITLE
fix(hotels): honest resurrection probe for deprecated Anyplace live test

### DIFF
--- a/internal/hotels/anyplace_test.go
+++ b/internal/hotels/anyplace_test.go
@@ -273,8 +273,20 @@ func TestSearchAnyplaceEndToEnd(t *testing.T) {
 	}
 }
 
-// TestSearchAnyplaceLiveIntegration hits the real Anyplace endpoints. Opt-in
+// TestSearchAnyplaceLiveIntegration probes the real Anyplace endpoints. Opt-in
 // only: gated behind TRVL_TEST_LIVE_INTEGRATIONS=1 and skipped by -short.
+//
+// Anyplace is DEPRECATED / off by default (see anyplaceEnabled, 2026-06-20):
+// the site moved to client-side rendering and the former SSR / _next/data city
+// routes now 308-redirect to the homepage shell. The shipped contract — parser
+// correctness against fixtures and the honest-skip (disabled -> nil,nil) path —
+// is covered deterministically by TestSearchAnyplaceEndToEnd. This live test is
+// therefore a *resurrection probe*: it force-enables the provider and reports
+// whether a stable data path has returned. A live transport/endpoint failure
+// (the current, expected reality) is an honest Skip, not a test failure —
+// mirroring the easyJet AKAMAI_BLOCK precedent. The test only FAILS if the live
+// call succeeds yet yields zero listings, which would be a genuine parser
+// regression worth surfacing.
 func TestSearchAnyplaceLiveIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping live integration in -short mode")
@@ -288,11 +300,13 @@ func TestSearchAnyplaceLiveIntegration(t *testing.T) {
 
 	hotels, err := SearchAnyplace(context.Background(), "Lisbon", HotelSearchOptions{Currency: "USD"})
 	if err != nil {
-		t.Fatalf("live SearchAnyplace: %v", err)
+		// Expected while Anyplace remains deprecated (dead SSR/_next/data path).
+		// Honest skip: signals "upstream still down", not a code defect.
+		t.Skipf("anyplace live endpoint still unavailable (provider remains deprecated): %v", err)
 	}
 	if len(hotels) == 0 {
-		t.Fatal("live integration returned zero hotels")
+		t.Fatal("live call succeeded but returned zero hotels (parser regression)")
 	}
-	t.Logf("live Anyplace returned %d listings; first: %s @ %.0f %s",
+	t.Logf("live Anyplace returned %d listings; first: %s @ %.0f %s — endpoint resurrected, candidate to re-enable",
 		len(hotels), hotels[0].Name, hotels[0].Price, hotels[0].Currency)
 }


### PR DESCRIPTION
## What

`TestSearchAnyplaceLiveIntegration` failed (`t.Fatal`) whenever the live Anyplace endpoint was unreachable. Anyplace has been **deprecated / off-by-default since 2026-06-20** — the site moved to client-side rendering and its former SSR / `_next/data` city routes now 308-redirect to the homepage shell.

Verified live:
```
anyplace fetch city: unexpected status 308 for
https://www.anyplace.com/_next/data/<buildId>/listings/lisbon.json
```
(`internal/hotels/anyplace.go:269`)

So the live test asserted a data path the codebase deliberately abandoned and could never pass — surfacing a known-dead upstream as a code defect.

## Change

Convert the live integration into an honest **resurrection probe**:
- live transport/endpoint failure → `t.Skip` ("upstream still down, provider remains deprecated"), mirroring the easyJet `AKAMAI_BLOCK` precedent;
- a successful live call with **zero** listings still **fails** (genuine parser regression);
- a successful call with listings logs "endpoint resurrected, candidate to re-enable".

## Why this is safe

The shipped contract is already covered deterministically by `TestSearchAnyplaceEndToEnd`:
- parser correctness against fixtures (2 listings), and
- the honest-skip path (`anyplaceEnabled=false` → `(nil, nil)`).

No production code changed; no deterministic coverage removed; test-only diff.

## Evidence
- Offline suite: `go test -run Anyplace ./internal/hotels/` → `ok`
- Live probe now: `--- SKIP: TestSearchAnyplaceLiveIntegration` with the 308 diagnostic (was `--- FAIL`)
- `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_015DqVXekuAxWnf2JNoPLsgX
