### PR TITLE
ci: rebuild GitNexus index after stale cache failure

### DIFF
--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -44,8 +44,17 @@ jobs:
           restore-keys: |
             gitnexus-${{ runner.os }}-
 
-      - name: Analyze (incremental)
-        run: npx --yes gitnexus analyze
+      - name: Analyze (incremental with clean fallback)
+        run: |
+          set -euo pipefail
+
+          if npx --yes gitnexus analyze; then
+            exit 0
+          fi
+
+          echo "::warning::Incremental GitNexus analysis failed; clearing restored .gitnexus cache and retrying from a clean index"
+          rm -rf .gitnexus
+          npx --yes gitnexus analyze
 
       - name: Publish index metadata
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Hardens `gitnexus-index` so it keeps the incremental cached path when healthy.
- If restored `.gitnexus` cache is incompatible and `npx gitnexus analyze` fails, the workflow clears `.gitnexus` and retries from a clean index.
- Addresses current main failures where GitNexus/LBug reports `Trying to insert into an index on table File but its extension is not loaded`.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gitnexus-index.yml")'`\n- Fake-`npx` harness: first analyze exits non-zero, stale `.gitnexus` is removed, second analyze creates `meta.json`, `calls=2`\n- `git diff --check`\n- `actionlint .github/workflows/gitnexus-index.yml`\n\n## Notes\nThis is a CI/repo-quality fix only; no production code changes.