### PR TITLE
hotels: quiet SerpAPI room fallback debug logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -627,7 +627,7 @@ done with trvl alone.
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **trvl** (20610 symbols, 62036 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **trvl** (21724 symbols, 65509 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Make targets pin `GOTOOLCHAIN=go1.26.3` so local build/test entrypoints match CI
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **trvl** (20610 symbols, 62036 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **trvl** (21724 symbols, 65509 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/internal/hotels/serpapi_fallback.go
+++ b/internal/hotels/serpapi_fallback.go
@@ -2,7 +2,6 @@ package hotels
 
 import (
 	"context"
-	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -71,16 +70,13 @@ func trySerpAPIPriceFallback(ctx context.Context, opts HotelPriceOpts) *models.H
 
 func trySerpAPIRoomFallback(ctx context.Context, opts RoomSearchOptions) ([]RoomType, string, string) {
 	if strings.TrimSpace(serpapiAPIKeyFunc()) == "" {
-		log.Printf("DEBUG serpapi room fallback skipped: no SERPAPI_KEY")
 		return nil, "", ""
 	}
 
 	query, place := serpapiFallbackQuery(ctx, opts.HotelID, opts.Location)
 	if query == "" {
-		log.Printf("DEBUG serpapi room fallback aborted: empty query (hotelID=%q location=%q place=%v)", opts.HotelID, opts.Location, place != nil)
 		return nil, "", ""
 	}
-	log.Printf("DEBUG serpapi room fallback: query=%q placeResolved=%v", query, place != nil)
 
 	guests := opts.Guests
 	if guests <= 0 {
@@ -106,7 +102,6 @@ func trySerpAPIRoomFallback(ctx context.Context, opts RoomSearchOptions) ([]Room
 	for page := 0; page < serpapiFallbackMaxPages; page++ {
 		result, err := serpapiSearchHotelsFunc(ctx, searchOpts)
 		if err != nil || result == nil {
-			log.Printf("DEBUG serpapi room fallback: search failed page=%d query=%q err=%v", page, query, err)
 			lastErr = err
 			break
 		}
@@ -121,7 +116,6 @@ func trySerpAPIRoomFallback(ctx context.Context, opts RoomSearchOptions) ([]Room
 		searchOpts.NextPageToken = token
 	}
 	if hotel == nil {
-		log.Printf("DEBUG serpapi room fallback: no hotel matched in %d properties across pages (query=%q name=%q)", scanned, query, opts.Location)
 		// A retryable bot-wall / 429 on the metered search is not a genuine
 		// "no match"; surface it so a withheld Google Hotels price is not read
 		// as absent inventory. Hard failures and plain misses stay silent.
@@ -131,10 +125,8 @@ func trySerpAPIRoomFallback(ctx context.Context, opts RoomSearchOptions) ([]Room
 	hotel = selectedSerpAPIPropertyDetails(ctx, hotel, searchOpts)
 	rooms := roomTypesFromSerpAPIHotel(hotel, opts.Currency)
 	if len(rooms) == 0 {
-		log.Printf("DEBUG serpapi room fallback: matched hotel %q but extracted 0 rooms", hotel.Name)
 		return nil, "", ""
 	}
-	log.Printf("DEBUG serpapi room fallback: matched %q, extracted %d rooms", hotel.Name, len(rooms))
 
 	name := hotel.Name
 	if name == "" && place != nil {

--- a/internal/hotels/serpapi_fallback_test.go
+++ b/internal/hotels/serpapi_fallback_test.go
@@ -1,7 +1,9 @@
 package hotels
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"testing"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
@@ -114,6 +116,7 @@ func TestSerpAPIPriceFallbackFetchesSelectedPropertyDetail(t *testing.T) {
 
 func TestSerpAPIRoomFallbackConvertsVerifiedRoomsAndRefundability(t *testing.T) {
 	const rawID = "0x133b6ab82c204df7:0x437369f021e5e869"
+	logOutput := captureStandardLog(t)
 	restore := stubSerpAPIFallback(t, &serpapi.MapsPlace{
 		Title:   "Hotel Continental Mare",
 		Address: "Via Baldassarre Cossa, 25, 80074 Ischia NA, Italy",
@@ -168,6 +171,9 @@ func TestSerpAPIRoomFallbackConvertsVerifiedRoomsAndRefundability(t *testing.T) 
 	if room.BreakfastIncluded == nil || !*room.BreakfastIncluded {
 		t.Fatalf("breakfast included = %#v, want true", room.BreakfastIncluded)
 	}
+	if got := logOutput.String(); got != "" {
+		t.Fatalf("standard log output = %q, want none for normal SerpAPI room fallback", got)
+	}
 }
 
 func TestSerpAPIRoomFallbackFetchesSelectedPropertyDetail(t *testing.T) {
@@ -215,6 +221,7 @@ func TestSerpAPIRoomFallbackFetchesSelectedPropertyDetail(t *testing.T) {
 }
 
 func TestSerpAPIFallbackSkipsWithoutKey(t *testing.T) {
+	logOutput := captureStandardLog(t)
 	origKey := serpapiAPIKeyFunc
 	origResolve := serpapiResolveGoogleMapsPlaceFunc
 	origSearch := serpapiSearchHotelsFunc
@@ -246,6 +253,18 @@ func TestSerpAPIFallbackSkipsWithoutKey(t *testing.T) {
 	if rooms != nil || name != "" || notice != "" {
 		t.Fatalf("room fallback = rooms %#v name %q notice %q, want empty without key", rooms, name, notice)
 	}
+	if got := logOutput.String(); got != "" {
+		t.Fatalf("standard log output = %q, want none without SERPAPI_KEY", got)
+	}
+}
+
+func captureStandardLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(previous) })
+	return &buf
 }
 
 func TestSearchPageFallbackRejectsBroadCityNameMatch(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove unconditional standard logger DEBUG output from the SerpAPI room fallback
- keep explicit fallback notices as API return values for caller-visible withheld-pricing/rate-limit states
- refresh GitNexus code-intelligence counters after re-analysis

## DoR
- ACs: normal/no-key SerpAPI room fallback paths do not write to the standard logger; fallback return behavior stays intact
- Scope/targets: internal/hotels/serpapi_fallback.go, internal/hotels/serpapi_fallback_test.go, generated GitNexus counter refresh in AGENTS.md/CLAUDE.md
- ROI/value: reduces noisy production stderr/log output and keeps diagnostics behind structured/level-gated paths, improving repo and runtime polish
- Risks: room availability fallback regression; hidden logging regression; generated GitNexus metadata drift
- Validation plan: focused regression tests, package test, vet, GitNexus impact/change checks, CI staticcheck

## Validation
- go test ./internal/hotels -run 'TestSerpAPIRoomFallbackConvertsVerifiedRoomsAndRefundability|TestSerpAPIFallbackSkipsWithoutKey' -count=1\n- go test ./internal/hotels -count=1\n- go vet ./internal/hotels\n- git diff --check\n- rg -n 'log\\.Printf\\(\"DEBUG' --glob '!**/*_test.go' --glob '!vendor/**' --glob '!dist/**' --glob '!node_modules/**' .; test $? -eq 1\n- npx gitnexus analyze\n- npx gitnexus impact trySerpAPIRoomFallback --direction upstream --repo trvl --depth 3: LOW risk, 1 direct caller, 0 affected processes\n- npx gitnexus detect-changes --scope unstaged --repo trvl: low risk, 0 affected processes\n\n## Notes\n- Local staticcheck binary is not installed; CI covers staticcheck.\n