### PR TITLE
Redact generated MCP HTTP token logs

### DIFF
--- a/cmd/trvl/mcp.go
+++ b/cmd/trvl/mcp.go
@@ -30,10 +30,11 @@ Claude Code and other MCP-compatible clients.
 Use --http to start an HTTP server instead. It listens on 127.0.0.1 by
 default; pass --host explicitly for gateway or remote access. HTTP mode
 requires bearer-token authentication, using --token, TRVL_MCP_TOKEN, or a
-random token generated at startup. Remote deployments can use scoped
-read/write bearer tokens or OAuth 2.1 access-token introspection; trvl acts as
-the MCP resource server and expects the OAuth provider or gateway to handle
-Authorization Code + PKCE.
+random token generated at startup. Generated tokens are redacted from logs; use
+--token or TRVL_MCP_TOKEN when a client needs a reusable token. Remote
+deployments can use scoped read/write bearer tokens or OAuth 2.1 access-token
+introspection; trvl acts as the MCP resource server and expects the OAuth
+provider or gateway to handle Authorization Code + PKCE.
 
 For safety, binding to a non-loopback host (e.g. --host 0.0.0.0) without any
 token or OAuth introspection configured is refused: remote exposure requires

--- a/docs/REMOTE-MCP-OAUTH.md
+++ b/docs/REMOTE-MCP-OAUTH.md
@@ -15,11 +15,12 @@ that injects tokens).
 
 Running `trvl mcp --http` binds to `127.0.0.1:8080` and requires a bearer
 token. If you do not supply one, trvl generates a random token at startup and
-prints it to the log. Nothing is reachable from another machine because the
-listener is loopback-only.
+redacts it from the startup log. Use `--token` or `TRVL_MCP_TOKEN` when a
+client needs a reusable token. Nothing is reachable from another machine
+because the listener is loopback-only.
 
 ```bash
-trvl mcp --http                   # 127.0.0.1:8080, random token printed at startup
+trvl mcp --http                   # 127.0.0.1:8080, random token generated and redacted
 trvl mcp --http --token hunter2   # 127.0.0.1:8080, fixed token
 ```
 
@@ -36,9 +37,9 @@ no authentication is configured; set --token/--read-token/--write-token (or
 TRVL_MCP_TOKEN), or --oauth-introspection-url, before binding to a non-loopback host
 ```
 
-This is deliberate. A remote listener with an auto-generated token printed to a
-log is weak, so trvl forces you to make the auth decision explicitly before it
-will accept connections from the network.
+This is deliberate. A remote listener with an implicit generated token is weak,
+so trvl forces you to make the auth decision explicitly before it will accept
+connections from the network.
 
 ## Scope model: read vs write
 

--- a/mcp/http.go
+++ b/mcp/http.go
@@ -325,13 +325,17 @@ func RunHTTPWithOptions(opts HTTPServerOptions) error {
 		generatedToken = true
 	}
 	if generatedToken {
-		log.Printf("trvl MCP generated HTTP bearer token: %s", opts.Token)
+		log.Print(generatedHTTPTokenLogMessage())
 	} else if strings.TrimSpace(opts.OAuthIntrospectionURL) != "" {
 		log.Printf("trvl MCP HTTP OAuth introspection auth enabled")
 	} else {
 		log.Printf("trvl MCP HTTP auth enabled")
 	}
 	return NewHTTPServerWithOptions(opts).ListenAndServe()
+}
+
+func generatedHTTPTokenLogMessage() string {
+	return "trvl MCP generated ephemeral HTTP bearer token (redacted); pass --token or set TRVL_MCP_TOKEN for client configuration"
 }
 
 func generateMCPToken() (string, error) {

--- a/mcp/http_token_log_test.go
+++ b/mcp/http_token_log_test.go
@@ -1,0 +1,17 @@
+package mcp
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestGeneratedHTTPTokenLogMessageIsRedacted(t *testing.T) {
+	msg := generatedHTTPTokenLogMessage()
+	if !strings.Contains(msg, "redacted") {
+		t.Fatalf("generated token log message = %q, want redaction notice", msg)
+	}
+	if tokenPattern := regexp.MustCompile(`\b[A-Za-z0-9_-]{43}\b`); tokenPattern.MatchString(msg) {
+		t.Fatalf("generated token log message contains token-shaped value: %q", msg)
+	}
+}


### PR DESCRIPTION
## Summary
- stop printing auto-generated localhost MCP HTTP bearer tokens in startup logs
- keep generated-token startup behavior, but redact the log and direct operators to --token/TRVL_MCP_TOKEN for client configuration
- update remote MCP docs and CLI help to match the safer default

## Acceptance Criteria
- Generated local HTTP startup auth logs do not contain a raw bearer value by default.
- HTTP auth documentation tells operators to use explicit reusable tokens for clients.
- Remote auth refusal behavior remains unchanged.

## Evidence
- GitNexus impact RunHTTPWithOptions: LOW risk, direct callers mcpCmd and RunHTTP.
- GitNexus detect-changes --scope staged: LOW risk, affected processes 0.
- go test ./mcp -run TestGeneratedHTTPTokenLogMessageIsRedacted -count=1
- go test ./mcp -count=1
- go test ./...
- go vet ./...
- staticcheck ./... using honnef.co/go/tools/cmd/staticcheck@v0.7.0
