### PR TITLE
ci: update GitNexus checkout pin

### DIFF
--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -30,7 +30,7 @@ jobs:
   index:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Update the GitNexus index workflow from `actions/checkout@v4` to the repo-standard pinned `actions/checkout` v7.0.0 SHA.
- Removes the remaining checkout v4 reference that produced GitHub Actions Node 20 runtime deprecation noise.

## Acceptance Criteria
- No `actions/checkout@v4` references remain under `.github/workflows`.
- `.github/workflows/gitnexus-index.yml` uses the verified `actions/checkout` v7.0.0 tag SHA.
- Workflow YAML remains parseable.

## Validation
- Exact grep check: no `actions/checkout@v4` remains under `.github/workflows`.
- Exact grep check: GitNexus workflow uses `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`.
- `git ls-remote --tags https://github.com/actions/checkout.git refs/tags/v7.0.0` resolves to the pinned SHA.
- `ruby -e` YAML parse for `.github/workflows/gitnexus-index.yml`.
- `git diff --check`.
- `npx gitnexus detect-changes --repo trvl --scope staged`.