### PR TITLE
ci: update GitNexus Node runtime actions

### DIFF
--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -32,12 +32,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
 
       - name: Restore/seed index cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .gitnexus
           key: gitnexus-${{ runner.os }}-${{ github.sha }}
@@ -57,7 +57,7 @@ jobs:
           npx --yes gitnexus analyze
 
       - name: Publish index metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gitnexus-meta
           path: .gitnexus/meta.json


### PR DESCRIPTION
## Summary
- Update the GitNexus index workflow from Node-20-era `actions/setup-node@v4`, `actions/cache@v4`, and `actions/upload-artifact@v4` refs to pinned current releases.
- Keeps the workflow aligned with GitHub Actions runtime deprecation guidance after the checkout pin update.

## Acceptance Criteria
- `.github/workflows/gitnexus-index.yml` has no `actions/setup-node@v4`, `actions/cache@v4`, or `actions/upload-artifact@v4` references.
- No workflow keeps those three actions on `@v4`.
- Replacement refs are pinned to verified upstream release tag SHAs.
- Workflow YAML remains parseable.

## Validation
- Exact grep check: no `setup-node/cache/upload-artifact @v4` refs remain in `.github/workflows/gitnexus-index.yml`.
- Exact grep check: no `setup-node/cache/upload-artifact @v4` refs remain under `.github/workflows`.
- `git ls-remote` tag checks for `actions/cache v6.1.0`, `actions/setup-node v6.4.0`, and `actions/upload-artifact v7.0.1`.
- `ruby -e` YAML parse for `.github/workflows/gitnexus-index.yml`.
- `git diff --check`.
- `npx gitnexus detect-changes --repo trvl --scope staged`.