### PR TITLE
ci: harden workflow runtime refs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,7 +188,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - name: Update npm package version
         run: |

--- a/.github/workflows/regression-test-gate.yml
+++ b/.github/workflows/regression-test-gate.yml
@@ -25,7 +25,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-regression-test') }}
     steps:
       - name: Checkout (full history for base..head diff)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Require a same-package regression test for fix PRs


### PR DESCRIPTION
## Summary
- Pin the regression-test gate checkout action to the verified actions/checkout v7.0.0 commit SHA
- Move the dormant CI npm-publish lane from Node 20 to Node 24, matching the canonical release publisher runtime

## Acceptance evidence
- Pinned refs: `rg "actions/checkout@v7" .github/workflows` returns no matches
- Runtime refs: `rg "node-version: \"20\"|node-version: 20" .github/workflows` returns no matches
- Workflow syntax: Ruby YAML parse passes for `.github/workflows/regression-test-gate.yml` and `.github/workflows/ci.yaml`
- Supply chain check: all workflow `uses:` refs are SHA-pinned
- Upstream provenance: `actions/checkout` v7.0.0 resolves to `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`; `actions/setup-node` v6.4.0 resolves to `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`
- Repo hygiene: `git diff --check` clean; `npx gitnexus detect-changes --repo trvl --scope staged` reports no code-symbol changes
