### PR TITLE
ci: enforce workflow hygiene

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,13 @@ permissions:
   contents: read
 
 jobs:
+  workflow-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Check workflow supply-chain hygiene
+        run: scripts/ci/check-workflow-hygiene.sh
+
   test:
     permissions:
       contents: write

--- a/scripts/ci/check-workflow-hygiene.sh
+++ b/scripts/ci/check-workflow-hygiene.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Guard GitHub Actions supply-chain hygiene. Keep this small and dependency-free
+# so it can run early in CI before heavier Go and security jobs.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail=0
+
+check() {
+  local message=$1
+  shift
+  if "$@"; then
+    printf 'ok: %s\n' "$message"
+  else
+    printf 'error: %s\n' "$message" >&2
+    fail=1
+  fi
+}
+
+all_workflow_uses_are_sha_pinned() {
+  local bad=0 line file line_no text ref
+  while IFS= read -r line; do
+    file=${line%%:*}
+    text=${line#*:}
+    line_no=${text%%:*}
+    text=${text#*:}
+    ref="$(printf '%s\n' "$text" | sed -E 's/^[[:space:]]*uses:[[:space:]]*([^[:space:]#]+).*/\1/')"
+    if [[ ! $ref =~ @[0-9a-f]{40}$ ]]; then
+      printf '%s:%s: %s\n' "$file" "$line_no" "$ref" >&2
+      bad=1
+    fi
+  done < <(grep -RInE '^[[:space:]]*uses:[[:space:]]*' .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null || true)
+
+  [ "$bad" -eq 0 ]
+}
+
+all_setup_node_jobs_use_node24() {
+  local bad=0 line file line_no text version
+  while IFS= read -r line; do
+    file=${line%%:*}
+    text=${line#*:}
+    line_no=${text%%:*}
+    text=${text#*:}
+    version="$(printf '%s\n' "$text" | sed -E 's/^[[:space:]]*node-version:[[:space:]]*["'\'']?([^"'\''[:space:]]+)["'\'']?.*/\1/')"
+    if [ "$version" != "24" ]; then
+      printf '%s:%s: node-version %s\n' "$file" "$line_no" "$version" >&2
+      bad=1
+    fi
+  done < <(grep -RInE '^[[:space:]]*node-version:' .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null || true)
+
+  [ "$bad" -eq 0 ]
+}
+
+no_unpinned_gitnexus_cli_calls() {
+  ! grep -RInE 'npx --yes gitnexus([[:space:]]|$)' \
+    .github/workflows scripts/gitnexus
+}
+
+gitnexus_version_is_pinned_consistently() {
+  local workflow_version script_default
+  workflow_version="$(sed -nE 's/^  GITNEXUS_VERSION:[[:space:]]*"([^"]+)".*/\1/p' .github/workflows/gitnexus-index.yml)"
+  script_default="$(sed -nE 's/.*GITNEXUS_VERSION:-([^}]+)}.*/\1/p' scripts/gitnexus/refresh.sh)"
+
+  [ -n "$workflow_version" ] &&
+    [ "$workflow_version" = "$script_default" ] &&
+    grep -q "gitnexus@\$GITNEXUS_VERSION" .github/workflows/gitnexus-index.yml &&
+    grep -q 'gitnexus@\$gitnexus_version' scripts/gitnexus/refresh.sh
+}
+
+gitnexus_docs_use_sha_pinned_cache_example() {
+  ! grep -q 'actions/cache@v4' scripts/gitnexus/README.md &&
+    grep -q 'actions/cache@[0-9a-f]\{40\}' scripts/gitnexus/README.md
+}
+
+check "workflow action uses refs are pinned to commit SHAs" all_workflow_uses_are_sha_pinned
+check "setup-node jobs use Node 24" all_setup_node_jobs_use_node24
+check "GitNexus CLI calls include an explicit npm package version" no_unpinned_gitnexus_cli_calls
+check "GitNexus CI and local refresh use the same pinned CLI version" gitnexus_version_is_pinned_consistently
+check "GitNexus cached-index docs use a SHA-pinned cache action example" gitnexus_docs_use_sha_pinned_cache_example
+
+exit "$fail"


### PR DESCRIPTION
## Summary
- Add a lightweight `workflow-hygiene` CI job before the heavier Go/security jobs
- Enforce SHA-pinned GitHub Actions refs, Node 24 for setup-node jobs, versioned GitNexus CLI calls, consistent GitNexus CI/local CLI pins, and SHA-pinned GitNexus cache docs

## Acceptance evidence
- `scripts/ci/check-workflow-hygiene.sh` passes on the current tree
- `bash -n scripts/ci/check-workflow-hygiene.sh` passes
- `.github/workflows/ci.yaml` parses as YAML
- `git diff --check` clean
- `npx gitnexus detect-changes --repo trvl --scope staged` reports no code-symbol changes

The guard catches the exact workflow hygiene regressions fixed in #393 and #394, so those fixes become policy rather than one-off cleanup.
