### PR TITLE
ci: enforce golangci-lint gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,12 @@ jobs:
       - name: Staticcheck
         if: runner.os != 'Windows'
         run: staticcheck ./...
+      - name: Install golangci-lint
+        if: runner.os != 'Windows'
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+      - name: Golangci-lint
+        if: runner.os != 'Windows'
+        run: golangci-lint run ./...
       - name: Install govulncheck
         if: runner.os != 'Windows'
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.4.0

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 GOTOOLCHAIN ?= go1.26.4
 GO ?= go
 GO_RUN = GOTOOLCHAIN=$(GOTOOLCHAIN) $(GO)
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS := -ldflags "-s -w -X main.Version=$(VERSION) -X github.com/MikkoParkkola/trvl/mcp.serverVersion=$(VERSION)"
@@ -30,16 +31,21 @@ test-live-probes:
 
 lint:
 	$(GO_RUN) vet ./...
-	@if command -v staticcheck >/dev/null 2>&1; then \
-		GOTOOLCHAIN=$(GOTOOLCHAIN) staticcheck ./...; \
-	else \
-		echo "staticcheck not installed, skipping"; \
+	@if ! command -v golangci-lint >/dev/null 2>&1; then \
+		echo "golangci-lint not installed. Install with: GOTOOLCHAIN=$(GOTOOLCHAIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)" >&2; \
+		exit 1; \
 	fi
-	@if command -v govulncheck >/dev/null 2>&1; then \
-		GOTOOLCHAIN=$(GOTOOLCHAIN) govulncheck ./...; \
-	else \
-		echo "govulncheck not installed, skipping"; \
+	GOTOOLCHAIN=$(GOTOOLCHAIN) golangci-lint run ./...
+	@if ! command -v staticcheck >/dev/null 2>&1; then \
+		echo "staticcheck not installed. Install with: GOTOOLCHAIN=$(GOTOOLCHAIN) go install honnef.co/go/tools/cmd/staticcheck@v0.7.0" >&2; \
+		exit 1; \
 	fi
+	GOTOOLCHAIN=$(GOTOOLCHAIN) staticcheck ./...
+	@if ! command -v govulncheck >/dev/null 2>&1; then \
+		echo "govulncheck not installed. Install with: GOTOOLCHAIN=$(GOTOOLCHAIN) go install golang.org/x/vuln/cmd/govulncheck@v1.4.0" >&2; \
+		exit 1; \
+	fi
+	GOTOOLCHAIN=$(GOTOOLCHAIN) govulncheck ./...
 
 distribution-metrics:
 	$(GO_RUN) run ./cmd/distribution-metrics

--- a/cmd/trvl/counterfactual_render.go
+++ b/cmd/trvl/counterfactual_render.go
@@ -45,9 +45,9 @@ func printSavingsSection(w io.Writer, header string, savings []counterfactual.Sa
 	if len(savings) == 0 {
 		return
 	}
-	fmt.Fprintln(w, header)
+	_, _ = fmt.Fprintln(w, header)
 	for _, s := range savings {
-		fmt.Fprintf(w, "  • %s%s\n", s.Description, asOfSuffix(s.AsOf, now))
+		_, _ = fmt.Fprintf(w, "  • %s%s\n", s.Description, asOfSuffix(s.AsOf, now))
 	}
 }
 

--- a/cmd/trvl/d2d_render.go
+++ b/cmd/trvl/d2d_render.go
@@ -17,17 +17,17 @@ func printDoorToDoor(w io.Writer, it multimodal.Itinerary) {
 	if total.Counts.Confirmed == 0 && total.Counts.Indicative == 0 && total.Counts.Unverified == 0 {
 		return
 	}
-	fmt.Fprintf(w, "     Door-to-door: %s %.2f confirmed", total.Currency, total.ConfirmedTotal)
+	_, _ = fmt.Fprintf(w, "     Door-to-door: %s %.2f confirmed", total.Currency, total.ConfirmedTotal)
 	if sum, n := legSum(total.IndicativeLegs); n > 0 {
-		fmt.Fprintf(w, " + %s %.2f indicative across %d leg(s) — verify before booking", total.Currency, sum, n)
+		_, _ = fmt.Fprintf(w, " + %s %.2f indicative across %d leg(s) — verify before booking", total.Currency, sum, n)
 	}
 	if sum, n := legSum(total.UnverifiedLegs); n > 0 {
-		fmt.Fprintf(w, " + %s %.2f unverified across %d leg(s)", total.Currency, sum, n)
+		_, _ = fmt.Fprintf(w, " + %s %.2f unverified across %d leg(s)", total.Currency, sum, n)
 	}
 	if total.MixedCurrency {
-		fmt.Fprintf(w, " (mixed currencies: %d leg(s) excluded)", len(total.ExcludedCurrencyLegs))
+		_, _ = fmt.Fprintf(w, " (mixed currencies: %d leg(s) excluded)", len(total.ExcludedCurrencyLegs))
 	}
-	fmt.Fprintf(w, " · band %s [%.0f–%.0f]\n", total.Band, total.BandLow, total.BandHigh)
+	_, _ = fmt.Fprintf(w, " · band %s [%.0f–%.0f]\n", total.Band, total.BandLow, total.BandHigh)
 }
 
 func itineraryToLegs(it multimodal.Itinerary) []d2d.Leg {

--- a/cmd/trvl/digest.go
+++ b/cmd/trvl/digest.go
@@ -78,8 +78,8 @@ func collectDigest(currency string) dealradar.Digest {
 func runDigest(cmd *cobra.Command, dryRun bool, currency string) error {
 	d := collectDigest(currency)
 	if dryRun {
-		fmt.Fprint(cmd.OutOrStdout(), d.Render())
-		return nil
+		_, err := fmt.Fprint(cmd.OutOrStdout(), d.Render())
+		return err
 	}
 	m, err := mailer.NewFromEnv()
 	if err != nil {
@@ -88,6 +88,6 @@ func runDigest(cmd *cobra.Command, dryRun bool, currency string) error {
 	if _, err := m.SendDigest(d.Subject(), d.Render()); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "deal-radar digest sent (%d deals)\n", len(d.Items))
-	return nil
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "deal-radar digest sent (%d deals)\n", len(d.Items))
+	return err
 }

--- a/cmd/trvl/pricesignal_render.go
+++ b/cmd/trvl/pricesignal_render.go
@@ -17,10 +17,10 @@ func printPricePosition(w io.Writer, pos *pricesignal.Position) {
 		return
 	}
 	if !pos.Confident {
-		fmt.Fprintf(w, "\nPrice position: not enough history yet (%d observation(s)) — current price shown, no trend.\n", pos.Observations)
+		_, _ = fmt.Fprintf(w, "\nPrice position: not enough history yet (%d observation(s)) — current price shown, no trend.\n", pos.Observations)
 		return
 	}
-	fmt.Fprintf(w, "\nPrice position: %s — %s of this route (low %.0f / median %.0f / high %.0f over %d obs, %s vs median).\n",
+	_, _ = fmt.Fprintf(w, "\nPrice position: %s — %s of this route (low %.0f / median %.0f / high %.0f over %d obs, %s vs median).\n",
 		verdictText(pos.Verdict),
 		bandText(pos.Band),
 		pos.Low, pos.Median, pos.High, pos.Observations,

--- a/cmd/trvl/rate_status.go
+++ b/cmd/trvl/rate_status.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/spf13/cobra"
@@ -14,8 +13,14 @@ func rateStatusCmd() *cobra.Command {
 		Short: "Show rate limit status for all providers",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rm := hotels.HotelRateManager
+			write := func(format string, args ...any) error {
+				_, err := fmt.Fprintf(cmd.OutOrStdout(), format, args...)
+				return err
+			}
 
-			fmt.Fprintf(os.Stdout, "=== Rate Limit Status ===\n\n")
+			if err := write("=== Rate Limit Status ===\n\n"); err != nil {
+				return err
+			}
 
 			for _, provider := range []string{"google", "booking", "trivago"} {
 				reqs, recent429s, throttled := rm.Stats(provider)
@@ -26,18 +31,38 @@ func rateStatusCmd() *cobra.Command {
 				} else if recent429s > 0 {
 					status = "⚠️  WARNING"
 				}
-				fmt.Fprintf(os.Stdout, "%-10s %s\n", provider+":", status)
-				fmt.Fprintf(os.Stdout, "  Requests:    %d\n", reqs)
-				fmt.Fprintf(os.Stdout, "  Recent 429s: %d\n", recent429s)
-				fmt.Fprintf(os.Stdout, "  Backoff:     %v\n", backoff)
-				fmt.Fprintf(os.Stdout, "\n")
+				if err := write("%-10s %s\n", provider+":", status); err != nil {
+					return err
+				}
+				if err := write("  Requests:    %d\n", reqs); err != nil {
+					return err
+				}
+				if err := write("  Recent 429s: %d\n", recent429s); err != nil {
+					return err
+				}
+				if err := write("  Backoff:     %v\n", backoff); err != nil {
+					return err
+				}
+				if err := write("\n"); err != nil {
+					return err
+				}
 			}
 
-			fmt.Fprintf(os.Stdout, "Tips:\n")
-			fmt.Fprintf(os.Stdout, "  • Wait 10s between consecutive searches\n")
-			fmt.Fprintf(os.Stdout, "  • Use broad date ranges (e.g. search a whole month)\n")
-			fmt.Fprintf(os.Stdout, "  • After a 429 error, wait 60s before retrying\n")
-			fmt.Fprintf(os.Stdout, "  • Run 'trvl rate-status' to check current status\n")
+			if err := write("Tips:\n"); err != nil {
+				return err
+			}
+			if err := write("  • Wait 10s between consecutive searches\n"); err != nil {
+				return err
+			}
+			if err := write("  • Use broad date ranges (e.g. search a whole month)\n"); err != nil {
+				return err
+			}
+			if err := write("  • After a 429 error, wait 60s before retrying\n"); err != nil {
+				return err
+			}
+			if err := write("  • Run 'trvl rate-status' to check current status\n"); err != nil {
+				return err
+			}
 
 			return nil
 		},

--- a/internal/hotels/agoda.go
+++ b/internal/hotels/agoda.go
@@ -284,7 +284,7 @@ func resolveAgodaCityID(ctx context.Context, location string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return 0, fmt.Errorf("autocomplete status %d", resp.StatusCode)
 	}
@@ -353,7 +353,7 @@ func fetchAgodaSearch(ctx context.Context, cityID int, opts HotelSearchOptions) 
 			continue
 		}
 		raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
-		resp.Body.Close()
+		closeErr := resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			// Agoda's /graphql/search is anti-bot sensitive and intermittently
 			// answers an otherwise-valid request with 400/403/429 (plus the
@@ -377,6 +377,10 @@ func fetchAgodaSearch(ctx context.Context, cityID int, opts HotelSearchOptions) 
 		}
 		if readErr != nil {
 			lastErr = readErr
+			continue
+		}
+		if closeErr != nil {
+			lastErr = closeErr
 			continue
 		}
 		var sr agodaSearchResponse

--- a/internal/hotels/anyplace_test.go
+++ b/internal/hotels/anyplace_test.go
@@ -235,11 +235,11 @@ func TestSearchAnyplaceEndToEnd(t *testing.T) {
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/listings/lisbon-portugal":
+		switch r.URL.Path {
+		case "/listings/lisbon-portugal":
 			w.Header().Set("Content-Type", "text/html")
 			_, _ = w.Write(html)
-		case r.URL.Path == "/_next/data/AbC123dEf456/listings/lisbon-portugal.json":
+		case "/_next/data/AbC123dEf456/listings/lisbon-portugal.json":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write(cityJSON)
 		default:

--- a/internal/hotels/uniplaces_test.go
+++ b/internal/hotels/uniplaces_test.go
@@ -153,11 +153,11 @@ func TestSearchUniplacesMockServer(t *testing.T) {
 	const wantBuildID = "search-06e8c5954f295939db05be8c4e59664a7fc91851"
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/accommodation/lisbon":
+		switch r.URL.Path {
+		case "/accommodation/lisbon":
 			w.Header().Set("Content-Type", "text/html")
 			_, _ = w.Write(listingHTML)
-		case r.URL.Path == "/_next/data/"+wantBuildID+"/en/accommodation/lisbon.json":
+		case "/_next/data/" + wantBuildID + "/en/accommodation/lisbon.json":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write(offersJSON)
 		default:

--- a/internal/models/canon.go
+++ b/internal/models/canon.go
@@ -75,7 +75,7 @@ func parseAmount(s string) float64 {
 		case t[sep] == ',':
 			// Comma is the decimal point; dots are thousands.
 			t = strings.ReplaceAll(t, ".", "")
-			t = strings.Replace(t, ",", ".", -1)
+			t = strings.ReplaceAll(t, ",", ".")
 		default:
 			// Dot is the decimal point; commas are thousands.
 			t = strings.ReplaceAll(t, ",", "")

--- a/internal/providers/cookies_test.go
+++ b/internal/providers/cookies_test.go
@@ -332,7 +332,7 @@ func TestWithInteractive(t *testing.T) {
 		t.Error("WithInteractive ctx must report true")
 	}
 	//lint:ignore SA1012 deliberately testing nil-safety of isInteractive
-	if isInteractive(nil) {
+	if isInteractive(nil) { //nolint:staticcheck
 		t.Error("nil ctx must not be interactive")
 	}
 }

--- a/internal/providers/tier1_client_test.go
+++ b/internal/providers/tier1_client_test.go
@@ -37,7 +37,11 @@ func TestTier1Client_Get_LiveTLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("Close response body: %v", err)
+		}
+	}()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -87,7 +91,11 @@ func TestTier1Client_SeedCookies_FromCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("Close response body: %v", err)
+		}
+	}()
 	if echo := resp.Header.Get("X-Echo-Cookie"); echo == "" {
 		t.Fatalf("expected Cookie header echoed, got empty")
 	}

--- a/internal/serpapi/serpapi.go
+++ b/internal/serpapi/serpapi.go
@@ -297,7 +297,7 @@ func GetPropertyDetails(ctx context.Context, opts SearchOptions, propertyToken s
 	if result.SearchMetadata.Status == "Error" {
 		return nil, fmt.Errorf("serpapi: error status")
 	}
-	if result.Hotel.Name == "" && result.Hotel.PropertyToken == "" && len(result.Hotel.Prices) == 0 && len(result.Hotel.FeaturedPrices) == 0 {
+	if result.Name == "" && result.PropertyToken == "" && len(result.Prices) == 0 && len(result.FeaturedPrices) == 0 {
 		return nil, fmt.Errorf("serpapi: property details response did not include hotel details")
 	}
 	return &result.Hotel, nil
@@ -479,7 +479,7 @@ func doSerpAPIRequest(req *http.Request, result any) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("serpapi: HTTP %d", resp.StatusCode)

--- a/internal/serpapi/serpapi_test.go
+++ b/internal/serpapi/serpapi_test.go
@@ -28,7 +28,9 @@ func TestSearchHotels_HTTP200(t *testing.T) {
 				TotalRate:    Rate{Extracted: 693, Lowest: "$693"},
 			}},
 		}
-		json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -65,7 +67,7 @@ func TestSearchHotelsVerifiedFetchesPropertyDetailsAndPromotesProviderTotal(t *t
 			listCalls++
 			assertQuery(t, q.Get("adults"), "2", "adults")
 			assertQuery(t, q.Get("gl"), "us", "gl")
-			json.NewEncoder(w).Encode(Response{
+			if err := json.NewEncoder(w).Encode(Response{
 				SearchMetadata: struct {
 					ID     string `json:"id"`
 					Status string `json:"status"`
@@ -77,13 +79,15 @@ func TestSearchHotelsVerifiedFetchesPropertyDetailsAndPromotesProviderTotal(t *t
 					TotalRate:     Rate{Extracted: 779, Lowest: "€779"},
 					Prices:        nil,
 				}},
-			})
+			}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
 			return
 		}
 
 		detailCalls++
 		assertQuery(t, q.Get("property_token"), "sorriso-token", "property_token")
-		json.NewEncoder(w).Encode(propertyDetailsResponse{
+		if err := json.NewEncoder(w).Encode(propertyDetailsResponse{
 			SearchMetadata: struct {
 				ID     string `json:"id"`
 				Status string `json:"status"`
@@ -97,7 +101,9 @@ func TestSearchHotelsVerifiedFetchesPropertyDetailsAndPromotesProviderTotal(t *t
 					TotalRate:    Rate{Extracted: 1102, Lowest: "€1,102"},
 				}},
 			},
-		})
+		}); err != nil {
+			t.Errorf("encode detail response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -154,7 +160,7 @@ func TestSearchHotelsVerifiedPopulatesPricesFromFeaturedOnlyDetail(t *testing.T)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		if q.Get("property_token") == "" {
-			json.NewEncoder(w).Encode(Response{
+			if err := json.NewEncoder(w).Encode(Response{
 				SearchMetadata: struct {
 					ID     string `json:"id"`
 					Status string `json:"status"`
@@ -166,10 +172,12 @@ func TestSearchHotelsVerifiedPopulatesPricesFromFeaturedOnlyDetail(t *testing.T)
 					TotalRate:     Rate{Extracted: 779, Lowest: "€779"},
 					Prices:        nil,
 				}},
-			})
+			}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
 			return
 		}
-		json.NewEncoder(w).Encode(propertyDetailsResponse{
+		if err := json.NewEncoder(w).Encode(propertyDetailsResponse{
 			SearchMetadata: struct {
 				ID     string `json:"id"`
 				Status string `json:"status"`
@@ -184,7 +192,9 @@ func TestSearchHotelsVerifiedPopulatesPricesFromFeaturedOnlyDetail(t *testing.T)
 					TotalRate:    Rate{Extracted: 1024, Lowest: "€1,024"},
 				}},
 			},
-		})
+		}); err != nil {
+			t.Errorf("encode detail response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -220,7 +230,7 @@ func TestSearchHotelsVerifiedMarksPropertiesBeyondDetailLimit(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		if q.Get("property_token") == "" {
-			json.NewEncoder(w).Encode(Response{
+			if err := json.NewEncoder(w).Encode(Response{
 				SearchMetadata: struct {
 					ID     string `json:"id"`
 					Status string `json:"status"`
@@ -237,10 +247,12 @@ func TestSearchHotelsVerifiedMarksPropertiesBeyondDetailLimit(t *testing.T) {
 						TotalRate:     Rate{Extracted: 200},
 					},
 				},
-			})
+			}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
 			return
 		}
-		json.NewEncoder(w).Encode(propertyDetailsResponse{
+		if err := json.NewEncoder(w).Encode(propertyDetailsResponse{
 			SearchMetadata: struct {
 				ID     string `json:"id"`
 				Status string `json:"status"`
@@ -252,7 +264,9 @@ func TestSearchHotelsVerifiedMarksPropertiesBeyondDetailLimit(t *testing.T) {
 					TotalRate: Rate{Extracted: 120},
 				}},
 			},
-		})
+		}); err != nil {
+			t.Errorf("encode detail response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -292,7 +306,7 @@ func TestSearchHotelsVerifiedUsesLocalCacheForDuplicateListAndDetailRequests(t *
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("property_token") == "" {
 			listCalls++
-			json.NewEncoder(w).Encode(Response{
+			if err := json.NewEncoder(w).Encode(Response{
 				SearchMetadata: struct {
 					ID     string `json:"id"`
 					Status string `json:"status"`
@@ -303,12 +317,14 @@ func TestSearchHotelsVerifiedUsesLocalCacheForDuplicateListAndDetailRequests(t *
 					RatePerNight:  Rate{Extracted: 100},
 					TotalRate:     Rate{Extracted: 500},
 				}},
-			})
+			}); err != nil {
+				t.Errorf("encode list response: %v", err)
+			}
 			return
 		}
 
 		detailCalls++
-		json.NewEncoder(w).Encode(propertyDetailsResponse{
+		if err := json.NewEncoder(w).Encode(propertyDetailsResponse{
 			SearchMetadata: struct {
 				ID     string `json:"id"`
 				Status string `json:"status"`
@@ -320,7 +336,9 @@ func TestSearchHotelsVerifiedUsesLocalCacheForDuplicateListAndDetailRequests(t *
 					TotalRate: Rate{Extracted: 520},
 				}},
 			},
-		})
+		}); err != nil {
+			t.Errorf("encode detail response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -356,12 +374,14 @@ func TestSearchHotelsWithOptionsNoCacheBypassesLocalCache(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
 		assertQuery(t, r.URL.Query().Get("no_cache"), "true", "no_cache")
-		json.NewEncoder(w).Encode(Response{
+		if err := json.NewEncoder(w).Encode(Response{
 			SearchMetadata: struct {
 				ID     string `json:"id"`
 				Status string `json:"status"`
 			}{Status: "Success"},
-		})
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -409,12 +429,14 @@ func TestSearchHotelsWithOptionsPassesAccommodationCriteria(t *testing.T) {
 		assertQuery(t, q.Get("bathrooms"), "1", "bathrooms")
 		assertQuery(t, q.Get("next_page_token"), "next-token", "next_page_token")
 		assertQuery(t, q.Get("no_cache"), "true", "no_cache")
-		json.NewEncoder(w).Encode(Response{
+		if err := json.NewEncoder(w).Encode(Response{
 			SearchMetadata: struct {
 				ID     string `json:"id"`
 				Status string `json:"status"`
 			}{Status: "Success"},
-		})
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -494,7 +516,7 @@ func TestResolveGoogleMapsPlaceUsesDataCID(t *testing.T) {
 		assertQuery(t, q.Get("type"), "place", "type")
 		assertQuery(t, q.Get("data_cid"), "4860344902944680041", "data_cid")
 		assertQuery(t, q.Get("api_key"), "test_key", "api_key")
-		json.NewEncoder(w).Encode(mapsPlaceResponse{
+		if err := json.NewEncoder(w).Encode(mapsPlaceResponse{
 			SearchMetadata: struct {
 				ID     string `json:"id"`
 				Status string `json:"status"`
@@ -505,7 +527,9 @@ func TestResolveGoogleMapsPlaceUsesDataCID(t *testing.T) {
 				DataID:  "0x133b6ab82c204df7:0x437369f021e5e869",
 				DataCID: "4860344902944680041",
 			},
-		})
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -563,7 +587,9 @@ func TestSearchHotels_ErrorStatus(t *testing.T) {
 				Status string `json:"status"`
 			}{Status: "Error"},
 		}
-		json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -613,7 +639,9 @@ func TestSearchHotelsWithOptions_PaginationToken(t *testing.T) {
 			Properties: []Hotel{{Name: "Paged Hotel"}},
 		}
 		resp.SerpapiPagination.NextPageToken = "NEXT_PAGE_3"
-		json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	}))
 	defer srv.Close()
 

--- a/internal/travelctx/resolve.go
+++ b/internal/travelctx/resolve.go
@@ -266,10 +266,11 @@ func atof(s string) float64 {
 		return 0
 	}
 	var neg bool
-	if s[0] == '-' {
+	switch s[0] {
+	case '-':
 		neg = true
 		s = s[1:]
-	} else if s[0] == '+' {
+	case '+':
 		s = s[1:]
 	}
 	var intPart, fracPart float64

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -442,7 +442,7 @@ func argIntSlice(args map[string]any, key string) []int {
 			if part == "" {
 				continue
 			}
-			var n json.Number = json.Number(part)
+			n := json.Number(part)
 			i, err := n.Int64()
 			if err == nil {
 				result = append(result, int(i))

--- a/mcp/tools_cars.go
+++ b/mcp/tools_cars.go
@@ -166,9 +166,9 @@ func buildCarSearchSummary(result *models.CarSearchResult, opts cars.SearchOptio
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("Found %d rental car offers for %s from %s to %s", result.Count, opts.PickupLocation, opts.PickupDate, opts.DropoffDate))
+	_, _ = fmt.Fprintf(&sb, "Found %d rental car offers for %s from %s to %s", result.Count, opts.PickupLocation, opts.PickupDate, opts.DropoffDate)
 	if opts.DropoffLocation != "" && opts.DropoffLocation != opts.PickupLocation {
-		sb.WriteString(fmt.Sprintf(", returning at %s", opts.DropoffLocation))
+		_, _ = fmt.Fprintf(&sb, ", returning at %s", opts.DropoffLocation)
 	}
 	sb.WriteString(":\n\n")
 	limit := min(len(result.Offers), 5)
@@ -178,12 +178,12 @@ func buildCarSearchSummary(result *models.CarSearchResult, opts cars.SearchOptio
 		if name == "" {
 			name = offer.VehicleClass
 		}
-		sb.WriteString(fmt.Sprintf("%d. %s — %s %.2f", i+1, name, offer.Currency, offer.Price))
+		_, _ = fmt.Fprintf(&sb, "%d. %s — %s %.2f", i+1, name, offer.Currency, offer.Price)
 		if offer.VehicleClass != "" {
 			sb.WriteString(" · " + offer.VehicleClass)
 		}
 		if offer.Seats > 0 {
-			sb.WriteString(fmt.Sprintf(" · %d seats", offer.Seats))
+			_, _ = fmt.Fprintf(&sb, " · %d seats", offer.Seats)
 		}
 		if offer.BookingURL != "" {
 			sb.WriteString(" · " + offer.BookingURL)


### PR DESCRIPTION
Closes #398.

## What changed
- Adds pinned `golangci-lint v2.12.2` to Linux CI before tests.
- Makes `make lint` fail closed for missing `golangci-lint`, `staticcheck`, or `govulncheck` with install guidance.
- Fixes the resulting checked-error/staticcheck findings without changing provider behavior.

## Acceptance criteria
- TRVL.LINT.1: `golangci-lint v2.12.2 run ./...` exits 0.
- TRVL.LINT.2: CI PR/push runs pinned golangci-lint on Linux.
- TRVL.LINT.3: `make lint` fails closed when required tools are absent and passes with pinned tools installed.
- TRVL.LINT.4: default offline validation remains green.

## Validation
- `golangci-lint v2.12.2 run ./...` -> 0 issues.
- `make lint` -> `go vet`, `golangci-lint`, `staticcheck`, `govulncheck`; no vulnerabilities found.
- `go test ./...` -> pass.
- `scripts/ci/check-workflow-hygiene.sh` -> pass.
- `scripts/ci/check-language-hygiene.sh` -> pass, no tracked Python files.
- `gofmt -l $(git ls-files '*.go')` -> empty.\n- `git diff --check` -> clean.\n- Tracked text-file LOC scan -> no files over 800 LOC.\n- `npx --yes gitnexus@1.6.8 detect-changes --repo trvl --scope unstaged` -> low risk, 0 affected processes.