### PR TITLE
ci: allow changelog loc exception

### DIFF
--- a/.github/loc-allowlist.txt
+++ b/.github/loc-allowlist.txt
@@ -1,0 +1,3 @@
+# Tracked text files allowed to exceed the default 800-line ceiling.
+# Format: path # reason: specific justification (15+ chars).
+CHANGELOG.md # reason: append-only public release history stays root-visible for users and release tooling

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
         run: scripts/ci/check-workflow-hygiene.sh
       - name: Check language hygiene
         run: scripts/ci/check-language-hygiene.sh
+      - name: Check file-size hygiene
+        run: scripts/ci/check-file-size.sh
 
   test:
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Go-first repo hardening.** Replaced the remaining tracked Python ground-provider scraper with the native Go CDP path, and added CI enforcement that rejects tracked Python files unless explicitly allowlisted.
 - **Workflow supply-chain gates.** SHA-pinned workflow runtime actions, moved workflow Node jobs to Node 24, pinned GitNexus CLI usage, and added a workflow-hygiene guard so these constraints stay enforced.
-- **Go quality gates and release docs.** Added pinned `golangci-lint v2.12.2` to CI, made `make lint` fail closed when lint/security tools are missing, and completed v1.17 changelog compare links.
+- **Go quality gates and release docs.** Added pinned `golangci-lint v2.12.2` to CI, made `make lint` fail closed when lint/security tools are missing, completed v1.17 changelog compare links, and codified `CHANGELOG.md` as the single justified 800-line exception.
 
 ## [1.17.4] - 2026-06-27
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,13 @@ CI enforces a 50% line-coverage threshold. New packages are expected to land
 with coverage at or above that threshold; regressions in existing packages
 will block merge.
 
+Tracked text files default to an 800-line ceiling so source and docs stay
+reviewable. Split large files by topic or package before crossing that limit.
+Append-only public history files may be exceptions only when they are listed in
+`.github/loc-allowlist.txt` with a specific reason. `CHANGELOG.md` is currently
+the only approved exception because release history must remain root-visible for
+users, package managers, and release tooling.
+
 ## Testing Discipline
 
 - Unit tests run offline. HTTP must be mocked via `httptest` or an injected

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOLANGCI_LINT_VERSION ?= v2.12.2
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS := -ldflags "-s -w -X main.Version=$(VERSION) -X github.com/MikkoParkkola/trvl/mcp.serverVersion=$(VERSION)"
 
-.PHONY: build test test-proof test-coverage test-live-integrations test-live-probes lint distribution-metrics clean cross install safe-clean force-clean
+.PHONY: build test test-proof test-coverage test-live-integrations test-live-probes lint repo-hygiene distribution-metrics clean cross install safe-clean force-clean
 
 build:
 	@mkdir -p bin
@@ -29,7 +29,12 @@ test-live-integrations:
 test-live-probes:
 	TRVL_TEST_LIVE_PROBES=1 $(GO_RUN) test -v -count=1 ./... -run Probe
 
-lint:
+repo-hygiene:
+	scripts/ci/check-workflow-hygiene.sh
+	scripts/ci/check-language-hygiene.sh
+	scripts/ci/check-file-size.sh
+
+lint: repo-hygiene
 	$(GO_RUN) vet ./...
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "golangci-lint not installed. Install with: GOTOOLCHAIN=$(GOTOOLCHAIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)" >&2; \

--- a/scripts/ci/check-file-size.sh
+++ b/scripts/ci/check-file-size.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Keep tracked text files reviewable. Append-only public history files may exceed
+# the default line ceiling only when they have an explicit, justified allowlist.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+max_lines="${TRVL_MAX_TEXT_FILE_LINES:-800}"
+allowlist=".github/loc-allowlist.txt"
+fail=0
+
+trim_line() {
+  printf '%s\n' "$1" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/\r$//'
+}
+
+allowlist_path() {
+  printf '%s\n' "$1" | sed -E 's/[[:space:]]+#.*$//'
+}
+
+is_allowlisted() {
+  local target=$1 line path
+  [ -f "$allowlist" ] || return 1
+  while IFS= read -r line; do
+    line="$(trim_line "$line")"
+    if [ -z "$line" ] || [[ "$line" == \#* ]]; then
+      continue
+    fi
+    path="$(allowlist_path "$line")"
+    if [ "$path" = "$target" ]; then
+      return 0
+    fi
+  done < "$allowlist"
+  return 1
+}
+
+is_binary() {
+  case "$(file --mime "$1")" in
+    *charset=binary*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+line_count() {
+  wc -l < "$1" | tr -d '[:space:]'
+}
+
+if [ -f "$allowlist" ]; then
+  while IFS= read -r line; do
+    line="$(trim_line "$line")"
+    if [ -z "$line" ] || [[ "$line" == \#* ]]; then
+      continue
+    fi
+
+    path="$(allowlist_path "$line")"
+    if [ "$path" = "$line" ] || [[ ! "$line" =~ [[:space:]]#[[:space:]]reason:[[:space:]].{15,} ]]; then
+      printf '%s: allowlist entries must use: path # reason: specific justification\n' "$allowlist" >&2
+      fail=1
+      continue
+    fi
+
+    if ! git ls-files --error-unmatch "$path" >/dev/null 2>&1; then
+      printf 'error: file-size allowlist references a missing tracked file: %s\n' "$path" >&2
+      fail=1
+    fi
+  done < "$allowlist"
+fi
+
+checked=0
+allowed_oversized=0
+blocked_oversized=0
+while IFS= read -r -d '' path; do
+  if is_binary "$path"; then
+    continue
+  fi
+
+  checked=$((checked + 1))
+  lines="$(line_count "$path")"
+  if [ "$lines" -le "$max_lines" ]; then
+    continue
+  fi
+
+  if is_allowlisted "$path"; then
+    allowed_oversized=$((allowed_oversized + 1))
+    printf 'ok: %s has %s lines (> %s) and is allowlisted\n' "$path" "$lines" "$max_lines"
+    continue
+  fi
+
+  blocked_oversized=$((blocked_oversized + 1))
+  printf 'error: %s has %s lines (> %s). Split it, or add a justified exception to %s.\n' "$path" "$lines" "$max_lines" "$allowlist" >&2
+  fail=1
+done < <(git ls-files -z)
+
+if [ "$blocked_oversized" -eq 0 ]; then
+  printf 'ok: tracked text files respect the %s-line policy (%s checked, %s oversized allowlisted)\n' "$max_lines" "$checked" "$allowed_oversized"
+fi
+
+exit "$fail"


### PR DESCRIPTION
## Summary
- add a CI-backed tracked text file size guard with an 800-line default
- add `.github/loc-allowlist.txt` for explicit, reasoned exceptions
- document `CHANGELOG.md` as the only approved exception because release history is append-only and should stay root-visible
- run the new repo hygiene target from `make lint` and CI workflow hygiene

## Acceptance mapping
- Normal files remain governed by the 800-line rule: `scripts/ci/check-file-size.sh` rejects unallowlisted tracked text files above the threshold.
- `CHANGELOG.md` can grow long-term without policy churn: `.github/loc-allowlist.txt` records the exception with a reason, and CI validates the allowlist format.

## Validation
- `bash -n scripts/ci/check-file-size.sh`
- `scripts/ci/check-file-size.sh`
- `TRVL_MAX_TEXT_FILE_LINES=799 scripts/ci/check-file-size.sh` (proved `CHANGELOG.md` is allowlisted when over threshold)
- expected-fail probe with `TRVL_MAX_TEXT_FILE_LINES=668` verified an unallowlisted oversized file is rejected
- `make repo-hygiene`
- `git diff --check`
- `npx --yes gitnexus@1.6.8 detect-changes --repo trvl`
