### PR TITLE
ci: add Docker release diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: goreleaser
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -229,8 +230,12 @@ jobs:
       # base-image OS/library CVEs. Only push (multi-arch) if the scan is clean.
       - name: Build amd64 image for vulnerability scan
         run: |
+          set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
+          start="$(date -u +%s)"
+          echo "Docker scan image build started at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
           docker buildx build \
+            --progress=plain \
             --platform linux/amd64 \
             --build-arg VERSION="${VERSION}" \
             --tag "ghcr.io/mikkoparkkola/trvl:scan" \
@@ -239,6 +244,8 @@ jobs:
             --cache-to type=gha,mode=max,ignore-error=true \
             --load \
             .
+          end="$(date -u +%s)"
+          echo "Docker scan image build finished in $((end - start)) seconds"
 
       - name: Trivy image scan (block push on fixable HIGH/CRITICAL CVEs)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -252,8 +259,12 @@ jobs:
 
       - name: Build and push multi-arch image
         run: |
+          set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
+          start="$(date -u +%s)"
+          echo "Docker multi-arch build/push started at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
           docker buildx build \
+            --progress=plain \
             --platform linux/amd64,linux/arm64 \
             --build-arg VERSION="${VERSION}" \
             --tag "ghcr.io/mikkoparkkola/trvl:${VERSION}" \
@@ -263,6 +274,8 @@ jobs:
             --cache-to type=gha,mode=max,ignore-error=true \
             --push \
             .
+          end="$(date -u +%s)"
+          echo "Docker multi-arch build/push finished in $((end - start)) seconds"
 
   mcp-registry:
     runs-on: ubuntu-latest

--- a/scripts/ci/check-workflow-hygiene.sh
+++ b/scripts/ci/check-workflow-hygiene.sh
@@ -73,10 +73,39 @@ gitnexus_docs_use_sha_pinned_cache_example() {
     grep -q 'actions/cache@[0-9a-f]\{40\}' scripts/gitnexus/README.md
 }
 
+release_docker_job_has_timeout() {
+  awk '
+    /^  docker:/ { in_job=1; next }
+    in_job && /^  [a-zA-Z0-9_-]+:/ { exit }
+    in_job && /^[[:space:]]+timeout-minutes:[[:space:]]*[0-9]+/ { found=1 }
+    END { exit found ? 0 : 1 }
+  ' .github/workflows/release.yml
+}
+
+release_docker_builds_emit_plain_progress() {
+  [ "$(grep -c -- '--progress=plain' .github/workflows/release.yml)" -ge 2 ]
+}
+
+release_docker_trivy_blocks_before_push() {
+  local trivy_line push_line
+  trivy_line="$(grep -nF 'name: Trivy image scan (block push on fixable HIGH/CRITICAL CVEs)' .github/workflows/release.yml | cut -d: -f1)"
+  push_line="$(grep -nF 'name: Build and push multi-arch image' .github/workflows/release.yml | cut -d: -f1)"
+
+  [ -n "$trivy_line" ] &&
+    [ -n "$push_line" ] &&
+    [ "$trivy_line" -lt "$push_line" ] &&
+    grep -qF 'exit-code: "1"' .github/workflows/release.yml &&
+    grep -qF 'severity: HIGH,CRITICAL' .github/workflows/release.yml &&
+    grep -qF 'ignore-unfixed: true' .github/workflows/release.yml
+}
+
 check "workflow action uses refs are pinned to commit SHAs" all_workflow_uses_are_sha_pinned
 check "setup-node jobs use Node 24" all_setup_node_jobs_use_node24
 check "GitNexus CLI calls include an explicit npm package version" no_unpinned_gitnexus_cli_calls
 check "GitNexus CI and local refresh use the same pinned CLI version" gitnexus_version_is_pinned_consistently
 check "GitNexus cached-index docs use a SHA-pinned cache action example" gitnexus_docs_use_sha_pinned_cache_example
+check "release Docker job has an explicit timeout" release_docker_job_has_timeout
+check "release Docker buildx commands emit plain progress logs" release_docker_builds_emit_plain_progress
+check "release Docker push remains behind the Trivy HIGH/CRITICAL gate" release_docker_trivy_blocks_before_push
 
 exit "$fail"


### PR DESCRIPTION
## Summary
- add a 45-minute timeout to the release Docker job
- force plain buildx progress logs for the scan image and multi-arch push
- add workflow-hygiene guards for Docker timeout, buildx progress, and the Trivy-before-push gate

Fixes #404

## Validation
- `bash -n scripts/ci/check-workflow-hygiene.sh && scripts/ci/check-workflow-hygiene.sh`
- `make repo-hygiene`
- `git diff --check`
- `wc -l .github/workflows/release.yml scripts/ci/check-workflow-hygiene.sh`
- `npx --yes gitnexus@1.6.8 detect-changes --repo trvl`