### PR TITLE
ci: move GoReleaser action to Node 24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,6 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "UTC"
-    ignore:
-      # Pin goreleaser-action to v6.x. v7 adds a cosign self-verification of
-      # the downloaded goreleaser binary that is incompatible with the
-      # sigstore-bundle-v0.3 format goreleaser v2.4+ ships (cosign rejects
-      # the bundle: "does not contain cert"). PR #108 auto-bumped to v7.2.2
-      # and broke the v1.4.0 release. See the comment in release.yml.
-      - dependency-name: "goreleaser/goreleaser-action"
-        versions: [">=7"]
 
   - package-ecosystem: "gomod"
     directory: "/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,11 @@ jobs:
       # .goreleaser.yaml. Keyless mode uses the workflow's OIDC token
       # against Sigstore's Fulcio, no extra secrets needed.
       #
-      # Pin to v2.2.4: newer cosign versions (>=2.4.0) ship stricter bundle
-      # parsing that rejects the older bundle format goreleaser-action's
-      # own self-verification depends on, breaking the goreleaser download
-      # step. v2.2.4 is the widely-deployed version used by goreleaser's
-      # own release pipeline and is fully compatible with our signs: block.
+      # Pin to v2.2.4: this is the cosign version the release signing path has
+      # already proven with .goreleaser.yaml's signs: block. GoReleaser Action
+      # v7.2.2 still verifies the downloaded GoReleaser checksum, and its
+      # optional cosign verification skips older incompatible GoReleaser
+      # signatures instead of failing the download path.
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
@@ -93,7 +93,7 @@ jobs:
       # fails BOTH assertions, so it fails the job here and is never published.
       # --single-target + --snapshot keeps it fast and skips archives/signs.
       - name: Build snapshot binary for smoke test
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -158,15 +158,12 @@ jobs:
 
       - name: Run GoReleaser with Homebrew tap
         if: env.HAS_HOMEBREW_TAP_TOKEN == 'true'
-        # Pin to v6.4.0: goreleaser-action@v7 introduced a cosign-based
-        # self-verification of the downloaded goreleaser binary, which is
-        # incompatible with the new sigstore-bundle-v0.3 format goreleaser
-        # ships in v2.4+ (the action passes --bundle to cosign without the
-        # --new-bundle-format flag, so cosign rejects the bundle as
-        # "does not contain cert"). v6.4.0 skips that pre-flight check;
-        # our own signs: block in .goreleaser.yaml still uses the
-        # cosign-installer cosign for signing release artifacts correctly.
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        # Pin to v7.2.2: action.yml runs on Node 24, avoiding the Node 20
+        # forced-runtime annotation from v6.4.0. The action still verifies the
+        # downloaded GoReleaser checksum before executing it; release artifact
+        # signing stays controlled by the cosign install above and the signs:
+        # block in .goreleaser.yaml.
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -183,7 +180,7 @@ jobs:
 
       - name: Run GoReleaser without Homebrew tap
         if: env.HAS_HOMEBREW_TAP_TOKEN != 'true'
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/scripts/ci/check-workflow-hygiene.sh
+++ b/scripts/ci/check-workflow-hygiene.sh
@@ -73,6 +73,11 @@ gitnexus_docs_use_sha_pinned_cache_example() {
     grep -q 'actions/cache@[0-9a-f]\{40\}' scripts/gitnexus/README.md
 }
 
+release_goreleaser_action_uses_node24_pin() {
+  ! grep -qF 'goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a' .github/workflows/release.yml &&
+    [ "$(grep -cF 'goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2' .github/workflows/release.yml)" -eq 3 ]
+}
+
 release_docker_job_has_timeout() {
   awk '
     /^  docker:/ { in_job=1; next }
@@ -104,6 +109,7 @@ check "setup-node jobs use Node 24" all_setup_node_jobs_use_node24
 check "GitNexus CLI calls include an explicit npm package version" no_unpinned_gitnexus_cli_calls
 check "GitNexus CI and local refresh use the same pinned CLI version" gitnexus_version_is_pinned_consistently
 check "GitNexus cached-index docs use a SHA-pinned cache action example" gitnexus_docs_use_sha_pinned_cache_example
+check "release GoReleaser action uses the reviewed Node 24 pin" release_goreleaser_action_uses_node24_pin
 check "release Docker job has an explicit timeout" release_docker_job_has_timeout
 check "release Docker buildx commands emit plain progress logs" release_docker_builds_emit_plain_progress
 check "release Docker push remains behind the Trivy HIGH/CRITICAL gate" release_docker_trivy_blocks_before_push


### PR DESCRIPTION
## Summary
- upgrade the release workflow GoReleaser action calls from the Node 20 v6.4.0 pin to the pinned v7.2.2 Node 24 commit
- refresh the cosign/action compatibility comment to match current upstream behavior
- remove the stale Dependabot v7 ignore and add a workflow-hygiene guard against regressing to the old release action pin

Fixes #403

## Validation
- `gh api repos/goreleaser/goreleaser-action/git/ref/tags/v7.2.2 --jq .object.sha` -> `5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89`
- `gh api repos/goreleaser/goreleaser-action/contents/action.yml?ref=v7.2.2 --header "Accept: application/vnd.github.raw" | rg "using: 'node24'"`
- `bash -n scripts/ci/check-workflow-hygiene.sh && scripts/ci/check-workflow-hygiene.sh`
- `make repo-hygiene`
- `git diff --check`
- `wc -l .github/workflows/release.yml .github/dependabot.yml scripts/ci/check-workflow-hygiene.sh`
- `npx --yes gitnexus@1.6.8 detect-changes --repo trvl`