### PR TITLE
ci: lock Homebrew Formula distribution policy

### DIFF
--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -50,6 +50,22 @@ The 2026-05-12 baseline captured 337 GitHub release asset downloads and 0 npm `t
 | mcp.so | Submitted, not live | [chatmcp/mcpso#2288](https://github.com/chatmcp/mcpso/issues/2288) tracks the submission. `https://mcp.so/server/trvl` returned "Project not found" on 2026-05-12. |
 | Glama | Not live; repo metadata fixed | `https://glama.ai/api/mcp/v1/servers/MikkoParkkola/trvl` returned 404 on 2026-05-12. `glama.json` is now tracked so the repo exposes the maintainer manifest. Manual "Add Server" flow may still be required. |
 
+## Homebrew macOS Policy
+
+Decision: Formula-only until Developer ID notarization is proven in release CI.
+
+trvl intentionally publishes a Homebrew Formula through GoReleaser's `brews`
+configuration, not a Cask. The Formula install path relocates the CLI binary in
+a way that avoids the `com.apple.quarantine` launch failure that affected the
+prior Cask-style distribution attempt. A Cask must not be introduced unless the
+release workflow first signs and notarizes Darwin artifacts with a Developer ID
+certificate, staples the notarization ticket when applicable, and verifies a
+quarantined install can run `trvl version` on macOS before publishing.
+
+The existing Formula path stays the supported Homebrew channel until that full
+notarized-Cask path is implemented and proven. `scripts/ci/check-workflow-hygiene.sh`
+blocks accidental `homebrew_casks` reintroduction while this policy is active.
+
 ## Listing Copy
 
 Short description:

--- a/scripts/ci/check-workflow-hygiene.sh
+++ b/scripts/ci/check-workflow-hygiene.sh
@@ -104,6 +104,13 @@ release_docker_trivy_blocks_before_push() {
     grep -qF 'ignore-unfixed: true' .github/workflows/release.yml
 }
 
+release_homebrew_stays_formula_only_until_notarized() {
+  grep -q '^brews:' .goreleaser.yaml &&
+    ! grep -q '^homebrew_casks:' .goreleaser.yaml &&
+    grep -q 'release/build never run' .goreleaser.yaml &&
+    grep -q 'Formula-only until Developer ID notarization is proven in release CI' docs/DISTRIBUTION.md
+}
+
 check "workflow action uses refs are pinned to commit SHAs" all_workflow_uses_are_sha_pinned
 check "setup-node jobs use Node 24" all_setup_node_jobs_use_node24
 check "GitNexus CLI calls include an explicit npm package version" no_unpinned_gitnexus_cli_calls
@@ -113,5 +120,6 @@ check "release GoReleaser action uses the reviewed Node 24 pin" release_goreleas
 check "release Docker job has an explicit timeout" release_docker_job_has_timeout
 check "release Docker buildx commands emit plain progress logs" release_docker_builds_emit_plain_progress
 check "release Docker push remains behind the Trivy HIGH/CRITICAL gate" release_docker_trivy_blocks_before_push
+check "release Homebrew distribution stays Formula-only until notarized casks are proven" release_homebrew_stays_formula_only_until_notarized
 
 exit "$fail"


### PR DESCRIPTION
## Summary
- document the #405 decision: trvl stays Homebrew Formula-only until Developer ID notarization is proven in release CI
- state the cask prerequisites: Developer ID signing, notarization/stapling where applicable, and a quarantined macOS `trvl version` launch check before publishing
- add a workflow-hygiene guard that blocks accidental `homebrew_casks` reintroduction while the Formula-only policy is active

Fixes #405

## Validation
- `bash -n scripts/ci/check-workflow-hygiene.sh && scripts/ci/check-workflow-hygiene.sh`
- `make repo-hygiene`
- `git diff --check`
- `wc -l docs/DISTRIBUTION.md scripts/ci/check-workflow-hygiene.sh AGENTS.md CLAUDE.md`
- `if rg -q ^brews: .goreleaser.yaml && ! rg -q ^homebrew_casks: .goreleaser.yaml; then echo ok; else exit 1; fi`
- `npx --yes gitnexus@1.6.8 detect-changes --repo trvl`

## Notes
- I did not touch `.github/workflows/release.yml`; local hooks block direct edits to secret-bearing workflow paths. The new guard inspects the release config and distribution docs instead.
- `AGENTS.md` and `CLAUDE.md` have pre-existing local GitNexus count edits in my checkout and were not staged or committed.