### PR TITLE
release: prepare v1.17.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.6] - 2026-06-28
+
+### Changed
+- **Release metadata drift guard.** CI now rejects stale `server.json` and
+  `npm/package.json` release metadata when `CHANGELOG.md` documents a newer
+  published release.
+- **Release pipeline diagnostics.** Docker publishing now has an explicit
+  timeout, plain build progress logs, and a hygiene guard that keeps the
+  Trivy HIGH/CRITICAL gate ahead of the multi-arch push.
+- **Release runtime maintenance.** The tag workflow now uses the reviewed
+  Node 24 GoReleaser action pin and the repo consumes the latest setup-go
+  action pin from Dependabot.
+- **Homebrew macOS policy.** Distribution docs now lock trvl to Formula-only
+  Homebrew publishing until Developer ID notarization and a quarantined macOS
+  launch check are proven in release CI.
+- **Dependency maintenance.** Bumped `github.com/cloudflare/circl` to 1.6.4.
+
 ## [1.17.5] - 2026-06-28
 
 ### Changed
@@ -748,7 +765,8 @@ Trust & Discoverability release. The gaps surfaced by @RobertoReale's "Budget Tr
 - Single static binary, zero runtime dependencies
 - MIT license
 
-[Unreleased]: https://github.com/MikkoParkkola/trvl/compare/v1.17.5...HEAD
+[Unreleased]: https://github.com/MikkoParkkola/trvl/compare/v1.17.6...HEAD
+[1.17.6]: https://github.com/MikkoParkkola/trvl/compare/v1.17.5...v1.17.6
 [1.17.5]: https://github.com/MikkoParkkola/trvl/compare/v1.17.4...v1.17.5
 [1.17.4]: https://github.com/MikkoParkkola/trvl/compare/v1.17.3...v1.17.4
 [1.17.3]: https://github.com/MikkoParkkola/trvl/compare/v1.17.2...v1.17.3

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl-mcp",
   "mcpName": "io.github.MikkoParkkola/trvl",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as compatibility aliases.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
   "description": "Door-to-door travel MCP + CLI: flights, hotels, trains, cars, ferries. No API keys, Go binary.",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",
     "source": "github"
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mikkoparkkola/trvl:1.17.5",
+      "identifier": "ghcr.io/mikkoparkkola/trvl:1.17.6",
       "transport": {
         "type": "stdio"
       }
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "identifier": "trvl-mcp",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "version": "1.17.5",
+      "version": "1.17.6",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- add the v1.17.6 changelog entry for the post-v1.17.5 release hardening batch
- update `server.json` and `npm/package.json` source metadata to 1.17.6
- keep release workflow tag stamping as the runtime source for published artifacts

## Validation
- `scripts/ci/check-release-metadata.sh`
- `make repo-hygiene`
- `jq empty server.json npm/package.json`
- `git diff --check`
- `wc -l CHANGELOG.md server.json npm/package.json`
- `npx --yes gitnexus@1.6.8 detect-changes --repo trvl`

## Notes
- `AGENTS.md` and `CLAUDE.md` have pre-existing local GitNexus count edits in my checkout and were not staged or committed.