### PR TITLE
ci: avoid GoReleaser installer cosign drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@
 #
 # Optional secrets:
 #   HOMEBREW_TAP_TOKEN — PAT with `contents: write` on
-#     MikkoParkkola/homebrew-tap, enabling goreleaser's `homebrew_casks` block
-#     to auto-bump the cask. Formula freshness is enforced in homebrew-tap.
+#     MikkoParkkola/homebrew-tap, enabling goreleaser's `brews` block to
+#     auto-bump the formula. Casks stay disabled until notarization is proven.
 name: Release
 
 on:
@@ -65,15 +65,21 @@ jobs:
           # itself has to be 1.26.4, not just the build toolchain.
           go-version: "1.26.4"
 
+      # Install GoReleaser before cosign is on PATH so the action only performs
+      # checksum verification while installing the release tool.
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          install-only: true
+
       # Install cosign for hybrid release signing — see signs: block in
       # .goreleaser.yaml. Keyless mode uses the workflow's OIDC token
       # against Sigstore's Fulcio, no extra secrets needed.
       #
       # Pin to v2.2.4: this is the cosign version the release signing path has
-      # already proven with .goreleaser.yaml's signs: block. GoReleaser Action
-      # v7.2.2 still verifies the downloaded GoReleaser checksum, and its
-      # optional cosign verification skips older incompatible GoReleaser
-      # signatures instead of failing the download path.
+      # already proven with .goreleaser.yaml's signs: block.
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
@@ -82,7 +88,7 @@ jobs:
       # Smoke-test the packaged binary BEFORE the release pipeline publishes it
       # (issue #203 / AC RELEASE.FIX.2 + Fail-fast). v1.11.0 shipped a release
       # whose binaries were reported non-functional (silent, zero output) and
-      # the homebrew_casks step pushed the broken build to the tap before anyone
+      # the Homebrew publication step pushed the broken build to the tap before anyone
       # could run it. These steps build the exact host-arch binary GoReleaser
       # produces (same .goreleaser.yaml builds: block, including the darwin
       # codesign post-hook), execute it, and assert:
@@ -93,11 +99,7 @@ jobs:
       # fails BOTH assertions, so it fails the job here and is never published.
       # --single-target + --snapshot keeps it fast and skips archives/signs.
       - name: Build snapshot binary for smoke test
-        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: build --single-target --snapshot --clean
+        run: goreleaser build --single-target --snapshot --clean
         env:
           GOTOOLCHAIN: "go1.26.4"
 
@@ -158,18 +160,9 @@ jobs:
 
       - name: Run GoReleaser with Homebrew tap
         if: env.HAS_HOMEBREW_TAP_TOKEN == 'true'
-        # Pin to v7.2.2: action.yml runs on Node 24, avoiding the Node 20
-        # forced-runtime annotation from v6.4.0. The action still verifies the
-        # downloaded GoReleaser checksum before executing it; release artifact
-        # signing stays controlled by the cosign install above and the signs:
-        # block in .goreleaser.yaml.
-        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          # Docker is published by the Linux docker job below. Homebrew is
-          # published here when HOMEBREW_TAP_TOKEN can push to the tap repo.
-          args: release --clean --skip=docker
+        # Docker is published by the Linux docker job below. Homebrew is
+        # published here when HOMEBREW_TAP_TOKEN can push to the tap repo.
+        run: goreleaser release --clean --skip=docker
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -180,11 +173,7 @@ jobs:
 
       - name: Run GoReleaser without Homebrew tap
         if: env.HAS_HOMEBREW_TAP_TOKEN != 'true'
-        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean --skip=docker --skip=homebrew
+        run: goreleaser release --clean --skip=docker --skip=homebrew
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRVL_MLDSA_PRIVKEY_V1: ${{ secrets.TRVL_MLDSA_PRIVKEY_V1 }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.7] - 2026-06-28
+
+### Fixed
+- **Release pipeline GoReleaser install path.** The tag workflow now installs
+  GoReleaser before `cosign` is on `PATH`, then runs `goreleaser build` and
+  `goreleaser release` directly. This keeps artifact signing intact while
+  avoiding upstream checksum-bundle format drift in the action installer.
+- **Homebrew policy hygiene.** The release workflow comments and hygiene guard
+  now stay aligned with the Formula-only Homebrew policy.
+
 ## [1.17.6] - 2026-06-28
 
 ### Changed

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl-mcp",
   "mcpName": "io.github.MikkoParkkola/trvl",
-  "version": "1.17.6",
+  "version": "1.17.7",
   "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as compatibility aliases.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {

--- a/scripts/ci/check-workflow-hygiene.sh
+++ b/scripts/ci/check-workflow-hygiene.sh
@@ -75,7 +75,11 @@ gitnexus_docs_use_sha_pinned_cache_example() {
 
 release_goreleaser_action_uses_node24_pin() {
   ! grep -qF 'goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a' .github/workflows/release.yml &&
-    [ "$(grep -cF 'goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2' .github/workflows/release.yml)" -eq 3 ]
+    [ "$(grep -cF 'goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2' .github/workflows/release.yml)" -eq 1 ] &&
+    grep -qF 'install-only: true' .github/workflows/release.yml &&
+    grep -qF 'run: goreleaser build --single-target --snapshot --clean' .github/workflows/release.yml &&
+    grep -qF 'run: goreleaser release --clean --skip=docker' .github/workflows/release.yml &&
+    grep -qF 'run: goreleaser release --clean --skip=docker --skip=homebrew' .github/workflows/release.yml
 }
 
 release_docker_job_has_timeout() {
@@ -107,6 +111,7 @@ release_docker_trivy_blocks_before_push() {
 release_homebrew_stays_formula_only_until_notarized() {
   grep -q '^brews:' .goreleaser.yaml &&
     ! grep -q '^homebrew_casks:' .goreleaser.yaml &&
+    ! grep -q 'homebrew_casks' .github/workflows/release.yml &&
     grep -q 'release/build never run' .goreleaser.yaml &&
     grep -q 'Formula-only until Developer ID notarization is proven in release CI' docs/DISTRIBUTION.md
 }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
   "description": "Door-to-door travel MCP + CLI: flights, hotels, trains, cars, ferries. No API keys, Go binary.",
-  "version": "1.17.6",
+  "version": "1.17.7",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",
     "source": "github"
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mikkoparkkola/trvl:1.17.6",
+      "identifier": "ghcr.io/mikkoparkkola/trvl:1.17.7",
       "transport": {
         "type": "stdio"
       }
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "identifier": "trvl-mcp",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "version": "1.17.6",
+      "version": "1.17.7",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- Fixes the v1.17.6 tag release failure where `goreleaser/goreleaser-action@v7.2.2` attempted optional cosign verification of the GoReleaser v2.16.0 checksum bundle and failed before our binary build started.
- Installs GoReleaser once before cosign is on `PATH`, then runs `goreleaser build` and `goreleaser release` directly so artifact signing remains controlled by `.goreleaser.yaml`.
- Prepares v1.17.7 metadata because the already-pushed v1.17.6 tag failed before publishing artifacts.
- Removes stale `homebrew_casks` wording from the release workflow and locks that with the workflow hygiene guard.

## KPI Impact
- Operator/release impact: restores the tag release path for GitHub Release, Homebrew Formula, Docker, npm, and MCP registry publishing after the failed v1.17.6 run.

## Evidence
- Failure source: Release run 28318845536, GoReleaser job failed in `Build snapshot binary for smoke test` with `bundle does not contain cert for verification, please provide public key` from cosign before any trvl binary build.
- `scripts/ci/check-workflow-hygiene.sh`
- `scripts/ci/check-release-metadata.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml YAML parses"'`
- `make repo-hygiene`
- `git diff --check`
- `jq empty server.json npm/package.json`
- `actionlint .github/workflows/release.yml`
- `npx --yes gitnexus@1.6.8 detect-changes --repo trvl` -> low risk; only pre-existing AGENTS/CLAUDE symbol edits reported, release workflow/metadata not symbol-mapped.

## Risk / Rollback
- Risk: next real proof is a tag-triggered release run after merge; this change cannot fully exercise GitHub release publishing locally.
- Rollback: revert this PR and pin/replace the GoReleaser installer another way, but do not re-run the already-failed v1.17.6 tag as a success claim.
