### PR TITLE
test: close canonical DoD coverage gaps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,8 +87,8 @@ jobs:
             exit 1
           fi
           echo "Total coverage: ${COVERAGE}%"
-          if [ "$(echo "$COVERAGE < 75" | bc -l)" -eq 1 ]; then
-            echo "::error::Coverage ${COVERAGE}% is below 75% threshold"
+          if [ "$(echo "$COVERAGE < 80" | bc -l)" -eq 1 ]; then
+            echo "::error::Coverage ${COVERAGE}% is below 80% threshold"
             exit 1
           fi
       - name: Check coverage wiki

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -627,7 +627,7 @@ done with trvl alone.
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **trvl** (21724 symbols, 65509 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **trvl** (21830 symbols, 66688 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ trvl is a travel MCP server + CLI that gives any AI assistant (Claude, Cursor, W
 - Hotel providers working: Google Hotels, Booking.com (browser cookies), Airbnb (SSR/Niobe), Hostelworld (autocomplete), Trivago (Streamable HTTP MCP), HomeToGo (public SSR+JSON, vacation rentals)
 - Flight providers: Google Flights (hand-rolled protobuf), Kiwi, Skiplagged (hidden-city, opt-in), Ryanair (public API), Wizz Air (public unauthenticated), Air France–KLM Offers API v3 (opt-in), Transavia (official API, opt-in), easyJet (opt-in, `EASYJET_API_BASE` — public availability API is Akamai bot-defended/403, so no default-on path; honest typed `AKAMAI_BLOCK` status when unconfigured). Travelpayouts/Aviasales price signals are an opt-in source surfaced via `trvl pricetrends` (not in the bookable merge).
 - Enrichment (free, unauthenticated): weather (Open-Meteo), air quality (`trvl air`), sun times (`trvl sun`, sunrise-sunset.org), bike-share (`trvl bikes`, CityBikes)
-- CI: build, vet, staticcheck, govulncheck, race tests, coverage ≥50% on ubuntu + windows
+- CI: build, vet, staticcheck, govulncheck, race tests, coverage >=80% on ubuntu + windows
 - Latest release train: tag-triggered workflow + adhoc codesign identifier (PR #50)
 - npm wrapper, ICS calendar export, and the smart-router consolidation (compatibility aliases → 1 advertised `travel` tool, ~98.9% `tools/list` context reduction) landed in last ~90d (MIK-3081/3082/3083/3084 + 6-package wiring batch in PR #57)
 
@@ -30,7 +30,7 @@ trvl is a travel MCP server + CLI that gives any AI assistant (Claude, Cursor, W
 |---|---|---|
 | **No frameworks** — stdlib + carefully chosen libs only | Predictable behavior, minimal deps, long-lived binary | Add web frameworks, ORMs, DI containers |
 | **No API keys required by default** | Zero-friction onboarding; "API-first" phrasing uses *provider* APIs, not user-paid ones | Introduce paid-API requirements on default code paths |
-| **`GOTOOLCHAIN=go1.26.3` pinning via Makefile** | CI reproducibility; host `go` on PATH may be older | Run raw `go build/test` without the prefix on older hosts |
+| **`GOTOOLCHAIN=go1.26.4` pinning via Makefile** | CI reproducibility; host `go` on PATH may be older | Run raw `go build/test` without the prefix on older hosts |
 | **`internal/models` is the shared type package** | Unidirectional import flow; no cycles | Import from other `internal/` packages into `models/` |
 | **Live tests are opt-in** via `TRVL_TEST_LIVE_INTEGRATIONS=1` and `TRVL_TEST_LIVE_PROBES=1` | Default suite must be deterministic and offline | Enable live probes in the default `go test ./...` suite |
 | **Protobuf-style encoding for Google Flights is hand-rolled** (no `.proto` files) | The upstream format is undocumented; hand-rolled is auditable | Add `protoc` / `.proto`-generation to the build pipeline |
@@ -122,9 +122,9 @@ go vet ./...                        # Vet (CI runs this)
 
 ## CI
 
-GitHub Actions (`.github/workflows/ci.yaml`): build, vet, staticcheck, govulncheck, test with race detector, coverage threshold (50%). Runs on ubuntu + windows, Go 1.26.3.
+GitHub Actions (`.github/workflows/ci.yaml`): build, vet, staticcheck, govulncheck, test with race detector, coverage threshold (80%). Runs on ubuntu + windows, Go 1.26.4.
 
-Make targets pin `GOTOOLCHAIN=go1.26.3` so local build/test entrypoints match CI even when the host `go` on `PATH` is older. For raw `go ...` commands on such hosts, prefix `GOTOOLCHAIN=go1.26.3`.
+Make targets pin `GOTOOLCHAIN=go1.26.4` so local build/test entrypoints match CI even when the host `go` on `PATH` is older. For raw `go ...` commands on such hosts, prefix `GOTOOLCHAIN=go1.26.4`.
 
 ## Key Details
 
@@ -146,7 +146,7 @@ Make targets pin `GOTOOLCHAIN=go1.26.3` so local build/test entrypoints match CI
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **trvl** (21724 symbols, 65509 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **trvl** (21830 symbols, 66688 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,16 +75,16 @@ Every PR must pass the existing trvl quality gates. Run these locally before
 asking for review:
 
 ```bash
-GOTOOLCHAIN=go1.26.3 go vet ./...
-GOTOOLCHAIN=go1.26.3 go test -short -race ./...
+GOTOOLCHAIN=go1.26.4 go vet ./...
+GOTOOLCHAIN=go1.26.4 go test -short -race ./...
 staticcheck ./...
 govulncheck ./...
 ```
 
 The Makefile wraps these as `make lint` and `make test` and pins the
-toolchain; use the Make targets if your host `go` is older than 1.26.3.
+toolchain; use the Make targets if your host `go` is older than 1.26.4.
 
-CI enforces a 50% line-coverage threshold. New packages are expected to land
+CI enforces an 80% line-coverage threshold. New packages are expected to land
 with coverage at or above that threshold; regressions in existing packages
 will block merge.
 

--- a/cmd/trvl/cli_cmds_split6_test.go
+++ b/cmd/trvl/cli_cmds_split6_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/testutil"
 )
 
 func TestRelativeTimeStr_MultipleMinutesAgo(t *testing.T) {
@@ -323,9 +324,7 @@ func TestSuggestCmd_InvalidDestIATAV7(t *testing.T) {
 }
 
 func TestFlightsCmd_HomeOriginResolves(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping live HTTP test in short mode")
-	}
+	testutil.RequireLiveIntegration(t)
 	cmd := flightsCmd()
 	cmd.SetArgs([]string{"home", "BCN", "2026-07-01"})
 	_ = cmd.Execute()

--- a/cmd/trvl/offline_command_errors_test.go
+++ b/cmd/trvl/offline_command_errors_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestOfflineCommandValidationErrors(t *testing.T) {
+	t.Setenv("TRAVELPAYOUTS_TOKEN", "")
+
+	if err := executeCommandExpectError(t, pricetrendsCmd(), "HEL", "BCN"); err == nil || !strings.Contains(err.Error(), "pricetrends is opt-in") {
+		t.Fatalf("pricetrends error = %v", err)
+	}
+
+	if err := executeCommandExpectError(t, nestedCmd(), "HEL", "AMS", "bad", "2026-07-05", "2026-07-20", "2026-07-24"); err == nil || !strings.Contains(err.Error(), "invalid date") {
+		t.Fatalf("nested invalid-date error = %v", err)
+	}
+
+	cmd := forecastCmd()
+	if err := executeCommandExpectError(t, cmd, "HEL-CDG", "--price", "120", "--trip-date", "tomorrow"); err == nil || !strings.Contains(err.Error(), "invalid trip-date") {
+		t.Fatalf("forecast invalid-date error = %v", err)
+	}
+}
+
+func executeCommandExpectError(t *testing.T, cmd *cobra.Command, args ...string) error {
+	t.Helper()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}

--- a/cmd/trvl/offline_coverage_test.go
+++ b/cmd/trvl/offline_coverage_test.go
@@ -1,0 +1,794 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/cabinarb"
+	"github.com/MikkoParkkola/trvl/internal/dealquality"
+	"github.com/MikkoParkkola/trvl/internal/flights/afklm"
+	"github.com/MikkoParkkola/trvl/internal/forecast"
+	"github.com/MikkoParkkola/trvl/internal/hotels"
+	"github.com/MikkoParkkola/trvl/internal/los"
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/multidest"
+	"github.com/MikkoParkkola/trvl/internal/multimodal"
+	"github.com/MikkoParkkola/trvl/internal/pricesignal"
+	"github.com/MikkoParkkola/trvl/internal/railpass"
+	"github.com/MikkoParkkola/trvl/internal/serpapi"
+	"github.com/MikkoParkkola/trvl/internal/travelgraph"
+	"github.com/MikkoParkkola/trvl/internal/tripcoalesce"
+	"github.com/spf13/cobra"
+)
+
+func TestOfflineHelperParsersAndFileLoaders(t *testing.T) {
+	bookings, err := parseBookingArgs([]string{"alice:300:alice,bob", "bob:150:bob=2,alice=1"})
+	if err != nil {
+		t.Fatalf("parseBookingArgs: %v", err)
+	}
+	if len(bookings) != 2 || bookings[0].Payer != "alice" || bookings[1].Split[0].Weight != 2 {
+		t.Fatalf("bookings = %#v", bookings)
+	}
+
+	split, err := parseSplit(" alice , bob=2 ")
+	if err != nil {
+		t.Fatalf("parseSplit: %v", err)
+	}
+	if len(split) != 2 || split[0].Traveller != "alice" || split[1].Weight != 2 {
+		t.Fatalf("split = %#v", split)
+	}
+
+	path := filepath.Join(t.TempDir(), "bookings.json")
+	if err := os.WriteFile(path, []byte(`[{"payer":"alice","amount":42,"split":[{"traveller":"alice","weight":1}]}]`), 0o600); err != nil {
+		t.Fatalf("write bookings: %v", err)
+	}
+	fromFile, err := loadBookingsFromFile(path)
+	if err != nil {
+		t.Fatalf("loadBookingsFromFile: %v", err)
+	}
+	if len(fromFile) != 1 || fromFile[0].Amount != 42 {
+		t.Fatalf("fromFile = %#v", fromFile)
+	}
+
+	if _, err := parseBookingArgs([]string{":10"}); err == nil {
+		t.Fatal("expected empty payer error")
+	}
+	if _, err := parseSplit(" "); err == nil {
+		t.Fatal("expected empty split error")
+	}
+}
+
+func TestCabinAndLengthOfStayOfflineHelpers(t *testing.T) {
+	fares, err := parseCabinFares([]string{"economy:500:AY", "premium_economy:550"})
+	if err != nil {
+		t.Fatalf("parseCabinFares: %v", err)
+	}
+	if len(fares) != 2 || fares[0].Carrier != "AY" || fares[1].Cabin != cabinarb.CabinPremiumEconomy {
+		t.Fatalf("fares = %#v", fares)
+	}
+
+	quotes, err := parseLOSQuotes([]string{"5:400", "6:390:r"})
+	if err != nil {
+		t.Fatalf("parseLOSQuotes: %v", err)
+	}
+	if len(quotes) != 2 || !quotes[1].Refundable {
+		t.Fatalf("quotes = %#v", quotes)
+	}
+
+	cabinOut := tempOutputFile(t)
+	renderCabinArbTable(cabinOut, []cabinarb.UpgradeRecommendation{{
+		Baseline:      cabinarb.CabinEconomy,
+		Target:        cabinarb.CabinPremiumEconomy,
+		BaselinePrice: 500,
+		TargetPrice:   550,
+		UpsellPercent: 10,
+		Reason:        "small upsell",
+	}}, 15)
+	if !strings.Contains(readTempOutput(t, cabinOut), "Upgrade recommendations") {
+		t.Fatal("expected cabin arbitrage table output")
+	}
+
+	losOut := tempOutputFile(t)
+	renderLosTable(losOut, 5, []los.Flip{{
+		Kind:              "stay_longer_pay_less",
+		BaselineNights:    5,
+		AlternativeNights: 6,
+		BaselineTotal:     400,
+		AlternativeTotal:  390,
+		TotalDelta:        -10,
+		Refundable:        true,
+		Reason:            "sixth night lowers total",
+	}})
+	if !strings.Contains(readTempOutput(t, losOut), "Length-of-stay alternatives") {
+		t.Fatal("expected LOS table output")
+	}
+}
+
+func TestFlightSerpapiAndNudgeOfflineHelpers(t *testing.T) {
+	flights := []models.FlightResult{
+		{Price: 0},
+		{Price: 320},
+		{Price: 180},
+	}
+	if got := cheapestFlightPrice(flights); got != 180 {
+		t.Fatalf("cheapestFlightPrice = %.0f, want 180", got)
+	}
+
+	flight := models.FlightResult{Legs: []models.FlightLeg{
+		{DepartureTime: "2026-07-01T06:55:00", AirlineCode: "AY"},
+		{DepartureTime: "2026-07-01T08:40:00", AirlineCode: "AY"},
+		{DepartureTime: "2026-07-01T09:50:00", AirlineCode: "KL"},
+	}}
+	if got := flightDepartHHMM(flight); got != "06:55" {
+		t.Fatalf("flightDepartHHMM = %q", got)
+	}
+	if got := strings.Join(flightAirlineCodes(flight), ","); got != "AY,KL" {
+		t.Fatalf("flightAirlineCodes = %q", got)
+	}
+
+	hotel := serpapi.Hotel{
+		FeaturedPrices: []serpapi.PriceOption{{
+			Source:    "ProviderA",
+			TotalRate: serpapi.Rate{Extracted: 500},
+		}},
+		Prices: []serpapi.PriceOption{{
+			Source:       "ProviderB",
+			RatePerNight: serpapi.Rate{Extracted: 120},
+		}},
+	}
+	if got := providerSummary(hotel, "EUR", 1); !strings.Contains(got, "ProviderA") || !strings.Contains(got, "...") {
+		t.Fatalf("providerSummary = %q", got)
+	}
+	if got := serpapiPriceStatus(hotel); got != "provider_prices_present" {
+		t.Fatalf("serpapiPriceStatus = %q", got)
+	}
+	if got := serpapiPluralSuffix(2); got != "s" {
+		t.Fatalf("serpapiPluralSuffix = %q", got)
+	}
+	if got := serpapiTimeout(20, false); got != 2*time.Minute {
+		t.Fatalf("serpapiTimeout = %s", got)
+	}
+	if got := parseSerpapiCSV("wifi, pool,, spa "); strings.Join(got, "|") != "wifi|pool|spa" {
+		t.Fatalf("parseSerpapiCSV = %#v", got)
+	}
+	ints, err := parseSerpapiIntCSV("3,4,5", "hotel-class")
+	if err != nil || len(ints) != 3 || ints[2] != 5 {
+		t.Fatalf("parseSerpapiIntCSV = %#v, err=%v", ints, err)
+	}
+	if got, err := serpapiRatingParam(4.6); err != nil || got != "9" {
+		t.Fatalf("serpapiRatingParam = %q, err=%v", got, err)
+	}
+
+	srcs := []travelgraph.SourceRef{{Kind: "watch", ID: "w1"}, {Kind: "route", ID: "HEL-BCN"}}
+	if got := formatSources(srcs); got != "watch:w1, route:HEL-BCN" {
+		t.Fatalf("formatSources = %q", got)
+	}
+}
+
+func TestMiscOfflineHelpers(t *testing.T) {
+	values := []string{"z", "a", "m"}
+	sortStrings(values)
+	if strings.Join(values, "") != "amz" {
+		t.Fatalf("sortStrings = %#v", values)
+	}
+	if got := len([]rune(progressBar(0.5, 10))); got != 10 {
+		t.Fatalf("progressBar length = %d", got)
+	}
+
+	if got, err := parseNonNegativeFloat("12.5"); err != nil || got != 12.5 {
+		t.Fatalf("parseNonNegativeFloat = %.1f, err=%v", got, err)
+	}
+	if _, err := parseNonNegativeFloat("-1"); err == nil {
+		t.Fatal("expected negative value error")
+	}
+	if got := colorizeHiddenCityRisk(10); !strings.Contains(got, "10/100") {
+		t.Fatalf("colorizeHiddenCityRisk low = %q", got)
+	}
+	if got := colorizeHiddenCityRisk(80); !strings.Contains(got, "80/100") {
+		t.Fatalf("colorizeHiddenCityRisk high = %q", got)
+	}
+}
+
+func TestCommandConstructorsDoNotRequireNetwork(t *testing.T) {
+	constructors := map[string]func() any{
+		"air":               func() any { return airCmd() },
+		"sun":               func() any { return sunCmd() },
+		"bikes":             func() any { return bikesCmd() },
+		"cabin-arb":         func() any { return cabinArbCmd() },
+		"expenses":          func() any { return expensesCmd() },
+		"forecast":          func() any { return forecastCmd() },
+		"hidden-city":       func() any { return hiddenCityCmd() },
+		"los":               func() any { return losCmd() },
+		"multimodal-plan":   func() any { return multimodalPlanCmd() },
+		"nested":            func() any { return nestedCmd() },
+		"nudges":            func() any { return nudgesCmd() },
+		"opportunities":     func() any { return opportunitiesCmd() },
+		"opportunity-score": func() any { return opportunityScoreCmd() },
+		"points-value":      func() any { return pointsValueCmd() },
+		"price-trends":      func() any { return pricetrendsCmd() },
+		"providers":         func() any { return providersCmd() },
+		"rail-pass":         func() any { return railPassCmd() },
+		"rate-status":       func() any { return rateStatusCmd() },
+		"reviews":           func() any { return reviewsCmd },
+		"rooms":             func() any { return roomsCmd() },
+		"route":             func() any { return routeCmd() },
+		"serpapi":           func() any { return serpapiCmd() },
+	}
+	for name, build := range constructors {
+		t.Run(name, func(t *testing.T) {
+			if got := build(); got == nil {
+				t.Fatalf("%s constructor returned nil", name)
+			}
+		})
+	}
+}
+
+func TestOfflineDeterministicCommandRunPaths(t *testing.T) {
+	oppCmd := opportunityScoreCmd()
+	addInheritedFormatFlag(t, oppCmd, "table")
+	oppOut := executeCommandWithStdout(t, oppCmd, "PRG:2026-07-01:2026-07-05:90:80:95", "--min-score", "70")
+	if !strings.Contains(oppOut, "PRG") || !strings.Contains(oppOut, "Overall") {
+		t.Fatalf("opportunity-score output = %q", oppOut)
+	}
+
+	candidateFile := filepath.Join(t.TempDir(), "candidates.json")
+	if err := os.WriteFile(candidateFile, []byte(`[{"Destination":"ROM","DepartDate":"2026-08-01","ReturnDate":"2026-08-05","Signals":{"ProfileMatch":80,"RequestMatch":70,"DealQuality":90}}]`), 0o600); err != nil {
+		t.Fatalf("write candidates: %v", err)
+	}
+	oppFileCmd := opportunityScoreCmd()
+	addInheritedFormatFlag(t, oppFileCmd, "json")
+	oppJSON := executeCommandWithStdout(t, oppFileCmd, "--file", candidateFile)
+	if !strings.Contains(oppJSON, `"Destination":"ROM"`) {
+		t.Fatalf("opportunity-score JSON output = %q", oppJSON)
+	}
+
+	railCmd := railPassCmd()
+	addInheritedFormatFlag(t, railCmd, "table")
+	railOut := executeCommandWithStdout(t, railCmd, "299", "DB:AMS:BRU:120:10", "SNCF:PAR:LYS:110")
+	if !strings.Contains(railOut, "Rail pass evaluation") || !strings.Contains(railOut, "Segments scored") {
+		t.Fatalf("rail-pass output = %q", railOut)
+	}
+
+	multidestFile := filepath.Join(t.TempDir(), "orderings.json")
+	if err := os.WriteFile(multidestFile, []byte(`[{"cities":["AMS","ROM"],"legs":[{"origin":"AMS","destination":"ROM","date":"2026-06-01","price":120}],"hotels":[{"city":"ROM","check_in":"2026-06-01","check_out":"2026-06-05","total_price":400}]}]`), 0o600); err != nil {
+		t.Fatalf("write multidest: %v", err)
+	}
+	multiCmd := multidestCmd()
+	addInheritedFormatFlag(t, multiCmd, "table")
+	multiOut := executeCommandWithStdout(t, multiCmd, "--file", multidestFile, "--top-k", "1")
+	if !strings.Contains(multiOut, "Top 1 multi-destination bundles") || !strings.Contains(multiOut, "AMS -> ROM") {
+		t.Fatalf("multidest output = %q", multiOut)
+	}
+
+	pointsList := executeCommandWithStdout(t, pointsValueCmd(), "--list", "--format", "json")
+	if !strings.Contains(pointsList, `"Slug"`) {
+		t.Fatalf("points-value list output = %q", pointsList)
+	}
+	pointsArb := executeCommandWithStdout(t, pointsValueCmd(), "--cash", "300", "--offer", "world-of-hyatt:12000", "--currency", "USD")
+	if !strings.Contains(pointsArb, "Hotel Points Arbitrage") || !strings.Contains(pointsArb, "World of Hyatt") {
+		t.Fatalf("points arbitrage output = %q", pointsArb)
+	}
+
+	var statusOut bytes.Buffer
+	statusCmd := rateStatusCmd()
+	statusCmd.SetOut(&statusOut)
+	statusCmd.SilenceUsage = true
+	statusCmd.SilenceErrors = true
+	if err := statusCmd.Execute(); err != nil {
+		t.Fatalf("rate-status Execute: %v", err)
+	}
+	if !strings.Contains(statusOut.String(), "Rate Limit Status") || !strings.Contains(statusOut.String(), "google:") {
+		t.Fatalf("rate-status output = %q", statusOut.String())
+	}
+}
+
+func TestOfflineRenderersForCompositePlans(t *testing.T) {
+	coalesced := &tripcoalesce.TripPlan{
+		Origin:      "HEL",
+		Destination: "LHR",
+		DepartDate:  "2026-07-01",
+		ReturnDate:  "2026-07-08",
+		Currency:    "EUR",
+		CheapestFlight: &models.FlightResult{
+			Price:    220,
+			Currency: "EUR",
+			Duration: 180,
+			Stops:    0,
+		},
+		CheapestHotel: &models.HotelResult{Name: "Central", Price: 100, Currency: "EUR"},
+		CheapestGround: &models.GroundRoute{
+			Provider: "eurostar",
+			Type:     "train",
+			Price:    80,
+			Currency: "EUR",
+		},
+		TotalCostEstimate: 400,
+		CostBreakdown: []tripcoalesce.CostComponent{
+			{Domain: "flights", Label: "cheapest flight", Amount: 220, Currency: "EUR"},
+			{Domain: "hotels", Label: "Central", Amount: 100, Currency: "EUR"},
+			{Domain: "ground", Label: "eurostar", Amount: 80, Currency: "EUR"},
+		},
+		Statuses: []tripcoalesce.DomainStatus{
+			{Domain: "flights", OK: true, Count: 1},
+			{Domain: "hotels", OK: true, Count: 1},
+			{Domain: "ground", OK: true, Count: 1},
+			{Domain: "rideshare", OK: false, Error: "not configured"},
+		},
+		Notes: []string{"floor estimate only"},
+	}
+	coalescedOut := captureStdout(t, func() { printCoalescedPlan(coalesced) })
+	if !strings.Contains(coalescedOut, "Floor estimate") || !strings.Contains(coalescedOut, "floor estimate only") {
+		t.Fatalf("coalesced output = %q", coalescedOut)
+	}
+	if got := domainNote(coalesced, "rideshare"); !strings.Contains(got, "not configured") {
+		t.Fatalf("domainNote = %q", got)
+	}
+	if got := domainNote(coalesced, "missing"); got != "no results" {
+		t.Fatalf("domainNote missing = %q", got)
+	}
+
+	plan := &multimodal.Plan{
+		From:       "Helsinki",
+		To:         "Tallinn",
+		Date:       "2026-07-01",
+		Discovered: 2,
+		Notes:      []string{"priced one route"},
+		Itineraries: []multimodal.Itinerary{{
+			From:        "Helsinki",
+			To:          "Tallinn",
+			Date:        "2026-07-01",
+			ModeChain:   "ferry",
+			TotalPrice:  42,
+			Currency:    "EUR",
+			DurationMin: 120,
+			BookingURL:  "https://example.test/ferry",
+			Legs: []multimodal.PricedLeg{{
+				Mode:        "ferry",
+				From:        "Helsinki",
+				To:          "Tallinn",
+				Price:       42,
+				Currency:    "EUR",
+				DurationMin: 120,
+				Provider:    "fixture",
+				Detail:      "day ferry",
+			}},
+			Warnings: []string{"verify before booking"},
+		}},
+	}
+	multimodalOut := captureStdout(t, func() { printMultimodalPlan(plan) })
+	if !strings.Contains(multimodalOut, "Multimodal") || !strings.Contains(multimodalOut, "day ferry") {
+		t.Fatalf("multimodal output = %q", multimodalOut)
+	}
+
+	emptyPlan := &multimodal.Plan{From: "A", To: "B", Date: "2026-07-01", Notes: []string{"nothing found"}}
+	stderr := captureStderrOffline(t, func() { printMultimodalPlan(emptyPlan) })
+	if !strings.Contains(stderr, "No multimodal itineraries") || !strings.Contains(stderr, "nothing found") {
+		t.Fatalf("empty multimodal stderr = %q", stderr)
+	}
+}
+
+func TestOfflinePureParsingVariants(t *testing.T) {
+	segments, err := parseRailSegments([]string{"120", "DB:AMS:BRU:89", "SNCF:PAR:LYS:45:12"})
+	if err != nil {
+		t.Fatalf("parseRailSegments: %v", err)
+	}
+	if len(segments) != 3 || segments[2].ReservationFee != 12 {
+		t.Fatalf("segments = %#v", segments)
+	}
+	if _, err := parseRailSegments([]string{"DB:AMS"}); err == nil {
+		t.Fatal("expected malformed rail segment error")
+	}
+
+	offers, err := parsePointsOffers([]string{"world-of-hyatt:12000:15", "hilton-honors:80000"})
+	if err != nil {
+		t.Fatalf("parsePointsOffers: %v", err)
+	}
+	if len(offers) != 2 || offers[0].CashFees != 15 {
+		t.Fatalf("offers = %#v", offers)
+	}
+	if _, err := parsePointsOffers([]string{"bad"}); err == nil {
+		t.Fatal("expected malformed points offer error")
+	}
+	if _, err := parsePositiveInt("0"); err == nil {
+		t.Fatal("expected positive int error")
+	}
+
+	rec := railpass.EvaluatePass(railpass.PassOption{Name: "Pass", Cost: 200}, []railpass.PointToPointSegment{{Price: 120}, {Price: 130}})
+	if rec.Verdict != railpass.VerdictMarginal && rec.Verdict != railpass.VerdictBuyPass {
+		t.Fatalf("rail recommendation = %#v", rec)
+	}
+
+	bundles := multidest.ScreenAndDrillDown([]multidest.Ordering{{
+		Cities: []string{"AMS", "ROM"},
+		Legs:   []multidest.Leg{{Origin: "AMS", Destination: "ROM", Price: 100}},
+		Hotels: []multidest.HotelCost{{City: "ROM", TotalPrice: 200}},
+	}}, multidest.ScreenOptions{})
+	if len(bundles) != 1 || bundles[0].GrandTotal != 300 {
+		t.Fatalf("bundles = %#v", bundles)
+	}
+}
+
+func TestOfflineAdditionalCommandRenderers(t *testing.T) {
+	expenseCmd := expensesCmd()
+	addInheritedFormatFlag(t, expenseCmd, "table")
+	expenseOut := executeCommandWithStdout(t, expenseCmd, "alice:300:alice,bob", "bob:100:bob")
+	if !strings.Contains(expenseOut, "alice") || !strings.Contains(expenseOut, "bob") {
+		t.Fatalf("expenses output = %q", expenseOut)
+	}
+
+	expenseFile := filepath.Join(t.TempDir(), "bookings.json")
+	if err := os.WriteFile(expenseFile, []byte(`[{"Payer":"alice","Amount":120,"Split":[{"Traveller":"alice","Weight":1},{"Traveller":"bob","Weight":1}]}]`), 0o600); err != nil {
+		t.Fatalf("write expense file: %v", err)
+	}
+	expenseJSONCmd := expensesCmd()
+	addInheritedFormatFlag(t, expenseJSONCmd, "json")
+	expenseJSON := executeCommandWithStdout(t, expenseJSONCmd, "--file", expenseFile)
+	if !strings.Contains(expenseJSON, `"Transfers"`) {
+		t.Fatalf("expenses JSON output = %q", expenseJSON)
+	}
+
+	carResult := &models.CarSearchResult{
+		Success: true,
+		Count:   1,
+		Offers: []models.CarOffer{{
+			Provider:     "skyscanner",
+			Supplier:     "Hertz",
+			VehicleName:  "Golf",
+			VehicleClass: "compact",
+			Price:        144,
+			Currency:     "EUR",
+			Seats:        5,
+			Pickup:       models.CarEndpoint{Location: "HEL"},
+		}},
+	}
+	carsOut := captureStdout(t, func() { printCarsTable(carResult) })
+	if !strings.Contains(carsOut, "Rental Cars") || !strings.Contains(carsOut, "Hertz") || intString(5) != "5" {
+		t.Fatalf("cars output = %q", carsOut)
+	}
+	carsErr := captureStderrOffline(t, func() { printCarsTable(&models.CarSearchResult{Error: "missing key"}) })
+	if !strings.Contains(carsErr, "missing key") || intString(0) != "-" {
+		t.Fatalf("cars error output = %q", carsErr)
+	}
+
+	reviewsOut := captureStdout(t, func() {
+		if err := printReviewsTable(&models.HotelReviewResult{
+			Name:    "Hotel Test",
+			Summary: models.ReviewSummary{AverageRating: 4.5, TotalReviews: 12},
+			Reviews: []models.HotelReview{{
+				Rating: 4.5,
+				Author: "Ada",
+				Date:   "2026-07-01",
+				Text:   strings.Repeat("good ", 30),
+			}},
+		}); err != nil {
+			t.Fatalf("printReviewsTable: %v", err)
+		}
+	})
+	if !strings.Contains(reviewsOut, "Hotel Test") || !strings.Contains(reviewsOut, "Ada") {
+		t.Fatalf("reviews output = %q", reviewsOut)
+	}
+
+	freeCancel, breakfast := true, true
+	refundable := false
+	roomsOut := captureStdout(t, func() {
+		if err := formatRoomsTable(&hotels.RoomAvailability{
+			HotelID:  "hotel-1",
+			Name:     "Room Test",
+			CheckIn:  "2026-07-01",
+			CheckOut: "2026-07-03",
+			Notice:   "fixture data",
+			Rooms: []hotels.RoomType{{
+				Name:              "Standard",
+				Price:             220,
+				Currency:          "EUR",
+				MaxGuests:         2,
+				BedType:           "Queen",
+				Board:             "room_only",
+				Provider:          "fixture",
+				Amenities:         []string{"wifi", "desk"},
+				FreeCancellation:  &freeCancel,
+				BreakfastIncluded: &breakfast,
+			}, {
+				Name:       "Budget",
+				Price:      180,
+				Currency:   "EUR",
+				Refundable: &refundable,
+			}},
+		}); err != nil {
+			t.Fatalf("formatRoomsTable: %v", err)
+		}
+	})
+	if !strings.Contains(roomsOut, "Room Test") || !strings.Contains(roomsOut, "Cheapest") {
+		t.Fatalf("rooms output = %q", roomsOut)
+	}
+	if got := prettyLabel("free_cancellation"); got != "Free cancellation" {
+		t.Fatalf("prettyLabel = %q", got)
+	}
+}
+
+func TestOfflinePricePositionRenderer(t *testing.T) {
+	var sparse bytes.Buffer
+	printPricePosition(&sparse, &pricesignal.Position{Observations: 3})
+	if !strings.Contains(sparse.String(), "not enough history") {
+		t.Fatalf("sparse price position = %q", sparse.String())
+	}
+
+	var confident bytes.Buffer
+	printPricePosition(&confident, &pricesignal.Position{
+		Confident:    true,
+		Verdict:      pricesignal.VerdictWait,
+		Band:         pricesignal.BandHigh,
+		Low:          100,
+		Median:       150,
+		High:         220,
+		VsMedianPct:  20,
+		Observations: 12,
+	})
+	if !strings.Contains(confident.String(), "WAIT") || !strings.Contains(confident.String(), "+20%") {
+		t.Fatalf("confident price position = %q", confident.String())
+	}
+	if verdictText("unknown") != "no verdict" || bandText("unknown") != "position unknown" || signedPct(-12) != "-12%" {
+		t.Fatal("expected fallback price-position labels")
+	}
+}
+
+func TestOfflineAwardScanAndRenderer(t *testing.T) {
+	t.Setenv("AFKL_KLM_COOKIES", "")
+	help := captureStderrOffline(t, func() {
+		if err := runAwardScan(context.Background(), "HEL", "CDG", "2026-07", "", "table"); err != nil {
+			t.Fatalf("runAwardScan no-cookie path: %v", err)
+		}
+	})
+	if !strings.Contains(help, "Award search requires") || !strings.Contains(help, "trvl flights HEL CDG 2026-07 --award") {
+		t.Fatalf("award no-cookie help = %q", help)
+	}
+
+	out := captureStdout(t, func() {
+		if err := printAwardTable(&afklm.AwardScanResult{
+			Origin:      "hel",
+			Destination: "cdg",
+			Offers: []afklm.AwardOffer{
+				{Date: "2026-07-02", FlightNumber: "KL2", DepartureTime: "10:00", ArrivalTime: "12:30", Miles: 14000, TaxEUR: 31.5, Cabin: "ECONOMY", Stops: 1, Available: true},
+				{Date: "2026-07-01", FlightNumber: "KL1", DepartureTime: "08:00", ArrivalTime: "10:30", Miles: 9000, TaxEUR: 28.0, Cabin: "BUSINESS", Available: true},
+			},
+			Errors: map[string]string{"2026-07-03": "temporary upstream miss"},
+		}); err != nil {
+			t.Fatalf("printAwardTable offers: %v", err)
+		}
+	})
+	for _, want := range []string{"Flying Blue Award Scan", "KL1", "ideal", "1 stop", "Errors on 1 date", "Book at:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("award table missing %q in %q", want, out)
+		}
+	}
+
+	empty := captureStdout(t, func() {
+		if err := printAwardTable(&afklm.AwardScanResult{Errors: map[string]string{"2026-07-04": "blocked"}}); err != nil {
+			t.Fatalf("printAwardTable empty: %v", err)
+		}
+	})
+	if !strings.Contains(empty, "No award offers found") || !strings.Contains(empty, "blocked") {
+		t.Fatalf("award empty table = %q", empty)
+	}
+	if !isMonthString("2026-07") || isMonthString("2026-07-01") {
+		t.Fatal("isMonthString classification mismatch")
+	}
+}
+
+func TestOfflineForecastRenderHelpers(t *testing.T) {
+	samples := []dealquality.Sample{{Price: 100}, {Price: 125}, {Price: 150}}
+	prices := samplesToFloat64(samples)
+	if len(prices) != 3 || prices[1] != 125 {
+		t.Fatalf("prices = %#v", prices)
+	}
+	if store, err := openHistoryStore(filepath.Join(t.TempDir(), "history.json")); err != nil || store == nil {
+		t.Fatalf("openHistoryStore override = %v, %v", store, err)
+	}
+
+	if got := renderSparkline(forecast.Curve{}); got != "(no data)" {
+		t.Fatalf("empty sparkline = %q", got)
+	}
+	if got := renderSparkline(forecast.Curve{Buckets: []int{0, 0, 0}}); len([]rune(got)) != 3 {
+		t.Fatalf("zero sparkline = %q", got)
+	}
+	curve := forecast.Curve{Buckets: []int{1, 3, 2}, Min: 80, Max: 160, Threshold: 120}
+	if got := renderSparkline(curve); !strings.ContainsRune(got, '\u258f') {
+		t.Fatalf("threshold sparkline = %q", got)
+	}
+
+	insufficient := tempOutputFile(t)
+	renderForecastTable(insufficient, "HEL-CDG", "flight", "summer", 200, forecast.Forecast{
+		InsufficientData: true,
+		Reason:           "need more samples",
+	}, forecast.Curve{})
+	if out := readTempOutput(t, insufficient); !strings.Contains(out, "recommendation suppressed") {
+		t.Fatalf("insufficient forecast table = %q", out)
+	}
+
+	confident := tempOutputFile(t)
+	renderForecastTable(confident, "HEL-CDG", "flight", "summer", 200, forecast.Forecast{
+		CommitNowConfidence:   72,
+		HorizonDays:           14,
+		HorizonProbability:    0.25,
+		DropProbability:       0.12,
+		ExpectedSavingsIfWait: 18.5,
+		Samples:               40,
+		Reason:                "buy now",
+	}, curve)
+	if out := readTempOutput(t, confident); !strings.Contains(out, "Commit-now confidence: 72/100") || !strings.Contains(out, "Price distribution") {
+		t.Fatalf("confident forecast table = %q", out)
+	}
+}
+
+func TestOfflineOpportunityWatchCommands(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	oldFormat := format
+	format = "table"
+	t.Cleanup(func() { format = oldFormat })
+
+	listEmpty := executeCommandWithStdout(t, opportunitiesCmd())
+	if !strings.Contains(listEmpty, "No opportunity watches") {
+		t.Fatalf("empty opportunities output = %q", listEmpty)
+	}
+
+	created := executeCommandWithStdout(t, opportunitiesCmd(), "create", "--favourites", "prg, krk", "--min-score", "90", "--min-nights", "4", "--max-nights", "6")
+	if !strings.Contains(created, "Created opportunity watch") || !strings.Contains(created, "PRG, KRK") {
+		t.Fatalf("create opportunity output = %q", created)
+	}
+
+	listed := executeCommandWithStdout(t, opportunitiesCmd())
+	if !strings.Contains(listed, "PRG,KRK") || !strings.Contains(listed, "90") || !strings.Contains(listed, "4-6") {
+		t.Fatalf("listed opportunities output = %q", listed)
+	}
+}
+
+func TestOfflineRouteAndExplainRenderers(t *testing.T) {
+	breakdown := captureStdout(t, func() {
+		printMatchBreakdown("Option A", 88, map[string]float64{
+			"budget fit": 0.90,
+			"duration":   0.75,
+		})
+	})
+	if !strings.Contains(breakdown, "profile match breakdown") || !strings.Contains(breakdown, "budget fit") {
+		t.Fatalf("match breakdown output = %q", breakdown)
+	}
+	if empty := captureStdout(t, func() { printMatchBreakdown("empty", 0, nil) }); empty != "" {
+		t.Fatalf("empty match breakdown output = %q", empty)
+	}
+
+	noRoute := captureStderrOffline(t, func() {
+		if err := printRouteTable(context.Background(), "EUR", &models.RouteSearchResult{Success: false, Error: "no path"}); err != nil {
+			t.Fatalf("printRouteTable no-route: %v", err)
+		}
+	})
+	if !strings.Contains(noRoute, "No routes found: no path") {
+		t.Fatalf("no-route output = %q", noRoute)
+	}
+
+	routeOut := captureStdout(t, func() {
+		err := printRouteTable(context.Background(), "EUR", &models.RouteSearchResult{
+			Success:     true,
+			Origin:      "Helsinki",
+			Destination: "Amsterdam",
+			Date:        "2026-07-01",
+			Count:       1,
+			Itineraries: []models.RouteItinerary{{
+				TotalPrice:    123.4,
+				Currency:      "EUR",
+				TotalDuration: 365,
+				Transfers:     2,
+				Legs: []models.RouteLeg{
+					{Mode: "flight", Provider: "google", FromCode: "HEL", ToCode: "CPH", Departure: "2026-07-01T08:00:00", Arrival: "2026-07-01T09:30:00", Duration: 90, Price: 80, Currency: "EUR"},
+					{Mode: "train", Provider: "db", From: "Copenhagen", To: "Amsterdam", Departure: "2026-07-01T10:30:00", Arrival: "2026-07-01T15:35:00", Duration: 305, Price: 43, Currency: "EUR"},
+				},
+			}},
+		})
+		if err != nil {
+			t.Fatalf("printRouteTable success: %v", err)
+		}
+	})
+	for _, want := range []string{"Route", "Option 1", "EUR 123", "2 transfers", "flight", "train", "HEL"} {
+		if !strings.Contains(routeOut, want) {
+			t.Fatalf("route table missing %q in %q", want, routeOut)
+		}
+	}
+	if modeIcon("walk") != "walk" || formatRoutePrice(0, "EUR") != "-" {
+		t.Fatal("route helper fallback mismatch")
+	}
+}
+
+func TestOfflineSelfUpdateShortCircuits(t *testing.T) {
+	oldVersion := Version
+	oldCheckOnly := selfUpdateCheckOnly
+	oldTarget := selfUpdateTargetVersion
+	oldForce := selfUpdateForceStandalone
+	t.Cleanup(func() {
+		Version = oldVersion
+		selfUpdateCheckOnly = oldCheckOnly
+		selfUpdateTargetVersion = oldTarget
+		selfUpdateForceStandalone = oldForce
+	})
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&out)
+	Version = "dev"
+	if err := runSelfUpdate(cmd, nil); err != nil {
+		t.Fatalf("dev self-update: %v", err)
+	}
+	if !strings.Contains(out.String(), "Install method: dev") || !strings.Contains(out.String(), "no self-update available") {
+		t.Fatalf("dev self-update output = %q", out.String())
+	}
+
+	out.Reset()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	Version = "1.2.3"
+	selfUpdateForceStandalone = true
+	selfUpdateCheckOnly = true
+	selfUpdateTargetVersion = "9.9.9"
+	if err := runSelfUpdate(cmd, nil); err != nil {
+		t.Fatalf("forced check-only self-update: %v", err)
+	}
+	if !strings.Contains(out.String(), "Target version: v9.9.9") || !strings.Contains(out.String(), "--check:") {
+		t.Fatalf("check-only self-update output = %q stderr=%q", out.String(), stderr.String())
+	}
+}
+
+func tempOutputFile(t *testing.T) *os.File {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "out-*.txt")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	return f
+}
+
+func readTempOutput(t *testing.T, f *os.File) string {
+	t.Helper()
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+	data, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	return string(data)
+}
+
+func addInheritedFormatFlag(t *testing.T, cmd *cobra.Command, value string) {
+	t.Helper()
+	if cmd.Flags().Lookup("format") != nil {
+		return
+	}
+	cmd.Flags().String("format", value, "output format")
+}
+
+func executeCommandWithStdout(t *testing.T, cmd *cobra.Command, args ...string) string {
+	t.Helper()
+	return captureStdout(t, func() {
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("%s Execute: %v", cmd.Name(), err)
+		}
+	})
+}
+
+func captureStderrOffline(t *testing.T, fn func()) string {
+	t.Helper()
+	f := tempOutputFile(t)
+	defer func() { _ = f.Close() }()
+	old := os.Stderr
+	os.Stderr = f
+	defer func() { os.Stderr = old }()
+	fn()
+	return readTempOutput(t, f)
+}

--- a/cmd/trvl/offline_coverage_test.go
+++ b/cmd/trvl/offline_coverage_test.go
@@ -747,6 +747,7 @@ func tempOutputFile(t *testing.T) *os.File {
 	if err != nil {
 		t.Fatalf("CreateTemp: %v", err)
 	}
+	t.Cleanup(func() { _ = f.Close() })
 	return f
 }
 

--- a/internal/cars/search_test.go
+++ b/internal/cars/search_test.go
@@ -3,6 +3,7 @@ package cars
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -130,5 +131,66 @@ func TestSearch_SkyscannerFixtureNormalizesOffers(t *testing.T) {
 	}
 	if len(result.ProviderStatuses) != 1 || result.ProviderStatuses[0].Status != "ok" {
 		t.Fatalf("provider statuses = %#v, want ok", result.ProviderStatuses)
+	}
+}
+
+func TestPureProviderParsingHelpers(t *testing.T) {
+	if MarketedProviderCount() != 1 {
+		t.Fatalf("MarketedProviderCount = %d", MarketedProviderCount())
+	}
+	if got := MarketedProviderNames(); len(got) != 1 || got[0] != ProviderSkyscanner {
+		t.Fatalf("MarketedProviderNames = %#v", got)
+	}
+
+	providers := normalizedProviders([]string{" skyscanner, custom ", "", "other"})
+	if strings.Join(providers, "|") != "skyscanner|custom|other" {
+		t.Fatalf("normalizedProviders = %#v", providers)
+	}
+	if got := normalizedProviders(nil); len(got) != 1 || got[0] != ProviderSkyscanner {
+		t.Fatalf("default providers = %#v", got)
+	}
+	if got := normalizedProviders([]string{" , "}); len(got) != 1 || got[0] != ProviderSkyscanner {
+		t.Fatalf("blank providers = %#v", got)
+	}
+
+	status := carProviderError("x", "Provider X", errors.New("bad shape"))
+	if status.Status != "error" || status.FixHintCode != "RESPONSE_SHAPE_CHANGED" || !strings.Contains(status.Error, "bad shape") {
+		t.Fatalf("carProviderError = %#v", status)
+	}
+
+	if got, ok := parsePriceString("EUR 1,234.50"); !ok || got != 1234.50 {
+		t.Fatalf("parsePriceString = %.2f/%v", got, ok)
+	}
+	if got, ok := parsePriceString("only text"); ok || got != 0 {
+		t.Fatalf("parsePriceString text = %.2f/%v", got, ok)
+	}
+
+	floatCases := []any{float64(3.5), float32(4.5), 5, int64(6), json.Number("7.5"), "EUR 8.50"}
+	for _, tc := range floatCases {
+		if got, ok := floatValue(tc); !ok || got <= 0 {
+			t.Fatalf("floatValue(%T) = %.2f/%v", tc, got, ok)
+		}
+	}
+	if _, ok := floatValue(struct{}{}); ok {
+		t.Fatal("unsupported float value should return ok=false")
+	}
+
+	if got := firstString(map[string]any{"vehicle_name": " Golf "}, "vehicleName"); got != "Golf" {
+		t.Fatalf("firstString normalized key = %q", got)
+	}
+	if got := firstFloat(map[string]any{"price": map[string]any{"amount": "42"}}, "price.amount"); got != 42 {
+		t.Fatalf("firstFloat nested = %.2f", got)
+	}
+	if got := firstInt(map[string]any{"seats": json.Number("5")}, "seats"); got != 5 {
+		t.Fatalf("firstInt = %d", got)
+	}
+	if got, ok := firstBool(map[string]any{"free_cancel": "included"}, "freeCancel"); !ok || !got {
+		t.Fatalf("firstBool = %v/%v", got, ok)
+	}
+	if got, ok := boolValue("no"); !ok || got {
+		t.Fatalf("boolValue no = %v/%v", got, ok)
+	}
+	if _, ok := boolValue("maybe"); ok {
+		t.Fatal("boolValue maybe should be unknown")
 	}
 }

--- a/internal/flights/breaker_wire_test.go
+++ b/internal/flights/breaker_wire_test.go
@@ -60,6 +60,18 @@ func TestOutcomeFailed(t *testing.T) {
 	}
 }
 
+func resetFlightBreakerForTest(t *testing.T, keys ...string) {
+	t.Helper()
+	for _, key := range keys {
+		flightBreaker.RecordSuccess(key)
+	}
+	t.Cleanup(func() {
+		for _, key := range keys {
+			flightBreaker.RecordSuccess(key)
+		}
+	})
+}
+
 var errTest = errProbe("boom")
 
 type errProbe string

--- a/internal/flights/easyjet_test.go
+++ b/internal/flights/easyjet_test.go
@@ -150,6 +150,7 @@ func TestEasyjetSearchEligible_RequiresSharedClientAndConfig(t *testing.T) {
 // never a crash. This is the Case-C deliverable: the opt-in path is wired and
 // reports its unavailability truthfully.
 func TestSearchFlightsCore_EasyjetHonestStatusWhenUnconfigured(t *testing.T) {
+	resetFlightBreakerForTest(t, "easyjet")
 	t.Setenv("EASYJET_API_BASE", "")
 	body := makeFlightResponseBody(t)
 	ts := flightsTestServer(t, 200, body)

--- a/internal/flights/norwegian_test.go
+++ b/internal/flights/norwegian_test.go
@@ -237,6 +237,7 @@ func TestNorwegianRoundTripComposesViaSearchSingleLCC(t *testing.T) {
 // and never a crash. This is the opt-in deliverable: the path is wired and
 // reports its unavailability truthfully.
 func TestSearchFlightsCore_NorwegianHonestStatusWhenUnconfigured(t *testing.T) {
+	resetFlightBreakerForTest(t, "norwegian")
 	t.Setenv("NORWEGIAN_API_BASE", "")
 	body := makeFlightResponseBody(t)
 	ts := flightsTestServer(t, 200, body)

--- a/internal/flights/vueling_test.go
+++ b/internal/flights/vueling_test.go
@@ -151,6 +151,7 @@ func TestVuelingSearchEligible_RequiresSharedClientAndConfig(t *testing.T) {
 // never a crash. This is the opt-in deliverable: the path is wired and reports
 // its unavailability truthfully.
 func TestSearchFlightsCore_VuelingHonestStatusWhenUnconfigured(t *testing.T) {
+	resetFlightBreakerForTest(t, "vueling")
 	t.Setenv("VUELING_API_BASE", "")
 	body := makeFlightResponseBody(t)
 	ts := flightsTestServer(t, 200, body)

--- a/internal/hotelarb/hotelarb_test.go
+++ b/internal/hotelarb/hotelarb_test.go
@@ -175,3 +175,63 @@ func TestHoldStoreRoundTripsActiveHoldsJSON(t *testing.T) {
 		t.Fatalf("Path = %q, want active_holds.json under store dir", got)
 	}
 }
+
+func TestHoldStoreGetUpdateAndRemove(t *testing.T) {
+	store := NewHoldStore(t.TempDir())
+	id, err := store.Add(Hold{
+		HotelName:     "Editable Stay",
+		CheckIn:       "2026-06-01",
+		CheckOut:      "2026-06-03",
+		OriginalPrice: 240,
+		Currency:      "EUR",
+		Refundable:    true,
+	})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	hold, ok := store.Get(id)
+	if !ok {
+		t.Fatalf("Get(%q) returned false", id)
+	}
+	hold.LastSeenPrice = 210
+	if err := store.Update(hold); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	updated, ok := store.Get(id)
+	if !ok || updated.LastSeenPrice != 210 {
+		t.Fatalf("updated hold = %#v, ok=%v", updated, ok)
+	}
+
+	removed, err := store.Remove(id)
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if !removed {
+		t.Fatal("Remove returned false for existing hold")
+	}
+	if _, ok := store.Get(id); ok {
+		t.Fatal("hold still present after Remove")
+	}
+	removed, err = store.Remove(id)
+	if err != nil {
+		t.Fatalf("Remove missing: %v", err)
+	}
+	if removed {
+		t.Fatal("Remove returned true for missing hold")
+	}
+}
+
+func TestDefaultHoldStoreUsesHomeTrvlDirectory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	store, err := DefaultHoldStore()
+	if err != nil {
+		t.Fatalf("DefaultHoldStore: %v", err)
+	}
+	want := filepath.Join(home, ".trvl", "active_holds.json")
+	if got := store.Path(); got != want {
+		t.Fatalf("Path = %q, want %q", got, want)
+	}
+}

--- a/internal/hotelarb/hotelarb_test.go
+++ b/internal/hotelarb/hotelarb_test.go
@@ -225,6 +225,7 @@ func TestHoldStoreGetUpdateAndRemove(t *testing.T) {
 func TestDefaultHoldStoreUsesHomeTrvlDirectory(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 
 	store, err := DefaultHoldStore()
 	if err != nil {

--- a/internal/livecheck/livecheck_test.go
+++ b/internal/livecheck/livecheck_test.go
@@ -19,3 +19,64 @@ func TestChecker_UnsupportedType(t *testing.T) {
 		t.Errorf("price = %f, want 0 on error", price)
 	}
 }
+
+func TestChecker_FlightSpecificDateHonorsCancelledContext(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	price, currency, cheapestDate, err := Checker{}.CheckPrice(ctx, watch.Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "BCN",
+		DepartDate:  "2026-07-01",
+		Currency:    "EUR",
+	})
+	if err == nil {
+		t.Fatal("expected cancelled context error")
+	}
+	if price != 0 || currency != "" || cheapestDate != "" {
+		t.Fatalf("price/currency/date = %.2f/%q/%q, want zero values on error", price, currency, cheapestDate)
+	}
+}
+
+func TestChecker_FlightRangeWithCancelledContextReturnsNoFabricatedPrice(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	price, currency, cheapestDate, err := Checker{}.CheckPrice(ctx, watch.Watch{
+		Type:        "flight",
+		Origin:      "HEL",
+		Destination: "BCN",
+		DepartFrom:  "2026-07-01",
+		DepartTo:    "2026-07-07",
+		Currency:    "EUR",
+	})
+	// Calendar search may normalize a cancelled/empty result to nil error; the
+	// invariant here is that no price is fabricated.
+	_ = err
+	if price != 0 || currency != "" || cheapestDate != "" {
+		t.Fatalf("price/currency/date = %.2f/%q/%q, want zero values", price, currency, cheapestDate)
+	}
+}
+
+func TestChecker_HotelHonorsCancelledContext(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	price, currency, cheapestDate, err := Checker{}.CheckPrice(ctx, watch.Watch{
+		Type:        "hotel",
+		Destination: "Helsinki",
+		DepartDate:  "2026-07-01",
+		ReturnDate:  "2026-07-03",
+		Currency:    "EUR",
+	})
+	if err == nil {
+		t.Fatal("expected cancelled context error")
+	}
+	if price != 0 || currency != "" || cheapestDate != "" {
+		t.Fatalf("price/currency/date = %.2f/%q/%q, want zero values on error", price, currency, cheapestDate)
+	}
+}

--- a/internal/models/accommodation_test.go
+++ b/internal/models/accommodation_test.go
@@ -164,3 +164,99 @@ func TestEvaluateAccommodationOfferStampsVerifiedPrice(t *testing.T) {
 		t.Fatal("CheckedAt = zero, want stamped for a verified price")
 	}
 }
+
+func TestAccommodationPriceTrustHelpers(t *testing.T) {
+	if HotelPriceEligibleForFinalTripCost(HotelResult{Price: 0}) {
+		t.Fatal("zero hotel price should not be final-trip eligible")
+	}
+	if !HotelPriceEligibleForFinalTripCost(HotelResult{Price: 120}) {
+		t.Fatal("legacy hotel price with no trust fields should remain eligible")
+	}
+	if HotelPriceEligibleForFinalTripCost(HotelResult{Price: 120, PriceBasis: PriceBasisLeadIn}) {
+		t.Fatal("lead-in hotel price should not be final-trip eligible")
+	}
+	if HotelPriceEligibleForFinalTripCost(HotelResult{Price: 120, PriceBasis: PriceBasisRoomTotal, PriceConfidence: PriceConfidenceUnverified}) {
+		t.Fatal("unverified hotel price should not be final-trip eligible")
+	}
+	if !HotelPriceEligibleForFinalTripCost(HotelResult{Price: 120, PriceBasis: PriceBasisTaxInclusiveTotal, PriceConfidence: PriceConfidenceVerified}) {
+		t.Fatal("verified tax-inclusive hotel price should be final-trip eligible")
+	}
+	if HotelPriceEligibleForFinalTripCost(HotelResult{Price: 120, PriceBasis: "unknown", PriceConfidence: PriceConfidenceVerified}) {
+		t.Fatal("unknown hotel price basis should not be final-trip eligible")
+	}
+
+	if comparableAccommodationPrice(AccommodationOffer{TotalPrice: 300, NightlyPrice: 100}) != 300 {
+		t.Fatal("total accommodation price should win")
+	}
+	if comparableAccommodationPrice(AccommodationOffer{NightlyPrice: 100}) != 100 {
+		t.Fatal("nightly accommodation price should be fallback")
+	}
+	if !needsWholeUnitEvidence(AccommodationTypeEntireApartment) || !needsWholeUnitEvidence(AccommodationTypeVilla) {
+		t.Fatal("whole-unit accommodation types should need whole-unit evidence")
+	}
+	if needsWholeUnitEvidence(AccommodationTypeHotelRoom) {
+		t.Fatal("hotel rooms should not need whole-unit evidence")
+	}
+}
+
+func TestHotelPriceTrustFallsBackToMostRepresentedCurrency(t *testing.T) {
+	now := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	hotel := HotelResult{
+		Name: "Currency Mix",
+		Sources: []PriceSource{
+			{Provider: "a", Price: 140, Currency: "USD", PriceBasis: PriceBasisRoomTotal, PriceConfidence: PriceConfidenceRoomLevel},
+			{Provider: "b", Price: 110, Currency: "EUR", PriceBasis: PriceBasisRoomTotal, PriceConfidence: PriceConfidenceVerified},
+			{Provider: "c", Price: 120, Currency: "USD", PriceBasis: PriceBasisRoomTotal, PriceConfidence: PriceConfidenceVerified},
+			{Provider: "ignored", Price: 0, Currency: "GBP"},
+		},
+	}
+
+	FinalizeHotelResultPriceTrust(&hotel, "JPY", now)
+	if hotel.Currency != "USD" || hotel.Price != 120 || hotel.PriceConfidence != PriceConfidenceVerified {
+		t.Fatalf("selected headline = %.0f %s/%s", hotel.Price, hotel.Currency, hotel.PriceConfidence)
+	}
+	if !containsString(hotel.PriceWarnings, PriceWarningMixedSourceCurrencies) {
+		t.Fatalf("PriceWarnings = %v, want mixed-currency warning", hotel.PriceWarnings)
+	}
+}
+
+func TestModelPureRankingAndConfidenceHelpers(t *testing.T) {
+	c := Confidence{Rated: true, Score: 1.2}
+	if c.Percent() != 100 {
+		t.Fatalf("Percent high clamp = %d", c.Percent())
+	}
+	c.Score = -0.2
+	if c.Percent() != 0 {
+		t.Fatalf("Percent low clamp = %d", c.Percent())
+	}
+	if got := (Confidence{}).Percent(); got != 0 {
+		t.Fatalf("unrated Percent = %d", got)
+	}
+	if unrated := UnratedConfidence("no signal"); unrated.Rated || unrated.Label != ConfidenceUnrated || unrated.Basis != "no signal" {
+		t.Fatalf("UnratedConfidence = %#v", unrated)
+	}
+
+	if got := (FlightResult{Price: 200, ComparablePrice: 180}).PriceForRanking(); got != 180 {
+		t.Fatalf("PriceForRanking comparable = %.0f", got)
+	}
+	if got := (FlightResult{Price: 200}).PriceForRanking(); got != 200 {
+		t.Fatalf("PriceForRanking base = %.0f", got)
+	}
+	if !(FlightResult{Sources: []PriceSource{{Freshness: FreshnessStale}}}).HasStalePrice() {
+		t.Fatal("stale source should mark flight stale")
+	}
+	if (FlightResult{Sources: []PriceSource{{Freshness: FreshnessLive}}}).HasStalePrice() {
+		t.Fatal("live source should not mark flight stale")
+	}
+
+	flights := []FlightResult{{Price: 0}, {Price: 300}, {Price: 120}}
+	SortFlightsByPrice(flights)
+	if flights[0].Price != 120 || flights[1].Price != 300 || flights[2].Price != 0 {
+		t.Fatalf("SortFlightsByPrice = %#v", flights)
+	}
+
+	parsed, err := ParseDate("2026-07-01")
+	if err != nil || parsed.Format("2006-01-02") != "2026-07-01" {
+		t.Fatalf("ParseDate = %v/%v", parsed, err)
+	}
+}

--- a/internal/multimodal/composer_test.go
+++ b/internal/multimodal/composer_test.go
@@ -269,3 +269,120 @@ func TestLegSpecsForRoute_SingleModeNoLegs(t *testing.T) {
 		t.Errorf("single-mode route should yield one end-to-end leg, got %+v", specs)
 	}
 }
+
+func TestProductionSeamsAndPurePickers(t *testing.T) {
+	planner := NewPlanner(true)
+	if planner.Discover == nil || planner.Price == nil || planner.Hacks == nil || !planner.AllowBrowser {
+		t.Fatalf("NewPlanner did not wire production seams: %#v", planner)
+	}
+
+	pricer := productionLegPricer(false)
+	if _, ok := pricer(context.Background(), LegSpec{Mode: "drive", From: "A", To: "B"}); ok {
+		t.Fatal("drive legs should not be treated as bookable provider fares")
+	}
+	if _, ok := pricer(context.Background(), LegSpec{Mode: "walk", From: "A", To: "B"}); ok {
+		t.Fatal("walk legs should not be treated as bookable provider fares")
+	}
+	if _, ok := pricer(context.Background(), LegSpec{Mode: "fly", From: "Unknownville", To: "Nowhere"}); ok {
+		t.Fatal("unresolvable flight endpoints should be unpriced")
+	}
+	if _, ok := pricer(context.Background(), LegSpec{Mode: "train", From: "", To: "Paris"}); ok {
+		t.Fatal("ground legs with missing endpoints should be unpriced")
+	}
+
+	if code, ok := resolveAirport("hel"); !ok || code != "HEL" {
+		t.Fatalf("resolveAirport IATA = %q/%v", code, ok)
+	}
+	if code, ok := resolveAirport("Helsinki"); !ok || code != "HEL" {
+		t.Fatalf("resolveAirport city = %q/%v", code, ok)
+	}
+	if _, ok := resolveAirport("Unknownville"); ok {
+		t.Fatal("unknown city should not resolve to an airport")
+	}
+
+	bestFlight, ok := cheapestFlight([]models.FlightResult{
+		{Price: 0, Currency: "EUR"},
+		{Price: 200, Currency: ""},
+		{Price: 300, ComparablePrice: 180, Currency: "EUR", Provider: "google"},
+		{Price: 190, Currency: "EUR", Provider: "kiwi"},
+	})
+	if !ok || bestFlight.Provider != "google" {
+		t.Fatalf("cheapestFlight = %#v/%v", bestFlight, ok)
+	}
+	if _, ok := cheapestFlight([]models.FlightResult{{Price: 0, Currency: "EUR"}}); ok {
+		t.Fatal("empty priced flight set should not produce a cheapest flight")
+	}
+
+	bestRoute, ok := cheapestRoute([]models.GroundRoute{
+		{Price: 0, Currency: "EUR"},
+		{Price: 40, Currency: ""},
+		{Price: 55, Currency: "EUR", Provider: "flixbus"},
+		{Price: 45, Currency: "EUR", Provider: "sncf"},
+	})
+	if !ok || bestRoute.Provider != "sncf" {
+		t.Fatalf("cheapestRoute = %#v/%v", bestRoute, ok)
+	}
+	if _, ok := cheapestRoute([]models.GroundRoute{{Price: 0, Currency: "EUR"}}); ok {
+		t.Fatal("empty priced route set should not produce a cheapest route")
+	}
+
+	if got := flightProvider(models.FlightResult{}); got != "flights" {
+		t.Fatalf("flightProvider default = %q", got)
+	}
+	if got := flightProvider(models.FlightResult{Provider: "kiwi"}); got != "kiwi" {
+		t.Fatalf("flightProvider explicit = %q", got)
+	}
+}
+
+func TestBoundRoutesAndIntegerFormatting(t *testing.T) {
+	routes := make([]models.GroundRoute, 0, 12)
+	for i := 0; i < 12; i++ {
+		price := float64(200 - i)
+		if i == 0 {
+			price = 0
+		}
+		routes = append(routes, models.GroundRoute{Price: price})
+	}
+	bounded := boundRoutes(routes)
+	if len(bounded) != maxRoutesPriced {
+		t.Fatalf("bounded len = %d, want %d", len(bounded), maxRoutesPriced)
+	}
+	for i := 1; i < len(bounded); i++ {
+		if indicativeSortKey(bounded[i-1]) > indicativeSortKey(bounded[i]) {
+			t.Fatalf("routes not sorted by indicative price: %#v", bounded)
+		}
+	}
+	if got := itoa(0); got != "0" {
+		t.Fatalf("itoa(0) = %q", got)
+	}
+	if got := itoa(-42); got != "-42" {
+		t.Fatalf("itoa(-42) = %q", got)
+	}
+	if got := itoa(12345); got != "12345" {
+		t.Fatalf("itoa(12345) = %q", got)
+	}
+}
+
+func TestPlan_BoundsLargeDiscoverySet(t *testing.T) {
+	routes := make([]models.GroundRoute, 0, 12)
+	for i := 0; i < 12; i++ {
+		r := route2("bus", "Hub", "train", "Helsinki", "London", float64(100+i), "EUR")
+		r.BookingURL = itoa(i)
+		routes = append(routes, r)
+	}
+	p := plannerWith(discoverFixed(routes...), fakePricer{
+		"bus":   {Price: 10, Currency: "EUR"},
+		"train": {Price: 20, Currency: "EUR"},
+	}.price)
+
+	plan, err := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if plan.Discovered != 12 || plan.Priced != maxRoutesPriced {
+		t.Fatalf("discovered/priced = %d/%d", plan.Discovered, plan.Priced)
+	}
+	if len(plan.Notes) == 0 {
+		t.Fatalf("expected truncation note for large discovery set")
+	}
+}

--- a/mcp/coverage_boost2_test.go
+++ b/mcp/coverage_boost2_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/hacks"
 	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/testutil"
 )
 
 // Test helper constructors for option types.
@@ -213,9 +214,7 @@ func TestHandleDetectTravelHacks_MissingOrigin(t *testing.T) {
 
 func TestHandleDetectTravelHacks_DefaultCurrency(t *testing.T) {
 	t.Parallel()
-	if testing.Short() {
-		t.Skip("skipping live HTTP test in short mode")
-	}
+	testutil.RequireLiveIntegration(t)
 	content, result, err := handleDetectTravelHacks(context.Background(), map[string]any{
 		"origin": "HEL", "destination": "PRG", "date": "2026-07-01",
 	}, nil, nil, nil)

--- a/mcp/server_extra_test.go
+++ b/mcp/server_extra_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/testutil"
 )
 
 // --- HTTP handler tests ---
@@ -240,9 +242,7 @@ func TestHTTPHandler_POST_ToolsList(t *testing.T) {
 
 func TestHTTPHandler_POST_ToolsCall(t *testing.T) {
 	t.Parallel()
-	if testing.Short() {
-		t.Skip("skipping live HTTP test in short mode")
-	}
+	testutil.RequireLiveIntegration(t)
 	hs := NewHTTPServer(0)
 
 	params := ToolCallParams{
@@ -503,9 +503,7 @@ func TestHTTPHandler_LargePayload(t *testing.T) {
 
 func TestAllToolHandlers(t *testing.T) {
 	t.Parallel()
-	if testing.Short() {
-		t.Skip("skipping live HTTP test in short mode")
-	}
+	testutil.RequireLiveIntegration(t)
 	handlers := []struct {
 		name     string
 		args     map[string]any

--- a/mcp/tools_workspace_test.go
+++ b/mcp/tools_workspace_test.go
@@ -102,3 +102,172 @@ func TestTravelRoutesWorkspaceActionToTripWorkspace(t *testing.T) {
 		t.Fatalf("intent = %q", routed.Intent)
 	}
 }
+
+func TestTripWorkspaceGetExportImportAndReadiness(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	_, created, err := handleCreateTrip(context.Background(), map[string]any{"name": "Workspace"}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create trip: %v", err)
+	}
+	tripID := created.(map[string]string)["id"]
+
+	_, saved, err := handleTripWorkspace(context.Background(), map[string]any{
+		"action":     "save_candidate",
+		"trip_id":    tripID,
+		"type":       "hotel",
+		"title":      "Central stay",
+		"provider":   "Google Hotels",
+		"price":      120.0,
+		"currency":   "EUR",
+		"url":        "https://example.com/hotel",
+		"checked_at": time.Now().Format(time.RFC3339),
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("save candidate: %v", err)
+	}
+	candidate := saved.(map[string]any)["candidate"].(trips.BookingCandidate)
+
+	_, gotStructured, err := handleTripWorkspace(context.Background(), map[string]any{
+		"action":  "get",
+		"trip_id": tripID,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+	gotTrip := gotStructured.(*trips.Trip)
+	if gotTrip.ID != tripID || len(gotTrip.Workspace.Candidates) != 1 {
+		t.Fatalf("workspace trip = %#v", gotTrip)
+	}
+
+	_, readinessStructured, err := handleTripWorkspace(context.Background(), map[string]any{
+		"action":       "booking_ready",
+		"trip_id":      tripID,
+		"candidate_id": candidate.ID,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("booking readiness: %v", err)
+	}
+	readiness := readinessStructured.(map[string]any)
+	if ready, _ := readiness["ready"].(bool); !ready {
+		t.Fatalf("readiness = %#v, want ready", readiness)
+	}
+
+	_, exportedStructured, err := handleTripWorkspace(context.Background(), map[string]any{
+		"action":  "export_json",
+		"trip_id": tripID,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("export json: %v", err)
+	}
+	exported := exportedStructured.(map[string]any)
+	rawJSON := exported["content"].(string)
+	if !strings.Contains(rawJSON, "Central stay") {
+		t.Fatalf("exported json missing candidate: %s", rawJSON)
+	}
+
+	_, markdownStructured, err := handleTripWorkspace(context.Background(), map[string]any{
+		"action":  "export_markdown",
+		"trip_id": tripID,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("export markdown: %v", err)
+	}
+	if !strings.Contains(markdownStructured.(map[string]any)["content"].(string), "Workspace") {
+		t.Fatalf("markdown export = %#v", markdownStructured)
+	}
+
+	_, importedStructured, err := handleTripWorkspace(context.Background(), map[string]any{
+		"action": "import_json",
+		"json":   rawJSON,
+		"name":   "Imported workspace",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("import json new trip: %v", err)
+	}
+	imported := importedStructured.(map[string]any)
+	if imported["trip_id"].(string) == "" {
+		t.Fatalf("imported = %#v", imported)
+	}
+
+	_, mergedStructured, err := handleTripWorkspace(context.Background(), map[string]any{
+		"action":  "import_json",
+		"trip_id": tripID,
+		"json":    rawJSON,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("import json merge: %v", err)
+	}
+	if mergedStructured.(map[string]any)["trip_id"].(string) != tripID {
+		t.Fatalf("merged = %#v", mergedStructured)
+	}
+}
+
+func TestTripWorkspaceReadinessReportsBlockersAndMissingCandidate(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	_, created, err := handleCreateTrip(context.Background(), map[string]any{"name": "Blocked candidate"}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create trip: %v", err)
+	}
+	tripID := created.(map[string]string)["id"]
+
+	_, _, err = handleTripWorkspace(context.Background(), map[string]any{
+		"action":  "save_candidate",
+		"trip_id": tripID,
+		"type":    "flight",
+		"title":   "Unpriced option",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("save incomplete candidate: %v", err)
+	}
+
+	_, structured, err := handleTripWorkspace(context.Background(), map[string]any{
+		"action":  "booking_ready",
+		"trip_id": tripID,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("booking readiness: %v", err)
+	}
+	result := structured.(map[string]any)
+	if ready, _ := result["ready"].(bool); ready {
+		t.Fatalf("readiness = %#v, want blockers", result)
+	}
+	if blockers := result["blockers"].([]string); len(blockers) < 2 {
+		t.Fatalf("blockers = %#v, want missing URL and price", blockers)
+	}
+
+	_, _, err = handleTripWorkspace(context.Background(), map[string]any{
+		"action":       "booking_ready",
+		"trip_id":      tripID,
+		"candidate_id": "missing",
+	}, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected missing candidate error")
+	}
+}
+
+func TestTripWorkspaceOptimizeItinerary(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	_, created, err := handleCreateTrip(context.Background(), map[string]any{"name": "Itinerary"}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create trip: %v", err)
+	}
+	tripID := created.(map[string]string)["id"]
+
+	_, structured, err := handleTripWorkspace(context.Background(), map[string]any{
+		"action":            "optimize_itinerary",
+		"trip_id":           tripID,
+		"max_route_minutes": 90,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("optimize itinerary: %v", err)
+	}
+	if structured == nil {
+		t.Fatal("expected optimization result")
+	}
+}

--- a/mcp/validation_helpers_test.go
+++ b/mcp/validation_helpers_test.go
@@ -127,3 +127,37 @@ func TestValidateOriginDest_CityNames(t *testing.T) {
 		t.Errorf("dest = %q, want HND (first airport for Tokyo alphabetically)", dest)
 	}
 }
+
+func TestValidateAirportListAndResolveLocationVariants(t *testing.T) {
+	t.Parallel()
+
+	list, err := validateAirportList(" hel, london ")
+	if err != nil {
+		t.Fatalf("validateAirportList city list: %v", err)
+	}
+	if !strings.HasPrefix(list, "HEL,") {
+		t.Fatalf("list = %q, want HEL first", list)
+	}
+
+	primary, err := resolvePrimaryAirport("London")
+	if err != nil {
+		t.Fatalf("resolvePrimaryAirport London: %v", err)
+	}
+	if primary == "" || len(primary) != 3 {
+		t.Fatalf("primary = %q, want IATA code", primary)
+	}
+
+	if got := resolveMCPLocation("hel"); got != "HEL" {
+		t.Fatalf("resolveMCPLocation IATA = %q", got)
+	}
+	if got := resolveMCPLocation("Tokyo"); got != "HND" {
+		t.Fatalf("resolveMCPLocation Tokyo = %q, want HND", got)
+	}
+	if got := resolveMCPLocation("not-an-airport"); got != "NOT-AN-AIRPORT" {
+		t.Fatalf("resolveMCPLocation unknown = %q", got)
+	}
+
+	if _, err := validateAirportList("not-an-airport"); err == nil {
+		t.Fatal("expected invalid airport list error")
+	}
+}


### PR DESCRIPTION
## Summary
- raise CI coverage enforcement to the canonical 80% floor
- update stale Go/coverage docs to Go 1.26.4 and 80% coverage
- add deterministic offline tests across CLI, MCP, and shared helper paths
- keep live integrations opt-in and isolate flight breaker state in provider-status tests

## Validation
- go test ./cmd/trvl ./internal/flights ./mcp -run 'TestOffline|TestSearchFlightsCore_(Easyjet|Norwegian|Vueling)HonestStatusWhenUnconfigured|TestTripWorkspace|TestValidateAirportListAndResolveLocationVariants|TestHTTPHandler_POST_ToolsCall|TestAllToolHandlers$|TestHandleDetectTravelHacks_DefaultCurrency|TestFlightsCmd_HomeOriginResolves' -count=1 -v\n- go test -p=1 -race -coverprofile /tmp/trvl-race-cover-postrebase.out ./...\n- go tool cover total: 80.5%; raw 36574/45461 = 80.4514%\n- go vet ./...\n- staticcheck ./...\n- golangci-lint run ./...\n- govulncheck ./...\n- make repo-hygiene\n- gofmt -l touched Go files: empty\n- git diff --check HEAD\n- GitNexus detect-changes: no uncommitted changes detected\n\n## Notes\n- CodeRabbit not used: no license available.\n- Live probes not run; default tests remain offline and deterministic.\n- CHANGELOG.md remains the allowlisted >800 LOC exception.\n\n## KPI Impact\n- Raises default quality gate from 75% CI coverage enforcement to the canonical 80% Standard coverage floor.\n- Reduces regression risk around live-test gating and shared flight breaker state.