### PR TITLE
test(flights): make live provider probes a trustworthy drift alarm

### DIFF
--- a/.github/workflows/live-probes.yml
+++ b/.github/workflows/live-probes.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   live-probes:
@@ -29,3 +30,34 @@ jobs:
         # -run Probe selects every *_probe_test.go test across the module; the
         # env gate flips them from skipped to live.
         run: TRVL_TEST_LIVE_PROBES=1 go test -count=1 -run Probe ./...
+      - name: Open drift alert on failure
+        # A scheduled red run nobody watches is not visibility. On a probe
+        # failure (only on the scheduled run, not manual dispatch), open or
+        # refresh a single tracking issue so provider drift surfaces actively.
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const title = 'Live provider probe failure (wire-format drift)';
+            const body = [
+              'A scheduled live provider probe failed. This usually means a provider',
+              'rotated its wire format (the MIK-6531 class) and a production-shaped',
+              'request now returns an error or stopped filtering.',
+              '',
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n');
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'provider-drift',
+            });
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: existing.data[0].number, body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['provider-drift'],
+              });
+            }

--- a/internal/flights/advanced_probe_test.go
+++ b/internal/flights/advanced_probe_test.go
@@ -70,11 +70,11 @@ func testCheckedBagsBudgetRoute(t *testing.T, client *batchexec.Client) {
 	}
 
 	probes := []filterProbe{
-		{"[0,0]_baseline", []any{0, 0}},
-		{"[1,0]_carryon", []any{1, 0}},
-		{"[1,1]_carry+check", []any{1, 1}},
-		{"[0,1]_checked_only", []any{0, 1}},
-		{"[0,2]_2checked", []any{0, 2}},
+		{name: "[0,0]_baseline", value: []any{0, 0}, expectOK: true},
+		{name: "[1,0]_carryon", value: []any{1, 0}, expectOK: true},
+		{name: "[1,1]_carry+check", value: []any{1, 1}, expectOK: true},
+		{name: "[0,1]_checked_only", value: []any{0, 1}, expectOK: true},
+		{name: "[0,2]_2checked", value: []any{0, 2}, expectOK: true},
 	}
 
 	results := make([]probeResult, len(probes))
@@ -111,6 +111,7 @@ func testCheckedBagsBudgetRoute(t *testing.T, client *batchexec.Client) {
 				status:   status,
 				count:    count,
 				bodySize: len(body),
+				expectOK: p.expectOK,
 			}
 			t.Logf("%-20s  status=%d  flights=%d  body=%d bytes",
 				p.name, status, count, len(body))
@@ -196,11 +197,11 @@ func testAllianceVariants(t *testing.T, client *batchexec.Client) {
 	}
 
 	probes := []filterProbe{
-		{"nil_baseline", nil},
-		{"ONEWORLD", []any{"ONEWORLD"}},
-		{"SKYTEAM", []any{"SKYTEAM"}},
-		{"STAR_ALLIANCE", []any{"STAR_ALLIANCE"}},
-		{"STAR+ONEWORLD", []any{"STAR_ALLIANCE", "ONEWORLD"}},
+		{name: "nil_baseline", value: nil, expectOK: true},
+		{name: "ONEWORLD", value: []any{"ONEWORLD"}, expectOK: true},
+		{name: "SKYTEAM", value: []any{"SKYTEAM"}, expectOK: true},
+		{name: "STAR_ALLIANCE", value: []any{"STAR_ALLIANCE"}, expectOK: true},
+		{name: "STAR+ONEWORLD", value: []any{"STAR_ALLIANCE", "ONEWORLD"}, expectOK: true},
 	}
 
 	results := make([]probeResult, len(probes))
@@ -237,6 +238,7 @@ func testAllianceVariants(t *testing.T, client *batchexec.Client) {
 				status:   status,
 				count:    count,
 				bodySize: len(body),
+				expectOK: p.expectOK,
 			}
 			t.Logf("%-20s  status=%d  flights=%d  body=%d bytes",
 				p.name, status, count, len(body))

--- a/internal/flights/alliance_codes_probe_test.go
+++ b/internal/flights/alliance_codes_probe_test.go
@@ -55,12 +55,12 @@ func TestAllianceCodes(t *testing.T) {
 	// ---- Part 1: Numeric codes at segment[5] ----
 	t.Run("NumericCodes", func(t *testing.T) {
 		probes := []filterProbe{
-			{"int_1", []any{1}},
-			{"int_2", []any{2}},
-			{"int_3", []any{3}},
-			{"str_1", []any{"1"}},
-			{"str_2", []any{"2"}},
-			{"str_3", []any{"3"}},
+			{name: "int_1", value: []any{1}},
+			{name: "int_2", value: []any{2}},
+			{name: "int_3", value: []any{3}},
+			{name: "str_1", value: []any{"1"}},
+			{name: "str_2", value: []any{"2"}},
+			{name: "str_3", value: []any{"3"}},
 		}
 		results := runSegmentProbes(t, client, origin, dest, date, baseOpts, 5, probes)
 
@@ -86,9 +86,9 @@ func TestAllianceCodes(t *testing.T) {
 	// ---- Part 2: Known string codes for reference ----
 	t.Run("StringCodes", func(t *testing.T) {
 		probes := []filterProbe{
-			{"STAR_ALLIANCE", []any{"STAR_ALLIANCE"}},
-			{"ONEWORLD", []any{"ONEWORLD"}},
-			{"SKYTEAM", []any{"SKYTEAM"}},
+			{name: "STAR_ALLIANCE", value: []any{"STAR_ALLIANCE"}, expectOK: true},
+			{name: "ONEWORLD", value: []any{"ONEWORLD"}, expectOK: true},
+			{name: "SKYTEAM", value: []any{"SKYTEAM"}, expectOK: true},
 		}
 		results := runSegmentProbes(t, client, origin, dest, date, baseOpts, 5, probes)
 
@@ -107,10 +107,10 @@ func TestAllianceCodes(t *testing.T) {
 	// ---- Part 3: Multi-alliance AND vs OR ----
 	t.Run("MultiAlliance", func(t *testing.T) {
 		probes := []filterProbe{
-			{"SA+OW_combined", []any{"STAR_ALLIANCE", "ONEWORLD"}},
-			{"SA+ST_combined", []any{"STAR_ALLIANCE", "SKYTEAM"}},
-			{"OW+ST_combined", []any{"ONEWORLD", "SKYTEAM"}},
-			{"all_three", []any{"STAR_ALLIANCE", "ONEWORLD", "SKYTEAM"}},
+			{name: "SA+OW_combined", value: []any{"STAR_ALLIANCE", "ONEWORLD"}, expectOK: true},
+			{name: "SA+ST_combined", value: []any{"STAR_ALLIANCE", "SKYTEAM"}, expectOK: true},
+			{name: "OW+ST_combined", value: []any{"ONEWORLD", "SKYTEAM"}, expectOK: true},
+			{name: "all_three", value: []any{"STAR_ALLIANCE", "ONEWORLD", "SKYTEAM"}, expectOK: true},
 		}
 		results := runSegmentProbes(t, client, origin, dest, date, baseOpts, 5, probes)
 
@@ -139,10 +139,10 @@ func TestAllianceCodes(t *testing.T) {
 	// ---- Part 4: Case sensitivity ----
 	t.Run("CaseSensitivity", func(t *testing.T) {
 		probes := []filterProbe{
-			{"STAR_ALLIANCE_upper", []any{"STAR_ALLIANCE"}},
-			{"star_alliance_lower", []any{"star_alliance"}},
-			{"Star_Alliance_mixed", []any{"Star_Alliance"}},
-			{"StarAlliance_nounderscore", []any{"StarAlliance"}},
+			{name: "STAR_ALLIANCE_upper", value: []any{"STAR_ALLIANCE"}, expectOK: true},
+			{name: "star_alliance_lower", value: []any{"star_alliance"}},
+			{name: "Star_Alliance_mixed", value: []any{"Star_Alliance"}},
+			{name: "StarAlliance_nounderscore", value: []any{"StarAlliance"}},
 		}
 		results := runSegmentProbes(t, client, origin, dest, date, baseOpts, 5, probes)
 

--- a/internal/flights/alliance_probe_test.go
+++ b/internal/flights/alliance_probe_test.go
@@ -58,10 +58,10 @@ func TestAllianceProbe(t *testing.T) {
 
 	// Alliance value formats to try at each position.
 	formats := []filterProbe{
-		{"str_STAR_ALLIANCE", []any{"STAR_ALLIANCE"}},
-		{"int_1", []any{1}},
-		{"scalar_1", 1},
-		{"nested_str", []any{[]any{"STAR_ALLIANCE"}}},
+		{name: "str_STAR_ALLIANCE", value: []any{"STAR_ALLIANCE"}},
+		{name: "int_1", value: []any{1}},
+		{name: "scalar_1", value: 1},
+		{name: "nested_str", value: []any{[]any{"STAR_ALLIANCE"}}},
 	}
 
 	// ---- Part 1: Settings positions (outer[1][pos]) ----
@@ -93,14 +93,14 @@ func TestAllianceProbe(t *testing.T) {
 	// ---- Part 3: Extra formats at pos 25 (wider exploration) ----
 	t.Run("Settings_pos25_extra", func(t *testing.T) {
 		extraFormats := []filterProbe{
-			{"int_2_skyteam", []any{2}},
-			{"int_3_oneworld", []any{3}},
-			{"nested_int", []any{[]any{1}}},
-			{"str_lowercase", []any{"star_alliance"}},
-			{"str_StarAlliance", []any{"StarAlliance"}},
-			{"double_nested", []any{[]any{[]any{"STAR_ALLIANCE"}}}},
-			{"str_with_nil", []any{"STAR_ALLIANCE", nil}},
-			{"int_pair", []any{1, nil}},
+			{name: "int_2_skyteam", value: []any{2}},
+			{name: "int_3_oneworld", value: []any{3}},
+			{name: "nested_int", value: []any{[]any{1}}},
+			{name: "str_lowercase", value: []any{"star_alliance"}},
+			{name: "str_StarAlliance", value: []any{"StarAlliance"}},
+			{name: "double_nested", value: []any{[]any{[]any{"STAR_ALLIANCE"}}}},
+			{name: "str_with_nil", value: []any{"STAR_ALLIANCE", nil}},
+			{name: "int_pair", value: []any{1, nil}},
 		}
 		results := runSettingsProbes(t, client, "HEL", "LHR", searchDate, baseOpts, 25, extraFormats)
 		analyzeAllianceResults(t, "settings[25]_extra", baseline, results)

--- a/internal/flights/filters_probe_test.go
+++ b/internal/flights/filters_probe_test.go
@@ -18,12 +18,14 @@ import (
 // Positions tested:
 //
 //	segment[2]   departure time window [startHour, endHour]
-//	segment[13]  emissions filter (1 = less emissions only)
-//	outer[1][25] alliance filter (["STAR_ALLIANCE"], ["ONEWORLD"], etc.)
+//	segment[5]   alliance filter (["STAR_ALLIANCE"], etc.) -- PRODUCTION position
+//	segment[13]  emissions filter ([]any{1} = less emissions only)
+//	outer[1][25] alliance filter -- ABANDONED, returns 400 (kept as exploration)
 //
 // For each filter we send: nil (baseline) and one or more constrained values.
 // If the constrained value returns fewer flights than nil, the filter works.
-// If any probe returns HTTP 400, the wire format is wrong.
+// A 400 on a production-shaped probe (expectOK) is a drift alarm: Google changed
+// the wire format. A 400 on an exploratory probe is expected and only logged.
 func TestFiltersProbe(t *testing.T) {
 	testutil.RequireLiveProbe(t)
 
@@ -51,60 +53,73 @@ func TestFiltersProbe(t *testing.T) {
 		}
 	}
 
-	// ---- Departure Time ----
+	// ---- Departure Time (segment[2]) ----
 	t.Run("DepartureTime", func(t *testing.T) {
 		probes := []filterProbe{
-			{"nil", nil},
-			{"[6,12]_morning", []any{6, 12}},
-			{"[18,24]_evening", []any{18, 24}},
-			{"[0,6]_redeye", []any{0, 6}},
-			{"[12,18]_afternoon", []any{12, 18}},
+			{name: "nil", value: nil, expectOK: true},
+			{name: "[6,12]_morning", value: []any{6, 12}, expectOK: true},
+			{name: "[18,24]_evening", value: []any{18, 24}, expectOK: true},
+			{name: "[0,6]_redeye", value: []any{0, 6}, expectOK: true},
+			{name: "[12,18]_afternoon", value: []any{12, 18}, expectOK: true},
 		}
 		results := runSegmentProbes(t, client, "HEL", "LHR", searchDate, baseOpts, 2, probes)
 		analyzeResults(t, "DEPART_TIME", results)
 	})
 
 	// ---- Emissions (segment[13]) ----
-	// Scalar 1 returns 400. Probe alternative wire formats.
+	// Production ships []any{1} here (see emissionsFilter). Scalar 1 returns 400
+	// and is kept only as an exploratory probe documenting why.
 	t.Run("Emissions", func(t *testing.T) {
 		probes := []filterProbe{
-			{"nil", nil},
-			{"1_scalar", 1},
-			{"[1]_array", []any{1}},
-			{"true", true},
-			{"[1,nil]", []any{1, nil}},
-			{"[nil,1]", []any{nil, 1}},
+			{name: "nil", value: nil, expectOK: true},
+			{name: "[1]_array_PROD", value: []any{1}, expectOK: true}, // production wire format
+			{name: "1_scalar", value: 1},                              // exploratory: known 400
+			{name: "true", value: true},                               // exploratory
+			{name: "[1,nil]", value: []any{1, nil}},                   // exploratory
+			{name: "[nil,1]", value: []any{nil, 1}},                   // exploratory
 		}
 		results := runSegmentProbes(t, client, "HEL", "LHR", searchDate, baseOpts, 13, probes)
 		analyzeResults(t, "EMISSIONS_seg13", results)
 	})
 
-	// ---- Emissions at segment[14] (maybe off-by-one?) ----
+	// ---- Emissions at segment[14] (exploratory off-by-one check) ----
+	// Position 14 is currently hardcoded to 3 in buildSegment; these probes are
+	// pure exploration, not a production format, so none assert.
 	t.Run("Emissions_pos14", func(t *testing.T) {
 		probes := []filterProbe{
-			{"nil", nil},
-			{"1_scalar", 1},
-			{"[1]_array", []any{1}},
+			{name: "nil", value: nil},
+			{name: "1_scalar", value: 1},
+			{name: "[1]_array", value: []any{1}},
 		}
-		// Position 14 is currently hardcoded to 3 in buildSegment.
-		// Probe with emissions values there instead.
 		results := runSegmentProbes(t, client, "HEL", "LHR", searchDate, baseOpts, 14, probes)
 		analyzeResults(t, "EMISSIONS_seg14", results)
 	})
 
-	// ---- Alliance (outer[1][25]) ----
-	// String arrays return 400. Probe alternative formats.
-	t.Run("Alliance", func(t *testing.T) {
+	// ---- Alliance (segment[5], PRODUCTION position) ----
+	// Production moved the alliance filter off the abandoned outer[1][25] slot to
+	// segment[5] with an uppercased string array (see alliancesFilter +
+	// search_filters.go). This probe verifies that live format still works -- a
+	// 400 here is the drift alarm MIK-6531 was about.
+	t.Run("Alliance_seg5", func(t *testing.T) {
 		probes := []filterProbe{
-			{"nil", nil},
-			{"str_STAR_ALLIANCE", []any{"STAR_ALLIANCE"}},
-			{"int_1", []any{1}},                           // maybe integer codes?
-			{"int_2", []any{2}},                           // ONEWORLD as int?
-			{"int_3", []any{3}},                           // SKYTEAM as int?
-			{"nested_str", []any{[]any{"STAR_ALLIANCE"}}}, // nested array?
-			{"nested_int", []any{[]any{1}}},               // nested int array?
-			{"scalar_1", 1},                               // scalar int
-			{"scalar_str", "STAR_ALLIANCE"},               // scalar string
+			{name: "nil", value: nil, expectOK: true},
+			{name: "str_STAR_ALLIANCE_PROD", value: []any{"STAR_ALLIANCE"}, expectOK: true},
+			{name: "str_ONEWORLD_PROD", value: []any{"ONEWORLD"}, expectOK: true},
+		}
+		results := runSegmentProbes(t, client, "HEL", "LHR", searchDate, baseOpts, 5, probes)
+		analyzeResults(t, "ALLIANCE_seg5", results)
+	})
+
+	// ---- Alliance (outer[1][25], ABANDONED position) ----
+	// Kept as exploration documenting why the settings slot was abandoned: every
+	// shape here returns 400. expectOK=false everywhere so it never false-alarms.
+	t.Run("Alliance_pos25_abandoned", func(t *testing.T) {
+		probes := []filterProbe{
+			{name: "nil", value: nil},
+			{name: "str_STAR_ALLIANCE", value: []any{"STAR_ALLIANCE"}},
+			{name: "int_1", value: []any{1}},
+			{name: "nested_str", value: []any{[]any{"STAR_ALLIANCE"}}},
+			{name: "scalar_str", value: "STAR_ALLIANCE"},
 		}
 		results := runSettingsProbes(t, client, "HEL", "LHR", searchDate, baseOpts, 25, probes)
 		analyzeResults(t, "ALLIANCE_pos25", results)
@@ -112,9 +127,16 @@ func TestFiltersProbe(t *testing.T) {
 }
 
 // filterProbe defines a single probe: a name and a value to patch in.
+//
+// expectOK marks a probe as production-shaped: the wire format trvl actually
+// ships. A production-shaped probe that returns HTTP 400 means Google rotated
+// the format out from under us -- that is a real, alarm-worthy regression.
+// Exploratory probes (expectOK=false) deliberately send abandoned or candidate
+// shapes to learn what Google accepts; a 400 there is expected and only logged.
 type filterProbe struct {
-	name  string
-	value any
+	name     string
+	value    any
+	expectOK bool
 }
 
 // probeResult captures one probe's outcome.
@@ -124,6 +146,7 @@ type probeResult struct {
 	count    int
 	bodySize int
 	err      error
+	expectOK bool
 }
 
 // runSegmentProbes patches a position inside segment[0] (the outbound segment,
@@ -164,6 +187,7 @@ func runSegmentProbes(t *testing.T, client *batchexec.Client, origin, dest, date
 				status:   status,
 				count:    count,
 				bodySize: len(body),
+				expectOK: p.expectOK,
 			}
 			t.Logf("%-20s  status=%d  flights=%d  body=%d bytes",
 				p.name, status, count, len(body))
@@ -210,6 +234,7 @@ func runSettingsProbes(t *testing.T, client *batchexec.Client, origin, dest, dat
 				status:   status,
 				count:    count,
 				bodySize: len(body),
+				expectOK: p.expectOK,
 			}
 			t.Logf("%-20s  status=%d  flights=%d  body=%d bytes",
 				p.name, status, count, len(body))
@@ -321,10 +346,17 @@ func analyzeResults(t *testing.T, label string, results []probeResult) {
 		}
 	}
 
-	// Check for 400s -- indicates broken wire format.
+	// A 400 on a production-shaped probe (expectOK) means Google rotated the
+	// wire format and trvl is now broken in production -- that is the drift
+	// alarm. A 400 on an exploratory probe is expected and only logged.
 	for _, r := range results {
-		if r.status == 400 {
-			t.Errorf("BUG: %s=%s returns 400 -- wire format rejected by Google", label, r.name)
+		if r.status != 400 {
+			continue
+		}
+		if r.expectOK {
+			t.Errorf("DRIFT: %s=%s returns 400 -- PRODUCTION wire format rejected by Google", label, r.name)
+		} else {
+			t.Logf("exploratory %s=%s returns 400 (expected for non-production shape)", label, r.name)
 		}
 	}
 


### PR DESCRIPTION
## Gap closed: the provider drift alarm was crying wolf

trvl talks to Google Flights via an undocumented, reverse-engineered wire format that Google rotates without notice (MIK-6531 was exactly that — the alliance filter silently moved positions and started returning HTTP 400). The only thing that pings the live API is the env-gated probe suite, run nightly by `live-probes.yml`.

Problem: that suite was **not trustworthy**. `analyzeResults` flagged *any* 400 as a `BUG`, but the probes deliberately fire known-bad shapes (scalar emissions, the abandoned `outer[1][25]` alliance slot) to explore what Google accepts. Result: a guaranteed false failure on every live run. An alarm that always rings gets ignored — so a *real* drift would have been lost in the noise.

## What changed

- **`filterProbe.expectOK`** tags production-shaped probes (the wire format trvl actually ships). `analyzeResults` now raises a `DRIFT` error **only** when a production-shaped probe returns 400 — the real signal. Exploratory 400s are logged, not failed.
- **New `Alliance_seg5` probe** verifies the *live* production position (`segment[5]` string array), not just the abandoned `outer[1][25]`. This is the probe that would have caught MIK-6531.
- Production formats marked `expectOK` across the suite; exploration of abandoned positions demoted to log-only.
- **`live-probes.yml`**: on a scheduled probe failure, open or refresh a single `provider-drift` tracking issue. A red run nobody watches isn't visibility.

## Validation

- `go vet ./internal/flights/` clean; `gofmt -l` clean.
- `go test ./internal/flights/` passes offline (probes self-skip without `TRVL_TEST_LIVE_PROBES=1`).
- Live behaviour unchanged for genuine production formats; only the false-alarm logic and abandoned-position assertions changed.

Test-only + workflow change. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
