### PR TITLE
test(afklm): cover round-trip leg + TTL date helpers (73.8%->75.4%)

### DIFF
--- a/internal/flights/afklm/provider_test.go
+++ b/internal/flights/afklm/provider_test.go
@@ -142,3 +142,54 @@ func TestProviderCabinMapping(t *testing.T) {
 		}
 	}
 }
+
+// TestBoundDirection locks the round-trip leg tagging: bound 0 is the outbound,
+// bound 1 the inbound/return, and any further bounds (open-jaw / multi-city)
+// stay untagged. This is the native return-ticket leg mapping for AF-KLM, so a
+// regression here would mislabel return flights.
+func TestBoundDirection(t *testing.T) {
+	cases := []struct {
+		idx  int
+		want string
+	}{
+		{0, "outbound"},
+		{1, "inbound"},
+		{2, ""},  // open-jaw third bound: untagged
+		{5, ""},  // multi-city
+		{-1, ""}, // defensive: never expected, must not panic or mislabel
+	}
+	for _, tc := range cases {
+		if got := boundDirection(tc.idx); got != tc.want {
+			t.Errorf("boundDirection(%d): got %q, want %q", tc.idx, got, tc.want)
+		}
+	}
+}
+
+// TestParseLayover covers the success path and every failure branch: empty
+// endpoints and unparseable datetimes must report ok=false so the caller skips
+// the layover diff rather than computing garbage from zero-value times.
+func TestParseLayover(t *testing.T) {
+	prev, cur, ok := parseLayover("2026-05-15T10:30:00", "2026-05-15T12:45:00")
+	if !ok {
+		t.Fatal("parseLayover(valid pair): ok=false, want true")
+	}
+	if got := cur.Sub(prev); got != 2*time.Hour+15*time.Minute {
+		t.Errorf("layover gap: got %v, want 2h15m", got)
+	}
+
+	failCases := []struct {
+		name             string
+		prevArr, nextDep string
+	}{
+		{"empty_prev", "", "2026-05-15T12:45:00"},
+		{"empty_next", "2026-05-15T10:30:00", ""},
+		{"both_empty", "", ""},
+		{"bad_prev", "garbage", "2026-05-15T12:45:00"},
+		{"bad_next", "2026-05-15T10:30:00", "not-a-time"},
+	}
+	for _, tc := range failCases {
+		if _, _, ok := parseLayover(tc.prevArr, tc.nextDep); ok {
+			t.Errorf("parseLayover(%s): ok=true, want false", tc.name)
+		}
+	}
+}

--- a/internal/flights/afklm/search_test.go
+++ b/internal/flights/afklm/search_test.go
@@ -323,3 +323,50 @@ func TestDaysUntilDepartureTTLTable(t *testing.T) {
 		}
 	}
 }
+
+// TestDaysFromISOBranches covers the parse-fallback and clamp branches that the
+// TTL table (happy "2006-01-02" path only) leaves untested: the RFC3339
+// fallback used by LowestFaresRequest.FromDate, empty/garbage input, and a past
+// date clamping to 0 instead of going negative.
+func TestDaysFromISOBranches(t *testing.T) {
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"empty", "", 0},
+		{"garbage", "not-a-date", 0},
+		{"calendar_date", "2026-05-01", 10},
+		{"rfc3339_fallback", "2026-05-01T08:30:00Z", 10},
+		{"rfc3339_offset", "2026-05-01T23:30:00+02:00", 10},
+		{"past_clamps_to_zero", "2026-04-01", 0},
+		{"today_is_zero", "2026-04-21", 0},
+	}
+	for _, tc := range cases {
+		if got := daysFromISO(tc.in, now); got != tc.want {
+			t.Errorf("daysFromISO(%q): got %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestDaysUntilDepartureWrapper covers the connection-extraction wrapper: empty
+// connections returns 0, and a populated first connection delegates to
+// daysFromISO.
+func TestDaysUntilDepartureWrapper(t *testing.T) {
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+
+	if got := daysUntilDeparture(AvailableOffersRequest{}, now); got != 0 {
+		t.Errorf("daysUntilDeparture(empty connections): got %d, want 0", got)
+	}
+
+	req := AvailableOffersRequest{
+		RequestedConnections: []RequestedConnection{
+			{DepartureDate: "2026-05-01"}, // 10 days out
+			{DepartureDate: "2026-09-01"}, // ignored: only first connection drives TTL
+		},
+	}
+	if got := daysUntilDeparture(req, now); got != 10 {
+		t.Errorf("daysUntilDeparture(first=2026-05-01): got %d, want 10", got)
+	}
+}


### PR DESCRIPTION
## Gap closed: AF-KLM provider coverage, focused on the return-ticket path

The Air France-KLM provider sat at **73.8%** — the lowest of the live flight providers. The gap wasn't dead code; it was the *failure and edge branches* of four pure helpers, exercised only on their happy paths. Those branches are exactly where a quiet correctness regression hides.

All four are now at **100%**, fully offline and deterministic (no network, no keychain):

| Helper | What was untested | Why it matters |
|---|---|---|
| `boundDirection` | the `>=2` open-jaw / multi-city branch | native return-ticket leg tagging (bound 0 = outbound, 1 = inbound/return). The integration test only hit bounds 0/1, so a mislabel of a third bound would have slipped through. |
| `parseLayover` | empty + unparseable datetime branches | on bad input it must report `ok=false` so the caller skips the layover calc instead of diffing zero-value times. |
| `daysFromISO` | RFC3339 fallback, garbage input, past-date clamp | `LowestFaresRequest.FromDate` is RFC3339; the TTL table only covered the `2006-01-02` calendar path. |
| `daysUntilDeparture` | empty-connections guard | drives cache TTL selection. |

Package coverage: 73.8% → 75.4%. The rest of the gap is network/keychain-bound (`NewClient`, `do`, `keychainLookup`) and isn't deterministically testable offline without mock infrastructure this repo doesn't have — left honest rather than gamed.

Test-only. No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
