### PR TITLE
refactor(livecheck): unify cheapest-price selector, fix negative-price edge (50%->59.7%)

### DIFF
--- a/internal/livecheck/livecheck.go
+++ b/internal/livecheck/livecheck.go
@@ -39,6 +39,29 @@ func (Checker) CheckPrice(ctx context.Context, w watch.Watch) (float64, string, 
 	}
 }
 
+// cheapest returns the element with the lowest positive price. A zero or
+// negative price never displaces a positive one, and the first positive price
+// wins ties — the exact semantics the flight/date/hotel selection loops used to
+// duplicate inline. If no element has a positive price it returns the first
+// element (an honest "found nothing priceable"). Callers guarantee a non-empty
+// slice; the price accessor lets one helper serve all three result types.
+//
+// The sentinel is "best has price <= 0" rather than the inline loops' "== 0":
+// this is a no-op for real provider data (prices are never negative) but makes
+// the selector correct in the degenerate case where the first element carries a
+// negative price and a later one is genuinely positive.
+func cheapest[T any](items []T, price func(T) float64) T {
+	best := items[0]
+	bestP := price(best)
+	for _, x := range items[1:] {
+		p := price(x)
+		if p > 0 && (bestP <= 0 || p < bestP) {
+			best, bestP = x, p
+		}
+	}
+	return best
+}
+
 func checkFlight(ctx context.Context, w watch.Watch) (float64, string, string, error) {
 	// Route watch or date range: use calendar/dates search.
 	if w.IsRouteWatch() || w.IsDateRange() {
@@ -55,12 +78,7 @@ func checkFlight(ctx context.Context, w watch.Watch) (float64, string, string, e
 		return 0, "", "", nil
 	}
 
-	cheapest := result.Flights[0]
-	for _, f := range result.Flights[1:] {
-		if f.Price > 0 && (cheapest.Price == 0 || f.Price < cheapest.Price) {
-			cheapest = f
-		}
-	}
+	cheapest := cheapest(result.Flights, func(f models.FlightResult) float64 { return f.Price })
 	return cheapest.Price, cheapest.Currency, w.DepartDate, nil
 }
 
@@ -89,12 +107,7 @@ func checkFlightRange(ctx context.Context, w watch.Watch) (float64, string, stri
 	// with zero new provider calls. Best-effort: never affect the check result.
 	persistDateGrid(w.Origin, w.Destination, result.Dates)
 
-	cheapest := result.Dates[0]
-	for _, d := range result.Dates[1:] {
-		if d.Price > 0 && (cheapest.Price == 0 || d.Price < cheapest.Price) {
-			cheapest = d
-		}
-	}
+	cheapest := cheapest(result.Dates, func(d models.DatePriceResult) float64 { return d.Price })
 	return cheapest.Price, cheapest.Currency, cheapest.Date, nil
 }
 
@@ -159,11 +172,6 @@ func checkHotel(ctx context.Context, w watch.Watch) (float64, string, string, er
 		return 0, "", "", nil
 	}
 
-	cheapest := result.Hotels[0]
-	for _, h := range result.Hotels[1:] {
-		if h.Price > 0 && (cheapest.Price == 0 || h.Price < cheapest.Price) {
-			cheapest = h
-		}
-	}
+	cheapest := cheapest(result.Hotels, func(h models.HotelResult) float64 { return h.Price })
 	return cheapest.Price, cheapest.Currency, checkIn, nil
 }

--- a/internal/livecheck/livecheck_test.go
+++ b/internal/livecheck/livecheck_test.go
@@ -4,8 +4,77 @@ import (
 	"context"
 	"testing"
 
+	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/watch"
 )
+
+// TestCheapest covers the shared lowest-positive-price selector that the
+// flight, date-grid, and hotel checks all delegate to. The selection rules are
+// load-bearing: a 0/negative price (an honest "no price found" from a provider)
+// must never displace a real positive price, and the first positive price wins
+// ties so the result is deterministic.
+func TestCheapest(t *testing.T) {
+	price := func(f models.FlightResult) float64 { return f.Price }
+
+	cases := []struct {
+		name     string
+		in       []models.FlightResult
+		wantPx   float64
+		wantCurr string
+	}{
+		{
+			name:     "single element",
+			in:       []models.FlightResult{{Price: 100, Currency: "EUR"}},
+			wantPx:   100,
+			wantCurr: "EUR",
+		},
+		{
+			name:     "lowest positive wins",
+			in:       []models.FlightResult{{Price: 300, Currency: "EUR"}, {Price: 120, Currency: "USD"}, {Price: 250, Currency: "GBP"}},
+			wantPx:   120,
+			wantCurr: "USD",
+		},
+		{
+			name:     "zero never displaces a positive",
+			in:       []models.FlightResult{{Price: 200, Currency: "EUR"}, {Price: 0, Currency: "SEK"}},
+			wantPx:   200,
+			wantCurr: "EUR",
+		},
+		{
+			name:     "leading zero replaced by later positive",
+			in:       []models.FlightResult{{Price: 0, Currency: "SEK"}, {Price: 175, Currency: "EUR"}},
+			wantPx:   175,
+			wantCurr: "EUR",
+		},
+		{
+			name:     "negative price ignored",
+			in:       []models.FlightResult{{Price: -50, Currency: "DKK"}, {Price: 90, Currency: "EUR"}},
+			wantPx:   90,
+			wantCurr: "EUR",
+		},
+		{
+			name:     "all non-positive falls back to first",
+			in:       []models.FlightResult{{Price: 0, Currency: "NOK"}, {Price: -1, Currency: "DKK"}},
+			wantPx:   0,
+			wantCurr: "NOK",
+		},
+		{
+			name:     "first positive wins ties",
+			in:       []models.FlightResult{{Price: 100, Currency: "USD"}, {Price: 100, Currency: "GBP"}},
+			wantPx:   100,
+			wantCurr: "USD",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cheapest(tc.in, price)
+			if got.Price != tc.wantPx || got.Currency != tc.wantCurr {
+				t.Errorf("cheapest: got {%v %q}, want {%v %q}", got.Price, got.Currency, tc.wantPx, tc.wantCurr)
+			}
+		})
+	}
+}
 
 // TestChecker_UnsupportedType is deterministic and hits no network: an
 // unsupported watch type must return an error rather than a fabricated price.


### PR DESCRIPTION
## Unify the cheapest-price selector across flight/date/hotel re-price checks

The watch re-price checks (`checkFlight`, `checkFlightRange`, `checkHotel`) each carried their own copy of the same "pick the lowest positive price" loop — three copies of load-bearing selection logic, none unit-tested, because they all sit behind live provider calls. Coverage sat at 50%.

**What changed:**

- Collapsed the three loops into one generic helper, `cheapest[T](items, price)`, and tested it directly: lowest-positive wins, a `0`/negative price never displaces a real one, a leading zero is replaced by a later positive, and the first positive wins ties (so the result is deterministic). The helper is now 100% covered; package **50% → 59.7%**.
- Writing the test surfaced a latent edge case all three inline loops shared: the "no price yet" sentinel was `best.Price == 0`, so a *negative* first price was never displaced by a later positive one. Real providers never emit negative prices, so it never bit — but the selector should be correct, so the sentinel is now `<= 0`. No behaviour change for real data; the only affected case (negative-then-positive) cannot occur from live searches.

Behaviour for every real input is identical to the three loops it replaces. The remaining uncovered lines in this package are the provider-call wiring itself, which needs live flight/hotel APIs and isn't deterministically unit-testable without dependency injection the package doesn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
