### PR TITLE
feat(hotels): booking-readiness verdict from composed trust signals (MIK-6232)

### DIFF
--- a/cmd/trvl/rooms.go
+++ b/cmd/trvl/rooms.go
@@ -186,7 +186,7 @@ func formatRoomsTable(result *hotels.RoomAvailability) error {
 		fmt.Printf("Notice: %s\n\n", result.Notice)
 	}
 
-	headers := []string{"Room", "Price", "Guests", "Bed", "Board", "Cancellation", "Provider", "Amenities"}
+	headers := []string{"Room", "Price", "Readiness", "Guests", "Bed", "Board", "Cancellation", "Provider", "Amenities"}
 	rows := make([][]string, 0, len(result.Rooms))
 	var prices priceScale
 
@@ -213,6 +213,7 @@ func formatRoomsTable(result *hotels.RoomAvailability) error {
 		rows = append(rows, []string{
 			room.Name,
 			priceText,
+			readinessLabel(room),
 			guestsText,
 			room.BedType,
 			boardLabel(room),
@@ -274,6 +275,22 @@ func cancellationLabel(room hotels.RoomType) string {
 		return "Non refundable"
 	}
 	return ""
+}
+
+// readinessLabel renders the composed booking-readiness verdict (MIK-6232) for
+// the rooms table. Blank when the room carries no verdict (e.g. legacy data),
+// so the column never fabricates confidence.
+func readinessLabel(room hotels.RoomType) string {
+	switch room.Readiness {
+	case hotels.ReadinessReady:
+		return "Ready"
+	case hotels.ReadinessCaution:
+		return "Caution"
+	case hotels.ReadinessUnverified:
+		return "Unverified"
+	default:
+		return ""
+	}
 }
 
 // roomHighlight builds a compact one-line decision summary (board +

--- a/internal/hotels/booking_readiness.go
+++ b/internal/hotels/booking_readiness.go
@@ -1,0 +1,60 @@
+package hotels
+
+import (
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// Booking-readiness contract (MIK-6232).
+//
+// "Bookable" is not binary. A room's price can be live while its deep link is
+// already dead, its room identity is a property-level lead-in rather than a
+// real rate, or its refundability is simply unknown. trvl surfaced those
+// signals separately (link durability #168, match confidence, refundability)
+// but never composed them, so an agent could not tell a safe save from a risky
+// one at a glance.
+//
+// roomReadiness composes the four signals into one verdict. It is conservative
+// by construction: any unknown input forces a downgrade, and a missing field
+// never upgrades readiness. Over-claiming "ready" on a dead link is the exact
+// trust failure this prevents.
+const (
+	// ReadinessReady — a real bookable price, a durable (non-expiring) link, an
+	// exact room-level identity, and known refundability. Safe to act on.
+	ReadinessReady = "ready"
+	// ReadinessCaution — a real bookable price, but at least one trust signal is
+	// weak or unknown: an expiring link, an unconfirmed identity, or unknown
+	// refundability. Bookable, but verify before relying on it.
+	ReadinessCaution = "caution"
+	// ReadinessUnverified — no usable bookable price, so neither the link nor the
+	// identity can be trusted to land on a real rate.
+	ReadinessUnverified = "unverified"
+)
+
+// roomReadiness returns the booking-readiness verdict for a single room.
+//
+// The four contract inputs (MIK-6232) map to existing room fields:
+//
+//   - verified:            roomEffectivePrice(room) > 0 (a real bookable price)
+//   - link_stable:         the provider link is durable, not an expiring redirect
+//   - identity_confirmed:  an exact room-level match, not a similar/property lead-in
+//   - refundability_known: the provider stated whether the rate is refundable
+//
+// Any unknown input downgrades; readiness is never upgraded on missing data.
+func roomReadiness(room RoomType) string {
+	// No usable price -> nothing to trust. The cheapest, most common failure.
+	if roomEffectivePrice(room) <= 0 {
+		return ReadinessUnverified
+	}
+	// An empty URL classifies as "" (not "stable"), so a missing link cannot
+	// reach "ready" -- the conservative outcome.
+	linkStableOK := ClassifyLinkDurability(room.ProviderURL) == linkStable
+	identityConfirmed := strings.TrimSpace(room.MatchConfidence) == models.RoomInventoryMatchExact
+	refundabilityKnown := room.Refundable != nil
+
+	if linkStableOK && identityConfirmed && refundabilityKnown {
+		return ReadinessReady
+	}
+	return ReadinessCaution
+}

--- a/internal/hotels/booking_readiness_test.go
+++ b/internal/hotels/booking_readiness_test.go
@@ -1,0 +1,85 @@
+package hotels
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func boolPtrRO(b bool) *bool { return &b }
+
+// readyRoom returns a room that satisfies every readiness input, so each test
+// can knock out exactly one signal and assert the downgrade. (MIK-6232 AC.4)
+func readyRoom() RoomType {
+	return RoomType{
+		Name:            "Deluxe Double",
+		Price:           120,
+		Currency:        "EUR",
+		ProviderURL:     "https://www.booking.com/hotel/example.html", // durable -> stable
+		MatchConfidence: models.RoomInventoryMatchExact,               // identity confirmed
+		Refundable:      boolPtrRO(true),                              // refundability known
+	}
+}
+
+func TestRoomReadiness_AllSignalsKnown_Ready(t *testing.T) {
+	if got := roomReadiness(readyRoom()); got != ReadinessReady {
+		t.Fatalf("all signals known: want %q, got %q", ReadinessReady, got)
+	}
+}
+
+// AC.1/AC.2: no usable price -> unverified, regardless of other signals.
+func TestRoomReadiness_NoPrice_Unverified(t *testing.T) {
+	r := readyRoom()
+	r.Price, r.NightlyPrice, r.TotalPrice = 0, 0, 0
+	if got := roomReadiness(r); got != ReadinessUnverified {
+		t.Fatalf("no price: want %q, got %q", ReadinessUnverified, got)
+	}
+}
+
+// AC.2: expiring link forces a downgrade from ready.
+func TestRoomReadiness_ExpiringLink_Caution(t *testing.T) {
+	r := readyRoom()
+	r.ProviderURL = "https://www.google.com/aclk?ad=redirect" // expiring redirect
+	if got := roomReadiness(r); got != ReadinessCaution {
+		t.Fatalf("expiring link: want %q, got %q", ReadinessCaution, got)
+	}
+}
+
+// AC.2: a missing link is unknown -> never "ready".
+func TestRoomReadiness_NoLink_Caution(t *testing.T) {
+	r := readyRoom()
+	r.ProviderURL = ""
+	if got := roomReadiness(r); got != ReadinessCaution {
+		t.Fatalf("no link: want %q, got %q", ReadinessCaution, got)
+	}
+}
+
+// AC.2: a non-exact (similar) identity is not confirmed -> downgrade.
+func TestRoomReadiness_UnconfirmedIdentity_Caution(t *testing.T) {
+	r := readyRoom()
+	r.MatchConfidence = models.RoomInventoryMatchSimilar
+	if got := roomReadiness(r); got != ReadinessCaution {
+		t.Fatalf("unconfirmed identity: want %q, got %q", ReadinessCaution, got)
+	}
+}
+
+// AC.2: unknown refundability (nil) forces a downgrade -- the exact "never
+// upgrade on missing data" rule.
+func TestRoomReadiness_RefundabilityUnknown_Caution(t *testing.T) {
+	r := readyRoom()
+	r.Refundable = nil
+	if got := roomReadiness(r); got != ReadinessCaution {
+		t.Fatalf("unknown refundability: want %q, got %q", ReadinessCaution, got)
+	}
+}
+
+// A non-refundable but *known* rate still satisfies refundability_known; with
+// every other signal present it is ready. Guards against conflating "known
+// non-refundable" with "unknown".
+func TestRoomReadiness_KnownNonRefundable_Ready(t *testing.T) {
+	r := readyRoom()
+	r.Refundable = boolPtrRO(false)
+	if got := roomReadiness(r); got != ReadinessReady {
+		t.Fatalf("known non-refundable: want %q, got %q", ReadinessReady, got)
+	}
+}

--- a/internal/hotels/rooms.go
+++ b/internal/hotels/rooms.go
@@ -10,18 +10,22 @@ import (
 
 // RoomType represents a specific room category at a hotel.
 type RoomType struct {
-	Name               string                      `json:"name"`
-	Price              float64                     `json:"price"`
-	NightlyPrice       float64                     `json:"nightly_price,omitempty"`
-	TotalPrice         float64                     `json:"total_price,omitempty"`
-	TaxesAndFees       float64                     `json:"taxes_and_fees,omitempty"`
-	TaxesFeesIncluded  *bool                       `json:"taxes_fees_included,omitempty"`
-	Currency           string                      `json:"currency"`
-	Provider           string                      `json:"provider,omitempty"`
-	ProviderURL        string                      `json:"provider_url,omitempty"`
-	RateID             string                      `json:"rate_id,omitempty"`
-	RatePlanName       string                      `json:"rate_plan_name,omitempty"`
-	MatchConfidence    string                      `json:"match_confidence,omitempty"`
+	Name              string  `json:"name"`
+	Price             float64 `json:"price"`
+	NightlyPrice      float64 `json:"nightly_price,omitempty"`
+	TotalPrice        float64 `json:"total_price,omitempty"`
+	TaxesAndFees      float64 `json:"taxes_and_fees,omitempty"`
+	TaxesFeesIncluded *bool   `json:"taxes_fees_included,omitempty"`
+	Currency          string  `json:"currency"`
+	Provider          string  `json:"provider,omitempty"`
+	ProviderURL       string  `json:"provider_url,omitempty"`
+	RateID            string  `json:"rate_id,omitempty"`
+	RatePlanName      string  `json:"rate_plan_name,omitempty"`
+	MatchConfidence   string  `json:"match_confidence,omitempty"`
+	// Readiness is the composed booking-readiness verdict (ready|caution|
+	// unverified) from roomReadiness: one trustworthy gate over the scattered
+	// price, link-durability, identity, and refundability signals. See MIK-6232.
+	Readiness          string                      `json:"readiness,omitempty"`
 	MaxGuests          int                         `json:"max_guests,omitempty"`
 	BedType            string                      `json:"bed_type,omitempty"`
 	SizeM2             float64                     `json:"size_m2,omitempty"`
@@ -239,6 +243,14 @@ func GetRoomAvailabilityWithOpts(ctx context.Context, opts RoomSearchOptions) (*
 	// lead-in), then cheapest-first within a tier, so the most actionable price
 	// surfaces first and unpriced lead-ins sink to the bottom.
 	sortRoomsByBookability(rooms)
+
+	// Compose the per-room booking-readiness verdict over the now-final trust
+	// signals (price, link durability, room identity, refundability). One gate
+	// the agent and CLI can lead with instead of re-deriving from scattered
+	// fields. See MIK-6232.
+	for i := range rooms {
+		rooms[i].Readiness = roomReadiness(rooms[i])
+	}
 
 	return &RoomAvailability{
 		Success:  true,


### PR DESCRIPTION
## What

Composes trvl's scattered per-room trust signals into one booking-readiness verdict so an AI agent (or the CLI table) can lead with rooms it can actually trust, instead of re-deriving confidence from four separate fields.

A room price can be live while its deep link is already dead, its identity is a property-level lead-in rather than a real rate, or refundability is simply not stated. Those signals existed (link durability #168, match confidence, refundability) but were never combined.

## How

`roomReadiness(RoomType) -> ready | caution | unverified`, composed from:
- **verified** - `roomEffectivePrice > 0` (a real bookable price)
- **link_stable** - `ClassifyLinkDurability` is durable, not an expiring redirect
- **identity_confirmed** - exact room-level match, not similar/property lead-in
- **refundability_known** - provider stated whether the rate is refundable

Conservative by construction: any missing input downgrades, and readiness is never upgraded on absent data. Over-claiming "ready" on a dead link is the exact trust failure prevented.

## Surfaces (AC.3)

- `RoomType.Readiness` field flows into MCP/JSON output automatically via json tags
- CLI rooms table gains a **Readiness** column (absent-safe: blank when no verdict)

## Acceptance criteria

- TRVL.BRC.1 - verdict computed from the four trust signals
- TRVL.BRC.2 - any missing input forces a downgrade (never "ready" with an absent field)
- TRVL.BRC.3 - verdict surfaced in CLI table + MCP/JSON
- TRVL.BRC.4 - tests cover each downgrade path (no price, expiring link, missing link, non-exact identity, absent refundability) plus a known-non-refundable guard

## Tests

`go test -race ./internal/hotels/ ./cmd/trvl/` green locally; build + vet clean.

Closes MIK-6232

🤖 Generated with [Claude Code](https://claude.com/claude-code)
