### PR TITLE
feat(telemetry): privacy-preserving daily active-user heartbeat (MIK-6568)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,27 @@ Full troubleshooting: [docs/CLI.md](docs/CLI.md).
 
 Part of a suite of MCP tools: [mcp-gateway](https://github.com/MikkoParkkola/mcp-gateway) (universal gateway) · [nab](https://github.com/MikkoParkkola/nab) (web extraction with anti-bot) · [axterminator](https://github.com/MikkoParkkola/axterminator) (macOS GUI automation).
 
+## Privacy & telemetry
+
+trvl sends one anonymous heartbeat per install per day so the project knows roughly how many people use it and on which platforms. That is the entire purpose. The heartbeat carries only:
+
+- a fixed project tag (`trvl`) and event name (`heartbeat`)
+- the trvl version
+- the Go runtime string (OS, architecture, Go version, e.g. `darwin/arm64/go1.26.4`)
+- a random install id generated locally on first run (stored in `~/.trvl/install-id`)
+
+It never sends your IP, hostname, username, search queries, or any travel data. The collector derives coarse geography server-side from the request and only reports it in aggregate, with a minimum group size of 5 (k-anonymity), so no single install is identifiable. The request has a 3-second timeout and fails silently. If the collector is down or slow, trvl behaves exactly as if telemetry were off.
+
+To turn it off, set any one of these before running trvl:
+
+```bash
+export TRVL_NO_TELEMETRY=1   # trvl-specific switch
+export NO_TELEMETRY=1        # common convention
+export DO_NOT_TRACK=1        # cross-tool Do-Not-Track signal
+```
+
+It is also skipped automatically in CI and for development builds. Override the endpoint with `TRVL_TELEMETRY_ENDPOINT` if you run your own collector. The collector and its aggregation rules are tracked in MIK-6565.
+
 ## Legal & license
 
 trvl is a **personal-use tool** that reads public-facing web APIs (Google Flights, Google Hotels, and others). It does not bypass authentication or circumvent rate limits; request patterns are throttled to look like manual browsing. Automated access may violate some providers' Terms of Service — you are responsible for compliance in your jurisdiction.

--- a/cmd/trvl/main.go
+++ b/cmd/trvl/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/MikkoParkkola/trvl/internal/selfupdate"
+	"github.com/MikkoParkkola/trvl/internal/telemetry"
 )
 
 func main() {
@@ -17,6 +18,13 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	selfupdate.CheckInBackground(ctx, Version, os.Stderr)
 	defer cancel()
+
+	// Fire-and-forget anonymous active-user heartbeat (at most once / 24h).
+	// Uses a non-cancellable context so a fast exit doesn't abort it mid-send;
+	// the 3s client timeout bounds it. Opt out with TRVL_NO_TELEMETRY /
+	// NO_TELEMETRY / DO_NOT_TRACK; auto-skipped for CI and dev builds. See
+	// telemetry.HeartbeatInBackground (MIK-6568).
+	telemetry.HeartbeatInBackground(context.Background(), Version)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/internal/telemetry/heartbeat.go
+++ b/internal/telemetry/heartbeat.go
@@ -1,0 +1,221 @@
+package telemetry
+
+// Privacy-preserving active-user heartbeat (MIK-6568).
+//
+// trvl emits at most one anonymous heartbeat per install per day to the shared
+// MIK-6565 collector so the project has a directional active-user and (server-
+// side, aggregate, k-anonymity >= 5) geography signal. The client never sends
+// an IP, hostname, username, or any host identity. The design deliberately
+// mirrors the fire-and-forget daily update check (internal/selfupdate) so the
+// footprint and risk are minimal.
+//
+// It is failure-open: any collector timeout, 4xx, or 5xx is swallowed and never
+// reaches the product path. It is also opt-out via several standard env vars
+// (DO_NOT_TRACK, NO_TELEMETRY, TRVL_NO_TELEMETRY) and auto-suppressed for CI,
+// dev builds, and tests. Importing this package without calling
+// HeartbeatInBackground performs no network I/O — there are no init() effects.
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/selfupdate"
+)
+
+const (
+	projectID      = "trvl"
+	heartbeatEvent = "heartbeat"
+
+	// defaultEndpoint is the shared MIK-6565 collector. Overridable via
+	// TRVL_TELEMETRY_ENDPOINT. The send is failure-open, so the client can
+	// ship before the collector is live (sends simply no-op until then).
+	// ponytail: confirm/replace with the real MIK-6565 URL before AC.7 deploy.
+	defaultEndpoint = "https://telemetry.trvl.app/v1/heartbeat"
+
+	// heartbeatFile is the daily-cap timestamp cache in ~/.trvl, matching the
+	// per-user state dir the rest of trvl uses (selfupdate, prefs, providers).
+	heartbeatFile = "heartbeat"
+	installIDFile = "install-id"
+
+	sendInterval   = 24 * time.Hour
+	maxPayloadSize = 2048
+)
+
+// optOutEnvs are honored independently; any set (non-empty, not "0"/"false")
+// suppresses the heartbeat. DO_NOT_TRACK is the cross-tool DNT analog (trvl has
+// no browser surface; documented as such), NO_TELEMETRY is the common
+// convention, TRVL_NO_TELEMETRY is the project-native switch.
+var optOutEnvs = []string{"DO_NOT_TRACK", "NO_TELEMETRY", "TRVL_NO_TELEMETRY"}
+
+var errPayloadTooLarge = errors.New("telemetry: payload exceeds size cap")
+
+// heartbeatPayload is the entire wire contract. No IP, host, or identity field
+// exists by construction — geography is derived server-side in aggregate.
+type heartbeatPayload struct {
+	Project   string `json:"project"`
+	Event     string `json:"event"`
+	Version   string `json:"version"`
+	Runtime   string `json:"runtime"`
+	InstallID string `json:"install_id,omitempty"`
+}
+
+// HeartbeatInBackground fires a daily anonymous heartbeat in a detached
+// goroutine and returns immediately (before the network call completes).
+//
+// It claims the daily slot synchronously (writes the timestamp before
+// dispatching) so the at-most-one-per-24h cap holds even when the collector is
+// unreachable. Pass a non-cancellable context (e.g. context.Background()) so a
+// fast-exiting command does not abort the send mid-flight; the bounded client
+// timeout is the only deadline that matters.
+func HeartbeatInBackground(ctx context.Context, version string) {
+	if suppressed(version) {
+		return
+	}
+	dir, err := cacheDir()
+	if err != nil {
+		return
+	}
+	if !dueForSend(dir, time.Now()) {
+		return
+	}
+	// Claim the slot up-front: failure-open daily cap (one attempt / 24h max).
+	_ = markSent(dir, time.Now())
+	id := installID(dir)
+	go func() { _ = send(ctx, endpoint(), buildPayload(version, id)) }()
+}
+
+// suppressed reports whether the heartbeat must not fire. Under `go test` it is
+// always true so a test run never beacons; the env/CI/dev paths are tested via
+// suppressedExceptTest.
+func suppressed(version string) bool {
+	if testing.Testing() {
+		return true
+	}
+	return suppressedExceptTest(version)
+}
+
+func suppressedExceptTest(version string) bool {
+	if version == "" || version == "dev" {
+		return true
+	}
+	if selfupdate.IsCIEnv() {
+		return true
+	}
+	for _, k := range optOutEnvs {
+		if v := os.Getenv(k); v != "" && v != "0" && v != "false" {
+			return true
+		}
+	}
+	return false
+}
+
+func endpoint() string {
+	if e := os.Getenv("TRVL_TELEMETRY_ENDPOINT"); e != "" {
+		return e
+	}
+	return defaultEndpoint
+}
+
+func buildPayload(version, id string) heartbeatPayload {
+	return heartbeatPayload{
+		Project:   projectID,
+		Event:     heartbeatEvent,
+		Version:   version,
+		Runtime:   runtime.GOOS + "/" + runtime.GOARCH + "/" + runtime.Version(),
+		InstallID: id,
+	}
+}
+
+// send POSTs the payload with a bounded 3s client timeout. Returns an error
+// only for the caller's own bookkeeping; callers swallow it (failure-open).
+func send(ctx context.Context, url string, p heartbeatPayload) error {
+	return sendWithClient(ctx, url, &http.Client{Timeout: 3 * time.Second}, p)
+}
+
+// sendWithClient is the testable core: tests inject a short-timeout client so
+// the timeout path does not block a real 3s. A 5xx is swallowed (returns nil)
+// because the collector being unhealthy must never reach the product path.
+func sendWithClient(ctx context.Context, url string, client *http.Client, p heartbeatPayload) error {
+	body, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+	if len(body) > maxPayloadSize {
+		return errPayloadTooLarge
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	return resp.Body.Close()
+}
+
+// dueForSend reports whether 24h have elapsed since the last recorded send (or
+// there is no record yet). Read errors are treated as "due" — best-effort.
+func dueForSend(dir string, now time.Time) bool {
+	data, err := os.ReadFile(filepath.Join(dir, heartbeatFile))
+	if err != nil {
+		return true
+	}
+	last, err := time.Parse(time.RFC3339, string(bytes.TrimSpace(data)))
+	if err != nil {
+		return true
+	}
+	return now.Sub(last) >= sendInterval
+}
+
+// markSent records now as the last-send timestamp (0600, atomic rename).
+func markSent(dir string, now time.Time) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, heartbeatFile)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(now.UTC().Format(time.RFC3339)), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// installID returns a stable random per-install id, generating and persisting
+// one on first use. Best-effort: any failure returns "" (the field is omitted).
+func installID(dir string) string {
+	path := filepath.Join(dir, installIDFile)
+	if data, err := os.ReadFile(path); err == nil {
+		if id := string(bytes.TrimSpace(data)); id != "" {
+			return id
+		}
+	}
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return ""
+	}
+	id := hex.EncodeToString(buf[:])
+	if err := os.MkdirAll(dir, 0o700); err == nil {
+		_ = os.WriteFile(path, []byte(id), 0o600)
+	}
+	return id
+}
+
+func cacheDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".trvl"), nil
+}

--- a/internal/telemetry/heartbeat_test.go
+++ b/internal/telemetry/heartbeat_test.go
@@ -1,0 +1,216 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestHeartbeat_DailyCap proves the at-most-one-per-24h cap: once a send is
+// recorded, a second attempt inside 24h is suppressed; after 24h it is due.
+func TestHeartbeat_DailyCap(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+
+	if !dueForSend(dir, now) {
+		t.Fatal("first call must be due (no prior record)")
+	}
+	if err := markSent(dir, now); err != nil {
+		t.Fatalf("markSent: %v", err)
+	}
+	if dueForSend(dir, now.Add(time.Hour)) {
+		t.Fatal("second call within 24h must be suppressed")
+	}
+	if dueForSend(dir, now.Add(23*time.Hour+59*time.Minute)) {
+		t.Fatal("just under 24h must be suppressed")
+	}
+	if !dueForSend(dir, now.Add(24*time.Hour)) {
+		t.Fatal("at/after 24h must be due again")
+	}
+}
+
+// TestHeartbeat_PayloadFields locks the wire contract: exactly the documented
+// fields, with no surprise additions that could carry identity.
+func TestHeartbeat_PayloadFields(t *testing.T) {
+	p := buildPayload("1.2.3", "abc123")
+	if p.Project != "trvl" || p.Event != "heartbeat" || p.Version != "1.2.3" {
+		t.Fatalf("unexpected payload: %+v", p)
+	}
+	if p.Runtime == "" {
+		t.Fatal("runtime must be populated")
+	}
+
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	allowed := map[string]bool{"project": true, "event": true, "version": true, "runtime": true, "install_id": true}
+	for k := range m {
+		if !allowed[k] {
+			t.Fatalf("unexpected field %q in payload (possible identity leak)", k)
+		}
+	}
+}
+
+// TestHeartbeat_OptOut proves every opt-out path suppresses, and that a clean
+// (non-CI, opted-in, released) build is NOT suppressed.
+func TestHeartbeat_OptOut(t *testing.T) {
+	// Establish a clean baseline: clear CI signals and every opt-out var so the
+	// negative case is deterministic even when the suite itself runs in CI.
+	clearEnv(t)
+	if suppressedExceptTest("1.0.0") {
+		t.Fatal("clean released build must not be suppressed")
+	}
+
+	for _, env := range optOutEnvs {
+		clearEnv(t)
+		t.Setenv(env, "1")
+		if !suppressedExceptTest("1.0.0") {
+			t.Fatalf("%s=1 must suppress the heartbeat", env)
+		}
+	}
+
+	clearEnv(t)
+	t.Setenv("CI", "true")
+	if !suppressedExceptTest("1.0.0") {
+		t.Fatal("CI must suppress the heartbeat")
+	}
+
+	for _, v := range []string{"", "dev"} {
+		clearEnv(t)
+		if !suppressedExceptTest(v) {
+			t.Fatalf("dev build (version=%q) must suppress the heartbeat", v)
+		}
+	}
+
+	// The public entrypoint is always suppressed under `go test`.
+	if !suppressed("1.0.0") {
+		t.Fatal("suppressed() must be true under testing.Testing()")
+	}
+}
+
+// TestHeartbeat_Timeout proves a hanging collector does not block: a short
+// client deadline returns an error well before the real 3s budget.
+func TestHeartbeat_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Slower than the client timeout below, but bounded so srv.Close()
+		// (which waits for in-flight handlers) does not hang the test.
+		time.Sleep(300 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 50 * time.Millisecond}
+	start := time.Now()
+	err := sendWithClient(context.Background(), srv.URL, client, buildPayload("1.0.0", "id"))
+	if err == nil {
+		t.Fatal("hanging collector must surface a timeout error to the caller")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("timeout took too long: %v", elapsed)
+	}
+}
+
+// TestHeartbeat_PayloadSize proves the real payload is well under the 2KB cap
+// and that an oversize payload is rejected rather than sent.
+func TestHeartbeat_PayloadSize(t *testing.T) {
+	raw, err := json.Marshal(buildPayload("1.2.3", "0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if len(raw) > maxPayloadSize {
+		t.Fatalf("payload %d bytes exceeds cap %d", len(raw), maxPayloadSize)
+	}
+
+	huge := buildPayload(string(make([]byte, maxPayloadSize+1)), "id")
+	if err := sendWithClient(context.Background(), "http://127.0.0.1:0", http.DefaultClient, huge); err != errPayloadTooLarge {
+		t.Fatalf("oversize payload: want errPayloadTooLarge, got %v", err)
+	}
+}
+
+// TestHeartbeat_ServerError proves a 5xx from the collector is swallowed
+// (failure-open): the product path sees success.
+func TestHeartbeat_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	if err := sendWithClient(context.Background(), srv.URL, http.DefaultClient, buildPayload("1.0.0", "id")); err != nil {
+		t.Fatalf("5xx must be swallowed (failure-open), got %v", err)
+	}
+}
+
+// TestHeartbeat_SendPath proves the happy path: the collector receives a POST
+// with the exact JSON contract.
+func TestHeartbeat_SendPath(t *testing.T) {
+	got := make(chan heartbeatPayload, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("content-type = %q, want application/json", ct)
+		}
+		var p heartbeatPayload
+		_ = json.NewDecoder(r.Body).Decode(&p)
+		got <- p
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	if err := sendWithClient(context.Background(), srv.URL, http.DefaultClient, buildPayload("9.9.9", "deadbeef")); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	select {
+	case p := <-got:
+		if p.Project != "trvl" || p.Event != "heartbeat" || p.Version != "9.9.9" || p.InstallID != "deadbeef" {
+			t.Fatalf("collector received %+v", p)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("collector never received the heartbeat")
+	}
+}
+
+// TestHeartbeat_NoNetworkOnImport proves HeartbeatInBackground is a no-op under
+// test (testing.Testing() suppresses) — importing the package never beacons.
+func TestHeartbeat_NoNetworkOnImport(t *testing.T) {
+	// Must not panic, must not block, must return immediately.
+	HeartbeatInBackground(context.Background(), "1.0.0")
+}
+
+func TestInstallID_StableAndPersisted(t *testing.T) {
+	dir := t.TempDir()
+	first := installID(dir)
+	if first == "" {
+		t.Fatal("install id must be generated")
+	}
+	if second := installID(dir); second != first {
+		t.Fatalf("install id not stable: %q != %q", first, second)
+	}
+	if _, err := os.Stat(filepath.Join(dir, installIDFile)); err != nil {
+		t.Fatalf("install id not persisted: %v", err)
+	}
+}
+
+// clearEnv blanks the CI signals and opt-out vars so suppression tests are
+// deterministic regardless of the host environment (including CI runners).
+func clearEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI",
+		"TRAVIS", "BUILDKITE", "DRONE", "JENKINS_URL", "TEAMCITY_VERSION",
+		"BITBUCKET_BUILD_NUMBER", "APPVEYOR", "CODEBUILD_BUILD_ID",
+		"TRVL_DISABLE_UPDATE_CHECK", "DO_NOT_TRACK", "NO_TELEMETRY", "TRVL_NO_TELEMETRY",
+	} {
+		t.Setenv(k, "")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a privacy-preserving, opt-out daily active-user heartbeat so the project has a directional sense of usage and platform mix without collecting anything identifying. Implements MIK-6568.

The design mirrors the existing fire-and-forget self-update check (`internal/selfupdate`): stdlib only, no new dependencies, failure-open, bounded timeout, and capped to at most one send per install per 24h.

## What it collects

Only these fields:
- project tag (`trvl`) and event name (`heartbeat`)
- trvl version
- Go runtime string (OS / arch / Go version, e.g. `darwin/arm64/go1.26.4`)
- a random install id generated locally on first run (`~/.trvl/install-id`)

No IP, hostname, username, search queries, or travel data. Geography is derived server-side in aggregate with a minimum group size of 5 (k-anonymity), tracked in MIK-6565.

## Opt-out & suppression

- Opt out: `TRVL_NO_TELEMETRY`, `NO_TELEMETRY`, or `DO_NOT_TRACK`
- Auto-skipped in CI, for dev builds (`version == "" | "dev"`), and under `go test`
- Endpoint overridable via `TRVL_TELEMETRY_ENDPOINT`
- 3s client timeout, fully failure-open (any timeout/4xx/5xx is swallowed)

## Acceptance criteria

- [x] AC.1 TRVL.AU.1 — `HeartbeatInBackground` called once at startup; async; <=1 event/install/24h via cache file
- [x] AC.2 TRVL.AU.2 — payload limited to project/event/version/runtime/install_id; no host identity
- [x] AC.3 TRVL.AU.3 — opt-out envs + CI + dev + test suppression; no init() network I/O
- [x] AC.4 TRVL.AU.4 — `http.Client{Timeout: 3 * time.Second}`, single async, failure-open, payload <=2048B, no go.mod change
- [x] AC.5 — `heartbeat_test.go` suite green (`go test -race ./internal/telemetry/...` ok, `go vet` clean)
- [x] AC.6 — README documents collected fields, every opt-out env, k-anonymity, and the MIK-6565 collector
- [ ] AC.7 — deploy/collector verification deferred; see note below

## Note on the endpoint (AC.7)

The default endpoint is a placeholder constant. The client is failure-open, so it can land before the MIK-6565 collector is live (sends simply no-op until then). The real collector URL should replace `defaultEndpoint` in `internal/telemetry/heartbeat.go` (or be supplied via `TRVL_TELEMETRY_ENDPOINT`) once MIK-6565 is deployed. Flagging so AC.7 is tracked rather than silently skipped.

Closes MIK-6568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
