### PR TITLE
release: prepare v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-06-28
+
+### Added
+- **Return-ticket flight search.** Flight queries now ask Google for native
+  round-trip fares first and fall back to stitching one-way legs only when no
+  round-trip offer exists, so returned itineraries reflect real round-trip
+  pricing instead of two separate one-way prices added together.
+- **Booking-readiness verdict for hotels.** Each hotel result now carries a
+  `ready` / `caution` / `unverified` label derived from its price, link
+  stability, room-match confidence, and refundability signals. Results with a
+  trustworthy, bookable price lead the list.
+- **Trip landed cost.** Trip plans now include airport transfers and city tax
+  in the total, with a clear message when a plan runs over budget.
+- **Per-package trip enrichment.** Trip packages now attach weather, public
+  holidays, and local events, each with a typed status so missing data is
+  explicit rather than silent.
+- **Anonymous usage heartbeat (opt-out).** trvl sends at most one anonymous
+  heartbeat per install per day so the project can gauge active usage and
+  platform mix. It carries no IP, hostname, username, search query, or travel
+  data, only a project tag, the version, the Go runtime string, and a random
+  local install id. It is off in CI, dev builds, and tests, and you can opt out
+  with `TRVL_NO_TELEMETRY`, `NO_TELEMETRY`, or `DO_NOT_TRACK`. See the README
+  "Privacy & telemetry" section.
+
 ## [1.17.7] - 2026-06-28
 
 ### Fixed

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl-mcp",
   "mcpName": "io.github.MikkoParkkola/trvl",
-  "version": "1.17.7",
+  "version": "1.18.0",
   "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as compatibility aliases.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
   "description": "Door-to-door travel MCP + CLI: flights, hotels, trains, cars, ferries. No API keys, Go binary.",
-  "version": "1.17.7",
+  "version": "1.18.0",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",
     "source": "github"
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mikkoparkkola/trvl:1.17.7",
+      "identifier": "ghcr.io/mikkoparkkola/trvl:1.18.0",
       "transport": {
         "type": "stdio"
       }
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "identifier": "trvl-mcp",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "version": "1.17.7",
+      "version": "1.18.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

First feature release since v1.17.7. Bumps `CHANGELOG.md`, `npm/package.json`, and `server.json` to `1.18.0` together so the release metadata drift guard passes.

## What ships in 1.18.0

- **Return-ticket flight search** (MIK-6612) — native Google round-trip fares queried before stitching one-way legs.
- **Hotel booking-readiness verdict** (MIK-6232) — `ready` / `caution` / `unverified` per result; priced, bookable results lead.
- **Trip landed cost + per-package enrichment** (MIK-6530) — transfers + city tax in the total, over-budget message, and weather/holidays/events per package with typed status.
- **Opt-out anonymous usage heartbeat** (MIK-6568) — at most one anonymous heartbeat per install/day; no identifying data; off in CI/dev/tests; opt out via `TRVL_NO_TELEMETRY` / `NO_TELEMETRY` / `DO_NOT_TRACK`.

## After merge

Tag `v1.18.0` on the merge commit to trigger the GoReleaser signed-release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
