### PR TITLE
feat(telemetry): add heartbeat collector

### DIFF
--- a/cmd/trvl-telemetry/README.md
+++ b/cmd/trvl-telemetry/README.md
@@ -1,0 +1,55 @@
+# trvl-telemetry
+
+This is the server side of the trvl heartbeat. The CLI sends one anonymous
+heartbeat per install per day (see `internal/telemetry/heartbeat.go`); this
+binary receives those POSTs and writes the accepted ones to a file, one JSON
+object per line.
+
+## What it accepts
+
+A heartbeat is a small JSON object with exactly these fields and nothing else:
+
+```json
+{"project":"trvl","event":"heartbeat","version":"1.2.3","runtime":"linux/amd64/go1.26.4","install_id":"<hex>"}
+```
+
+The collector rejects anything that does not fit the contract:
+
+- not a POST -> 405
+- not `application/json` -> 415
+- body over 2 KB -> 413
+- any field outside the allowed set -> 400 (this is the identity-leak guard)
+- malformed JSON or a missing required field -> 400
+
+A valid heartbeat gets a `204 No Content`. The collector never reads or stores
+the client IP, hostname, or any request header. Only the payload fields above
+reach disk.
+
+## Run it
+
+```sh
+go run ./cmd/trvl-telemetry -addr :8080 -out heartbeats.ndjson
+```
+
+Both flags have defaults, so plain `go run ./cmd/trvl-telemetry` listens on
+`:8080` and appends to `heartbeats.ndjson` in the working directory.
+
+To build a standalone binary:
+
+```sh
+go build -o trvl-telemetry ./cmd/trvl-telemetry
+./trvl-telemetry -addr :8080 -out /var/lib/trvl/heartbeats.ndjson
+```
+
+## Deploy notes
+
+Point the CLI at the running collector through the `TRVL_TELEMETRY_ENDPOINT`
+environment variable, or set the production URL as the default endpoint in
+`internal/telemetry/heartbeat.go`. The path the binary serves is
+`/v1/heartbeat`.
+
+Put it behind a TLS-terminating proxy and keep the output file on durable
+storage. The store is a flat append-only NDJSON file, which is enough for a
+daily low-volume signal; if traffic ever grows past what one file can handle,
+swap the writer for a real datastore. Nothing else in the design assumes the
+file format.

--- a/cmd/trvl-telemetry/main.go
+++ b/cmd/trvl-telemetry/main.go
@@ -1,0 +1,164 @@
+// Command trvl-telemetry is the receiver for the trvl CLI daily heartbeat
+// (MIK-6565). The CLI emits at most one anonymous heartbeat per install per day
+// (see internal/telemetry/heartbeat.go); this standalone binary accepts those
+// POSTs, validates them against the exact wire contract, and appends each
+// accepted heartbeat to a newline-delimited JSON (NDJSON) file.
+//
+// Privacy is the whole point: the collector stores only the documented payload
+// fields. It never records the client IP, hostname, User-Agent, or any other
+// request header — there is no code path that reads them.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"io"
+	"log"
+	"mime"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+// maxPayloadSize mirrors the client cap (internal/telemetry/heartbeat.go). A
+// body larger than this is rejected before any parsing.
+const maxPayloadSize = 2048
+
+// allowedFields is the entire wire contract, mirroring the `allowed` map in
+// internal/telemetry/heartbeat_test.go. Any key outside this set is rejected as
+// a possible identity leak — the collector persists only these fields.
+var allowedFields = map[string]bool{
+	"project":    true,
+	"event":      true,
+	"version":    true,
+	"runtime":    true,
+	"install_id": true,
+}
+
+// heartbeat is the only shape the collector accepts or stores. It carries no
+// IP, host, or identity field by construction.
+type heartbeat struct {
+	Project   string `json:"project"`
+	Event     string `json:"event"`
+	Version   string `json:"version"`
+	Runtime   string `json:"runtime"`
+	InstallID string `json:"install_id,omitempty"`
+}
+
+// collector accepts heartbeats and appends accepted ones to out.
+//
+// ponytail: NDJSON append is the right amount of machinery for a daily,
+// low-volume, single-writer heartbeat — one record per install per day. Move to
+// a real store (object storage, a columnar warehouse) only if volume warrants;
+// until then a flat append-only file is auditable, greppable, and dependency-free.
+type collector struct {
+	mu  sync.Mutex
+	out io.Writer
+}
+
+func newCollector(out io.Writer) *collector {
+	return &collector{out: out}
+}
+
+// ServeHTTP validates the request against the wire contract and persists it.
+// Each failure mode maps to the narrowest correct HTTP status; success is 204.
+// No request metadata (remote address, headers beyond Content-Type) is read.
+func (c *collector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Content-Type must be application/json; tolerate a charset parameter.
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		http.Error(w, "unsupported media type", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	// Cap the read at one byte over the limit so we can detect oversize without
+	// buffering an unbounded body.
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxPayloadSize+1))
+	if err != nil {
+		http.Error(w, "read error", http.StatusBadRequest)
+		return
+	}
+	if len(body) > maxPayloadSize {
+		http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	// Identity-leak guard: decode generically first and reject any field outside
+	// the allowed set. This also catches malformed JSON.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		http.Error(w, "malformed json", http.StatusBadRequest)
+		return
+	}
+	for k := range raw {
+		if !allowedFields[k] {
+			http.Error(w, "unexpected field", http.StatusBadRequest)
+			return
+		}
+	}
+
+	var hb heartbeat
+	if err := json.Unmarshal(body, &hb); err != nil {
+		http.Error(w, "malformed json", http.StatusBadRequest)
+		return
+	}
+	if hb.Project == "" || hb.Event == "" {
+		http.Error(w, "missing required field", http.StatusBadRequest)
+		return
+	}
+
+	if err := c.append(hb); err != nil {
+		// Log the failure without any client identity.
+		log.Printf("telemetry: append failed: %v", err)
+		http.Error(w, "storage error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// append writes one canonical NDJSON line. Re-marshaling the typed struct (not
+// the raw body) guarantees only allowed fields ever reach disk.
+func (c *collector) append(hb heartbeat) error {
+	line, err := json.Marshal(hb)
+	if err != nil {
+		return err
+	}
+	line = append(line, '\n')
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, err = c.out.Write(line)
+	return err
+}
+
+func main() {
+	addr := flag.String("addr", ":8080", "listen address")
+	out := flag.String("out", "heartbeats.ndjson", "NDJSON output file for accepted heartbeats")
+	flag.Parse()
+
+	f, err := os.OpenFile(*out, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		log.Fatalf("telemetry: open output: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	mux := http.NewServeMux()
+	mux.Handle("/v1/heartbeat", newCollector(f))
+
+	srv := &http.Server{
+		Addr:              *addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	log.Printf("telemetry collector listening on %s, appending to %s", *addr, *out)
+	if err := srv.ListenAndServe(); err != nil {
+		log.Fatalf("telemetry: server: %v", err)
+	}
+}

--- a/cmd/trvl-telemetry/main_test.go
+++ b/cmd/trvl-telemetry/main_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// validBody is a well-formed heartbeat matching the wire contract exactly.
+const validBody = `{"project":"trvl","event":"heartbeat","version":"1.2.3","runtime":"linux/amd64/go1.26.4","install_id":"deadbeef"}`
+
+// TestServeHTTP_Validation covers every accept/reject path of the collector.
+func TestServeHTTP_Validation(t *testing.T) {
+	cases := []struct {
+		name        string
+		method      string
+		contentType string
+		body        string
+		wantStatus  int
+	}{
+		{
+			name:        "happy path returns 204",
+			method:      http.MethodPost,
+			contentType: "application/json",
+			body:        validBody,
+			wantStatus:  http.StatusNoContent,
+		},
+		{
+			name:        "content type with charset is accepted",
+			method:      http.MethodPost,
+			contentType: "application/json; charset=utf-8",
+			body:        validBody,
+			wantStatus:  http.StatusNoContent,
+		},
+		{
+			name:        "wrong method rejected",
+			method:      http.MethodGet,
+			contentType: "application/json",
+			body:        validBody,
+			wantStatus:  http.StatusMethodNotAllowed,
+		},
+		{
+			name:        "wrong content type rejected",
+			method:      http.MethodPost,
+			contentType: "text/plain",
+			body:        validBody,
+			wantStatus:  http.StatusUnsupportedMediaType,
+		},
+		{
+			name:        "missing content type rejected",
+			method:      http.MethodPost,
+			contentType: "",
+			body:        validBody,
+			wantStatus:  http.StatusUnsupportedMediaType,
+		},
+		{
+			name:        "oversize body rejected",
+			method:      http.MethodPost,
+			contentType: "application/json",
+			body:        `{"project":"trvl","event":"heartbeat","version":"` + strings.Repeat("x", maxPayloadSize) + `"}`,
+			wantStatus:  http.StatusRequestEntityTooLarge,
+		},
+		{
+			name:        "unknown field rejected as identity leak",
+			method:      http.MethodPost,
+			contentType: "application/json",
+			body:        `{"project":"trvl","event":"heartbeat","version":"1.2.3","ip":"203.0.113.7"}`,
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "malformed json rejected",
+			method:      http.MethodPost,
+			contentType: "application/json",
+			body:        `{"project":"trvl",`,
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "missing required field rejected",
+			method:      http.MethodPost,
+			contentType: "application/json",
+			body:        `{"version":"1.2.3","runtime":"linux/amd64/go1.26.4"}`,
+			wantStatus:  http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sink bytes.Buffer
+			srv := httptest.NewServer(newCollector(&sink))
+			defer srv.Close()
+
+			req, err := http.NewRequest(tc.method, srv.URL, strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			if tc.contentType != "" {
+				req.Header.Set("Content-Type", tc.contentType)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("do request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+
+			// Only the happy paths may persist anything.
+			if tc.wantStatus != http.StatusNoContent && sink.Len() != 0 {
+				t.Fatalf("rejected request must not persist, got %q", sink.String())
+			}
+		})
+	}
+}
+
+// TestServeHTTP_PersistsToFile proves an accepted heartbeat is appended to the
+// NDJSON file with exactly the wire-contract fields and nothing else.
+func TestServeHTTP_PersistsToFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "heartbeats.ndjson")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	srv := httptest.NewServer(newCollector(f))
+	defer srv.Close()
+
+	// Send two heartbeats to confirm append semantics (one record per line).
+	bodies := []string{
+		validBody,
+		`{"project":"trvl","event":"heartbeat","version":"9.9.9","runtime":"darwin/arm64/go1.26.4","install_id":"cafef00d"}`,
+	}
+	for _, b := range bodies {
+		resp, err := http.Post(srv.URL, "application/json", strings.NewReader(b))
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", resp.StatusCode)
+		}
+		_ = resp.Body.Close()
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	var lines []string
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	for sc.Scan() {
+		if line := sc.Text(); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	if len(lines) != 2 {
+		t.Fatalf("got %d NDJSON lines, want 2: %q", len(lines), string(data))
+	}
+
+	// First record must round-trip to exactly the sent fields.
+	var got heartbeat
+	if err := json.Unmarshal([]byte(lines[0]), &got); err != nil {
+		t.Fatalf("unmarshal stored line: %v", err)
+	}
+	want := heartbeat{
+		Project:   "trvl",
+		Event:     "heartbeat",
+		Version:   "1.2.3",
+		Runtime:   "linux/amd64/go1.26.4",
+		InstallID: "deadbeef",
+	}
+	if got != want {
+		t.Fatalf("stored record = %+v, want %+v", got, want)
+	}
+
+	// Defense in depth: the stored line must contain only allowed keys.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(lines[0]), &raw); err != nil {
+		t.Fatalf("unmarshal stored line to map: %v", err)
+	}
+	for k := range raw {
+		if !allowedFields[k] {
+			t.Fatalf("stored record leaked field %q", k)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds the receiver for the daily usage heartbeat the CLI already sends. Until now the heartbeat POSTed to a placeholder endpoint with nothing listening; this is the collector that catches it.

`cmd/trvl-telemetry/` — a standalone `net/http` server, standard library only, no new dependencies, `go.mod` untouched:

- POST-only, `application/json` only, 2 KB body cap.
- Identity-leak guard: rejects any field outside the exact allowed set `{project, event, version, runtime, install_id}`, mirroring the `allowed` map the heartbeat test enforces. Unknown field is a `400`.
- Accepted heartbeats are re-marshaled from the typed struct and appended as newline-delimited JSON; replies `204`.
- Privacy: never reads or logs the client IP or any header beyond `Content-Type`. Only payload fields hit disk.
- Configurable via `-addr :8080` and `-out heartbeats.ndjson`.

Status mapping: non-POST → 405, wrong content-type → 415, oversize → 413, unknown field / malformed JSON / missing required field → 400, success → 204.

## Tests

Table-driven `httptest` coverage: happy-path 204, charset-tolerant content-type, wrong method, wrong/missing content-type, oversize, unknown-field, malformed JSON, missing required field, and a persistence test asserting two POSTed heartbeats land as two NDJSON lines with exactly the right fields and no leaked keys. Rejections persist nothing.

- `go build ./...` — clean
- `go vet ./cmd/trvl-telemetry/...` — clean
- `go test ./...` (full suite, 100 packages) — all pass, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
