### PR TITLE
fix(probes): edge-blocks are transient, not wire-format drift (#430)

### DIFF
--- a/internal/flights/roundtrip_native_probe_test.go
+++ b/internal/flights/roundtrip_native_probe_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/testutil"
 )
 
 // TestProbeNativeRoundTrip hits live Google Flights with a NATIVE round-trip
@@ -126,6 +128,12 @@ func TestProbeRoundTripOrchestrator(t *testing.T) {
 	if err != nil {
 		t.Logf("orchestrator err: %v", err)
 	}
+	// A throttled / edge-blocked CI run (Google + Kiwi 429 or AKAMAI_BLOCK from a
+	// datacenter IP) legitimately yields zero native fares — that is transient
+	// noise, not a wire-format regression, so skip (yellow) instead of failing
+	// (red). Real drift surfaces as a non-transient error or a 200 with no native
+	// fares and clean provider statuses, which still fails below.
+	testutil.SkipIfTransient(t, err)
 	if res == nil {
 		t.Fatal("nil result")
 	}
@@ -149,6 +157,18 @@ func TestProbeRoundTripOrchestrator(t *testing.T) {
 		t.Logf("  status %s: %s results=%d", s.ID, s.Status, s.Results)
 	}
 	if native == 0 {
+		// Before reding the build, check whether the native providers were
+		// edge-blocked/throttled this run (status error carrying a transient
+		// marker or the AKAMAI_BLOCK fix-hint). If so, zero native fares is
+		// noise, not drift.
+		for _, s := range res.ProviderStatuses {
+			if s.Status == "ok" {
+				continue
+			}
+			if testutil.IsTransientMsg(s.Error) || strings.EqualFold(s.FixHintCode, "AKAMAI_BLOCK") {
+				t.Skipf("skipping: native providers blocked/throttled this run (%s: %s %s) — not a regression", s.ID, s.Error, s.FixHintCode)
+			}
+		}
 		t.Errorf("expected at least one native round-trip fare (Google/Kiwi) in merged results")
 	}
 }

--- a/internal/flights/roundtrip_native_probe_test.go
+++ b/internal/flights/roundtrip_native_probe_test.go
@@ -157,16 +157,23 @@ func TestProbeRoundTripOrchestrator(t *testing.T) {
 		t.Logf("  status %s: %s results=%d", s.ID, s.Status, s.Results)
 	}
 	if native == 0 {
-		// Before reding the build, check whether the native providers were
-		// edge-blocked/throttled this run (status error carrying a transient
-		// marker or the AKAMAI_BLOCK fix-hint). If so, zero native fares is
-		// noise, not drift.
+		// Before reding the build, check whether the NATIVE round-trip providers
+		// (Google/Kiwi/Skiplagged, IDs prefixed "native_roundtrip:") were
+		// edge-blocked/throttled this run. Only their failure makes zero native
+		// fares noise rather than drift. Statuses from the one-way fallback legs
+		// (prefixed "outbound:"/"inbound:") include opt-in carriers like
+		// easyJet/Vueling that are *perpetually* AKAMAI_BLOCK'd by default, so
+		// scanning them would mask the exact Google/Kiwi regression this probe
+		// exists to catch.
 		for _, s := range res.ProviderStatuses {
+			if !strings.HasPrefix(s.ID, "native_roundtrip:") {
+				continue
+			}
 			if s.Status == "ok" {
 				continue
 			}
 			if testutil.IsTransientMsg(s.Error) || strings.EqualFold(s.FixHintCode, "AKAMAI_BLOCK") {
-				t.Skipf("skipping: native providers blocked/throttled this run (%s: %s %s) — not a regression", s.ID, s.Error, s.FixHintCode)
+				t.Skipf("skipping: native round-trip provider blocked/throttled this run (%s: %s %s) — not a regression", s.ID, s.Error, s.FixHintCode)
 			}
 		}
 		t.Errorf("expected at least one native round-trip fare (Google/Kiwi) in merged results")

--- a/internal/hotels/hometogo_test.go
+++ b/internal/hotels/hometogo_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/testutil"
 )
 
 // loadHomeToGoFixture reads a saved HomeToGo search payload from testdata.
@@ -255,6 +257,7 @@ func TestSearchHomeToGoLiveProbe(t *testing.T) {
 	defer func() { hometogoEnabled = origEnabled }()
 
 	hotels, err := SearchHomeToGo(context.Background(), "Berlin", HotelSearchOptions{Currency: "EUR"})
+	testutil.SkipIfTransient(t, err) // 403/429 from CI datacenter IPs is edge-block noise, not wire-format drift
 	if err != nil {
 		t.Fatalf("live SearchHomeToGo: %v", err)
 	}

--- a/internal/testutil/transient.go
+++ b/internal/testutil/transient.go
@@ -7,17 +7,20 @@ import (
 
 // transientMarkers are substrings that identify an error as transient network
 // noise rather than a genuine provider regression. These come up nightly when
-// the CI runner's datacenter IP gets throttled by no-key providers (Google
-// Flights/Hotels return HTTP 429; Skiplagged's origin returns 429/502). A
-// rate-limited night is noise: it must not red the Live Probes workflow,
-// otherwise the signal we actually care about (a rotated API, a re-stubbed
-// checker, a real format change) drowns in flapping.
+// the CI runner's datacenter IP gets throttled or edge-blocked by no-key
+// providers (Google Flights/Hotels return HTTP 429; Skiplagged's origin returns
+// 429/502; HomeToGo and Wizz's CloudFront/Akamai edge return HTTP 403 to
+// datacenter IPs). A rate-limited or edge-blocked night is noise: it must not
+// red the Live Probes workflow, otherwise the signal we actually care about (a
+// rotated API path, a re-stubbed checker, a real format change) drowns in
+// flapping.
 //
-// The classification is deliberately conservative: only well-known throttle and
-// transient-gateway markers are matched, plus the context-deadline that follows
-// the batchexec client's internal 429 retry/backoff loop. A 200 response with an
-// unexpected body shape ("unexpected flight data format") is NOT transient and
-// still fails — that is real drift worth surfacing.
+// The classification is deliberately conservative: only well-known throttle,
+// edge-block, and transient-gateway markers are matched, plus the
+// context-deadline that follows the batchexec client's internal 429 retry/backoff
+// loop. A 200 response with an unexpected body shape ("unexpected flight data
+// format") and a rotated version path (404 / "version path rotated") are NOT
+// transient and still fail — those are real drift worth surfacing.
 var transientMarkers = []string{
 	"429",
 	"rate limited",
@@ -25,6 +28,10 @@ var transientMarkers = []string{
 	"unexpected status 429",
 	"bad gateway",
 	"502",
+	"403",
+	"forbidden",
+	"akamai_block",
+	"edge-blocked",
 	"context deadline exceeded",
 	"timeout",
 	"connection reset",

--- a/internal/testutil/transient_test.go
+++ b/internal/testutil/transient_test.go
@@ -13,6 +13,10 @@ func TestIsTransientMsg(t *testing.T) {
 		"context deadline exceeded",
 		"i/o timeout",
 		"connection reset by peer",
+		"hometogo resolve: unexpected status 403 for https://www.hometogo.com/berlin/",
+		"HTTP 403 Forbidden",
+		"wizzair: status 403 (edge-blocked, body=\"...\")",
+		"provider blocked: AKAMAI_BLOCK",
 	}
 	for _, m := range transient {
 		if !IsTransientMsg(m) {


### PR DESCRIPTION
Fixes the alerting defect behind issue #430.

The nightly Live Probes workflow filed a generic "wire-format drift" alert bundling one real failure (Wizz Air version-path rotation, a 404) with two false alarms (a Skiplagged 429 and a HomeToGo 403). The 429 and 403 are transient throttle and edge-block noise from the CI runner's datacenter IP — not provider regressions — but they red the run and drown the signal that matters.

The probe design already separates these: testutil.SkipIfTransient yellows on transient noise and reds on real drift. Two gaps let the noise through:

1. transientMarkers covered 429, 502, and timeout but not 403, edge-block, or Akamai. A 403 to a datacenter IP is the same CloudFront or Akamai edge-block the Wizz client already models as ErrWizzBlocked and the AKAMAI_BLOCK fix-hint. Added markers 403, forbidden, akamai_block, edge-blocked. A rotated version path (404, "version path rotated") stays NON-transient and still reds.
2. TestSearchHomeToGoLiveProbe used a bare t.Fatalf, bypassing the helper. Now routes the error through SkipIfTransient first.
3. TestProbeRoundTripOrchestrator reded on native==0 with no transient guard, so a throttled Google plus Kiwi run failed. Now skips on a transient orchestrator error and on a provider status carrying a transient error or AKAMAI_BLOCK fix-hint.

Net effect: the nightly reds only on genuine drift (rotated paths, re-stubbed checkers, format changes), not on CI-IP throttling.

Out of scope (separate data fix): the actual Wizz Air version-path bump. be.wizzair.com rotated past the last-known-good 29.3.0. Discover the current version from the web app's embedded apiUrl and update wizzDefaultVersion; the WIZZAIR_API_VERSION override and typed ErrWizzVersionRotated already exist. The site edge-blocks datacenter IPs, so discovery needs a residential-IP browser.

Tests: added 403 and Akamai cases to the transient classifier test; go test -short on the three touched packages is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)