### PR TITLE
fix(flights): bump Wizz Air API version 29.3.0 to 29.4.0 (#430)

### DIFF
--- a/internal/flights/wizzair.go
+++ b/internal/flights/wizzair.go
@@ -98,7 +98,12 @@ var ErrWizzRejected = errors.New("wizzair declined the request (validationCodes)
 // serve. Both were previously swallowed into an opaque "unexpected status 400"
 // that red-flagged the probe. SearchWizzair now reads the body and classifies
 // these into ErrWizzBlocked / ErrWizzRejected (see classifyWizzStatus).
-const wizzDefaultVersion = "29.3.0"
+//
+// 2026-06-30 (#430): rotated "29.3.0" -> "29.4.0". The scheduled live probe
+// 404'd on the 29.3.0 path (the rotation signature). New version read from the
+// web app's live config — be.wizzair.com/29.4.0/Api/asset/culture serves from a
+// residential IP — confirming the path segment advanced one minor.
+const wizzDefaultVersion = "29.4.0"
 
 // wizzVersion is the active API version. Overridable in tests; the env var
 // WIZZAIR_API_VERSION takes precedence at request time via wizzResolvedVersion.

--- a/internal/flights/wizzair_test.go
+++ b/internal/flights/wizzair_test.go
@@ -7,9 +7,26 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
+
+// TestWizzDefaultVersionWellFormed guards the wizzDefaultVersion constant
+// against a malformed value. This matters because the version is bumped both by
+// hand and (per #430) by an automated discovery sentinel that rewrites the
+// constant from a CI probe — a typo or a non-version string there would silently
+// produce a broken request URL (be.wizzair.com/<garbage>/Api/...) that 404s on
+// every search. A semver-shaped guard catches that at build time.
+func TestWizzDefaultVersionWellFormed(t *testing.T) {
+	if !regexp.MustCompile(`^\d+\.\d+\.\d+$`).MatchString(wizzDefaultVersion) {
+		t.Fatalf("wizzDefaultVersion = %q, want a bare semver like \"29.4.0\"", wizzDefaultVersion)
+	}
+	// The resolved version must land in the timetable URL path verbatim.
+	if got := wizzTimetableURL(); !strings.Contains(got, "/"+wizzDefaultVersion+"/Api/") {
+		t.Fatalf("wizzTimetableURL() = %q, expected to contain /%s/Api/", got, wizzDefaultVersion)
+	}
+}
 
 func loadFixture(t *testing.T, name string) []byte {
 	t.Helper()


### PR DESCRIPTION
The data half of #430. The scheduled live probe 404'd on the `29.3.0` timetable path — the rotation signature `ErrWizzVersionRotated` keys on. Wizz advanced its API version path segment one minor to `29.4.0`.

New value read from the live web-app config: `be.wizzair.com/29.4.0/Api/asset/culture` serves from a residential IP (the site edge-blocks datacenter IPs, so this was verified from a normal connection, per the wizzair.go discovery note).

- One-line const bump in `internal/flights/wizzair.go` plus a dated history-comment entry matching the existing `10.1.0 -> 29.3.0` format.
- The three `wizzVersion = "29.3.0"` lines in the test file are explicit httptest fixtures (independent of the default) and intentionally unchanged.
- PR #432 already hardened the probe so transient edge-blocks no longer masquerade as this rotation. The `WIZZAIR_API_VERSION` env override remains the manual lever for the next rotation.

Tests: `go test -short ./internal/flights` green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)