### PR TITLE
feat(ci): auto-discover Wizz Air API version rotations (#430)

### DIFF
--- a/.github/workflows/wizzair-version-sentinel.yml
+++ b/.github/workflows/wizzair-version-sentinel.yml
@@ -66,8 +66,10 @@ jobs:
 
           sed -i -E "s/(wizzDefaultVersion = \")[0-9]+\.[0-9]+\.[0-9]+(\")/\1${NEW}\2/" internal/flights/wizzair.go
           gofmt -w internal/flights/wizzair.go
-          # Validate the bump compiles and the format guard passes before proposing it.
-          GOTOOLCHAIN=go1.26.4 go test ./internal/flights/ -run 'TestWizzDefaultVersion' -count=1
+          # Validate the bump: the whole flights package must compile and pass.
+          # (Running the full package, not a -run filter, avoids the Go footgun
+          # where an unmatched filter exits 0 and validates nothing.)
+          GOTOOLCHAIN=go1.26.4 go test ./internal/flights/ -count=1
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -82,9 +84,13 @@ jobs:
           Oracle proves the version *path* is live; it cannot confirm a priced search end-to-end (the timetable endpoint edge-blocks datacenter IPs). The opt-in nightly live probe validates real search from its own vantage.
 
           Labeled \`skip-regression-test\`: data-only bump, and \`TestWizzDefaultVersionWellFormed\` already guards the constant's shape."
+          # Ensure the bypass label exists first (gh pr create --label errors if a
+          # label is absent); idempotent, no-op when it already exists.
+          gh label create skip-regression-test \
+            --description "Auditable bypass of the regression-test-gate for genuinely untestable fixes" \
+            --color ededed 2>/dev/null || true
           gh pr create --title "fix(flights): bump Wizz Air API version ${CUR} -> ${NEW} (auto, #430)" \
             --body "$body" --label skip-regression-test
-          # Hands-off merge when a PAT is configured (so CI runs on the PR).
           gh pr merge "$branch" --auto --squash --delete-branch || \
             echo "auto-merge not armed (no PAT? CI will not start on a GITHUB_TOKEN PR) — merge manually."
 

--- a/.github/workflows/wizzair-version-sentinel.yml
+++ b/.github/workflows/wizzair-version-sentinel.yml
@@ -1,0 +1,105 @@
+name: Wizz Air version sentinel
+
+# Auto-discovers Wizz Air API version-path rotations and opens a PR bumping
+# wizzDefaultVersion — so the manual "find the new version in DevTools" chore
+# (#430) disappears. The discovery oracle (scripts/wizzair-discover-version.sh)
+# probes be.wizzair.com/<v>/Api/asset/culture behind CloudFront: 404 = path gone,
+# 200/405 = path live. It is datacenter-reachable, so this runs in plain CI with
+# no residential vantage or headless browser — and so it does NOT violate the
+# binary's deliberate "no runtime auto-discovery" design (wizzair.go): the binary
+# stays pure; this is external maintenance automation that proposes a reviewable,
+# test-gated diff.
+#
+# Hands-off setup (optional): add a fine-grained PAT secret WIZZAIR_SENTINEL_PAT
+# (contents:write + pull-requests:write). With it, the bump PR triggers CI and
+# auto-merges. Without it the PR still opens (via GITHUB_TOKEN) but needs a
+# one-click manual merge, because PRs opened by GITHUB_TOKEN do not start CI.
+
+on:
+  schedule:
+    - cron: "31 6 * * *" # 06:31 UTC daily, offset from the 05:17 live probes
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  sentinel:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: "1.26.4"
+
+      - name: Discover current Wizz Air API version
+        id: discover
+        run: |
+          set +e
+          out="$(bash scripts/wizzair-discover-version.sh)"
+          echo "$out"
+          status="$(printf '%s\n' "$out" | tail -1 | sed -n 's/.*STATUS=\([a-z]*\).*/\1/p')"
+          current="$(printf '%s\n' "$out" | tail -1 | sed -n 's/.*CURRENT=\([0-9.]*\).*/\1/p')"
+          new="$(printf '%s\n' "$out" | tail -1 | sed -n 's/.*NEW=\([0-9.]*\).*/\1/p')"
+          {
+            echo "status=$status"
+            echo "current=$current"
+            echo "new=$new"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open version-bump PR
+        if: steps.discover.outputs.status == 'rotated'
+        env:
+          GH_TOKEN: ${{ secrets.WIZZAIR_SENTINEL_PAT || github.token }}
+          CUR: ${{ steps.discover.outputs.current }}
+          NEW: ${{ steps.discover.outputs.new }}
+        run: |
+          set -euo pipefail
+          branch="auto/wizzair-version-${NEW}"
+          # Idempotent: if the bump PR already exists, do nothing.
+          if gh pr list --head "$branch" --state open --json number -q 'length' | grep -qx 0; then :; else
+            echo "PR for $branch already open; nothing to do."; exit 0
+          fi
+
+          sed -i -E "s/(wizzDefaultVersion = \")[0-9]+\.[0-9]+\.[0-9]+(\")/\1${NEW}\2/" internal/flights/wizzair.go
+          gofmt -w internal/flights/wizzair.go
+          # Validate the bump compiles and the format guard passes before proposing it.
+          GOTOOLCHAIN=go1.26.4 go test ./internal/flights/ -run 'TestWizzDefaultVersion' -count=1
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git commit -am "fix(flights): bump Wizz Air API version ${CUR} -> ${NEW} (auto, #430)"
+          git push -u origin "$branch"
+
+          body="Automated by the Wizz Air version sentinel.
+
+          The \`${CUR}\` API version path 404'd on the live oracle (rotation signature) and \`${NEW}\` is now live (\`be.wizzair.com/${NEW}/Api/asset/culture\` returns a non-404). Bumps \`wizzDefaultVersion\`.
+
+          Oracle proves the version *path* is live; it cannot confirm a priced search end-to-end (the timetable endpoint edge-blocks datacenter IPs). The opt-in nightly live probe validates real search from its own vantage.
+
+          Labeled \`skip-regression-test\`: data-only bump, and \`TestWizzDefaultVersionWellFormed\` already guards the constant's shape."
+          gh pr create --title "fix(flights): bump Wizz Air API version ${CUR} -> ${NEW} (auto, #430)" \
+            --body "$body" --label skip-regression-test
+          # Hands-off merge when a PAT is configured (so CI runs on the PR).
+          gh pr merge "$branch" --auto --squash --delete-branch || \
+            echo "auto-merge not armed (no PAT? CI will not start on a GITHUB_TOKEN PR) — merge manually."
+
+      - name: Open tracking issue when discovery exhausts the search range
+        if: steps.discover.outputs.status == 'unknown'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CUR: ${{ steps.discover.outputs.current }}
+        run: |
+          set -euo pipefail
+          title="Wizz Air version rotated beyond auto-discovery range"
+          body="The Wizz Air version sentinel found that \`${CUR}\` rotated away (404 on the live oracle) but no candidate version in the bounded search range (next minors/patches/majors) is live. Wizz likely jumped further than the walk covers. Read the current version from be.wizzair.com (DevTools Network tab -> any be.wizzair.com request -> /<version>/Api/...) and bump \`wizzDefaultVersion\` in internal/flights/wizzair.go, or widen the search in scripts/wizzair-discover-version.sh."
+          existing="$(gh issue list --state open --label provider-drift --search "in:title $title" --json number -q '.[0].number')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body" --label provider-drift
+          fi

--- a/.github/workflows/wizzair-version-sentinel.yml
+++ b/.github/workflows/wizzair-version-sentinel.yml
@@ -38,12 +38,25 @@ jobs:
       - name: Discover current Wizz Air API version
         id: discover
         run: |
+          # The script's non-zero exits encode status (10 rotated / 2 exhausted /
+          # 3 inconclusive), so we capture rather than fail on them — but we then
+          # VALIDATE the parsed status. A blank or unrecognized status (e.g. the
+          # source grep stopped matching after a refactor) must fail loudly, not
+          # let the scheduled run go green having silently done nothing.
           set +e
           out="$(bash scripts/wizzair-discover-version.sh)"
+          set -e
           echo "$out"
-          status="$(printf '%s\n' "$out" | tail -1 | sed -n 's/.*STATUS=\([a-z]*\).*/\1/p')"
-          current="$(printf '%s\n' "$out" | tail -1 | sed -n 's/.*CURRENT=\([0-9.]*\).*/\1/p')"
-          new="$(printf '%s\n' "$out" | tail -1 | sed -n 's/.*NEW=\([0-9.]*\).*/\1/p')"
+          last="$(printf '%s\n' "$out" | tail -1)"
+          status="$(printf '%s\n' "$last" | sed -n 's/.*STATUS=\([a-z]*\).*/\1/p')"
+          current="$(printf '%s\n' "$last" | sed -n 's/.*CURRENT=\([0-9.]*\).*/\1/p')"
+          new="$(printf '%s\n' "$last" | sed -n 's/.*NEW=\([0-9.]*\).*/\1/p')"
+          case "$status" in
+            ok|rotated|exhausted|inconclusive) : ;;
+            *)
+              echo "::error title=Sentinel discovery broken::Unrecognized discovery output (status='$status'). The probe script likely failed or its contract changed. Last line: $last"
+              exit 1 ;;
+          esac
           {
             echo "status=$status"
             echo "current=$current"
@@ -95,7 +108,7 @@ jobs:
             echo "auto-merge not armed (no PAT? CI will not start on a GITHUB_TOKEN PR) — merge manually."
 
       - name: Open tracking issue when discovery exhausts the search range
-        if: steps.discover.outputs.status == 'unknown'
+        if: steps.discover.outputs.status == 'exhausted'
         env:
           GH_TOKEN: ${{ github.token }}
           CUR: ${{ steps.discover.outputs.current }}

--- a/scripts/wizzair-discover-version.sh
+++ b/scripts/wizzair-discover-version.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# wizzair-discover-version.sh — discover Wizz Air's current API version path.
+#
+# Why this exists (#430): Wizz rotates the {version} segment in
+# be.wizzair.com/{version}/Api/... with no announcement. When it rotates, the
+# old path 404s and every Wizz search fails (ErrWizzVersionRotated). Bumping the
+# version was a manual DevTools chore; this automates the discovery half.
+#
+# The oracle: GET be.wizzair.com/<v>/Api/asset/culture behind CloudFront returns
+#   - 404            -> that version path does NOT exist (rotated away / future)
+#   - 200 or 405     -> that version path EXISTS (405 = route present, wrong verb)
+#   - 403/429/5xx    -> inconclusive (edge throttle / transient); do NOT act
+# Verified reachable from datacenter IPs (no residential vantage needed), so this
+# runs in plain CI. It proves the version PATH is live; it cannot prove a priced
+# search works (the timetable endpoint edge-blocks datacenter IPs) — but a live
+# path is exactly what clears the 404 rotation failure.
+#
+# Output (stdout, last line is machine-readable):
+#   STATUS=ok        CURRENT=<v>                 -> current still live, no change
+#   STATUS=rotated   CURRENT=<v> NEW=<w>         -> rotated; <w> is the new live version
+#   STATUS=unknown   CURRENT=<v>                 -> rotated but no candidate found in range
+#   STATUS=inconclusive CURRENT=<v>              -> probes blocked/throttled; try later
+# Exit codes: 0 ok | 10 rotated | 2 unknown | 3 inconclusive | 1 usage error
+set -euo pipefail
+
+UA="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+HOST="https://be.wizzair.com"
+
+# probe <version> -> echoes live|absent|inconclusive
+probe() {
+	local v="$1" code
+	code="$(curl -s -o /dev/null -m 12 -A "$UA" -w '%{http_code}' "$HOST/$v/Api/asset/culture" 2>/dev/null || echo 000)"
+	case "$code" in
+		404) echo absent ;;
+		200|405) echo live ;;
+		*) echo inconclusive ;;  # 403/429/5xx/000 -> transient, not a verdict
+	esac
+}
+
+# Resolve current version: CLI arg, else WIZZAIR_API_VERSION, else the source const.
+current="${1:-${WIZZAIR_API_VERSION:-}}"
+if [ -z "$current" ]; then
+	src="$(dirname "$0")/../internal/flights/wizzair.go"
+	current="$(grep -oE 'wizzDefaultVersion = "[0-9]+\.[0-9]+\.[0-9]+"' "$src" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+fi
+[ -n "$current" ] || { echo "STATUS=usage (could not resolve current version)"; exit 1; }
+
+IFS=. read -r MA MI PA <<<"$current"
+
+# Is the current version still live?
+case "$(probe "$current")" in
+	live) echo "STATUS=ok CURRENT=$current"; exit 0 ;;
+	inconclusive) echo "STATUS=inconclusive CURRENT=$current"; exit 3 ;;
+	absent) : ;;  # rotated — fall through to discovery
+esac
+
+# Discovery walk, most-likely first. History (10.1.0 -> 29.3.0 -> 29.4.0) shows
+# minor +1 is the common rotation, with occasional larger jumps. Bounded probes.
+candidates=()
+for d in 1 2 3 4 5 6; do candidates+=("$MA.$((MI+d)).0"); done   # next minors
+for d in 1 2 3;       do candidates+=("$MA.$MI.$((PA+d))"); done    # next patches
+candidates+=("$((MA+1)).0.0" "$((MA+1)).1.0" "$((MA+2)).0.0")        # next majors
+
+saw_inconclusive=false
+for c in "${candidates[@]}"; do
+	case "$(probe "$c")" in
+		live) echo "STATUS=rotated CURRENT=$current NEW=$c"; exit 10 ;;
+		inconclusive) saw_inconclusive=true ;;
+	esac
+	sleep 1  # be polite to the edge
+done
+
+if $saw_inconclusive; then
+	echo "STATUS=inconclusive CURRENT=$current"; exit 3
+fi
+echo "STATUS=unknown CURRENT=$current"; exit 2

--- a/scripts/wizzair-discover-version.sh
+++ b/scripts/wizzair-discover-version.sh
@@ -18,7 +18,7 @@
 # Output (stdout, last line is machine-readable):
 #   STATUS=ok        CURRENT=<v>                 -> current still live, no change
 #   STATUS=rotated   CURRENT=<v> NEW=<w>         -> rotated; <w> is the new live version
-#   STATUS=unknown   CURRENT=<v>                 -> rotated but no candidate found in range
+#   STATUS=exhausted   CURRENT=<v>                 -> rotated but no candidate found in range
 #   STATUS=inconclusive CURRENT=<v>              -> probes blocked/throttled; try later
 # Exit codes: 0 ok | 10 rotated | 2 unknown | 3 inconclusive | 1 usage error
 set -euo pipefail
@@ -73,4 +73,4 @@ done
 if $saw_inconclusive; then
 	echo "STATUS=inconclusive CURRENT=$current"; exit 3
 fi
-echo "STATUS=unknown CURRENT=$current"; exit 2
+echo "STATUS=exhausted CURRENT=$current"; exit 2


### PR DESCRIPTION
Eliminates the manual "find the new Wizz Air version in DevTools and bump the constant" chore behind #430. A daily sentinel discovers version-path rotations and opens a PR — optionally fully hands-off.

## The oracle (the key finding)
Wizz rotates the version segment in its API path with no announcement; when it does, the old path 404s and every Wizz search fails. The frontend site edge-blocks datacenter IPs, but the **API host is reachable** and version-discriminating behind CloudFront:

| Probe | Result | Meaning |
|---|---|---|
| live version | 200 or 405 | path exists |
| rotated version | 404 | path gone |
| transient block | 403, 429, 5xx | inconclusive — never acted on |

A 3-state oracle, so a flaky edge response can't trigger a false rotation hunt. Proven reachable from a datacenter IP, so this runs in plain GitHub Actions — no residential vantage, no headless browser.

## What it does
- `scripts/wizzair-discover-version.sh` — probes the oracle. If the current version is live, no-op. If rotated, walks likely next versions (minor +1 first, then patches, then next major) until one is live.
- `.github/workflows/wizzair-version-sentinel.yml` — runs it daily. On rotation: bumps the constant, validates with the format guard test, opens a PR, and arms auto-merge. Beyond the search range it opens a tracking issue instead of guessing wrong.

## Design note
This does not contradict the binary's deliberate "no runtime auto-discovery" stance (documented in the flights package). The binary stays pure — discovery never runs inside it. This is external maintenance automation that proposes a reviewable, test-gated diff, exactly the layer where a CI probe belongs.

## Demonstrated live
- current 29.4.0 then STATUS=ok (no change)
- simulated stale 29.3.0 then STATUS=rotated NEW=29.4.0 (discovered via the walk)

## One optional setup for full hands-off
Add a fine-grained PAT secret `WIZZAIR_SENTINEL_PAT` (contents + pull-requests write). With it, the bump PR triggers CI and auto-merges. Without it the PR still opens but needs a one-click merge, because PRs opened by the default token don't start CI.

Pairs with #434 (the manual 29.3.0 to 29.4.0 bump + the format guard this relies on). Merge #434 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)