### PR TITLE
feat(flights): runtime self-healing for Wizz Air version rotations (#430)

### DIFF
--- a/internal/flights/wizzair.go
+++ b/internal/flights/wizzair.go
@@ -15,21 +15,23 @@ package flights
 // internal/baggage).
 //
 // VERSION ROTATION (verified gotcha): the {version} path segment rotates
-// periodically (observed "10.1.0", "27.x", ...). It is NOT hardcoded into the
-// URL builder. Resolution order (first hit wins):
+// periodically (observed "10.1.0", "29.3.0", "29.4.0", ...). It is NOT hardcoded
+// into the URL builder. Resolution order (first hit wins):
 //
 //  1. WIZZAIR_API_VERSION env var (operator override, no code change / redeploy).
-//  2. wizzVersion package var (overridable in tests; seeded from the const).
+//  2. wizzVersion package var — seeded from the const, updated by runtime
+//     self-healing (and loaded from the ~/.trvl cache at startup).
 //
-// wizzDefaultVersion is the last-known-good value. There is deliberately NO
-// live-discovery path: Wizz's current API version is JS-gated and has no clean
-// server-side HTTP endpoint that reliably returns it, and a headless-browser
-// dependency is forbidden (single static binary, no frameworks). When the
-// segment rotates, the timetable endpoint 404s; SearchWizzair detects that and
-// returns ErrWizzVersionRotated, which the aggregate renders as a typed,
-// actionable ProviderStatus (FixHintCode "WIZZ_VERSION_ROTATED") telling the
-// operator to set WIZZAIR_API_VERSION. The env override is the authoritative,
-// zero-deploy manual fix.
+// wizzDefaultVersion is the last-known-good value and the cold-start fallback.
+// Resolution order at request time (first hit wins): WIZZAIR_API_VERSION env
+// override; a previously self-healed version cached in ~/.trvl/wizzair_version.json;
+// then this constant. When the segment rotates, the timetable endpoint 404s and
+// SearchWizzair self-heals at runtime (see wizzair_selfheal.go): it discovers the
+// new version via the be.wizzair.com/<v>/Api/asset/culture oracle and retries —
+// the retry is the end-to-end verification. If healing is disabled
+// (WIZZAIR_API_VERSION pin or WIZZAIR_NO_AUTOHEAL=1) or no candidate is live, the
+// rotation surfaces as a typed, actionable ProviderStatus (FixHintCode
+// "WIZZ_VERSION_ROTATED") telling the operator to set WIZZAIR_API_VERSION.
 //
 // Tracking: low-cost-carrier provider breadth (flights domain); GH #115.
 
@@ -40,6 +42,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -55,12 +58,12 @@ import (
 // it with errors.Is and render a typed, actionable ProviderStatus instead of a
 // silent failure. The wrapped message carries the version that was tried.
 //
-// Why no auto-discovery: Wizz's current API version is JS-gated and has no clean
-// server-side HTTP endpoint that reliably returns it. A guessed-but-unverified
-// discovery mechanism would be worse than none (it could pin the wrong version),
-// and a headless-browser dependency is forbidden by the single-binary principle.
-// The honest design is graceful degradation plus the WIZZAIR_API_VERSION env
-// override as the authoritative manual fix.
+// On this error SearchWizzair self-heals (wizzair_selfheal.go): it discovers the
+// current version via the asset/culture oracle and retries — verifying the new
+// version end-to-end from the caller's real IP. This sentinel is still the
+// terminal outcome when healing is disabled (WIZZAIR_API_VERSION pin /
+// WIZZAIR_NO_AUTOHEAL=1) or discovery finds no live candidate, so graceful
+// degradation plus the env override remains the floor.
 var ErrWizzVersionRotated = errors.New("wizzair API version path rotated")
 
 // ErrWizzBlocked is the sentinel for a non-200 whose body is NOT Wizz's own JSON
@@ -123,6 +126,8 @@ func wizzResolvedVersion() string {
 	if v := strings.TrimSpace(os.Getenv("WIZZAIR_API_VERSION")); v != "" {
 		return v
 	}
+	wizzVersionMu.RLock()
+	defer wizzVersionMu.RUnlock()
 	return wizzVersion
 }
 
@@ -220,6 +225,8 @@ func SearchWizzair(ctx context.Context, origin, destination, date, currency stri
 	if currency == "" {
 		currency = "EUR"
 	}
+	// Adopt a previously-healed version (if any) before the first request.
+	wizzMaybeLoadCache()
 	if err := wizzLimiter.Wait(ctx); err != nil {
 		return nil, err
 	}
@@ -241,6 +248,26 @@ func SearchWizzair(ctx context.Context, origin, destination, date, currency stri
 		return nil, fmt.Errorf("wizzair: marshal request: %w", err)
 	}
 
+	results, err := wizzSearchOnce(ctx, payload, date, currency)
+	// Self-heal on a version rotation: discover the new version, swap it in, and
+	// retry once. The retry IS the end-to-end verification — it only succeeds if
+	// the discovered version actually serves a priced timetable response.
+	if errors.Is(err, ErrWizzVersionRotated) && wizzHealEnabled() {
+		stale := wizzResolvedVersion()
+		if newV, ok := wizzHeal(ctx, stale); ok && newV != stale {
+			slog.Warn("wizzair self-healed API version after rotation", "from", stale, "to", newV)
+			if werr := wizzLimiter.Wait(ctx); werr == nil {
+				results, err = wizzSearchOnce(ctx, payload, date, currency)
+			}
+		}
+	}
+	return results, err
+}
+
+// wizzSearchOnce performs one timetable request at the currently-resolved
+// version and maps the response. A rotated version surfaces as
+// ErrWizzVersionRotated (404) for the caller to optionally heal and retry.
+func wizzSearchOnce(ctx context.Context, payload []byte, date, currency string) ([]models.FlightResult, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, wizzTimetableURL(), bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("wizzair: build request: %w", err)
@@ -249,7 +276,7 @@ func SearchWizzair(ctx context.Context, origin, destination, date, currency stri
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Origin", "https"+"://"+"wizzair.com")
 	req.Header.Set("Referer", "https"+"://"+"wizzair.com/")
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36")
+	req.Header.Set("User-Agent", wizzBrowserUA)
 
 	resp, err := wizzClient.Do(req)
 	if err != nil {

--- a/internal/flights/wizzair.go
+++ b/internal/flights/wizzair.go
@@ -248,14 +248,18 @@ func SearchWizzair(ctx context.Context, origin, destination, date, currency stri
 		return nil, fmt.Errorf("wizzair: marshal request: %w", err)
 	}
 
+	// Capture the version this attempt will use BEFORE the request, so a
+	// concurrent heal between the failure and the heal call can't make us walk
+	// past an already-working version (we'd otherwise treat the healed version as
+	// the stale one and probe its successors).
+	used := wizzResolvedVersion()
 	results, err := wizzSearchOnce(ctx, payload, date, currency)
 	// Self-heal on a version rotation: discover the new version, swap it in, and
 	// retry once. The retry IS the end-to-end verification — it only succeeds if
 	// the discovered version actually serves a priced timetable response.
 	if errors.Is(err, ErrWizzVersionRotated) && wizzHealEnabled() {
-		stale := wizzResolvedVersion()
-		if newV, ok := wizzHeal(ctx, stale); ok && newV != stale {
-			slog.Warn("wizzair self-healed API version after rotation", "from", stale, "to", newV)
+		if newV, ok := wizzHeal(ctx, used); ok && newV != used {
+			slog.Warn("wizzair self-healed API version after rotation", "from", used, "to", newV)
 			if werr := wizzLimiter.Wait(ctx); werr == nil {
 				results, err = wizzSearchOnce(ctx, payload, date, currency)
 			}

--- a/internal/flights/wizzair_selfheal.go
+++ b/internal/flights/wizzair_selfheal.go
@@ -181,7 +181,10 @@ func wizzPersistVersion(v string) {
 // stale) compiled-in default. Skipped under a test host or an operator pin.
 func wizzMaybeLoadCache() {
 	wizzHealCacheOnce.Do(func() {
-		if !wizzRealHost() || strings.TrimSpace(os.Getenv("WIZZAIR_API_VERSION")) != "" {
+		// Skip under a test host or whenever healing is off (operator pin or
+		// WIZZAIR_NO_AUTOHEAL): the opt-out must fully restore fail-clean and must
+		// not silently adopt a previously-cached healed version.
+		if !wizzRealHost() || !wizzHealEnabled() {
 			return
 		}
 		path, ok := wizzCachePath()

--- a/internal/flights/wizzair_selfheal.go
+++ b/internal/flights/wizzair_selfheal.go
@@ -1,0 +1,202 @@
+package flights
+
+// Runtime self-healing for Wizz Air API version rotations (#430).
+//
+// Wizz rotates the {version} segment in be.wizzair.com/{version}/Api/... with no
+// announcement; the old path then 404s and every Wizz search fails. The original
+// design deliberately had NO runtime discovery, on two premises that have since
+// been disproven:
+//
+//   - "No clean server-side endpoint returns the version." False: the
+//     be.wizzair.com/<v>/Api/asset/culture route is a deterministic oracle —
+//     404 = version path absent, 200/405 = present — over plain HTTP, no JS, no
+//     headless browser (so the single-binary principle is intact).
+//   - "A guessed version could be wrong." The binary is in fact the BEST verifier:
+//     it runs from the user's real (often residential) IP, so after discovering a
+//     candidate it confirms end-to-end by retrying the real timetable search —
+//     something CI (edge-blocked on that endpoint) fundamentally cannot do.
+//
+// So on a rotation 404, SearchWizzair discovers the new version, swaps it in,
+// caches it to ~/.trvl/wizzair_version.json, and retries once — the rotation is
+// invisible to the user. Disabled when WIZZAIR_API_VERSION is set (operator pin)
+// or WIZZAIR_NO_AUTOHEAL=1 (opt back into fail-clean behaviour). The CI sentinel
+// (.github/workflows/wizzair-version-sentinel.yml) is kept as belt-and-suspenders
+// to keep the committed default fresh for cold-start installs.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// wizzBrowserUA is the browser-like User-Agent used for both the timetable
+// request and the discovery probe (Wizz's edge is friendlier to it).
+const wizzBrowserUA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+
+var (
+	// wizzVersionMu guards concurrent reads (wizzResolvedVersion) and heal-time
+	// writes of wizzVersion, so the aggregate's parallel provider goroutines stay
+	// race-free under -race.
+	wizzVersionMu sync.RWMutex
+	// wizzHealCacheOnce loads the on-disk cached version exactly once per process.
+	wizzHealCacheOnce sync.Once
+	// wizzHealLimiter throttles discovery probes so a rotation can't burst the edge.
+	wizzHealLimiter = rate.NewLimiter(rate.Every(time.Second), 1)
+)
+
+// wizzHealEnabled reports whether runtime self-healing should run. An operator
+// pin (WIZZAIR_API_VERSION) or an explicit opt-out (WIZZAIR_NO_AUTOHEAL=1) keeps
+// the old fail-clean behaviour.
+func wizzHealEnabled() bool {
+	if strings.TrimSpace(os.Getenv("WIZZAIR_API_VERSION")) != "" {
+		return false
+	}
+	return os.Getenv("WIZZAIR_NO_AUTOHEAL") != "1"
+}
+
+// wizzRealHost reports whether requests target the real Wizz host (not an
+// httptest server). Cache load/persist only happen against the real host so unit
+// tests stay hermetic.
+func wizzRealHost() bool { return wizzHost == "https"+"://"+"be.wizzair.com" }
+
+// wizzProbeVersion classifies a version path via the asset/culture oracle:
+// "absent" (404), "live" (200/405), or "inconclusive" (transient/edge/transport).
+func wizzProbeVersion(ctx context.Context, v string) string {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wizzHost+"/"+v+"/Api/asset/culture", nil)
+	if err != nil {
+		return "inconclusive"
+	}
+	req.Header.Set("User-Agent", wizzBrowserUA)
+	resp, err := wizzClient.Do(req)
+	if err != nil {
+		return "inconclusive"
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return "absent"
+	case http.StatusOK, http.StatusMethodNotAllowed:
+		return "live"
+	default:
+		return "inconclusive"
+	}
+}
+
+// wizzNextCandidates returns likely rotation targets from the stale X.Y.Z, most
+// likely first: next minors (history shows minor +1 is the common rotation),
+// then patches, then the next majors. Bounded; a jump beyond this range is left
+// to the operator / CI sentinel.
+func wizzNextCandidates(cur string) []string {
+	p := strings.Split(cur, ".")
+	if len(p) != 3 {
+		return nil
+	}
+	ma, e1 := strconv.Atoi(p[0])
+	mi, e2 := strconv.Atoi(p[1])
+	pa, e3 := strconv.Atoi(p[2])
+	if e1 != nil || e2 != nil || e3 != nil {
+		return nil
+	}
+	out := make([]string, 0, 12)
+	for d := 1; d <= 6; d++ {
+		out = append(out, itoa3(ma, mi+d, 0))
+	}
+	for d := 1; d <= 3; d++ {
+		out = append(out, itoa3(ma, mi, pa+d))
+	}
+	out = append(out, itoa3(ma+1, 0, 0), itoa3(ma+1, 1, 0), itoa3(ma+2, 0, 0))
+	return out
+}
+
+func itoa3(a, b, c int) string {
+	return strconv.Itoa(a) + "." + strconv.Itoa(b) + "." + strconv.Itoa(c)
+}
+
+// wizzHeal discovers a live version when `stale` has rotated. Serialized via the
+// write lock so concurrent searches don't stampede the edge; idempotent — a
+// caller arriving after another goroutine already healed gets the new version.
+// Returns ("", false) when no candidate in range is live (caller keeps the typed
+// rotation error — graceful degradation preserved).
+func wizzHeal(ctx context.Context, stale string) (string, bool) {
+	wizzVersionMu.Lock()
+	defer wizzVersionMu.Unlock()
+	if wizzVersion != stale {
+		return wizzVersion, true // another goroutine already healed
+	}
+	for _, c := range wizzNextCandidates(stale) {
+		_ = wizzHealLimiter.Wait(ctx)
+		if wizzProbeVersion(ctx, c) == "live" {
+			wizzVersion = c
+			wizzPersistVersion(c)
+			return c, true
+		}
+	}
+	return "", false
+}
+
+type wizzVersionCache struct {
+	Version      string `json:"version"`
+	DiscoveredAt string `json:"discovered_at"`
+}
+
+func wizzCachePath() (string, bool) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", false
+	}
+	return filepath.Join(home, ".trvl", "wizzair_version.json"), true
+}
+
+// wizzPersistVersion best-effort writes the discovered version so a restart skips
+// rediscovery. No-op against a test host or on any I/O error (caching is an
+// optimisation, never load-bearing).
+func wizzPersistVersion(v string) {
+	if !wizzRealHost() {
+		return
+	}
+	path, ok := wizzCachePath()
+	if !ok {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	b, err := json.Marshal(wizzVersionCache{Version: v, DiscoveredAt: time.Now().UTC().Format(time.RFC3339)})
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, b, 0o644)
+}
+
+// wizzMaybeLoadCache loads a previously-healed version once per process, so a
+// fresh run starts from the last-known-live version rather than the (possibly
+// stale) compiled-in default. Skipped under a test host or an operator pin.
+func wizzMaybeLoadCache() {
+	wizzHealCacheOnce.Do(func() {
+		if !wizzRealHost() || strings.TrimSpace(os.Getenv("WIZZAIR_API_VERSION")) != "" {
+			return
+		}
+		path, ok := wizzCachePath()
+		if !ok {
+			return
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return
+		}
+		var c wizzVersionCache
+		if json.Unmarshal(b, &c) == nil && len(strings.Split(c.Version, ".")) == 3 {
+			wizzVersionMu.Lock()
+			wizzVersion = c.Version
+			wizzVersionMu.Unlock()
+		}
+	})
+}

--- a/internal/flights/wizzair_selfheal_test.go
+++ b/internal/flights/wizzair_selfheal_test.go
@@ -1,0 +1,154 @@
+package flights
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestWizzNextCandidates checks the rotation-walk order: next minors first
+// (the common rotation), then patches, then the next majors.
+func TestWizzNextCandidates(t *testing.T) {
+	got := wizzNextCandidates("29.3.0")
+	if len(got) == 0 {
+		t.Fatal("no candidates generated")
+	}
+	if got[0] != "29.4.0" {
+		t.Errorf("first candidate = %q, want 29.4.0 (minor +1 is most likely)", got[0])
+	}
+	want := map[string]bool{"29.4.0": false, "29.5.0": false, "29.3.1": false, "30.0.0": false}
+	for _, c := range got {
+		if _, ok := want[c]; ok {
+			want[c] = true
+		}
+	}
+	for v, seen := range want {
+		if !seen {
+			t.Errorf("expected candidate %q not in walk %v", v, got)
+		}
+	}
+	if c := wizzNextCandidates("not-a-version"); c != nil {
+		t.Errorf("malformed input should yield nil candidates, got %v", c)
+	}
+}
+
+// TestWizzProbeVersion classifies the asset/culture oracle responses.
+func TestWizzProbeVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/29.4.0/"):
+			w.WriteHeader(http.StatusMethodNotAllowed) // live: route exists, GET not allowed
+		case strings.Contains(r.URL.Path, "/29.9.9/"):
+			w.WriteHeader(http.StatusForbidden) // transient edge block
+		default:
+			w.WriteHeader(http.StatusNotFound) // absent
+		}
+	}))
+	defer srv.Close()
+	orig := wizzHost
+	wizzHost = srv.URL
+	defer func() { wizzHost = orig }()
+
+	cases := map[string]string{"29.4.0": "live", "29.3.0": "absent", "29.9.9": "inconclusive"}
+	for v, want := range cases {
+		if got := wizzProbeVersion(context.Background(), v); got != want {
+			t.Errorf("probe(%s) = %q, want %q", v, got, want)
+		}
+	}
+}
+
+// TestSearchWizzair_SelfHealsOnRotation is the integration proof: the stale
+// configured version 404s on the timetable endpoint, the asset/culture oracle
+// reveals the rotated-to version is live, and SearchWizzair transparently
+// rediscovers it and returns results — without the operator touching anything.
+func TestSearchWizzair_SelfHealsOnRotation(t *testing.T) {
+	const stale, live = "29.3.0", "29.4.0"
+	fixture := loadFixture(t, "wizzair_timetable.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		liveVersion := strings.Contains(r.URL.Path, "/"+live+"/")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/Api/asset/culture"):
+			if liveVersion {
+				w.WriteHeader(http.StatusMethodNotAllowed) // oracle: live
+			} else {
+				w.WriteHeader(http.StatusNotFound) // oracle: absent
+			}
+		case strings.HasSuffix(r.URL.Path, "/Api/search/timetable"):
+			if liveVersion {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(fixture)
+			} else {
+				w.WriteHeader(http.StatusNotFound) // stale version: rotation 404
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	origHost, origVer := wizzHost, wizzVersion
+	wizzHost = srv.URL
+	wizzVersion = stale
+	defer func() { wizzHost, wizzVersion = origHost, origVer }()
+	t.Setenv("WIZZAIR_API_VERSION", "")  // no operator pin
+	t.Setenv("WIZZAIR_NO_AUTOHEAL", "")  // healing enabled
+
+	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	if err != nil {
+		t.Fatalf("self-heal search should succeed, got error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 result after self-heal, got %d", len(out))
+	}
+	if got := wizzResolvedVersion(); got != live {
+		t.Errorf("version after heal = %q, want %q", got, live)
+	}
+}
+
+// TestSearchWizzair_NoHealWhenPinned proves an operator pin (WIZZAIR_API_VERSION)
+// disables self-healing: the rotation 404 surfaces as the typed sentinel instead
+// of silently rediscovering — the operator stays in control.
+func TestSearchWizzair_NoHealWhenPinned(t *testing.T) {
+	probed := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/Api/asset/culture") {
+			probed = true
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	origHost, origVer := wizzHost, wizzVersion
+	wizzHost = srv.URL
+	wizzVersion = "10.1.0"
+	defer func() { wizzHost, wizzVersion = origHost, origVer }()
+	t.Setenv("WIZZAIR_API_VERSION", "29.3.0") // operator pin -> healing disabled
+
+	_, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	if err == nil {
+		t.Fatal("want rotation error when pinned, got nil")
+	}
+	if probed {
+		t.Error("self-heal discovery ran despite an operator pin; it must not")
+	}
+}
+
+// TestWizzHealEnabled covers the enable/disable matrix.
+func TestWizzHealEnabled(t *testing.T) {
+	t.Setenv("WIZZAIR_API_VERSION", "")
+	t.Setenv("WIZZAIR_NO_AUTOHEAL", "")
+	if !wizzHealEnabled() {
+		t.Error("healing should be enabled by default")
+	}
+	t.Setenv("WIZZAIR_API_VERSION", "29.3.0")
+	if wizzHealEnabled() {
+		t.Error("operator pin must disable healing")
+	}
+	t.Setenv("WIZZAIR_API_VERSION", "")
+	t.Setenv("WIZZAIR_NO_AUTOHEAL", "1")
+	if wizzHealEnabled() {
+		t.Error("WIZZAIR_NO_AUTOHEAL=1 must disable healing")
+	}
+}


### PR DESCRIPTION
Your call: put the version self-healing in the binary instead of only in CI. It's the better architecture, and it makes the CI sentinel (#435) belt-and-suspenders rather than the primary mechanism (kept, per your "keep both").

## Why the binary is the right home
The flights package used to argue against runtime discovery on two premises, both disproven this session:
1. "No clean server-side endpoint returns the version." The asset-culture route is a deterministic oracle (404 means gone, 200 or 405 means live), plain HTTP, no JS, no browser.
2. "A guessed version could be wrong." The binary is the best verifier: it runs from the user's real (often residential) IP, so after discovering a candidate it confirms end-to-end with a real priced timetable search, which CI fundamentally cannot (edge-blocked on that endpoint).

## Behaviour
On a rotation 404, SearchWizzair discovers the live version, swaps it in, caches it to the trvl config dir, and retries once. The retry is the verification. The rotation becomes invisible, the failing search just succeeds. First search after a rotation pays a few discovery probes; every one after is normal (in-memory plus on-disk cache).

## Bounds and safety
- Disabled under an operator pin (WIZZAIR_API_VERSION) or WIZZAIR_NO_AUTOHEAL=1, both restoring the prior fail-clean behaviour.
- One heal attempt per call; if nothing in the search range is live, the typed error surfaces unchanged (graceful degradation preserved).
- Serialized by a read-write mutex so the aggregate's parallel provider goroutines stay race-free, verified under the race detector.
- No new dependency, no headless browser. Single-binary principle holds.

Also updated the now-stale "no auto-discovery by design" comments whose premise was disproven.

## Tests
Self-heal-on-rotation integration proof, no-heal-when-pinned, oracle classification, candidate-walk order, plus the enable and disable matrix. Full package green under the race detector (149s).

Closes the loop with #432 (alerting), #434 (manual bump), #435 (CI sentinel): the version is now hardened, fixed, and self-healing at three layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)