### PR TITLE
fix(flights): cache never downgrades below compiled default (orphaned 436 fix)

### DIFF
--- a/internal/flights/wizzair_selfheal.go
+++ b/internal/flights/wizzair_selfheal.go
@@ -122,6 +122,27 @@ func itoa3(a, b, c int) string {
 	return strconv.Itoa(a) + "." + strconv.Itoa(b) + "." + strconv.Itoa(c)
 }
 
+// wizzVersionNewer reports whether semver a is strictly newer than b. Returns
+// false for equal versions and for any malformed (non X.Y.Z numeric) input — so
+// a corrupt cache is never adopted.
+func wizzVersionNewer(a, b string) bool {
+	pa, pb := strings.Split(a, "."), strings.Split(b, ".")
+	if len(pa) != 3 || len(pb) != 3 {
+		return false
+	}
+	for i := 0; i < 3; i++ {
+		na, ea := strconv.Atoi(pa[i])
+		nb, eb := strconv.Atoi(pb[i])
+		if ea != nil || eb != nil {
+			return false
+		}
+		if na != nb {
+			return na > nb
+		}
+	}
+	return false
+}
+
 // wizzHeal discovers a live version when `stale` has rotated. Serialized via the
 // write lock so concurrent searches don't stampede the edge; idempotent — a
 // caller arriving after another goroutine already healed gets the new version.
@@ -196,7 +217,12 @@ func wizzMaybeLoadCache() {
 			return
 		}
 		var c wizzVersionCache
-		if json.Unmarshal(b, &c) == nil && len(strings.Split(c.Version, ".")) == 3 {
+		// Only adopt the cache when it is strictly NEWER than the compiled
+		// default. Otherwise a release that bumps wizzDefaultVersion past a user's
+		// cached value would be silently downgraded back to the stale cache (and
+		// could then fail if Wizz had moved beyond the heal walk's range from it).
+		// wizzVersionNewer also rejects a malformed/corrupt cache (returns false).
+		if json.Unmarshal(b, &c) == nil && wizzVersionNewer(c.Version, wizzDefaultVersion) {
 			wizzVersionMu.Lock()
 			wizzVersion = c.Version
 			wizzVersionMu.Unlock()

--- a/internal/flights/wizzair_selfheal_test.go
+++ b/internal/flights/wizzair_selfheal_test.go
@@ -135,6 +135,28 @@ func TestSearchWizzair_NoHealWhenPinned(t *testing.T) {
 	}
 }
 
+// TestWizzVersionNewer guards the cache anti-downgrade comparator: a cached
+// version is adopted only when strictly newer than the compiled default.
+func TestWizzVersionNewer(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"29.5.0", "29.4.0", true},  // newer minor
+		{"29.4.1", "29.4.0", true},  // newer patch
+		{"30.0.0", "29.9.9", true},  // newer major
+		{"29.4.0", "29.4.0", false}, // equal
+		{"29.3.0", "29.4.0", false}, // older -> do not adopt (no downgrade)
+		{"bad", "29.4.0", false},    // malformed -> reject
+		{"29.4", "29.4.0", false},   // wrong shape -> reject
+	}
+	for _, c := range cases {
+		if got := wizzVersionNewer(c.a, c.b); got != c.want {
+			t.Errorf("wizzVersionNewer(%q,%q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
 // TestWizzHealEnabled covers the enable/disable matrix.
 func TestWizzHealEnabled(t *testing.T) {
 	t.Setenv("WIZZAIR_API_VERSION", "")


### PR DESCRIPTION
Lands the third codex fix for #436 that was orphaned by a merge-timing gap.

## What happened
PR #436 (runtime self-healing) went through three rounds of review at gpt-5.5 extra-high reasoning. Round 3 flagged a P2 cache-downgrade hazard, which I fixed in commit 8aedeb0 — but #436 had already auto-merged (I pre-armed auto-merge, and CI on the prior commit fired the merge before this fix was pushed). So two of the three review fixes landed in main; this one was stranded on the deleted feature branch. Cherry-picked here.

## The bug (live in main until this merges)
On startup, wizzMaybeLoadCache adopts the cached version file unconditionally. After a release that bumps the compiled wizzDefaultVersion past a user's cached value, the binary silently downgrades itself back to the stale cached version — and if Wizz had rotated beyond the heal walk's range from that old value, searches keep failing even though the shipped default was correct.

## The fix
Adopt the cache only when it is strictly newer than the compiled default (new wizzVersionNewer semver comparator); a malformed or corrupt cache is also rejected. Unit-tested across newer, equal, older, and malformed inputs.

## Process note
This is the concrete cost of arming auto-merge before the final review returned, on a PR where every review round found a real bug. Owning it; the rule going forward is to wait for one clean review before arming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)