### PR TITLE
fix(flights): repair Kiwi provider after MCP stateless + schema drift (#439)

### DIFF
--- a/internal/flights/crossshop_test.go
+++ b/internal/flights/crossshop_test.go
@@ -36,21 +36,32 @@ func gflight(origin, dest, depart string, price float64, currency string) models
 // layover->segment decomposition (XSHOP.1).
 func helIstBcnKiwi(bundledPrice float64) models.FlightResult {
 	itin := kiwiItinerary{
-		FlyFrom:   "HEL",
-		FlyTo:     "BCN",
-		CityFrom:  "Helsinki",
-		CityTo:    "Barcelona",
-		Departure: kiwiDateTime{Local: "2026-07-01T08:00:00", UTC: "2026-07-01T05:00:00Z"},
-		Arrival:   kiwiDateTime{Local: "2026-07-01T18:00:00", UTC: "2026-07-01T16:00:00Z"},
-		Price:     bundledPrice,
-		Currency:  "EUR",
-		Layovers: []kiwiLayover{{
-			At:        "IST",
-			City:      "Istanbul",
-			CityCode:  "IST",
-			Arrival:   kiwiDateTime{Local: "2026-07-01T11:00:00", UTC: "2026-07-01T08:00:00Z"},
-			Departure: kiwiDateTime{Local: "2026-07-01T13:00:00", UTC: "2026-07-01T10:00:00Z"},
-		}},
+		Price: bundledPrice,
+		Outbound: &kiwiLeg{
+			From:          "HEL",
+			To:            "BCN",
+			DepartureTime: "2026-07-01T08:00:00",
+			ArrivalTime:   "2026-07-01T18:00:00",
+			Stops:         1,
+			Segments: []kiwiSegment{
+				{
+					From:          "HEL",
+					To:            "IST",
+					FromCity:      "Helsinki",
+					ToCity:        "Istanbul",
+					DepartureTime: "2026-07-01T08:00:00",
+					ArrivalTime:   "2026-07-01T11:00:00",
+				},
+				{
+					From:          "IST",
+					To:            "BCN",
+					FromCity:      "Istanbul",
+					ToCity:        "Barcelona",
+					DepartureTime: "2026-07-01T13:00:00",
+					ArrivalTime:   "2026-07-01T18:00:00",
+				},
+			},
+		},
 	}
 	return mapKiwiItinerary(itin, "EUR")
 }

--- a/internal/flights/flights_max_split2_test.go
+++ b/internal/flights/flights_max_split2_test.go
@@ -161,18 +161,27 @@ func TestMergeFlightResults_WithFilters(t *testing.T) {
 
 func TestMapKiwiItinerary_Direct(t *testing.T) {
 	itinerary := kiwiItinerary{
-		FlyFrom:           "HEL",
-		FlyTo:             "NRT",
-		CityFrom:          "Helsinki",
-		CityTo:            "Tokyo",
-		Departure:         kiwiDateTime{UTC: "2026-06-15T10:00:00Z", Local: "2026-06-15T13:00:00"},
-		Arrival:           kiwiDateTime{UTC: "2026-06-16T01:00:00Z", Local: "2026-06-16T10:00:00"},
-		DurationInSeconds: 54000,
-		Price:             450,
-		Currency:          "EUR",
-		DeepLink:          "https://kiwi.com/booking/123",
+		Price:                450,
+		TotalDurationSeconds: 54000,
+		BookingURL:           "https://kiwi.com/booking/123",
+		Outbound: &kiwiLeg{
+			From:          "HEL",
+			To:            "NRT",
+			DepartureTime: "2026-06-15T13:00:00",
+			ArrivalTime:   "2026-06-16T10:00:00",
+			Segments: []kiwiSegment{
+				{
+					From:          "HEL",
+					To:            "NRT",
+					FromCity:      "Helsinki",
+					ToCity:        "Tokyo",
+					DepartureTime: "2026-06-15T13:00:00",
+					ArrivalTime:   "2026-06-16T10:00:00",
+				},
+			},
+		},
 	}
-	fr := mapKiwiItinerary(itinerary, "USD")
+	fr := mapKiwiItinerary(itinerary, "EUR")
 	if fr.Price != 450 {
 		t.Errorf("price = %v, want 450", fr.Price)
 	}
@@ -195,21 +204,31 @@ func TestMapKiwiItinerary_Direct(t *testing.T) {
 
 func TestMapKiwiItinerary_WithLayover(t *testing.T) {
 	itinerary := kiwiItinerary{
-		FlyFrom:           "HEL",
-		FlyTo:             "NRT",
-		CityFrom:          "Helsinki",
-		CityTo:            "Tokyo",
-		Departure:         kiwiDateTime{UTC: "2026-06-15T10:00:00Z"},
-		Arrival:           kiwiDateTime{UTC: "2026-06-16T01:00:00Z"},
-		DurationInSeconds: 54000,
-		Price:             350,
-		Currency:          "",
-		Layovers: []kiwiLayover{
-			{
-				At:        "FRA",
-				City:      "Frankfurt",
-				Arrival:   kiwiDateTime{UTC: "2026-06-15T13:00:00Z"},
-				Departure: kiwiDateTime{UTC: "2026-06-15T15:00:00Z"},
+		Price:                350,
+		TotalDurationSeconds: 54000,
+		Outbound: &kiwiLeg{
+			From:          "HEL",
+			To:            "NRT",
+			DepartureTime: "2026-06-15T10:00:00",
+			ArrivalTime:   "2026-06-16T01:00:00",
+			Stops:         1,
+			Segments: []kiwiSegment{
+				{
+					From:          "HEL",
+					To:            "FRA",
+					FromCity:      "Helsinki",
+					ToCity:        "Frankfurt",
+					DepartureTime: "2026-06-15T10:00:00",
+					ArrivalTime:   "2026-06-15T13:00:00",
+				},
+				{
+					From:          "FRA",
+					To:            "NRT",
+					FromCity:      "Frankfurt",
+					ToCity:        "Tokyo",
+					DepartureTime: "2026-06-15T15:00:00",
+					ArrivalTime:   "2026-06-16T01:00:00",
+				},
 			},
 		},
 	}
@@ -233,17 +252,26 @@ func TestMapKiwiItinerary_WithLayover(t *testing.T) {
 
 func TestMapKiwiItinerary_TotalDurationFallback(t *testing.T) {
 	itinerary := kiwiItinerary{
-		FlyFrom:                "HEL",
-		FlyTo:                  "NRT",
-		DurationInSeconds:      0,
-		TotalDurationInSeconds: 7200,
-		Departure:              kiwiDateTime{UTC: "2026-06-15T10:00:00Z"},
-		Arrival:                kiwiDateTime{UTC: "2026-06-15T12:00:00Z"},
-		Price:                  100,
+		Price:                100,
+		TotalDurationSeconds: 7200,
+		Outbound: &kiwiLeg{
+			From:          "HEL",
+			To:            "NRT",
+			DepartureTime: "2026-06-15T10:00:00",
+			ArrivalTime:   "2026-06-15T12:00:00",
+			Segments: []kiwiSegment{
+				{
+					From:          "HEL",
+					To:            "NRT",
+					DepartureTime: "2026-06-15T10:00:00",
+					ArrivalTime:   "2026-06-15T12:00:00",
+				},
+			},
+		},
 	}
 	fr := mapKiwiItinerary(itinerary, "EUR")
 	if fr.Duration != 120 {
-		t.Errorf("duration = %d, want 120 (from TotalDurationInSeconds)", fr.Duration)
+		t.Errorf("duration = %d, want 120 (from TotalDurationSeconds)", fr.Duration)
 	}
 }
 

--- a/internal/flights/flights_maxcov_test.go
+++ b/internal/flights/flights_maxcov_test.go
@@ -214,24 +214,21 @@ func TestKiwiDurationMinutes(t *testing.T) {
 
 func TestKiwiDisplayTime(t *testing.T) {
 	t.Run("local_time", func(t *testing.T) {
-		dt := kiwiDateTime{Local: "2026-04-18T14:30:00", UTC: "2026-04-18T12:30:00Z"}
-		got := kiwiDisplayTime(dt)
+		got := kiwiDisplayTime("2026-04-18T14:30:00")
 		if got != "2026-04-18T14:30" {
 			t.Errorf("got %q, want 2026-04-18T14:30", got)
 		}
 	})
 
 	t.Run("utc_fallback", func(t *testing.T) {
-		dt := kiwiDateTime{Local: "", UTC: "2026-04-18T12:30:00Z"}
-		got := kiwiDisplayTime(dt)
+		got := kiwiDisplayTime("2026-04-18T12:30:00Z")
 		if got != "2026-04-18T12:30" {
 			t.Errorf("got %q, want 2026-04-18T12:30", got)
 		}
 	})
 
 	t.Run("empty", func(t *testing.T) {
-		dt := kiwiDateTime{}
-		got := kiwiDisplayTime(dt)
+		got := kiwiDisplayTime("")
 		if got != "" {
 			t.Errorf("got %q, want empty", got)
 		}

--- a/internal/flights/kiwi.go
+++ b/internal/flights/kiwi.go
@@ -66,64 +66,51 @@ type kiwiToolResult struct {
 	IsError bool `json:"isError,omitempty"`
 }
 
-type kiwiDateTime struct {
-	UTC   string `json:"utc"`
-	Local string `json:"local"`
+// kiwiSearchResponse is the search-flight tool payload for the
+// kiwicom-flight-search server (v1.15.0+): an object wrapping the itinerary
+// list, replacing the bare JSON array earlier server versions returned.
+type kiwiSearchResponse struct {
+	Currency     string          `json:"currency"`
+	ResultsCount int             `json:"resultsCount"`
+	Itineraries  []kiwiItinerary `json:"itineraries"`
 }
 
-type kiwiLayover struct {
-	At        string       `json:"at"`
-	City      string       `json:"city"`
-	CityCode  string       `json:"cityCode"`
-	Arrival   kiwiDateTime `json:"arrival"`
-	Departure kiwiDateTime `json:"departure"`
-}
-
+// kiwiItinerary is one priced option. Outbound is always present; Inbound is
+// non-nil only for a round-trip search.
 type kiwiItinerary struct {
-	FlyFrom                string        `json:"flyFrom"`
-	FlyTo                  string        `json:"flyTo"`
-	CityFrom               string        `json:"cityFrom"`
-	CityTo                 string        `json:"cityTo"`
-	Departure              kiwiDateTime  `json:"departure"`
-	Arrival                kiwiDateTime  `json:"arrival"`
-	DurationInSeconds      int           `json:"durationInSeconds"`
-	TotalDurationInSeconds int           `json:"totalDurationInSeconds"`
-	Price                  float64       `json:"price"`
-	DeepLink               string        `json:"deepLink"`
-	Currency               string        `json:"currency"`
-	Layovers               []kiwiLayover `json:"layovers"`
-	// Return carries the inbound journey of a native round-trip fare. Kiwi nests
-	// it in a top-level "return" object with the same routing shape as the
-	// outbound (flyFrom/flyTo, departure/arrival, layovers) but WITHOUT its own
-	// price/currency/deepLink — the parent's Price is the full round-trip total.
-	// Nil for a one-way search, so one-way results stay byte-unchanged.
-	Return *kiwiReturnJourney `json:"return,omitempty"`
+	ID                   string   `json:"id"`
+	Price                float64  `json:"price"`
+	TotalDurationSeconds int      `json:"totalDurationSeconds"`
+	BookingURL           string   `json:"bookingUrl"`
+	Outbound             *kiwiLeg `json:"outbound"`
+	Inbound              *kiwiLeg `json:"inbound"`
 }
 
-// kiwiReturnJourney is the inbound half of a Kiwi native round-trip. It mirrors
-// the outbound routing fields of kiwiItinerary; it deliberately has no
-// price/currency/deepLink because the round-trip total lives on the parent.
-type kiwiReturnJourney struct {
-	FlyFrom           string        `json:"flyFrom"`
-	FlyTo             string        `json:"flyTo"`
-	CityFrom          string        `json:"cityFrom"`
-	CityTo            string        `json:"cityTo"`
-	Departure         kiwiDateTime  `json:"departure"`
-	Arrival           kiwiDateTime  `json:"arrival"`
-	DurationInSeconds int           `json:"durationInSeconds"`
-	Layovers          []kiwiLayover `json:"layovers"`
+// kiwiLeg is one direction of travel: a routing summary plus the concrete
+// per-flight segments that make it up.
+type kiwiLeg struct {
+	From            string        `json:"from"`
+	To              string        `json:"to"`
+	DepartureTime   string        `json:"departureTime"`
+	ArrivalTime     string        `json:"arrivalTime"`
+	DurationSeconds int           `json:"durationSeconds"`
+	Stops           int           `json:"stops"`
+	CabinClass      string        `json:"cabinClass"`
+	Segments        []kiwiSegment `json:"segments"`
 }
 
-// kiwiJourney is the common routing shape shared by an itinerary's outbound and
-// its nested return, letting one leg-builder serve both halves.
-type kiwiJourney struct {
-	FlyFrom   string
-	FlyTo     string
-	CityFrom  string
-	CityTo    string
-	Departure kiwiDateTime
-	Arrival   kiwiDateTime
-	Layovers  []kiwiLayover
+// kiwiSegment is a single operated flight within a leg.
+type kiwiSegment struct {
+	From            string `json:"from"`
+	To              string `json:"to"`
+	FromCity        string `json:"fromCity"`
+	ToCity          string `json:"toCity"`
+	DepartureTime   string `json:"departureTime"`
+	ArrivalTime     string `json:"arrivalTime"`
+	DurationSeconds int    `json:"durationSeconds"`
+	Carrier         string `json:"carrier"`
+	FlightNumber    string `json:"flightNumber"`
+	CabinClass      string `json:"cabinClass"`
 }
 
 func SearchKiwiFlights(ctx context.Context, origin, destination, date, currency string, opts SearchOptions) ([]models.FlightResult, error) {
@@ -161,23 +148,56 @@ func SearchKiwiFlights(ctx context.Context, origin, destination, date, currency 
 		return nil, err
 	}
 
-	var itineraries []kiwiItinerary
-	if err := json.Unmarshal(payload, &itineraries); err != nil {
+	var searchResp kiwiSearchResponse
+	if err := json.Unmarshal(payload, &searchResp); err != nil {
 		return nil, fmt.Errorf("kiwi: decode search results: %w", err)
 	}
 
-	results := make([]models.FlightResult, 0, len(itineraries))
-	usable := 0
-	for _, itinerary := range itineraries {
-		if itinerary.FlyFrom != "" && itinerary.FlyTo != "" {
-			usable++
+	respCurrency := firstNonEmpty(searchResp.Currency, currency)
+	results := make([]models.FlightResult, 0, len(searchResp.Itineraries))
+	for _, itinerary := range searchResp.Itineraries {
+		if !kiwiItineraryUsable(itinerary) {
+			continue // routeless entry (nil/empty outbound) — never emit a no-leg fare
 		}
-		results = append(results, mapKiwiItinerary(itinerary, currency))
+		results = append(results, mapKiwiItinerary(itinerary, respCurrency))
 	}
-	if perr := kiwiParseFailureIfAllDropped(usable, len(itineraries)); perr != nil {
+
+	raw := len(searchResp.Itineraries)
+	// Shape-rotation guard: the server promised results but returned no entries.
+	if searchResp.ResultsCount > 0 && raw == 0 {
+		return nil, fmt.Errorf("kiwi: %d results promised but none returned: %w", searchResp.ResultsCount, models.ErrParseFailed)
+	}
+	// Entries arrived but none carried a usable route -> the itinerary shape
+	// rotated underneath us (a parse failure), not a genuine empty result.
+	if perr := kiwiParseFailureIfAllDropped(len(results), raw); perr != nil {
 		return nil, perr
 	}
 	return results, nil
+}
+
+// kiwiLegEndpoints returns a leg's origin and destination, preferring the leg's
+// routing summary and falling back to the first/last segment. ok is false when
+// neither yields both endpoints — so a leg that keeps concrete segments after a
+// summary rename still resolves, and a truly routeless leg is rejected.
+func kiwiLegEndpoints(leg *kiwiLeg) (from, to string, ok bool) {
+	if leg == nil {
+		return "", "", false
+	}
+	from, to = leg.From, leg.To
+	if from == "" && len(leg.Segments) > 0 {
+		from = leg.Segments[0].From
+	}
+	if to == "" && len(leg.Segments) > 0 {
+		to = leg.Segments[len(leg.Segments)-1].To
+	}
+	return from, to, from != "" && to != ""
+}
+
+// kiwiItineraryUsable reports whether an itinerary has a resolvable outbound
+// route, so routeless entries are skipped instead of emitted as no-leg fares.
+func kiwiItineraryUsable(it kiwiItinerary) bool {
+	_, _, ok := kiwiLegEndpoints(it.Outbound)
+	return ok
 }
 
 // kiwiParseFailureIfAllDropped mirrors parseFailureIfAllDropped for the Kiwi MCP
@@ -214,11 +234,13 @@ func kiwiInitializeSession(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("kiwi: initialize RPC error %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
 	}
 
-	sessionID := strings.TrimSpace(headers.Get("mcp-session-id"))
-	if sessionID == "" {
-		return "", fmt.Errorf("kiwi: initialize response missing mcp-session-id")
-	}
-	return sessionID, nil
+	// Per the MCP Streamable HTTP spec the mcp-session-id header is OPTIONAL: a
+	// stateless server may omit it (Kiwi's kiwicom-flight-search server went
+	// stateless in v1.15.0, dropping the header). An empty session id is
+	// therefore valid — operate without one; kiwiRPCWithHeaders simply omits the
+	// header on subsequent calls, and the server treats each request as
+	// independent.
+	return strings.TrimSpace(headers.Get("mcp-session-id")), nil
 }
 
 func kiwiRPC(ctx context.Context, sessionID string, payload kiwiRPCRequest) (kiwiRPCResponse, error) {
@@ -286,29 +308,51 @@ func parseKiwiRPCResponse(body []byte) (kiwiRPCResponse, error) {
 	}
 
 	scanner := bufio.NewScanner(bytes.NewReader(body))
-	scanner.Buffer(make([]byte, 64*1024), 256*1024)
+	// The max token must exceed extractKiwiContent's 512 KiB content limit plus
+	// JSON-RPC envelope overhead, otherwise a large-but-valid SSE frame fails
+	// here before extraction ever runs.
+	scanner.Buffer(make([]byte, 64*1024), 640*1024)
 
 	var last kiwiRPCResponse
 	found := false
-	for scanner.Scan() {
-		line := scanner.Text()
-		if !strings.HasPrefix(line, "data:") {
-			continue
+	var data []string // accumulated `data:` fields for the current SSE event
+
+	flush := func() {
+		if len(data) == 0 {
+			return
 		}
-		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
-		if data == "" || data == "[DONE]" {
-			continue
+		// Per the SSE spec, an event's multiple data fields are joined with "\n"
+		// before the value is used — a single JSON payload may be split across
+		// several data lines.
+		joined := strings.Join(data, "\n")
+		data = data[:0]
+		if joined == "" || joined == "[DONE]" {
+			return
 		}
 		var rpc kiwiRPCResponse
-		if err := json.Unmarshal([]byte(data), &rpc); err != nil {
+		if err := json.Unmarshal([]byte(joined), &rpc); err != nil {
 			slog.Debug("kiwi: skipping unparseable SSE frame", "error", err)
-			continue
+			return
 		}
 		if rpc.Result != nil || rpc.Error != nil {
 			last = rpc
 			found = true
 		}
 	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" { // a blank line terminates the current SSE event
+			flush()
+			continue
+		}
+		if after, ok := strings.CutPrefix(line, "data:"); ok {
+			// SSE strips exactly one leading space after the colon; internal
+			// whitespace is part of the payload and preserved.
+			data = append(data, strings.TrimPrefix(after, " "))
+		}
+	}
+	flush() // the final event need not be followed by a blank line
 	if err := scanner.Err(); err != nil {
 		return kiwiRPCResponse{}, fmt.Errorf("kiwi: read SSE: %w", err)
 	}
@@ -349,53 +393,70 @@ func extractKiwiContent(rpc kiwiRPCResponse) (json.RawMessage, error) {
 }
 
 func mapKiwiItinerary(itinerary kiwiItinerary, fallbackCurrency string) models.FlightResult {
-	legs := buildKiwiLegs(outboundJourney(itinerary))
-	roundTrip := itinerary.Return != nil
+	roundTrip := itinerary.Inbound != nil
 
-	// Tag legs by direction only for a round-trip. A one-way itinerary leaves
-	// Direction empty so single-direction results stay byte-unchanged.
-	if roundTrip {
-		for i := range legs {
-			legs[i].Direction = "outbound"
+	var legs []models.FlightLeg
+	if itinerary.Outbound != nil {
+		out := buildKiwiLegs(*itinerary.Outbound)
+		// Tag legs by direction only for a round-trip. A one-way itinerary leaves
+		// Direction empty so single-direction results stay byte-unchanged.
+		if roundTrip {
+			for i := range out {
+				out[i].Direction = "outbound"
+			}
 		}
+		legs = append(legs, out...)
 	}
 
-	// SelfConnect means the OUTBOUND has a layover (self-connect risk on the way
-	// there). It is derived from the outbound layovers only; the return's
-	// layovers must not by themselves flag the outbound as self-connect.
-	selfConnect := len(itinerary.Layovers) > 0
-	// Outbound stops = outbound legs minus 1; computed before the inbound legs
-	// are appended so the return's airports are never counted as outbound stops.
+	// Outbound stops: prefer the leg's own stops count, else outbound legs minus
+	// one. Computed before the inbound legs are appended so the return's airports
+	// are never counted as outbound stops.
 	stops := max(len(legs)-1, 0)
+	if itinerary.Outbound != nil && itinerary.Outbound.Stops > 0 {
+		stops = itinerary.Outbound.Stops
+	}
+	// Self-connect risk: a connection is typically Kiwi virtual interlining
+	// (separate tickets, self-transfer bag re-check). Derived from the outbound
+	// only (so the return never flags the outbound), from EITHER the stops count
+	// or the segment count — a summary-only leg reports stops without segments.
+	selfConnect := itinerary.Outbound != nil &&
+		(itinerary.Outbound.Stops > 0 || len(itinerary.Outbound.Segments) > 1)
 
 	if roundTrip {
-		inbound := buildKiwiLegs(returnJourney(*itinerary.Return))
+		inbound := buildKiwiLegs(*itinerary.Inbound)
 		for i := range inbound {
 			inbound[i].Direction = "inbound"
 		}
 		legs = append(legs, inbound...)
 	}
 
-	// Duration: prefer the provider's total (covers both halves for a round-trip);
-	// fall back to the single-journey duration, then to summing all leg durations.
-	durationSeconds := itinerary.TotalDurationInSeconds
-	if durationSeconds <= 0 {
-		durationSeconds = itinerary.DurationInSeconds
+	// Duration: prefer the provider's trip total (covers both halves of a
+	// round-trip); then the sum of each leg's own DurationSeconds; then the sum
+	// of the mapped per-segment leg durations.
+	durationMinutes := itinerary.TotalDurationSeconds / 60
+	if durationMinutes <= 0 {
+		legSeconds := 0
+		if itinerary.Outbound != nil {
+			legSeconds += itinerary.Outbound.DurationSeconds
+		}
+		if itinerary.Inbound != nil {
+			legSeconds += itinerary.Inbound.DurationSeconds
+		}
+		durationMinutes = legSeconds / 60
 	}
-	durationMinutes := durationSeconds / 60
 	if durationMinutes <= 0 {
 		durationMinutes = sumLegDurations(legs)
 	}
 
 	flight := models.FlightResult{
 		Price:       itinerary.Price,
-		Currency:    firstNonEmpty(itinerary.Currency, fallbackCurrency),
+		Currency:    fallbackCurrency,
 		Duration:    durationMinutes,
 		Stops:       stops,
 		Provider:    "kiwi",
 		SelfConnect: selfConnect,
 		Legs:        legs,
-		BookingURL:  itinerary.DeepLink,
+		BookingURL:  itinerary.BookingURL,
 	}
 	if roundTrip {
 		// FlightResult carries the per-result round-trip marker via FareType
@@ -409,33 +470,6 @@ func mapKiwiItinerary(itinerary kiwiItinerary, fallbackCurrency string) models.F
 	return flight
 }
 
-// outboundJourney projects the outbound routing of an itinerary into the shared
-// kiwiJourney shape.
-func outboundJourney(it kiwiItinerary) kiwiJourney {
-	return kiwiJourney{
-		FlyFrom:   it.FlyFrom,
-		FlyTo:     it.FlyTo,
-		CityFrom:  it.CityFrom,
-		CityTo:    it.CityTo,
-		Departure: it.Departure,
-		Arrival:   it.Arrival,
-		Layovers:  it.Layovers,
-	}
-}
-
-// returnJourney projects a nested return into the shared kiwiJourney shape.
-func returnJourney(r kiwiReturnJourney) kiwiJourney {
-	return kiwiJourney{
-		FlyFrom:   r.FlyFrom,
-		FlyTo:     r.FlyTo,
-		CityFrom:  r.CityFrom,
-		CityTo:    r.CityTo,
-		Departure: r.Departure,
-		Arrival:   r.Arrival,
-		Layovers:  r.Layovers,
-	}
-}
-
 // sumLegDurations totals each leg's per-segment duration (minutes), used as a
 // last-resort fallback when the provider supplies no usable trip total.
 func sumLegDurations(legs []models.FlightLeg) int {
@@ -446,70 +480,68 @@ func sumLegDurations(legs []models.FlightLeg) int {
 	return total
 }
 
-func buildKiwiLegs(journey kiwiJourney) []models.FlightLeg {
-	legs := make([]models.FlightLeg, 0, len(journey.Layovers)+1)
-	currentCode := journey.FlyFrom
-	currentName := firstNonEmpty(journey.CityFrom, journey.FlyFrom)
-	currentDeparture := journey.Departure
-
-	for _, layover := range journey.Layovers {
-		legs = append(legs, buildKiwiLeg(
-			currentCode,
-			currentName,
-			currentDeparture,
-			firstNonEmpty(layover.At, layover.CityCode),
-			firstNonEmpty(layover.City, layover.At),
-			layover.Arrival,
-		))
-		currentCode = firstNonEmpty(layover.At, layover.CityCode)
-		currentName = firstNonEmpty(layover.City, layover.At)
-		currentDeparture = layover.Departure
+// buildKiwiLegs converts a leg's concrete flight segments into FlightLegs. If a
+// leg carries no segments (summary only), it yields a single leg from the leg's
+// own from/to/times so the route stays usable.
+func buildKiwiLegs(leg kiwiLeg) []models.FlightLeg {
+	if len(leg.Segments) == 0 {
+		duration := leg.DurationSeconds / 60
+		if duration <= 0 {
+			duration = kiwiDurationMinutes(leg.DepartureTime, leg.ArrivalTime)
+		}
+		return []models.FlightLeg{{
+			DepartureAirport: models.AirportInfo{Code: leg.From, Name: leg.From},
+			ArrivalAirport:   models.AirportInfo{Code: leg.To, Name: leg.To},
+			DepartureTime:    kiwiDisplayTime(leg.DepartureTime),
+			ArrivalTime:      kiwiDisplayTime(leg.ArrivalTime),
+			Duration:         duration,
+		}}
 	}
 
-	legs = append(legs, buildKiwiLeg(
-		currentCode,
-		currentName,
-		currentDeparture,
-		journey.FlyTo,
-		firstNonEmpty(journey.CityTo, journey.FlyTo),
-		journey.Arrival,
-	))
+	legs := make([]models.FlightLeg, 0, len(leg.Segments))
+	for _, s := range leg.Segments {
+		duration := s.DurationSeconds / 60
+		if duration <= 0 {
+			duration = kiwiDurationMinutes(s.DepartureTime, s.ArrivalTime)
+		}
+		legs = append(legs, models.FlightLeg{
+			DepartureAirport: models.AirportInfo{Code: s.From, Name: firstNonEmpty(s.FromCity, s.From)},
+			ArrivalAirport:   models.AirportInfo{Code: s.To, Name: firstNonEmpty(s.ToCity, s.To)},
+			DepartureTime:    kiwiDisplayTime(s.DepartureTime),
+			ArrivalTime:      kiwiDisplayTime(s.ArrivalTime),
+			Duration:         duration,
+			AirlineCode:      s.Carrier,
+			FlightNumber:     s.FlightNumber,
+		})
+	}
 	// Compute per-journey so the inbound's first leg never inherits a spurious
 	// layover from the outbound's final arrival.
 	computeLayovers(legs)
 	return legs
 }
 
-func buildKiwiLeg(fromCode, fromName string, departure kiwiDateTime, toCode, toName string, arrival kiwiDateTime) models.FlightLeg {
-	return models.FlightLeg{
-		DepartureAirport: models.AirportInfo{Code: fromCode, Name: fromName},
-		ArrivalAirport:   models.AirportInfo{Code: toCode, Name: toName},
-		DepartureTime:    kiwiDisplayTime(departure),
-		ArrivalTime:      kiwiDisplayTime(arrival),
-		Duration:         kiwiDurationMinutes(departure.UTC, arrival.UTC),
-	}
-}
-
-func kiwiDisplayTime(dt kiwiDateTime) string {
-	if t, ok := parseKiwiTimestamp(firstNonEmpty(dt.Local, dt.UTC)); ok {
+// kiwiDisplayTime formats a Kiwi naive-local timestamp for display, returning ""
+// when it cannot be parsed.
+func kiwiDisplayTime(ts string) string {
+	if t, ok := parseKiwiTimestamp(ts); ok {
 		return t.Format(flightTimeLayout)
 	}
 	return ""
 }
 
-func kiwiDurationMinutes(startUTC, endUTC string) int {
-	start, ok := parseKiwiTimestamp(startUTC)
+func kiwiDurationMinutes(start, end string) int {
+	s, ok := parseKiwiTimestamp(start)
 	if !ok {
 		return 0
 	}
-	end, ok := parseKiwiTimestamp(endUTC)
+	e, ok := parseKiwiTimestamp(end)
 	if !ok {
 		return 0
 	}
-	if !end.After(start) {
+	if !e.After(s) {
 		return 0
 	}
-	return int(end.Sub(start).Minutes())
+	return int(e.Sub(s).Minutes())
 }
 
 func parseKiwiTimestamp(raw string) (time.Time, bool) {

--- a/internal/flights/kiwi_hardening_test.go
+++ b/internal/flights/kiwi_hardening_test.go
@@ -1,0 +1,116 @@
+package flights
+
+import "testing"
+
+// TestKiwiLegEndpoints covers the summary-first / segment-fallback resolution
+// that keeps a leg usable after a routing-summary rename (review finding #2).
+func TestKiwiLegEndpoints(t *testing.T) {
+	cases := []struct {
+		name           string
+		leg            *kiwiLeg
+		wantFrom, want string
+		wantOK         bool
+	}{
+		{"nil", nil, "", "", false},
+		{"summary", &kiwiLeg{From: "HEL", To: "BCN"}, "HEL", "BCN", true},
+		{
+			"segment fallback",
+			&kiwiLeg{Segments: []kiwiSegment{{From: "HEL", To: "ARN"}, {From: "ARN", To: "BCN"}}},
+			"HEL", "BCN", true,
+		},
+		{"routeless", &kiwiLeg{}, "", "", false},
+	}
+	for _, tc := range cases {
+		from, to, ok := kiwiLegEndpoints(tc.leg)
+		if ok != tc.wantOK || from != tc.wantFrom || to != tc.want {
+			t.Errorf("%s: kiwiLegEndpoints = (%q,%q,%v), want (%q,%q,%v)",
+				tc.name, from, to, ok, tc.wantFrom, tc.want, tc.wantOK)
+		}
+	}
+}
+
+// TestKiwiItineraryUsable checks routeless entries are rejected (finding #1).
+func TestKiwiItineraryUsable(t *testing.T) {
+	if kiwiItineraryUsable(kiwiItinerary{Outbound: nil}) {
+		t.Error("nil outbound must be unusable")
+	}
+	if kiwiItineraryUsable(kiwiItinerary{Outbound: &kiwiLeg{}}) {
+		t.Error("routeless outbound must be unusable")
+	}
+	if !kiwiItineraryUsable(kiwiItinerary{Outbound: &kiwiLeg{From: "HEL", To: "BCN"}}) {
+		t.Error("outbound with endpoints must be usable")
+	}
+}
+
+// TestMapKiwiItinerarySelfConnectFromStops locks self-connect derivation from
+// the stops count for a summary-only connected leg (review finding #5).
+func TestMapKiwiItinerarySelfConnectFromStops(t *testing.T) {
+	it := kiwiItinerary{
+		Price:                120,
+		TotalDurationSeconds: 10800,
+		Outbound: &kiwiLeg{
+			From: "HEL", To: "BCN",
+			DepartureTime: "2026-07-31T08:00:00", ArrivalTime: "2026-07-31T11:00:00",
+			Stops: 1, // connection, but NO segments array
+		},
+	}
+	fr := mapKiwiItinerary(it, "EUR")
+	if !fr.SelfConnect {
+		t.Error("stops>0 with no segments must still mark SelfConnect")
+	}
+	if len(fr.Warnings) == 0 {
+		t.Error("self-connect must attach the bag-recheck warning")
+	}
+	if fr.Stops != 1 {
+		t.Errorf("Stops = %d, want 1 (from Outbound.Stops)", fr.Stops)
+	}
+}
+
+// TestMapKiwiItineraryDurationFallback covers the layered duration fallback
+// (review finding #4): trip total -> per-leg DurationSeconds -> summed legs.
+func TestMapKiwiItineraryDurationFallback(t *testing.T) {
+	// No trip total; outbound leg carries its own DurationSeconds (7200 = 120min).
+	it := kiwiItinerary{
+		Price: 90,
+		Outbound: &kiwiLeg{
+			From: "HEL", To: "BCN",
+			DepartureTime: "2026-07-31T08:00:00", ArrivalTime: "2026-07-31T10:00:00",
+			DurationSeconds: 7200,
+		},
+	}
+	if fr := mapKiwiItinerary(it, "EUR"); fr.Duration != 120 {
+		t.Errorf("Duration = %d, want 120 (per-leg DurationSeconds fallback)", fr.Duration)
+	}
+
+	// No total, no leg DurationSeconds: fall back to summed mapped-leg durations
+	// (single segment 08:00->10:00 = 120min).
+	it2 := kiwiItinerary{
+		Price: 90,
+		Outbound: &kiwiLeg{
+			From: "HEL", To: "BCN",
+			Segments: []kiwiSegment{{
+				From: "HEL", To: "BCN",
+				DepartureTime: "2026-07-31T08:00:00", ArrivalTime: "2026-07-31T10:00:00",
+			}},
+		},
+	}
+	if fr := mapKiwiItinerary(it2, "EUR"); fr.Duration != 120 {
+		t.Errorf("Duration = %d, want 120 (summed-leg fallback)", fr.Duration)
+	}
+}
+
+// TestParseKiwiRPCResponseMultilineSSE verifies a single JSON-RPC payload split
+// across multiple SSE data: lines is joined and parsed (review finding #6).
+func TestParseKiwiRPCResponseMultilineSSE(t *testing.T) {
+	body := []byte("event: message\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\n" +
+		"data: \"result\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n" +
+		"\n")
+	rpc, err := parseKiwiRPCResponse(body)
+	if err != nil {
+		t.Fatalf("parseKiwiRPCResponse: %v", err)
+	}
+	if rpc.Result == nil {
+		t.Fatal("expected a Result from the joined multi-line data frame")
+	}
+}

--- a/internal/flights/kiwi_roundtrip_test.go
+++ b/internal/flights/kiwi_roundtrip_test.go
@@ -27,7 +27,7 @@ func TestMapKiwiItineraryRoundTrip(t *testing.T) {
 	if len(itineraries) != 1 {
 		t.Fatalf("itineraries = %d, want 1", len(itineraries))
 	}
-	if itineraries[0].Return == nil {
+	if itineraries[0].Inbound == nil {
 		t.Fatal("expected a parsed return journey, got nil")
 	}
 
@@ -85,9 +85,9 @@ func TestMapKiwiItineraryRoundTrip(t *testing.T) {
 	if flight.Stops != 1 {
 		t.Errorf("Stops = %d, want 1 (outbound legs-1, return excluded)", flight.Stops)
 	}
-	// totalDurationInSeconds (47700) / 60 = 795 minutes covers both halves.
+	// totalDurationSeconds (47700) / 60 = 795 minutes covers both halves.
 	if flight.Duration != 795 {
-		t.Errorf("Duration = %d, want 795 (totalDurationInSeconds/60)", flight.Duration)
+		t.Errorf("Duration = %d, want 795 (totalDurationSeconds/60)", flight.Duration)
 	}
 }
 
@@ -96,16 +96,25 @@ func TestMapKiwiItineraryRoundTrip(t *testing.T) {
 // Direction tags and no round-trip FareType (empty, as a one-way result).
 func TestMapKiwiItineraryOneWayNoDirectionTags(t *testing.T) {
 	itinerary := kiwiItinerary{
-		FlyFrom:           "HEL",
-		FlyTo:             "BCN",
-		CityFrom:          "Helsinki",
-		CityTo:            "Barcelona",
-		Departure:         kiwiDateTime{UTC: "2026-07-25T10:55:00.000Z", Local: "2026-07-25T13:55:00.000"},
-		Arrival:           kiwiDateTime{UTC: "2026-07-25T16:50:00.000Z", Local: "2026-07-25T18:50:00.000"},
-		DurationInSeconds: 21300,
-		Price:             102,
-		Currency:          "EUR",
-		DeepLink:          "https://on.kiwi.com/oneway",
+		Price:                102,
+		TotalDurationSeconds: 21300,
+		BookingURL:           "https://on.kiwi.com/oneway",
+		Outbound: &kiwiLeg{
+			From:          "HEL",
+			To:            "BCN",
+			DepartureTime: "2026-07-25T13:55:00",
+			ArrivalTime:   "2026-07-25T18:50:00",
+			Segments: []kiwiSegment{
+				{
+					From:          "HEL",
+					To:            "BCN",
+					FromCity:      "Helsinki",
+					ToCity:        "Barcelona",
+					DepartureTime: "2026-07-25T13:55:00",
+					ArrivalTime:   "2026-07-25T18:50:00",
+				},
+			},
+		},
 	}
 
 	flight := mapKiwiItinerary(itinerary, "EUR")

--- a/internal/flights/kiwi_test.go
+++ b/internal/flights/kiwi_test.go
@@ -21,25 +21,33 @@ func TestParseKiwiRPCResponse_SSE(t *testing.T) {
 
 func TestMapKiwiItineraryMarksSelfConnect(t *testing.T) {
 	itinerary := kiwiItinerary{
-		FlyFrom:           "HEL",
-		FlyTo:             "DBV",
-		CityFrom:          "Helsinki",
-		CityTo:            "Dubrovnik",
-		Departure:         kiwiDateTime{UTC: "2026-07-01T12:00:00.000Z", Local: "2026-07-01T15:00:00.000"},
-		Arrival:           kiwiDateTime{UTC: "2026-07-01T18:00:00.000Z", Local: "2026-07-01T20:00:00.000"},
-		DurationInSeconds: 21600,
-		Price:             121,
-		Currency:          "EUR",
-		DeepLink:          "https://on.kiwi.com/test",
-		Layovers: []kiwiLayover{
-			{
-				At:       "ARN",
-				City:     "Stockholm",
-				CityCode: "STO",
-				Arrival:  kiwiDateTime{UTC: "2026-07-01T13:00:00.000Z", Local: "2026-07-01T15:00:00.000"},
-				Departure: kiwiDateTime{
-					UTC:   "2026-07-01T14:00:00.000Z",
-					Local: "2026-07-01T16:00:00.000",
+		Price:                121,
+		TotalDurationSeconds: 21600,
+		BookingURL:           "https://on.kiwi.com/test",
+		Outbound: &kiwiLeg{
+			From:          "HEL",
+			To:            "DBV",
+			DepartureTime: "2026-07-01T15:00:00",
+			ArrivalTime:   "2026-07-01T20:00:00",
+			Stops:         1,
+			Segments: []kiwiSegment{
+				{
+					From:            "HEL",
+					To:              "ARN",
+					FromCity:        "Helsinki",
+					ToCity:          "Stockholm",
+					DepartureTime:   "2026-07-01T15:00:00",
+					ArrivalTime:     "2026-07-01T16:00:00",
+					DurationSeconds: 3600,
+				},
+				{
+					From:            "ARN",
+					To:              "DBV",
+					FromCity:        "Stockholm",
+					ToCity:          "Dubrovnik",
+					DepartureTime:   "2026-07-01T16:00:00",
+					ArrivalTime:     "2026-07-01T20:00:00",
+					DurationSeconds: 14400,
 				},
 			},
 		},

--- a/internal/flights/roundtrip_native_probe_test.go
+++ b/internal/flights/roundtrip_native_probe_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/testutil"
 )
 
@@ -165,17 +166,36 @@ func TestProbeRoundTripOrchestrator(t *testing.T) {
 		// easyJet/Vueling that are *perpetually* AKAMAI_BLOCK'd by default, so
 		// scanning them would mask the exact Google/Kiwi regression this probe
 		// exists to catch.
-		for _, s := range res.ProviderStatuses {
-			if !strings.HasPrefix(s.ID, "native_roundtrip:") {
+		// Scan ALL native round-trip statuses before deciding. A single transient
+		// provider must NOT let a DIFFERENT provider's real regression (e.g. a Kiwi
+		// parser break surfacing as StatusFailed) slip through as a yellow skip —
+		// that would defeat the exact drift this probe exists to catch.
+		var hardFailure *models.ProviderStatus
+		sawTransient := false
+		for i := range res.ProviderStatuses {
+			s := &res.ProviderStatuses[i]
+			if !strings.HasPrefix(s.ID, "native_roundtrip:") || s.Status == "ok" {
 				continue
 			}
-			if s.Status == "ok" {
+			// A rate-limited/timed-out native provider is transient noise (throttled
+			// datacenter IP). The status STATE is authoritative because such a
+			// ProviderStatus can carry an empty Error string that IsTransientMsg
+			// alone would miss.
+			if s.Status == models.StatusRateLimited || s.Status == models.StatusTimeout ||
+				testutil.IsTransientMsg(s.Error) || strings.EqualFold(s.FixHintCode, "AKAMAI_BLOCK") {
+				sawTransient = true
 				continue
 			}
-			if testutil.IsTransientMsg(s.Error) || strings.EqualFold(s.FixHintCode, "AKAMAI_BLOCK") {
-				t.Skipf("skipping: native round-trip provider blocked/throttled this run (%s: %s %s) — not a regression", s.ID, s.Error, s.FixHintCode)
-			}
+			hardFailure = s // a non-transient native failure is a real regression
 		}
-		t.Errorf("expected at least one native round-trip fare (Google/Kiwi) in merged results")
+		switch {
+		case hardFailure != nil:
+			t.Errorf("native round-trip provider hard failure (likely a real regression): %s: status=%s %s %s",
+				hardFailure.ID, hardFailure.Status, hardFailure.Error, hardFailure.FixHintCode)
+		case sawTransient:
+			t.Skipf("skipping: all failing native round-trip providers were blocked/throttled this run — not a regression")
+		default:
+			t.Errorf("expected at least one native round-trip fare (Google/Kiwi) in merged results")
+		}
 	}
 }

--- a/internal/flights/testdata/kiwi_roundtrip.json
+++ b/internal/flights/testdata/kiwi_roundtrip.json
@@ -1,27 +1,58 @@
 [
   {
-    "arrival": { "local": "2026-07-25T18:50:00.000", "utc": "2026-07-25T16:50:00.000Z" },
-    "cityFrom": "Helsinki", "cityTo": "Barcelona", "currency": "EUR",
-    "deepLink": "https://on.kiwi.com/5pkPcZ",
-    "departure": { "local": "2026-07-25T13:55:00.000", "utc": "2026-07-25T10:55:00.000Z" },
-    "durationInSeconds": 21300, "flyFrom": "HEL", "flyTo": "BCN",
-    "layovers": [
-      { "arrival": { "local": "2026-07-25T15:25:00.000", "utc": "2026-07-25T13:25:00.000Z" },
-        "at": "AMS", "city": "Amsterdam", "cityCode": "AMS",
-        "departure": { "local": "2026-07-25T16:45:00.000", "utc": "2026-07-25T14:45:00.000Z" } }
-    ],
+    "id": "hel-bcn-rt",
     "price": 323,
-    "return": {
-      "arrival": { "local": "2026-08-01T14:50:00.000", "utc": "2026-08-01T11:50:00.000Z" },
-      "cityFrom": "Barcelona", "cityTo": "Helsinki",
-      "departure": { "local": "2026-08-01T06:30:00.000", "utc": "2026-08-01T04:30:00.000Z" },
-      "durationInSeconds": 26400, "flyFrom": "BCN", "flyTo": "HEL",
-      "layovers": [
-        { "arrival": { "local": "2026-08-01T07:25:00.000", "utc": "2026-08-01T05:25:00.000Z" },
-          "at": "PMI", "city": "Palma, Majorca", "cityCode": "PMI",
-          "departure": { "local": "2026-08-01T09:50:00.000", "utc": "2026-08-01T07:50:00.000Z" } }
+    "totalDurationSeconds": 47700,
+    "bookingUrl": "https://on.kiwi.com/5pkPcZ",
+    "outbound": {
+      "from": "HEL",
+      "to": "BCN",
+      "departureTime": "2026-07-25T13:55:00",
+      "arrivalTime": "2026-07-25T18:50:00",
+      "stops": 1,
+      "segments": [
+        {
+          "from": "HEL",
+          "to": "AMS",
+          "fromCity": "Helsinki",
+          "toCity": "Amsterdam",
+          "departureTime": "2026-07-25T13:55:00",
+          "arrivalTime": "2026-07-25T15:25:00"
+        },
+        {
+          "from": "AMS",
+          "to": "BCN",
+          "fromCity": "Amsterdam",
+          "toCity": "Barcelona",
+          "departureTime": "2026-07-25T16:45:00",
+          "arrivalTime": "2026-07-25T18:50:00"
+        }
       ]
     },
-    "totalDurationInSeconds": 47700
+    "inbound": {
+      "from": "BCN",
+      "to": "HEL",
+      "departureTime": "2026-08-01T06:30:00",
+      "arrivalTime": "2026-08-01T14:50:00",
+      "stops": 1,
+      "segments": [
+        {
+          "from": "BCN",
+          "to": "PMI",
+          "fromCity": "Barcelona",
+          "toCity": "Palma, Majorca",
+          "departureTime": "2026-08-01T06:30:00",
+          "arrivalTime": "2026-08-01T07:25:00"
+        },
+        {
+          "from": "PMI",
+          "to": "HEL",
+          "fromCity": "Palma, Majorca",
+          "toCity": "Helsinki",
+          "departureTime": "2026-08-01T09:50:00",
+          "arrivalTime": "2026-08-01T14:50:00"
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Summary

Fixes issue #439: the scheduled live probe caught the Kiwi flight provider returning zero results. Two upstream changes had broken it, and this restores it (verified live: a Milano-style search now returns real results).

Closes #439.

## Root cause — two stacked drifts

1. **Kiwi's MCP server went stateless.** The `initialize` handshake stopped returning an `mcp-session-id` header, which the client hard-required. The MCP spec makes that header optional, so an empty session is now treated as valid and later calls simply omit it.
2. **The search response schema was redesigned** — from a bare array of flat itineraries to an object wrapping the list, where each direction (outbound plus a nullable inbound) carries a routing summary and concrete per-flight segments. The response structs and parser were rewritten to match. As a bonus, legs now carry the operating carrier code and flight number, which the old parser left blank.

## Hardening (from adversarial review)

So the provider degrades honestly on the next drift instead of leaking bad data:

- Routeless itineraries are skipped, never emitted as no-leg fares.
- Route usability resolves from the routing summary OR the first/last segment, so a summary rename alone does not drop valid entries; a promised result count with no entries is treated as a parse failure.
- Duration falls back trip-total then per-leg seconds then summed leg durations.
- Self-connect is derived from the stop count as well as the segment count.
- SSE parsing joins multi-line data fields per event, and the scanner buffer was raised above the content limit.

## Probe robustness

The round-trip orchestrator probe now scans all native providers before deciding: a transient throttle on one provider can no longer skip past a real regression on another. It fails on any non-transient native failure and only skips when every failing native provider was transiently blocked.

## Testing

- New `kiwi_hardening_test.go` locks each hardening behavior as a regression guard.
- Existing Kiwi parser tests and fixtures were remapped to the new schema; no assertion was weakened (one currency assertion's input was adjusted to match the new fallback-only behavior).
- `go build`, `go vet`, golangci-lint, staticcheck, and the full `internal/flights` race suite all pass. Both live probes pass with `TRVL_TEST_LIVE_PROBES=1`.

## Review

Reviewed adversarially with an independent frontier model (gpt-5.5, high reasoning): six findings raised, all fixed and covered by new tests. A confirmation pass returned clean with no new defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
