### PR TITLE
release: prepare v1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.0] - 2026-07-01
+
 ### Added
 - **Italo (NTV) Italian high-speed rail provider.** New default-on, no-key ground
   provider covering Italo's high-speed network (AGV/EVO trains across the
@@ -15,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returns real fares and schedules, and filters out the Trenitalia-operated
   solutions Italo resells so it never duplicates the dedicated Trenitalia
   provider. Ground provider roster is now 22 (24 transport providers overall).
+
+### Fixed
+- **Kiwi flight provider restored after upstream drift.** Kiwi's MCP server went
+  stateless (its initialize handshake stopped issuing a session id) and
+  redesigned its search response schema; both broke every Kiwi flight search.
+  The session id is now treated as optional per spec and the response parser was
+  rewritten to the new outbound/inbound-with-segments shape, so Kiwi results
+  return again — now with the operating carrier code and flight number per leg.
+  The round-trip orchestrator probe was also hardened so a transient throttle on
+  one native provider can no longer mask a real regression on another.
 
 ## [1.18.0] - 2026-06-28
 

--- a/internal/flights/wizzair_selfheal_test.go
+++ b/internal/flights/wizzair_selfheal_test.go
@@ -92,8 +92,8 @@ func TestSearchWizzair_SelfHealsOnRotation(t *testing.T) {
 	wizzHost = srv.URL
 	wizzVersion = stale
 	defer func() { wizzHost, wizzVersion = origHost, origVer }()
-	t.Setenv("WIZZAIR_API_VERSION", "")  // no operator pin
-	t.Setenv("WIZZAIR_NO_AUTOHEAL", "")  // healing enabled
+	t.Setenv("WIZZAIR_API_VERSION", "") // no operator pin
+	t.Setenv("WIZZAIR_NO_AUTOHEAL", "") // healing enabled
 
 	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
 	if err != nil {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl-mcp",
   "mcpName": "io.github.MikkoParkkola/trvl",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as legacy-compatible capabilities.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
   "description": "Door-to-door travel MCP + CLI: flights, hotels, trains, cars, ferries. No API keys, Go binary.",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",
     "source": "github"
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mikkoparkkola/trvl:1.18.0",
+      "identifier": "ghcr.io/mikkoparkkola/trvl:1.19.0",
       "transport": {
         "type": "stdio"
       }
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "identifier": "trvl-mcp",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "version": "1.18.0",
+      "version": "1.19.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Prepares the **v1.19.0** feature release — the first since v1.18.0.

This release ships two provider changes that already merged to main:
- **Italo (NTV) Italian high-speed rail provider** (#440) — new default-on, no-key ground provider. Ground roster is now 22 (24 transport providers overall).
- **Kiwi flight provider restored** (#441, closed #439) — repaired after Kiwi's MCP server went stateless and redesigned its search response schema; legs now also carry carrier code and flight number.

## Changes in this PR

- `CHANGELOG.md` — cut the `[1.19.0] - 2026-07-01` section (Italo added, Kiwi fixed).
- `server.json` + `npm/package.json` — bumped to 1.19.0 so the release metadata drift guard stays green.
- `internal/flights/wizzair_selfheal_test.go` — cleared a stray gofmt drift left by an earlier merge.

## Verification

- `scripts/ci/check-release-metadata.sh` passes (version, OCI identifier, and npm version all aligned to 1.19.0).
- Full `go test -race ./...` across the repo: 98 packages ok, 0 failures, 0 data races.
- gofmt clean.

After merge, pushing the `v1.19.0` tag triggers the goreleaser release workflow (binaries, container image, npm package, MCP registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
