### PR TITLE
docs(agents): correct ground provider count to 22 and add Italian rail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,7 +537,7 @@ Searches all providers (Google Hotels, Trivago, Airbnb, Booking.com, Hostelworld
 {"from": "Amsterdam", "to": "Paris", "date": "2026-07-01"}
 ```
 Optional: `type` ("bus"|"train"|"ferry"), `currency`, `max_price`, `provider`
-Searches 21+ providers in parallel including FlixBus, RegioJet, Eurostar, DB, NS, SNCF, Trainline, ferries. Eurostar Snap fares auto-searched for valid routes.
+Searches 22+ providers in parallel including FlixBus, RegioJet, Eurostar, DB, NS, SNCF, Trainline, Trenitalia, Italo, and ferries. Eurostar Snap fares auto-searched for valid routes.
 
 ### onboard_profile — Progressive user interview
 ```json


### PR DESCRIPTION
Corrects the last stale provider-count claim found while validating the v1.19.0 docs. AGENTS.md advertised 21-plus providers with a subset roster that was missing the two Italian-rail providers (Trenitalia and Italo); this bumps the count to 22-plus and lists both. Docs-only, no code change.

Generated with Claude Code