### PR TITLE
fix(mcp): stop profile MaxPrice hint silently truncating search_flights (#452)

### DIFF
--- a/internal/flights/results_test.go
+++ b/internal/flights/results_test.go
@@ -7,6 +7,72 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
+// TestMergeFlightResults_ProfileMaxPriceHintWouldTruncateMultiProvider
+// reproduces, at the real merge/filter pipeline, the exact symptom reported
+// in issue #452: search_flights via MCP returned only 4 kiwi-only flights for
+// FCO->HRG while the CLI and a direct flights.SearchFlights() call returned
+// 106 flights across every provider. The root cause was mcp.handleSearchFlights
+// silently setting opts.MaxPrice from a profile-derived AvgFlightPrice*1.5
+// hint whenever the caller omitted max_price — a hard filter applied here,
+// inside mergeFlightResults/filterFlightResults, AFTER each provider's raw
+// fetch count is already recorded in provider_statuses (so "google_flights:
+// ok, 91 results" and a 4-flight final list could coexist with no visible
+// signal of truncation).
+//
+// This test locks in both directions:
+//   - opts.MaxPrice == 0 (the fixed mcp.applyFlightProfileHints never sets
+//     it from a profile hint) must preserve every provider's flights.
+//   - opts.MaxPrice set to a stale/low ceiling (simulating the pre-fix bug)
+//     DOES collapse the merge down to the cheap provider only — proving this
+//     is genuinely the mechanism that produced the reported truncation, not
+//     just a hypothetical.
+func TestMergeFlightResults_ProfileMaxPriceHintWouldTruncateMultiProvider(t *testing.T) {
+	kiwiFlights := []models.FlightResult{
+		{Price: 120, Currency: "EUR", Provider: "kiwi", Legs: []models.FlightLeg{{DepartureAirport: models.AirportInfo{Code: "FCO"}, ArrivalAirport: models.AirportInfo{Code: "HRG"}, DepartureTime: "2026-08-10T06:00", ArrivalTime: "2026-08-10T10:00"}}},
+		{Price: 140, Currency: "EUR", Provider: "kiwi", Legs: []models.FlightLeg{{DepartureAirport: models.AirportInfo{Code: "FCO"}, ArrivalAirport: models.AirportInfo{Code: "HRG"}, DepartureTime: "2026-08-10T09:00", ArrivalTime: "2026-08-10T13:00"}}},
+	}
+	googleFlights := []models.FlightResult{
+		{Price: 410, Currency: "EUR", Provider: "google_flights", Legs: []models.FlightLeg{{DepartureAirport: models.AirportInfo{Code: "FCO"}, ArrivalAirport: models.AirportInfo{Code: "HRG"}, AirlineCode: "MS", DepartureTime: "2026-08-10T11:00", ArrivalTime: "2026-08-10T15:00"}}},
+		{Price: 455, Currency: "EUR", Provider: "google_flights", Legs: []models.FlightLeg{{DepartureAirport: models.AirportInfo{Code: "FCO"}, ArrivalAirport: models.AirportInfo{Code: "HRG"}, AirlineCode: "LH", DepartureTime: "2026-08-10T14:00", ArrivalTime: "2026-08-10T20:00"}}},
+	}
+
+	t.Run("fixed: no MaxPrice hint preserves every provider", func(t *testing.T) {
+		merged := mergeFlightResults(googleFlights, kiwiFlights, nil, SearchOptions{})
+		if len(merged) != len(kiwiFlights)+len(googleFlights) {
+			t.Fatalf("merged count = %d, want %d (kiwi + google_flights must both survive when no price ceiling is set — issue #452)",
+				len(merged), len(kiwiFlights)+len(googleFlights))
+		}
+		var sawGoogle, sawKiwi bool
+		for _, f := range merged {
+			switch f.Provider {
+			case "google_flights":
+				sawGoogle = true
+			case "kiwi":
+				sawKiwi = true
+			}
+		}
+		if !sawGoogle || !sawKiwi {
+			t.Fatalf("merged providers incomplete: sawGoogle=%v sawKiwi=%v, want both true", sawGoogle, sawKiwi)
+		}
+	})
+
+	t.Run("mechanism proof: a stale MaxPrice ceiling collapses to one provider", func(t *testing.T) {
+		// 300 mirrors AvgFlightPrice(200)*1.5 from a user profile whose
+		// historical average is far below this route's real fares — the
+		// exact shape of the bug that shipped before the fix.
+		merged := mergeFlightResults(googleFlights, kiwiFlights, nil, SearchOptions{MaxPrice: 300})
+		if len(merged) != len(kiwiFlights) {
+			t.Fatalf("merged count = %d, want %d (a stale price ceiling should reproduce the pre-fix truncation to kiwi-only)",
+				len(merged), len(kiwiFlights))
+		}
+		for _, f := range merged {
+			if f.Provider != "kiwi" {
+				t.Fatalf("unexpected provider %q survived the ceiling; want kiwi-only collapse (proves the truncation mechanism)", f.Provider)
+			}
+		}
+	})
+}
+
 func TestMergeFlightResults_SortsCheapestAndFiltersStops(t *testing.T) {
 	googleFlights := []models.FlightResult{
 		{

--- a/mcp/flight_profile_hints_test.go
+++ b/mcp/flight_profile_hints_test.go
@@ -1,0 +1,98 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/profile"
+)
+
+// TestApplyFlightProfileHints_DoesNotAutoApplyMaxPrice is a regression test
+// for the search_flights MCP truncation bug (issue #452): @gurubrix reported
+// that search_flights via MCP returned only 4 kiwi-only flights for FCO->HRG
+// while the CLI and a direct flights.SearchFlights() call — identical params —
+// returned 106 flights across every provider (kiwi, google_flights, egyptair,
+// lufthansa, ...). provider_statuses showed google_flights as "ok" with 91
+// results that never made it into the final flights[] array.
+//
+// Root cause: handleSearchFlights silently applied a profile-derived
+// AvgFlightPrice*1.5 budget ceiling to opts.MaxPrice whenever the caller did
+// not pass max_price explicitly. opts.MaxPrice is a hard post-fetch filter
+// (internal/flights.filterFlightResults), applied AFTER provider_statuses
+// already recorded each provider's raw fetch count — so a route priced above
+// the user's historical average silently collapsed the merged multi-provider
+// result down to whichever provider's flights happened to fit under the
+// ceiling (here: only the 4 cheapest Kiwi fares), with no signal in the
+// response that anything had been filtered. The CLI (cmd/trvl/flights.go)
+// never applies profile hints at all, so it returned the unfiltered set —
+// hence the MCP/CLI divergence for identical params.
+//
+// This test locks in the fix: a profile-derived MaxPrice hint must never be
+// auto-applied as a hard filter, matching CLI behavior exactly. See
+// internal/flights.TestMergeFlightResults_ProfileMaxPriceHintWouldTruncateMultiProvider
+// for the end-to-end reproduction of the reported symptom using the real
+// merge/filter pipeline.
+func TestApplyFlightProfileHints_DoesNotAutoApplyMaxPrice(t *testing.T) {
+	// hints.MaxPrice mirrors profile.FlightHints() deriving a ceiling from
+	// AvgFlightPrice*1.5 (see internal/profile/apply.go), simulating a user
+	// whose historical average is far below a specific route's real fares.
+	hints := profile.FlightSearchHints{MaxPrice: 300}
+	args := map[string]any{
+		"origin":         "FCO",
+		"destination":    "HRG",
+		"departure_date": "2026-08-10",
+		// No max_price passed by the caller.
+	}
+
+	got := applyFlightProfileHints(flights.SearchOptions{}, args, hints)
+
+	if got.MaxPrice != 0 {
+		t.Fatalf("MaxPrice = %d, want 0 (profile-derived budget hints must never be auto-applied as a hard filter — CLI parity, issue #452)", got.MaxPrice)
+	}
+}
+
+// TestApplyFlightProfileHints_ExplicitMaxPriceUnaffected verifies the fix does
+// not disturb a caller-supplied max_price: applyFlightProfileHints only ever
+// fills in defaults for parameters the caller left unset, and since MaxPrice
+// is no longer touched at all, an explicit opts.MaxPrice must survive
+// untouched.
+func TestApplyFlightProfileHints_ExplicitMaxPriceUnaffected(t *testing.T) {
+	hints := profile.FlightSearchHints{MaxPrice: 300}
+	args := map[string]any{"max_price": float64(500)}
+
+	got := applyFlightProfileHints(flights.SearchOptions{MaxPrice: 500}, args, hints)
+
+	if got.MaxPrice != 500 {
+		t.Fatalf("MaxPrice = %d, want 500 (explicit caller value must be preserved)", got.MaxPrice)
+	}
+}
+
+// TestApplyFlightProfileHints_CabinClassStillApplied proves the fix did not
+// overcorrect: CabinClass is a legitimate profile default (it narrows the
+// provider query itself rather than silently post-filtering an already-merged
+// result set) and must still apply when the caller has not set cabin_class
+// explicitly.
+func TestApplyFlightProfileHints_CabinClassStillApplied(t *testing.T) {
+	hints := profile.FlightSearchHints{CabinClass: int(models.Business)}
+	args := map[string]any{}
+
+	got := applyFlightProfileHints(flights.SearchOptions{}, args, hints)
+
+	if got.CabinClass != models.Business {
+		t.Fatalf("CabinClass = %v, want %v (legitimate cabin-class hint must still apply)", got.CabinClass, models.Business)
+	}
+}
+
+// TestApplyFlightProfileHints_ExplicitCabinClassUnaffected verifies an
+// explicit caller cabin_class arg blocks the profile hint from overriding it.
+func TestApplyFlightProfileHints_ExplicitCabinClassUnaffected(t *testing.T) {
+	hints := profile.FlightSearchHints{CabinClass: int(models.Business)}
+	args := map[string]any{"cabin_class": "economy"}
+
+	got := applyFlightProfileHints(flights.SearchOptions{CabinClass: models.Economy}, args, hints)
+
+	if got.CabinClass != models.Economy {
+		t.Fatalf("CabinClass = %v, want %v (explicit caller cabin_class must be preserved)", got.CabinClass, models.Economy)
+	}
+}

--- a/mcp/tools_flights.go
+++ b/mcp/tools_flights.go
@@ -348,9 +348,22 @@ func handleSearchFlights(ctx context.Context, args map[string]any, elicit Elicit
 	// merge.
 	prof, _ := profile.Load()
 	hints := profile.FlightHints(prof, primaryOrigin, primaryDest)
-	if _, explicit := args["cabin_class"]; !explicit && hints.CabinClass > 0 && opts.CabinClass == 0 {
-		opts.CabinClass = models.CabinClass(hints.CabinClass)
-	}
+	opts = applyFlightProfileHints(opts, args, hints)
+	// MaxPrice is intentionally NOT auto-applied as a hard filter — see the
+	// note above about PreferredAlliance. AvgFlightPrice*1.5 is a coarse,
+	// route-agnostic-ish ceiling; on a route priced above the user's
+	// historical average (e.g. a long-haul the user rarely books) it can
+	// silently discard the majority of legitimately fetched, on-budget
+	// inventory from every provider except the cheapest one — while
+	// provider_statuses still reports those providers "ok" (the filter runs
+	// after fetch, inside filterFlightResults), making the truncation
+	// invisible to the caller. This also breaks CLI parity: the CLI flights
+	// command never applies profile hints. Root cause of MIK issue #452
+	// (search_flights returning 4 kiwi-only flights instead of the full
+	// 106-flight multi-provider set for identical params). If a caller wants
+	// a price ceiling they pass `max_price` explicitly, or set an explicit
+	// preferences.BudgetFlightMax (applied uniformly to both CLI and MCP
+	// below via FilterFlightsByBudget).
 
 	result, err := dispatchFlightSearch(ctx, args, origin, dest, date, opts)
 	if err != nil {
@@ -636,6 +649,39 @@ func buildBookingContext(date, origin string, originSource travelctx.Source) *bo
 	bc.BookingWindow = string(window)
 	bc.Advisory = window.Advisory()
 	return bc
+}
+
+// applyFlightProfileHints layers profile-derived defaults onto opts, but only
+// for parameters the caller did not set explicitly.
+//
+// IMPORTANT: PreferredAlliance (and, by the same reasoning, MaxPrice) are
+// intentionally NOT auto-applied as hard filters here:
+//
+//   - Alliances: auto-applying the user's dominant alliance silently disables
+//     Kiwi and Skiplagged in the multi-provider merge (their eligibility
+//     checks bail when `len(opts.Alliances) > 0`) and over-narrows Google
+//     Flights to alliance-only routes. Reverted as part of the
+//     merge-zero-results regression (default search returned 0 flights when
+//     the user's profile had a preferred alliance set).
+//   - MaxPrice: AvgFlightPrice*1.5 is a coarse historical-average ceiling.
+//     On a route priced above the user's average (e.g. a long-haul they
+//     rarely book), auto-applying it as a hard `flights.SearchOptions.MaxPrice`
+//     silently discards the majority of legitimately fetched inventory from
+//     every provider except the cheapest one, while provider_statuses still
+//     reports those providers "ok" (the filter runs after fetch). It also
+//     breaks CLI parity: `cmd/trvl` never applies profile hints. Root cause
+//     of the search_flights truncation bug (MCP returned 4 kiwi-only flights
+//     instead of the full 106-flight multi-provider set for identical
+//     params).
+//
+// Only CabinClass is auto-applied: it narrows the provider query itself
+// (rather than post-filtering an already-fetched merge), so a caller sees a
+// consistent, non-silently-truncated result set either way.
+func applyFlightProfileHints(opts flights.SearchOptions, args map[string]any, hints profile.FlightSearchHints) flights.SearchOptions {
+	if _, explicit := args["cabin_class"]; !explicit && hints.CabinClass > 0 && opts.CabinClass == 0 {
+		opts.CabinClass = models.CabinClass(hints.CabinClass)
+	}
+	return opts
 }
 
 // dispatchFlightSearch routes a search_flights call to the right


### PR DESCRIPTION
Fixes #452 — `search_flights` via MCP stdio truncating multi-provider results.

## Root cause
`handleSearchFlights` (mcp/tools_flights.go) silently applied a **profile-derived MaxPrice ceiling** (`AvgFlightPrice * 1.5`) to `opts.MaxPrice` whenever the caller didn't pass an explicit `max_price`. That ceiling is a **hard post-fetch filter** in `internal/flights.filterFlightResults` — it runs *after* each provider's results are fetched and their `provider_statuses` counts recorded. So for a route priced above the user's historical average (e.g. FCO→HRG), it dropped nearly everything except the cheapest provider (Kiwi's 4), while `provider_statuses.google_flights` still reported `ok, results: 91`. That mismatch is exactly what @gurubrix observed. The CLI path never calls `profile.FlightHints`, so it returned the full 106-flight set.

This is the same failure shape as the earlier `PreferredAlliance` merge-zero regression — a profile hint silently narrowing the merged result set.

## Fix
Extracted `applyFlightProfileHints(opts, args, hints)` that auto-applies **only** `CabinClass` (which narrows the provider *query*, not a post-fetch filter) and no longer copies `hints.MaxPrice` into `opts.MaxPrice`. Explicit `max_price` from the caller and the separate `preferences.BudgetFlightMax` filter are untouched and behave identically on CLI and MCP.

## Tests
- `mcp/flight_profile_hints_test.go` (new, 4 tests): MaxPrice not auto-applied; explicit max_price unaffected; CabinClass still applied + explicit unaffected.
- `internal/flights/results_test.go`: `TestMergeFlightResults_ProfileMaxPriceHintWouldTruncateMultiProvider` reproduces the truncation against the real merge/filter pipeline.
- `go build ./...`, `go vet`, `go test ./mcp/... ./internal/flights/...` all pass.

Reviewed adversarially (codex/gpt-5.5, APPROVE). Follow-up noted: `CabinClass` auto-apply can still cause CLI-vs-MCP divergence for premium/luxury profiles — filed separately; not part of this truncation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
