### PR TITLE
chore(ci): unblock CI — Go 1.26.5 (stdlib OSV) + openpgp ignore + dynamic test dates

### DIFF
--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -33,3 +33,8 @@
 #
 # Keep this list EMPTY unless a vuln genuinely has no fix. The right fix for a
 # fixable vuln is to bump the dependency, not to ignore it.
+
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+ignoreUntil = 2026-10-09
+reason = "golang.org/x/crypto/openpgp: unmaintained/unsafe-by-design, no upstream fix (introduced:0, fixed:none). VERIFIED UNREACHABLE: `go mod why golang.org/x/crypto` reports 'main module does not need package golang.org/x/crypto', and `rg x/crypto/openpgp` finds zero imports in trvl. Indirect-only, unused. Re-review 2026-10-09 (bump/drop the transitive dep if a maintained replacement lands)."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.26.4"]
+        go-version: ["1.26.5"]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -168,7 +168,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       # Register QEMU user-static interpreters so buildx can emit
       # linux/arm64 images on the amd64 GitHub-hosted runner.
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
@@ -185,10 +185,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # goreleaser-action defaults GOTOOLCHAIN=local, which blocks the Go
           # toolchain auto-download in the before-hooks. go.mod requires
-          # >= 1.26.4 (stdlib CVE fixes GO-2026-5037/5039) but GitHub runners
-          # may still ship 1.26.3, so pin the toolchain so go fetches 1.26.4
+          # >= 1.26.5 (stdlib CVE fixes GO-2026-5037/5039) but GitHub runners
+          # may still ship 1.26.3, so pin the toolchain so go fetches 1.26.5
           # for the hooks and the release build.
-          GOTOOLCHAIN: "go1.26.4"
+          GOTOOLCHAIN: "go1.26.5"
           # HOMEBREW_TAP_TOKEN: a GitHub personal access token (classic) with
           # `repo` scope, stored as a repository secret. Goreleaser uses it to
           # push the auto-generated Homebrew formula to

--- a/.github/workflows/live-probes.yml
+++ b/.github/workflows/live-probes.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Live provider probes
         # -run Probe selects every *_probe_test.go test across the module; the
         # env gate flips them from skipped to live.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          # Must satisfy go.mod (>= 1.26.4 for stdlib CVE fixes); goreleaser
+          # Must satisfy go.mod (>= 1.26.5 for stdlib CVE fixes); goreleaser
           # resolves the module path with GOTOOLCHAIN=local, so the runner's Go
-          # itself has to be 1.26.4, not just the build toolchain.
-          go-version: "1.26.4"
+          # itself has to be 1.26.5, not just the build toolchain.
+          go-version: "1.26.5"
 
       # Install GoReleaser before cosign is on PATH so the action only performs
       # checksum verification while installing the release tool.
@@ -101,7 +101,7 @@ jobs:
       - name: Build snapshot binary for smoke test
         run: goreleaser build --single-target --snapshot --clean
         env:
-          GOTOOLCHAIN: "go1.26.4"
+          GOTOOLCHAIN: "go1.26.5"
 
       - name: Smoke-test packaged binary (gate release on a working CLI)
         run: |

--- a/.github/workflows/wizzair-version-sentinel.yml
+++ b/.github/workflows/wizzair-version-sentinel.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Discover current Wizz Air API version
         id: discover
@@ -82,7 +82,7 @@ jobs:
           # Validate the bump: the whole flights package must compile and pass.
           # (Running the full package, not a -run filter, avoids the Go footgun
           # where an unmatched filter exits 0 and validates nothing.)
-          GOTOOLCHAIN=go1.26.4 go test ./internal/flights/ -count=1
+          GOTOOLCHAIN=go1.26.5 go test ./internal/flights/ -count=1
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MikkoParkkola/trvl
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/andybalholm/brotli v1.2.1

--- a/internal/ground/ground_coverage2_split2_test.go
+++ b/internal/ground/ground_coverage2_split2_test.go
@@ -295,6 +295,10 @@ func TestSearchEuropeanSleeper_MockEmptyTrips(t *testing.T) {
 // ============================================================
 
 func TestSearchDigitransit_MockHappyPath2(t *testing.T) {
+	// Dynamic future date: the search query and the mock route times must be in
+	// the future or they get filtered as past. Was hard-coded to 2026-07-01,
+	// which broke once that date passed.
+	day := time.Now().AddDate(0, 1, 0)
 	origClient := httpClient
 	origLimiter := digitransitLimiter
 	t.Cleanup(func() {
@@ -311,16 +315,16 @@ func TestSearchDigitransit_MockHappyPath2(t *testing.T) {
 					"itineraries": []any{
 						map[string]any{
 							"duration":     5400,
-							"startTime":    float64(time.Date(2026, 7, 1, 8, 0, 0, 0, time.UTC).UnixMilli()),
-							"endTime":      float64(time.Date(2026, 7, 1, 9, 30, 0, 0, time.UTC).UnixMilli()),
+							"startTime":    float64(time.Date(day.Year(), day.Month(), day.Day(), 8, 0, 0, 0, time.UTC).UnixMilli()),
+							"endTime":      float64(time.Date(day.Year(), day.Month(), day.Day(), 9, 30, 0, 0, time.UTC).UnixMilli()),
 							"walkDistance": 500.0,
 							"waitingTime":  0,
 							"transfers":    0,
 							"legs": []any{
 								map[string]any{
 									"mode":       "RAIL",
-									"startTime":  float64(time.Date(2026, 7, 1, 8, 0, 0, 0, time.UTC).UnixMilli()),
-									"endTime":    float64(time.Date(2026, 7, 1, 9, 30, 0, 0, time.UTC).UnixMilli()),
+									"startTime":  float64(time.Date(day.Year(), day.Month(), day.Day(), 8, 0, 0, 0, time.UTC).UnixMilli()),
+									"endTime":    float64(time.Date(day.Year(), day.Month(), day.Day(), 9, 30, 0, 0, time.UTC).UnixMilli()),
 									"duration":   5400,
 									"from":       map[string]any{"name": "Helsinki", "stop": map[string]any{"code": "HEL"}},
 									"to":         map[string]any{"name": "Tampere", "stop": map[string]any{"code": "TRE"}},
@@ -341,7 +345,7 @@ func TestSearchDigitransit_MockHappyPath2(t *testing.T) {
 		Timeout:   5 * time.Second,
 	}
 
-	routes, err := SearchDigitransit(context.Background(), "Helsinki", "Tampere", "2026-07-01", "EUR")
+	routes, err := SearchDigitransit(context.Background(), "Helsinki", "Tampere", day.Format("2006-01-02"), "EUR")
 	if err != nil {
 		t.Fatalf("SearchDigitransit: %v", err)
 	}

--- a/mcp/tools_nested_test.go
+++ b/mcp/tools_nested_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 // TestOptimizeNestedRT_SavingsScenario (MIK-3076): with a stubbed pricer where
@@ -18,10 +19,16 @@ func TestOptimizeNestedRT_SavingsScenario(t *testing.T) {
 		}
 		return 300 // round-trip rooted on side A
 	}
+	// Dates must be in the future or optimizeNestedRT rejects them. The pricer
+	// is stubbed (date-independent), so only the relative window spacing matters
+	// — compute future dates so this test never goes stale (was hard-coded to
+	// 2026-07-01, which broke once that date passed).
+	base := time.Now().AddDate(0, 2, 0)
+	d := func(offset int) string { return base.AddDate(0, 0, offset).Format("2006-01-02") }
 	args := map[string]any{
 		"origin": "HEL", "destination": "AMS",
-		"window1_depart": "2026-07-01", "window1_return": "2026-07-05",
-		"window2_depart": "2026-07-20", "window2_return": "2026-07-24",
+		"window1_depart": d(0), "window1_return": d(4),
+		"window2_depart": d(19), "window2_return": d(23),
 	}
 	_, raw, err := optimizeNestedRT(context.Background(), args, stub)
 	if err != nil {


### PR DESCRIPTION
Unblocks trvl CI so the queue (including #453 and #454) can merge. Three pre-existing blockers, none from feature code:

## OSV vulnerability gate
- **Go 1.26.4 → 1.26.5** — clears stdlib advisories `GO-2026-4970` and `GO-2026-5856`.
- **`.github/osv-scanner.toml`** — time-boxed `IgnoredVulns` for `GO-2026-5932` (`golang.org/x/crypto/openpgp`, unmaintained-by-design, no upstream fix, `introduced:0 / fixed:none`). **Verified unreachable**: `go mod why golang.org/x/crypto` reports the main module doesn't need it; zero openpgp imports; `go list -deps` shows it isn't a built dependency. Handled per the config's documented time-boxed-exception pattern (reason + `ignoreUntil 2026-10-09`), not by weakening the gate.

## Test gate (`go test ./...`)
Two tests hard-coded `2026-07-01`, which broke once that date passed:
- `mcp/tools_nested_test.go` — stub pricer is date-independent; dates now dynamically future (same window offsets).
- `internal/ground/ground_coverage2_split2_test.go` (`TestSearchDigitransit_MockHappyPath2`) — search date + mock route times now dynamically future so the routes aren't filtered as past.

A full `go test -short ./...` had exactly these as the only failures; both packages are green after the fix. Other `2026-07-01` references in those files pass (their code paths don't filter past dates) and are left untouched.

Verified: `go build` + affected packages pass on 1.26.5. codex/gpt-5.5 review APPROVE (Go bump + OSV ignore + date fix; the second date fix is the identical reviewed pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
