### PR TITLE
fix(hotels): CLI+MCP parity — remove profile MaxPrice truncation, share adults-only exclusion

### DIFF
--- a/cmd/trvl/hotels.go
+++ b/cmd/trvl/hotels.go
@@ -173,12 +173,21 @@ func runHotels(cmd *cobra.Command, args []string) error {
 	}
 
 	// Apply preference-based filters (only when not already set via flags).
+	// Mirrors the MCP surface (mcp/tools_hotels buildHotelSearchRequest) so a
+	// user preference like BudgetPerNightMax constrains BOTH surfaces, not just
+	// MCP — the CLI previously ignored the budget preference entirely.
 	if prefs != nil {
 		if opts.Stars == 0 && prefs.MinHotelStars > 0 {
 			opts.Stars = prefs.MinHotelStars
 		}
 		if opts.MinRating == 0 && prefs.MinHotelRating > 0 {
 			opts.MinRating = prefs.MinHotelRating
+		}
+		if opts.MaxPrice == 0 && prefs.BudgetPerNightMax > 0 {
+			opts.MaxPrice = prefs.BudgetPerNightMax
+		}
+		if opts.MinPrice == 0 && prefs.BudgetPerNightMin > 0 {
+			opts.MinPrice = prefs.BudgetPerNightMin
 		}
 	}
 
@@ -192,11 +201,11 @@ func runHotels(cmd *cobra.Command, args []string) error {
 	}
 
 	// When the party includes children, never surface adults-only properties.
+	// Shared with the MCP surface via hotels.ApplySharedHotelPolicy so both
+	// behave identically.
 	if children > 0 && result != nil {
-		var hidden int
-		result.Hotels, hidden = excludeAdultsOnly(result.Hotels)
+		hidden := hotels.ApplySharedHotelPolicy(result, true)
 		if hidden > 0 {
-			result.Count = len(result.Hotels)
 			plural := "property"
 			if hidden != 1 {
 				plural = "properties"
@@ -439,20 +448,6 @@ func printHotelLinks(w io.Writer, hotels []models.HotelResult, location string) 
 			_, _ = fmt.Fprintf(w, "      Photo:         %s\n", u)
 		}
 	}
-}
-
-// excludeAdultsOnly returns the hotels with every adults-only property
-// removed, plus the count removed. The input slice is not mutated.
-func excludeAdultsOnly(in []models.HotelResult) (kept []models.HotelResult, hidden int) {
-	kept = make([]models.HotelResult, 0, len(in))
-	for _, h := range in {
-		if h.AdultsOnly {
-			hidden++
-			continue
-		}
-		kept = append(kept, h)
-	}
-	return kept, hidden
 }
 
 // formatProviderWarning builds a one-line transparency warning when any

--- a/cmd/trvl/hotels_adultsonly_test.go
+++ b/cmd/trvl/hotels_adultsonly_test.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"testing"
-
-	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
 // TestHotelsCmd_ChildrenFlagDefault verifies the --children flag exists and
 // defaults to 0 (no exclusion).
+//
+// The adults-only exclusion logic itself now lives in
+// internal/hotels.ApplySharedHotelPolicy (shared by the CLI and MCP surfaces)
+// and is tested there (internal/hotels/policy_test.go). This file only pins the
+// CLI-specific flag wiring.
 func TestHotelsCmd_ChildrenFlagDefault(t *testing.T) {
 	cmd := hotelsCmd()
 	f := cmd.Flags().Lookup("children")
@@ -16,47 +19,5 @@ func TestHotelsCmd_ChildrenFlagDefault(t *testing.T) {
 	}
 	if f.DefValue != "0" {
 		t.Errorf("expected --children default 0, got %q", f.DefValue)
-	}
-}
-
-// TestExcludeAdultsOnly verifies adults-only properties are filtered out and
-// counted, without mutating the input slice.
-func TestExcludeAdultsOnly(t *testing.T) {
-	in := []models.HotelResult{
-		{Name: "Family Resort"},
-		{Name: "TUI BLUE Madeira Gardens", AdultsOnly: true},
-		{Name: "City Hotel"},
-		{Name: "Quiet Retreat", AdultsOnly: true},
-	}
-
-	kept, hidden := excludeAdultsOnly(in)
-
-	if hidden != 2 {
-		t.Errorf("expected 2 hidden, got %d", hidden)
-	}
-	if len(kept) != 2 {
-		t.Fatalf("expected 2 kept, got %d", len(kept))
-	}
-	for _, h := range kept {
-		if h.AdultsOnly {
-			t.Errorf("adults-only hotel %q survived exclusion", h.Name)
-		}
-	}
-	// Input slice must not be mutated.
-	if len(in) != 4 {
-		t.Errorf("input slice mutated: len=%d", len(in))
-	}
-}
-
-// TestExcludeAdultsOnly_NoneFlagged verifies a party-safe result set passes
-// through unchanged.
-func TestExcludeAdultsOnly_NoneFlagged(t *testing.T) {
-	in := []models.HotelResult{{Name: "A"}, {Name: "B"}}
-	kept, hidden := excludeAdultsOnly(in)
-	if hidden != 0 {
-		t.Errorf("expected 0 hidden, got %d", hidden)
-	}
-	if len(kept) != 2 {
-		t.Errorf("expected 2 kept, got %d", len(kept))
 	}
 }

--- a/internal/hotels/policy.go
+++ b/internal/hotels/policy.go
@@ -1,0 +1,45 @@
+package hotels
+
+import "github.com/MikkoParkkola/trvl/internal/models"
+
+// ApplySharedHotelPolicy applies the post-search preference chain that BOTH the
+// CLI (cmd/trvl/hotels) and the MCP surface (mcp/tools_hotels, and by reuse
+// tools_accommodations) must run IDENTICALLY. It is the single source of truth
+// for that chain so the two surfaces cannot drift.
+//
+// This was extracted (trvl #452 follow-up, the hotels analogue of
+// flights.ApplySharedFlightPolicy) because the surfaces had already diverged:
+// the adults-only exclusion below lived only in the CLI, so the MCP surface
+// returned adults-only properties to a party that included children — the same
+// class of CLI/MCP parity bug behind the #452 MaxPrice truncation. One
+// implementation cannot drift.
+//
+// childrenPresent: pass true when the party includes children (CLI: children>0;
+// MCP: len(opts.ChildrenAges)>0). When true, properties flagged AdultsOnly are
+// removed and Count is kept consistent with the filtered set. Returns the number
+// of properties hidden so callers can surface a transparency note (the CLI does;
+// the MCP surface reflects it in the structured Count).
+func ApplySharedHotelPolicy(result *models.HotelSearchResult, childrenPresent bool) (hidden int) {
+	if result == nil {
+		return 0
+	}
+	if childrenPresent {
+		result.Hotels, hidden = excludeAdultsOnly(result.Hotels)
+		result.Count = len(result.Hotels)
+	}
+	return hidden
+}
+
+// excludeAdultsOnly returns the hotels with every adults-only property removed,
+// plus the count removed. The input slice is not mutated.
+func excludeAdultsOnly(in []models.HotelResult) (kept []models.HotelResult, hidden int) {
+	kept = make([]models.HotelResult, 0, len(in))
+	for _, h := range in {
+		if h.AdultsOnly {
+			hidden++
+			continue
+		}
+		kept = append(kept, h)
+	}
+	return kept, hidden
+}

--- a/internal/hotels/policy_test.go
+++ b/internal/hotels/policy_test.go
@@ -1,0 +1,131 @@
+package hotels
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// These tests pin the SHARED post-search hotel policy that both the CLI
+// (cmd/trvl/hotels.go) and the MCP surface (mcp/tools_hotels.go, and by reuse
+// mcp/tools_accommodations.go) now route through ApplySharedHotelPolicy.
+// Because both surfaces call this one function, their behaviour is identical by
+// construction — the CLI-vs-MCP drift behind trvl #452 (the flights MaxPrice
+// truncation) and the CLI-only adults-only exclusion can no longer happen
+// without failing these tests.
+
+func polHotels(adultsOnly ...bool) *models.HotelSearchResult {
+	h := make([]models.HotelResult, 0, len(adultsOnly))
+	for i, ao := range adultsOnly {
+		h = append(h, models.HotelResult{Name: "H", HotelID: string(rune('a' + i)), AdultsOnly: ao})
+	}
+	return &models.HotelSearchResult{Success: true, Hotels: h, Count: len(h)}
+}
+
+func TestApplySharedHotelPolicy_ExcludesAdultsOnlyWhenChildrenPresent(t *testing.T) {
+	r := polHotels(false, true, false, true)
+	hidden := ApplySharedHotelPolicy(r, true)
+	if hidden != 2 {
+		t.Fatalf("expected 2 adults-only hidden, got %d", hidden)
+	}
+	if len(r.Hotels) != 2 || r.Count != 2 {
+		t.Fatalf("expected 2 family-friendly hotels kept (count consistent), got %d (count=%d)", len(r.Hotels), r.Count)
+	}
+	for _, h := range r.Hotels {
+		if h.AdultsOnly {
+			t.Fatalf("adults-only property survived the exclusion")
+		}
+	}
+}
+
+func TestApplySharedHotelPolicy_NoExclusionWhenNoChildren(t *testing.T) {
+	// Parity requirement: with no children in the party, adults-only properties
+	// are perfectly bookable and must NOT be hidden on either surface.
+	r := polHotels(false, true, true)
+	hidden := ApplySharedHotelPolicy(r, false)
+	if hidden != 0 || len(r.Hotels) != 3 || r.Count != 3 {
+		t.Fatalf("no children -> keep all 3, hide none; got hidden=%d kept=%d count=%d", hidden, len(r.Hotels), r.Count)
+	}
+}
+
+func TestApplySharedHotelPolicy_CountConsistentAndNilSafe(t *testing.T) {
+	if got := ApplySharedHotelPolicy(nil, true); got != 0 { // must not panic on nil
+		t.Fatalf("nil result should hide 0, got %d", got)
+	}
+	r := polHotels(true, false)
+	ApplySharedHotelPolicy(r, true)
+	if r.Count != len(r.Hotels) {
+		t.Fatalf("Count (%d) must stay equal to len(Hotels) (%d)", r.Count, len(r.Hotels))
+	}
+}
+
+// TestHotelSearchPolicyParity is the anti-regression guard for CLI↔MCP
+// post-search policy drift on the hotel surfaces — the hotels analogue of
+// TestFlightSearchPolicyParity. Two halves:
+//
+//  1. Behaviour: given identical inputs the single shared policy produces one
+//     deterministic hotel set. Because BOTH surfaces route their post-search
+//     adults-only exclusion through ApplySharedHotelPolicy, testing it once
+//     tests both.
+//
+//  2. Source guard (non-tautological): it reads the actual CLI and MCP source
+//     and asserts each delegates to ApplySharedHotelPolicy, neither
+//     re-implements the exclusion inline (no bare excludeAdultsOnly call), and
+//     the MCP surface never re-seeds the hard price ceiling from the profile
+//     hint (opts.MaxPrice = hints.MaxPrice) — the exact #452/#453 truncation
+//     bug, whose hotel twin this PR removed.
+func TestHotelSearchPolicyParity(t *testing.T) {
+	t.Run("shared policy is deterministic for identical inputs", func(t *testing.T) {
+		cases := []struct {
+			name       string
+			adultsOnly []bool
+			children   bool
+			wantKept   int
+		}{
+			{"children hide adults-only", []bool{false, true, false}, true, 2},
+			{"no children keep all", []bool{false, true, true}, false, 3},
+			{"all family friendly", []bool{false, false}, true, 2},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got := polHotels(tc.adultsOnly...)
+				ApplySharedHotelPolicy(got, tc.children)
+				if len(got.Hotels) != tc.wantKept || got.Count != tc.wantKept {
+					t.Fatalf("got %d kept (count=%d), want %d", len(got.Hotels), got.Count, tc.wantKept)
+				}
+			})
+		}
+	})
+
+	t.Run("both surfaces delegate; neither re-implements the exclusion", func(t *testing.T) {
+		surfaces := map[string]string{
+			"CLI": "../../cmd/trvl/hotels.go",
+			"MCP": "../../mcp/tools_hotels.go",
+		}
+		for name, path := range surfaces {
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("%s: read %s: %v", name, path, err)
+			}
+			src := string(b)
+			if !strings.Contains(src, "ApplySharedHotelPolicy(") {
+				t.Errorf("%s (%s) no longer calls ApplySharedHotelPolicy — the shared adults-only exclusion must be exercised by both surfaces", name, path)
+			}
+			if strings.Contains(src, "excludeAdultsOnly(") {
+				t.Errorf("%s (%s) calls excludeAdultsOnly directly — the exclusion must live only in ApplySharedHotelPolicy, or the two surfaces will drift again (#452)", name, path)
+			}
+		}
+		// Direct guard against reintroducing the #452/#453 pre-search bug on the
+		// hotel MCP surface: seeding the hard opts.MaxPrice ceiling from the
+		// profile hint, which silently truncated the provider merge.
+		mcp, err := os.ReadFile(surfaces["MCP"])
+		if err != nil {
+			t.Fatalf("read MCP source: %v", err)
+		}
+		if strings.Contains(string(mcp), "opts.MaxPrice = hints.MaxPrice") {
+			t.Error("MCP reintroduced the truncation bug: opts.MaxPrice must NOT be seeded from the profile hint (it is a hard post-fetch ceiling that silently truncates the provider merge). A genuine user preference BudgetPerNightMax still applies; a profile hint must not.")
+		}
+	})
+}

--- a/mcp/tools_hotels.go
+++ b/mcp/tools_hotels.go
@@ -348,9 +348,13 @@ func buildHotelSearchRequest(args map[string]any) (hotelSearchRequest, error) {
 	if _, explicit := args["stars"]; !explicit && opts.Stars == 0 && hints.MinStars > 0 {
 		opts.Stars = hints.MinStars
 	}
-	if _, explicit := args["max_price"]; !explicit && opts.MaxPrice == 0 && hints.MaxPrice > 0 {
-		opts.MaxPrice = hints.MaxPrice
-	}
+	// NOTE: hints.MaxPrice (profile average nightly rate × budget flex) is
+	// deliberately NOT applied here. Seeding a hard price ceiling from a derived
+	// profile average silently truncates results the caller never asked to
+	// exclude — the exact bug fixed for flights in #453 (search_flights was
+	// dropping cheap options below a profile-derived cap). A genuine user
+	// preference (prefs.BudgetPerNightMax, applied above) still constrains the
+	// search; a profile *hint* must not. Do not re-add a hints.MaxPrice seed.
 	if _, explicit := args["property_type"]; !explicit && opts.PropertyType == "" && hints.PropertyType != "" {
 		opts.PropertyType = hints.PropertyType
 	}
@@ -382,6 +386,12 @@ func runHotelSearch(ctx context.Context, req hotelSearchRequest) (*models.HotelS
 		result.Hotels = preferences.FilterHotels(result.Hotels, req.Location, req.Prefs)
 		result.Count = len(result.Hotels)
 	}
+
+	// Shared CLI+MCP post-search policy: when the party includes children, never
+	// surface adults-only properties. Same applicator the CLI uses, so the two
+	// surfaces cannot drift. hidden count is ignored here — the structured Count
+	// already reflects the exclusion.
+	hotels.ApplySharedHotelPolicy(result, len(req.Options.ChildrenAges) > 0)
 
 	return result, nil
 }

--- a/mcp/tools_hotels_adultsonly_test.go
+++ b/mcp/tools_hotels_adultsonly_test.go
@@ -1,0 +1,95 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/hotels"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestHandleSearchHotels_ExcludesAdultsOnlyForChildren is the mcp-package
+// regression test for the CLI/MCP parity fix: the MCP search_hotels surface
+// must run the SAME adults-only exclusion the CLI does (via
+// internal/hotels.ApplySharedHotelPolicy) when the party includes children.
+// Before the fix, the exclusion lived only in cmd/trvl and the MCP surface
+// returned adults-only properties to families.
+//
+// Fail-before / pass-after: revert the ApplySharedHotelPolicy call in
+// runHotelSearch and this test fails (the adults-only property survives).
+func TestHandleSearchHotels_ExcludesAdultsOnlyForChildren(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolate from the operator's real prefs
+	orig := searchHotelsFunc
+	t.Cleanup(func() { searchHotelsFunc = orig })
+
+	searchHotelsFunc = func(_ context.Context, _ string, opts hotels.HotelSearchOptions) (*models.HotelSearchResult, error) {
+		return &models.HotelSearchResult{
+			Success: true,
+			Count:   3,
+			Hotels: []models.HotelResult{
+				{Name: "Family Inn", HotelID: "a"},
+				{Name: "TUI BLUE Adults Retreat", HotelID: "b", AdultsOnly: true},
+				{Name: "City Hotel", HotelID: "c"},
+			},
+		}, nil
+	}
+
+	_, structured, err := handleSearchHotels(context.Background(), map[string]any{
+		"location":     "Madeira",
+		"check_in":     "2026-06-15",
+		"check_out":    "2026-06-18",
+		"children_ages": []any{7}, // party includes a child -> exclude adults-only
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleSearchHotels: %v", err)
+	}
+
+	res, ok := structured.(hotelSearchResponse)
+	if !ok || res.HotelSearchResult == nil {
+		t.Fatalf("expected hotelSearchResponse, got %T", structured)
+	}
+	if res.Count != 2 || len(res.Hotels) != 2 {
+		t.Fatalf("adults-only property should be hidden for a party with children: got %d hotels (count=%d), want 2", len(res.Hotels), res.Count)
+	}
+	for _, h := range res.Hotels {
+		if h.AdultsOnly {
+			t.Errorf("adults-only property %q reached a family on the MCP surface", h.Name)
+		}
+	}
+}
+
+// TestHandleSearchHotels_KeepsAdultsOnlyWithoutChildren pins the parity
+// counterpart: with no children in the party, adults-only properties are
+// bookable and must NOT be hidden on the MCP surface (matching the CLI).
+func TestHandleSearchHotels_KeepsAdultsOnlyWithoutChildren(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolate from the operator's real prefs
+	orig := searchHotelsFunc
+	t.Cleanup(func() { searchHotelsFunc = orig })
+
+	searchHotelsFunc = func(_ context.Context, _ string, opts hotels.HotelSearchOptions) (*models.HotelSearchResult, error) {
+		return &models.HotelSearchResult{
+			Success: true,
+			Count:   2,
+			Hotels: []models.HotelResult{
+				{Name: "Adults Retreat", HotelID: "b", AdultsOnly: true},
+				{Name: "City Hotel", HotelID: "c"},
+			},
+		}, nil
+	}
+
+	_, structured, err := handleSearchHotels(context.Background(), map[string]any{
+		"location":  "Madeira",
+		"check_in":  "2026-06-15",
+		"check_out": "2026-06-18",
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handleSearchHotels: %v", err)
+	}
+	res, ok := structured.(hotelSearchResponse)
+	if !ok || res.HotelSearchResult == nil {
+		t.Fatalf("expected hotelSearchResponse, got %T", structured)
+	}
+	if len(res.Hotels) != 2 {
+		t.Fatalf("no children -> adults-only stays: got %d hotels, want 2", len(res.Hotels))
+	}
+}


### PR DESCRIPTION
## Problem
Hotels carried the same latent CLI/MCP divergence class that #452/#453 fixed for flights — a dual audit (grok 4.5 + Claude) found three heads:

1. **Profile MaxPrice truncation (the #453 twin)** — MCP seeded a hard `opts.MaxPrice` ceiling from `profile.HotelHints` (avg nightly × flex) when no explicit `max_price`, silently dropping cheaper properties the user never excluded. CLI never did this.
2. **Budget preference ignored on CLI** — `prefs.BudgetPerNightMax/Min` applied on MCP, ignored by CLI.
3. **Adults-only exclusion CLI-only** — MCP (and `search_accommodations` by reuse) returned adults-only properties to parties with children.

## Fix
- Remove the profile MaxPrice seeding on MCP (genuine `BudgetPerNightMax` still applies on **both**).
- Apply `BudgetPerNightMax/Min` on the CLI too (respecting explicit flags).
- Extract the exclusion into `internal/hotels.ApplySharedHotelPolicy(result, childrenPresent)`, called by both surfaces (CLI `children>0`; MCP `len(ChildrenAges)>0`). One implementation cannot drift.

## Tests
`internal/hotels/policy_test.go` pins the shared policy + a source-guard (mirrors flights) asserting neither surface re-implements the exclusion inline nor re-seeds `opts.MaxPrice=hints.MaxPrice`.

## Review
Dual-reviewed: **grok 4.5 APPROVE**, **codex gpt-5.5 APPROVE**. Build + `go test ./internal/hotels ./mcp ./cmd/trvl` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)