### PR TITLE
fix(ground): CLI+MCP parity — stop hard-filtering transport mode by profile hint

### DIFF
--- a/internal/ground/policy_test.go
+++ b/internal/ground/policy_test.go
@@ -1,0 +1,58 @@
+package ground
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestGroundSearchPolicyParity is the anti-regression source guard for
+// CLI↔MCP parity on ground transport mode filtering.
+//
+// The bug class: MCP used to seed opts.Type from profile.GroundHints
+// (PreferredType) when caller omitted `type`, causing filterGroundRoutes
+// to hard-drop every route whose type != the user's historical dominant
+// mode. The CLI (cmd/trvl/ground.go) never did this, so identical calls
+// returned different result sets.
+//
+// Decision (#453 class): profile-derived preferred mode must NOT be
+// applied as a hard filter. Explicit `type` still works; soft ranking
+// by preference is future work.
+//
+// This test's source-guard half reads the real source files and fails if
+// the seeding pattern (or equivalent) is reintroduced on either surface.
+func TestGroundSearchPolicyParity(t *testing.T) {
+	t.Run("neither surface seeds opts.Type from profile GroundHints (hard filter)", func(t *testing.T) {
+		surfaces := map[string]string{
+			"CLI": "../../cmd/trvl/ground.go",
+			"MCP": "../../mcp/tools_ground.go",
+		}
+		// Direct guards against reintroducing the exact seeding bug that
+		// only the MCP surface used to do (and that silently truncated
+		// results by transport mode, exactly as #453 did for MaxPrice).
+		forbidden := []string{
+			"opts.Type = hints.PreferredType",
+			"opts.Type = profile.GroundHints",
+			"Type: hints.PreferredType",
+			"Type = hints.PreferredType",
+		}
+		for name, path := range surfaces {
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("%s: read %s: %v", name, path, err)
+			}
+			src := string(b)
+			for _, pat := range forbidden {
+				if strings.Contains(src, pat) {
+					t.Errorf("%s (%s) contains %q — profile GroundHints must NOT feed opts.Type as a hard filter (parity with CLI; explicit type only; see #453 silent-truncation class)", name, path, pat)
+				}
+			}
+			// Catch the call site pattern that used to load and apply it.
+			// The explanatory comment in MCP contains the bare word but not the
+			// call form "GroundHints(" that the buggy code used.
+			if strings.Contains(src, "GroundHints(") {
+				t.Errorf("%s (%s) calls GroundHints — profile mode hints must not be used to set Type (would reintroduce hard filter parity divergence with CLI)", name, path)
+			}
+		}
+	})
+}

--- a/mcp/tools_ground.go
+++ b/mcp/tools_ground.go
@@ -13,6 +13,8 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/weather"
 )
 
+var searchGroundByNameFunc = ground.SearchByName
+
 func searchGroundTool() ToolDef {
 	return ToolDef{
 		Name:        "search_ground",
@@ -156,7 +158,7 @@ func handleSearchGround(ctx context.Context, args map[string]any, elicit ElicitF
 	// show all modes unless the caller passes `type`/`--type` explicitly.
 	// Profile mode-preference as a soft ranking signal remains future work.
 
-	result, err := ground.SearchByName(ctx, from, to, date, opts)
+	result, err := searchGroundByNameFunc(ctx, from, to, date, opts)
 	if err != nil {
 		return nil, nil, toolExecutionError("Ground transport search", err)
 	}

--- a/mcp/tools_ground.go
+++ b/mcp/tools_ground.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/MikkoParkkola/trvl/internal/ground"
 	"github.com/MikkoParkkola/trvl/internal/models"
-	"github.com/MikkoParkkola/trvl/internal/profile"
 	"github.com/MikkoParkkola/trvl/internal/transfer"
 	"github.com/MikkoParkkola/trvl/internal/trip"
 	"github.com/MikkoParkkola/trvl/internal/weather"
@@ -147,13 +146,15 @@ func handleSearchGround(ctx context.Context, args map[string]any, elicit ElicitF
 		opts.Providers = strings.Split(p, ",")
 	}
 
-	// Apply profile hint for preferred transport mode when the caller has not
-	// specified one explicitly.
-	if _, explicit := args["type"]; !explicit && opts.Type == "" {
-		prof, _ := profile.Load()
-		hints := profile.GroundHints(prof, from, to)
-		opts.Type = hints.PreferredType
-	}
+	// Explicit `type` arg is still respected as a hard filter (see
+	// filterGroundRoutes). We deliberately do NOT seed opts.Type from
+	// profile.GroundHints (or profile.Load) here. A profile-derived
+	// preferred mode must not become a hard filter that silently drops
+	// other modes (bus/train/ferry) the user never explicitly excluded.
+	// Same silent-truncation class as flights #453 (and the prior hotel
+	// HotelHints.MaxPrice seeding). After this change both CLI and MCP
+	// show all modes unless the caller passes `type`/`--type` explicitly.
+	// Profile mode-preference as a soft ranking signal remains future work.
 
 	result, err := ground.SearchByName(ctx, from, to, date, opts)
 	if err != nil {

--- a/mcp/tools_ground_policy_test.go
+++ b/mcp/tools_ground_policy_test.go
@@ -1,0 +1,72 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/ground"
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/profile"
+)
+
+func TestHandleSearchGround_ProfileDoesNotSeedType(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	// Persist a minimal profile fixture whose dominant ground mode is train.
+	// OLD pre-fix code in handleSearchGround would load via profile.Load +
+	// profile.GroundHints and seed opts.Type="train" (hard filter) when no
+	// explicit "type" arg was passed. This test (with fixture) ensures the
+	// MCP handler never consults profile for hard-filter seeding of Type.
+	p := &profile.TravelProfile{
+		TopGroundModes: []profile.ModeStats{{Mode: "train", Count: 100}},
+	}
+	if err := profile.Save(p); err != nil {
+		t.Fatalf("persist profile fixture: %v", err)
+	}
+
+	// Confirm the fixture would trigger the old bug path.
+	if h := profile.GroundHints(p, "Prague", "Vienna"); h.PreferredType != "train" {
+		t.Fatalf("GroundHints.PreferredType = %q, want train", h.PreferredType)
+	}
+
+	orig := searchGroundByNameFunc
+	t.Cleanup(func() { searchGroundByNameFunc = orig })
+
+	var captured ground.SearchOptions
+	searchGroundByNameFunc = func(_ context.Context, _, _, _ string, opts ground.SearchOptions) (*models.GroundSearchResult, error) {
+		captured = opts
+		return &models.GroundSearchResult{Success: true, Count: 0}, nil
+	}
+
+	t.Run("no explicit type yields empty opts.Type", func(t *testing.T) {
+		captured = ground.SearchOptions{}
+		_, _, err := handleSearchGround(context.Background(), map[string]any{
+			"from": "Prague",
+			"to":   "Vienna",
+			"date": "2026-07-10",
+		}, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("handleSearchGround without type: %v", err)
+		}
+		if captured.Type != "" {
+			t.Errorf("opts.Type = %q, want empty (profile-derived train must not seed hard filter)", captured.Type)
+		}
+	})
+
+	t.Run("explicit type bus is passed through", func(t *testing.T) {
+		captured = ground.SearchOptions{}
+		_, _, err := handleSearchGround(context.Background(), map[string]any{
+			"from": "Prague",
+			"to":   "Vienna",
+			"date": "2026-07-10",
+			"type": "bus",
+		}, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("handleSearchGround with type: %v", err)
+		}
+		if captured.Type != "bus" {
+			t.Errorf("opts.Type = %q, want bus", captured.Type)
+		}
+	})
+}


### PR DESCRIPTION
## Problem
The MCP ground handler seeded `opts.Type` from `profile.GroundHints` (the user's most-used mode) whenever no explicit `type` was given. Since `filterGroundRoutes` treats `opts.Type` as a **hard** filter, a user whose history skews *train* silently never saw a cheaper bus/ferry on MCP — while the CLI (flags only) showed all modes. Same silent-truncation class as flights #453 (MaxPrice) and the hotel `HotelHints.MaxPrice` seeding.

## Fix
Remove the profile `PreferredType` seeding on MCP. Both surfaces now show all modes unless the caller passes an explicit `type`/`--type`. Explicit type still filters. Profile mode-preference as a soft **ranking** signal (not a hard filter) is future work.

## Tests
`internal/ground/policy_test.go` — source-guard (mirrors flights/hotels) asserting neither surface seeds `opts.Type` from `GroundHints`.

## Review
Implemented by **grok 4.5**, reviewed by **Claude** (APPROVE); codex second-review in progress. Build + `go test ./internal/ground ./mcp ./cmd/trvl` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)