### PR TITLE
style: gofmt arc test files (trailing newline + map alignment)

### DIFF
--- a/internal/flights/policy_test.go
+++ b/internal/flights/policy_test.go
@@ -174,4 +174,3 @@ func TestFlightSearchPolicyParity(t *testing.T) {
 		}
 	})
 }
-

--- a/mcp/tools_hotels_adultsonly_test.go
+++ b/mcp/tools_hotels_adultsonly_test.go
@@ -35,9 +35,9 @@ func TestHandleSearchHotels_ExcludesAdultsOnlyForChildren(t *testing.T) {
 	}
 
 	_, structured, err := handleSearchHotels(context.Background(), map[string]any{
-		"location":     "Madeira",
-		"check_in":     "2026-06-15",
-		"check_out":    "2026-06-18",
+		"location":      "Madeira",
+		"check_in":      "2026-06-15",
+		"check_out":     "2026-06-18",
 		"children_ages": []any{7}, // party includes a child -> exclude adults-only
 	}, nil, nil, nil)
 	if err != nil {


### PR DESCRIPTION
Pure gofmt: trailing blank line in `policy_test.go` + map-key alignment in `tools_hotels_adultsonly_test.go`. trvl CI runs staticcheck, not `gofmt -l`, so these slipped past. No behaviour change. Found by DoD gofmt-clean gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)