### PR TITLE
fix(flights): remove afklmNewProvider global-swap data race in SearchMultiAirport

### DIFF
--- a/internal/flights/multi.go
+++ b/internal/flights/multi.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/MikkoParkkola/trvl/internal/flights/afklm"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -30,9 +29,10 @@ func SearchMultiAirport(ctx context.Context, origins, destinations []string, dat
 	// The find / tripsearch path + SearchMultiAirport fans N origins (home + nearby + rail+fly)
 	// to other providers unchanged. For AFKLM (1 QPS + hard 100 req/day quota) we issue
 	// at most one query per logical search, using the first (primary) origin/dest pair.
-	// Sub-searches in the fanout are suppressed via the afklmNewProvider seam so they
+	// Sub-searches in the fanout are suppressed via opts.suppressAFKLM so they
 	// treat AFKLM as unconfigured. AFKLM results carry their real departure airport codes
 	// and are simply pooled. Non-AFKLM providers are unaffected.
+	subOpts := opts
 	if opts.ReturnDate != "" && len(origins) > 0 && len(destinations) > 0 {
 		primO := origins[0]
 		primD := destinations[0]
@@ -43,10 +43,9 @@ func SearchMultiAirport(ctx context.Context, origins, destinations []string, dat
 			mu.Unlock()
 		}
 		// Suppress AFKLM in the parallel spread subs (they would otherwise each
-		// call NewProvider + search, burning quota). Restore after.
-		origAF := afklmNewProvider
-		afklmNewProvider = func() (*afklm.AFKLMProvider, error) { return nil, afklm.ErrNoCredential }
-		defer func() { afklmNewProvider = origAF }()
+		// call NewProvider + search, burning quota). Threaded via copied opts —
+		// no shared-global mutation, so concurrent SearchMultiAirport calls are race-free.
+		subOpts.suppressAFKLM = true
 	}
 
 	for _, orig := range origins {
@@ -60,7 +59,7 @@ func SearchMultiAirport(ctx context.Context, origins, destinations []string, dat
 				sem <- struct{}{}
 				defer func() { <-sem }()
 
-				result, err := SearchFlightsWithClient(ctx, client, o, d, date, opts)
+				result, err := SearchFlightsWithClient(ctx, client, o, d, date, subOpts)
 				if err != nil || !result.Success {
 					return // skip failed combos silently
 				}

--- a/internal/flights/roundtrip_native.go
+++ b/internal/flights/roundtrip_native.go
@@ -280,6 +280,12 @@ func searchAFKLMNativeRoundTrip(ctx context.Context, origin, destination, date, 
 		}}
 	}
 
+	// Fanout suppression (set by SearchMultiAirport on sub-searches): skip AFKLM
+	// so its 1-QPS/100-req-day quota is spent at most once per logical search.
+	if opts.suppressAFKLM {
+		return nil, nil
+	}
+
 	p, err := afklmNewProvider()
 	if errors.Is(err, afklm.ErrNoCredential) {
 		return nil, nil // silent, zero latency, zero user signal

--- a/internal/flights/roundtrip_test.go
+++ b/internal/flights/roundtrip_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -531,6 +532,55 @@ func TestSearchMultiAirport_Spread_AFKLMAtMostOnePerLogicalSearch(t *testing.T) 
 	}
 	if calls > 1 {
 		t.Errorf("AFKLM seam called %d times on spread RT search; want <=1 (primary only)", calls)
+	}
+}
+
+// TestSearchMultiAirport_ConcurrentRoundTrips_NoDataRace guards the fix that
+// removed the afklmNewProvider package-global swap from SearchMultiAirport.
+// The old code mutated that shared global on every RT spread search; two
+// concurrent SearchMultiAirport calls therefore write-write raced on it and
+// `go test -race` flagged it. Suppression now flows through a copied
+// SearchOptions.suppressAFKLM, so concurrent calls share no mutable state.
+// Run under -race this is clean; against the pre-fix code it fails.
+//
+// Beyond race-absence it also asserts the invariant the whole mechanism exists
+// to protect: the AFKLM seam is entered exactly once per logical search (the
+// primary pair) even under concurrency — fanout subs stay suppressed. With N
+// concurrent SearchMultiAirport calls the seam count must equal N, not N×combos.
+func TestSearchMultiAirport_ConcurrentRoundTrips_NoDataRace(t *testing.T) {
+	origNew := afklmNewProvider
+	defer func() { afklmNewProvider = origNew }()
+	var seamCalls int32
+	// Non-network stub so the primary AFKLM read resolves without credentials/net.
+	afklmNewProvider = func() (*afklm.AFKLMProvider, error) {
+		atomic.AddInt32(&seamCalls, 1)
+		return nil, afklm.ErrNoCredential
+	}
+	origF := afklmTestFlights
+	afklmTestFlights = nil
+	defer func() { afklmTestFlights = origF }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	opts := SearchOptions{ReturnDate: "2026-07-10"}
+
+	const n = 4
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Fanout subs fail fast offline; the point is concurrent entry into
+			// the AFKLM-suppression path, which must touch no shared mutable state.
+			_, _ = SearchMultiAirport(ctx, []string{"HEL", "AMS"}, []string{"BCN"}, "2026-07-01", opts)
+		}()
+	}
+	wg.Wait()
+
+	// Exactly one primary seam call per logical search; fanout fully suppressed.
+	// A regression that let fanout subs reach the seam would push this above n.
+	if got := atomic.LoadInt32(&seamCalls); got != n {
+		t.Errorf("AFKLM seam entered %d times across %d concurrent spread searches; want exactly %d (one primary each)", got, n, n)
 	}
 }
 

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -89,6 +89,14 @@ type SearchOptions struct {
 	// allowlist (TRVL_STEALTH_ALLOWLIST); a requested-but-unauthorized host
 	// runs the normal path and logs a single refusal line. See internal/stealth.
 	Stealth bool
+
+	// suppressAFKLM tells the native round-trip path to skip AFKLM inclusion
+	// for this sub-search. SearchMultiAirport sets it on the fanout sub-options
+	// (not the primary) so the 1-QPS/100-req-day AFKLM quota is spent at most
+	// once per logical search. Threaded via a copied SearchOptions rather than a
+	// mutated package global (which raced under concurrent SearchMultiAirport
+	// calls). Unexported: internal fanout control, not a user-facing knob.
+	suppressAFKLM bool
 }
 
 // defaults fills in zero-value fields with sensible defaults.
@@ -113,14 +121,23 @@ func SearchFlights(ctx context.Context, origin, destination, date string, opts S
 }
 
 // flightSearchKey builds a singleflight dedup key from the search parameters.
+//
+// suppressAFKLM is part of the key because it changes which providers a result
+// includes. Today the one-way singleflight path never sees it set (it is only
+// applied on the round-trip branch, which returns before this key is built), so
+// including it is a no-op for current callers. It is keyed anyway so that if a
+// future change ever routes a suppressed sub-search through singleflight, an
+// AFKLM-suppressed and an AFKLM-included request cannot collide on one cache
+// entry and serve each other's results.
 func flightSearchKey(origin, destination, date string, opts SearchOptions) string {
-	return fmt.Sprintf("flight|%s|%s|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%s|%s|%v|%v|%v|%s|%s|%s",
+	return fmt.Sprintf("flight|%s|%s|%s|%s|%d|%d|%d|%d|%d|%d|%d|%d|%s|%s|%v|%v|%v|%s|%s|%s|%v",
 		origin, destination, date, opts.ReturnDate,
 		opts.CabinClass, opts.MaxStops, opts.SortBy, opts.Adults,
 		opts.MaxPrice, opts.MaxDuration, opts.CarryOnBags, opts.CheckedBags,
 		opts.Currency, canonicalStringSlice(opts.Airlines),
 		opts.ExcludeBasic, opts.LessEmissions, opts.RequireCheckedBag,
 		canonicalStringSlice(opts.Alliances), opts.DepartAfter, opts.DepartBefore,
+		opts.suppressAFKLM,
 	)
 }
 


### PR DESCRIPTION
## What

`SearchMultiAirport` spent the AFKLM quota (1 QPS, 100 req/day) by swapping the package-global `afklmNewProvider` to a stub and restoring it with a deferred call, on every round-trip spread search. Two concurrent `SearchMultiAirport` calls wrote to that global at the same time, so the race detector flagged a write-write data race. The GPT second-opinion review on #475 surfaced it.

## Fix

Suppression now travels through a copied `SearchOptions.suppressAFKLM` (unexported) instead of mutating the global. The primary origin/dest pair runs with AFKLM enabled; the fanout sub-searches get `suppressAFKLM=true` and return before the provider constructor. Concurrent calls share no mutable state. `afklmNewProvider` stays as a sequential test-injection seam.

## Also in this change

- `flightSearchKey` now includes `suppressAFKLM`. Today the one-way singleflight path never sees it set (the round-trip branch returns before the key is built), so it is a no-op for current callers. It is keyed anyway so a future change that routes a suppressed sub-search through singleflight cannot collide a suppressed and an unsuppressed request on the same cache entry.
- The concurrent regression test asserts the quota invariant, not only race-absence: the AFKLM seam is entered exactly once per logical search (equal to N for N concurrent calls, not N times combos). A regression that let fanout subs reach the seam would push the count above N and fail.
- Dropped the now-unused afklm import from `multi.go`.

## Behavior

Unchanged for callers. AFKLM is still called at most once per logical search; `TestSearchMultiAirport_Spread_AFKLMAtMostOnePerLogicalSearch` is untouched and still passes.

## Verification

- Build, vet, gofmt, and staticcheck across the module are clean
- Race detector across the whole module: 98 packages ok, 0 races
- Swept the flights package for the same pattern (production code mutating a package var under concurrency); the other swap-restore vars (`afklmTestFlights`, `transaviaHost`, `wizzVersion`, `wizzHost`) live only in test files, which run serially. This was the only production instance.
