### PR TITLE
fix(models): carry fare-risk fields with cheapest source when folding duplicates

### DIFF
--- a/internal/models/resolve.go
+++ b/internal/models/resolve.go
@@ -149,6 +149,19 @@ func foldFlightSource(dst *FlightResult, src FlightResult) {
 		dst.Currency = cur
 		dst.Provider = prov
 		dst.BookingURL = url
+		// Fare-risk attributes must travel with the cheapest headline price so a
+		// consumer never ranks the cheapest provider while reading another
+		// provider's baggage / self-connect / fare terms (Frankenfare fix).
+		if prov == src.Provider {
+			dst.SelfConnect = src.SelfConnect
+			dst.FareType = src.FareType
+			dst.Warnings = src.Warnings
+			dst.CarryOnIncluded = src.CarryOnIncluded
+			dst.CheckedBagsIncluded = src.CheckedBagsIncluded
+			dst.ComparablePrice = src.ComparablePrice
+			dst.ComparableBreakdown = src.ComparableBreakdown
+			dst.Confidence = src.Confidence
+		}
 	}
 	dst.CheapestSource = prov
 	dst.Savings = savings
@@ -171,6 +184,15 @@ func foldGroundSource(dst *GroundRoute, src GroundRoute) {
 		dst.Currency = cur
 		dst.Provider = prov
 		dst.BookingURL = url
+		// Fare-risk attributes must travel with the cheapest headline price so a
+		// consumer never ranks the cheapest provider while reading another
+		// provider's amenities / seats / terms (Frankenfare fix).
+		if prov == src.Provider {
+			dst.PriceMax = src.PriceMax
+			dst.Amenities = src.Amenities
+			dst.SeatsLeft = src.SeatsLeft
+			dst.Confidence = src.Confidence
+		}
 	}
 	dst.CheapestSource = prov
 	dst.Savings = savings

--- a/internal/models/resolve_test.go
+++ b/internal/models/resolve_test.go
@@ -119,11 +119,11 @@ func TestResolveFlightSources_Frankenfare_CheaperSourceFareFieldsTravel(t *testi
 		in := []FlightResult{
 			{
 				Price: 180, Currency: "EUR", Provider: "google_flights", BookingURL: "g",
-				Legs: leg(), CheckedBagsIncluded: ptrInt(1),
+				Legs: leg(), CheckedBagsIncluded: ptrInt(1), CarryOnIncluded: ptrBool(true),
 			},
 			{
 				Price: 120, Currency: "EUR", Provider: "kiwi", BookingURL: "k",
-				Legs: leg(), CheckedBagsIncluded: ptrInt(0),
+				Legs: leg(), CheckedBagsIncluded: ptrInt(0), CarryOnIncluded: ptrBool(false),
 			},
 		}
 		out := ResolveFlightSources(in)
@@ -140,6 +140,9 @@ func TestResolveFlightSources_Frankenfare_CheaperSourceFareFieldsTravel(t *testi
 				got = *r.CheckedBagsIncluded
 			}
 			t.Errorf("CheckedBagsIncluded = %d, want deref 0 (not 1 from expensive source)", got)
+		}
+		if r.CarryOnIncluded == nil || *r.CarryOnIncluded {
+			t.Errorf("CarryOnIncluded = %v, want deref false (from cheaper source, not true from expensive)", r.CarryOnIncluded)
 		}
 		if len(r.Sources) != 2 {
 			t.Errorf("len(Sources)=%d want 2", len(r.Sources))

--- a/internal/models/resolve_test.go
+++ b/internal/models/resolve_test.go
@@ -95,3 +95,186 @@ func TestResolveFlightSources_NoCrossCurrencyCheapest(t *testing.T) {
 		t.Errorf("both sources should be retained, got %d", len(r.Sources))
 	}
 }
+
+// ptrBool and ptrInt are local test helpers for constructing *bool and *int
+// fields on FlightResult / GroundRoute (checked bags, seats left, etc.).
+func ptrBool(b bool) *bool { return &b }
+func ptrInt(i int) *int    { return &i }
+
+func TestResolveFlightSources_Frankenfare_CheaperSourceFareFieldsTravel(t *testing.T) {
+	// Common leg identity for all flight cases (same physical itinerary).
+	leg := func() []FlightLeg {
+		return []FlightLeg{{
+			AirlineCode:      "AY",
+			FlightNumber:     "101",
+			DepartureTime:    "2026-07-15T09:00:00Z",
+			DepartureAirport: AirportInfo{Code: "HEL"},
+			ArrivalAirport:   AirportInfo{Code: "BCN"},
+		}}
+	}
+
+	t.Run("bags_cheapest_wins_included_count", func(t *testing.T) {
+		// Case 1: Google reports 1 checked bag included; cheaper Kiwi reports 0.
+		// Result must carry Kiwi's (cheaper) baggage info, not Google's.
+		in := []FlightResult{
+			{
+				Price: 180, Currency: "EUR", Provider: "google_flights", BookingURL: "g",
+				Legs: leg(), CheckedBagsIncluded: ptrInt(1),
+			},
+			{
+				Price: 120, Currency: "EUR", Provider: "kiwi", BookingURL: "k",
+				Legs: leg(), CheckedBagsIncluded: ptrInt(0),
+			},
+		}
+		out := ResolveFlightSources(in)
+		if len(out) != 1 {
+			t.Fatalf("expected 1, got %d", len(out))
+		}
+		r := out[0]
+		if r.Price != 120 || r.Provider != "kiwi" {
+			t.Errorf("headline: price=%v provider=%q want 120/kiwi", r.Price, r.Provider)
+		}
+		if r.CheckedBagsIncluded == nil || *r.CheckedBagsIncluded != 0 {
+			got := -999
+			if r.CheckedBagsIncluded != nil {
+				got = *r.CheckedBagsIncluded
+			}
+			t.Errorf("CheckedBagsIncluded = %d, want deref 0 (not 1 from expensive source)", got)
+		}
+		if len(r.Sources) != 2 {
+			t.Errorf("len(Sources)=%d want 2", len(r.Sources))
+		}
+	})
+
+	t.Run("self_connect_cheapest_wins", func(t *testing.T) {
+		// Case 2: cheaper source is a self-connect; must propagate true.
+		in := []FlightResult{
+			{Price: 220, Currency: "EUR", Provider: "a", Legs: leg(), SelfConnect: false},
+			{Price: 140, Currency: "EUR", Provider: "b", Legs: leg(), SelfConnect: true},
+		}
+		r := ResolveFlightSources(in)[0]
+		if r.Price != 140 || !r.SelfConnect {
+			t.Errorf("Price=%v SelfConnect=%v want 140/true", r.Price, r.SelfConnect)
+		}
+	})
+
+	t.Run("faretype_and_warnings_travel_with_cheapest", func(t *testing.T) {
+		// Case 3: split tickets warning and FareSplitTickets must come from cheaper B.
+		in := []FlightResult{
+			{Price: 200, Currency: "EUR", Provider: "a", Legs: leg(), FareType: FareRoundTrip},
+			{Price: 160, Currency: "EUR", Provider: "b", Legs: leg(), FareType: FareSplitTickets, Warnings: []string{"separate tickets"}},
+		}
+		r := ResolveFlightSources(in)[0]
+		if r.Price != 160 || r.FareType != FareSplitTickets {
+			t.Errorf("Price=%v FareType=%q want 160/%q", r.Price, r.FareType, FareSplitTickets)
+		}
+		if len(r.Warnings) != 1 || r.Warnings[0] != "separate tickets" {
+			t.Errorf("Warnings=%v want [\"separate tickets\"]", r.Warnings)
+		}
+	})
+
+	t.Run("comparable_price_follows_cheapest_source", func(t *testing.T) {
+		// Case 4: ComparablePrice (the adjusted economics) must be taken from the cheapest src.
+		in := []FlightResult{
+			{Price: 150, Currency: "EUR", Provider: "a", Legs: leg(), ComparablePrice: 150},
+			{Price: 100, Currency: "EUR", Provider: "b", Legs: leg(), ComparablePrice: 170},
+		}
+		r := ResolveFlightSources(in)[0]
+		if r.Price != 100 || r.ComparablePrice != 170 {
+			t.Errorf("Price=%v ComparablePrice=%v want 100/170", r.Price, r.ComparablePrice)
+		}
+	})
+
+	t.Run("confidence_nil_on_cheapest_overwrites_prior_high", func(t *testing.T) {
+		// Case 5: when cheapest has nil Confidence, result must have nil (do not keep A's high).
+		high := &Confidence{Rated: true, Score: 0.92, Label: ConfidenceHigh, Basis: "test-high"}
+		in := []FlightResult{
+			{Price: 190, Currency: "EUR", Provider: "a", Legs: leg(), Confidence: high},
+			{Price: 130, Currency: "EUR", Provider: "b", Legs: leg(), Confidence: nil},
+		}
+		r := ResolveFlightSources(in)[0]
+		if r.Price != 130 || r.Confidence != nil {
+			t.Errorf("Price=%v Confidence=%#v want 130/nil", r.Price, r.Confidence)
+		}
+	})
+
+	t.Run("order_independent_cheapest_is_third", func(t *testing.T) {
+		// Case 6: cheapest folded last (or in middle); order must not matter.
+		base := leg()
+		a := FlightResult{Price: 210, Currency: "EUR", Provider: "a", BookingURL: "a", Legs: base, CheckedBagsIncluded: ptrInt(1)}
+		c := FlightResult{Price: 170, Currency: "EUR", Provider: "c", BookingURL: "c", Legs: base, CheckedBagsIncluded: ptrInt(2)}
+		b := FlightResult{Price: 150, Currency: "EUR", Provider: "b", BookingURL: "b", Legs: base, CheckedBagsIncluded: ptrInt(0)}
+		for _, order := range [][]FlightResult{{a, c, b}, {c, a, b}, {b, a, c}} {
+			out := ResolveFlightSources(order)
+			r := out[0]
+			if r.Price != 150 || r.Provider != "b" {
+				t.Errorf("in order %v: Price=%v Provider=%q want 150/b", providers(order), r.Price, r.Provider)
+				continue
+			}
+			if r.CheckedBagsIncluded == nil || *r.CheckedBagsIncluded != 0 {
+				t.Errorf("in order %v: CheckedBagsIncluded wrong", providers(order))
+			}
+			if len(r.Sources) != 3 {
+				t.Errorf("in order %v: len(Sources)=%d want 3", providers(order), len(r.Sources))
+			}
+		}
+	})
+}
+
+func providers(fs []FlightResult) []string {
+	ps := make([]string, len(fs))
+	for i, f := range fs {
+		ps[i] = f.Provider
+	}
+	return ps
+}
+
+func TestResolveGroundSources_Frankenfare_CheaperSourceFieldsTravel(t *testing.T) {
+	// Identity maker for ground: same type+stops+times+leg providers.
+	mk := func(provider string, price float64, amenities []string, seats *int, priceMax float64) GroundRoute {
+		return GroundRoute{
+			Provider:  provider,
+			Type:      "bus",
+			Price:     price,
+			PriceMax:  priceMax,
+			Currency:  "EUR",
+			Departure: GroundStop{City: "AMS", Station: "Amsterdam", Time: "2026-07-20T10:00:00Z"},
+			Arrival:   GroundStop{City: "BRU", Station: "Brussels", Time: "2026-07-20T13:30:00Z"},
+			Legs:      []GroundLeg{{Provider: "flix", Type: "bus"}},
+			Amenities: amenities,
+			SeatsLeft: seats,
+		}
+	}
+
+	t.Run("amenities_and_seats_follow_cheapest", func(t *testing.T) {
+		// Case 7 (ground mirror of bags): A has Amenities, B cheaper has nil Amenities + SeatsLeft=3.
+		// Expect cheapest price + B's offer fields (Amenities==nil, SeatsLeft=3).
+		a := mk("a", 30, []string{"wifi", "usb"}, nil, 0)
+		b := mk("b", 20, nil, ptrInt(3), 25)
+		out := ResolveGroundSources([]GroundRoute{a, b})
+		if len(out) != 1 {
+			t.Fatalf("expected 1, got %d", len(out))
+		}
+		r := out[0]
+		if r.Price != 20 || r.Provider != "b" {
+			t.Errorf("headline: price=%v provider=%q want 20/b", r.Price, r.Provider)
+		}
+		if r.Amenities != nil {
+			t.Errorf("Amenities=%v want nil (cheaper had none)", r.Amenities)
+		}
+		if r.SeatsLeft == nil || *r.SeatsLeft != 3 {
+			got := -999
+			if r.SeatsLeft != nil {
+				got = *r.SeatsLeft
+			}
+			t.Errorf("SeatsLeft = %d, want deref 3", got)
+		}
+		if len(r.Sources) != 2 {
+			t.Errorf("len(Sources)=%d want 2", len(r.Sources))
+		}
+		// PriceMax belongs to the cheapest provider too.
+		if r.PriceMax != 25 {
+			t.Errorf("PriceMax=%v want 25 (from cheapest)", r.PriceMax)
+		}
+	})
+}


### PR DESCRIPTION
## What

When several providers return the same physical itinerary, `ResolveFlightSources` and `ResolveGroundSources` collapse them into one result and keep the cheapest price as the headline. The fold only copied the price fields (price, currency, provider, booking URL) when a cheaper duplicate won. Every other offer-specific field stayed at whatever the first-seen source reported.

So a result could show the cheapest provider's price while reporting a different provider's baggage allowance, self-connect flag, warnings, fare type, comparable price, or booking confidence. The smart router ranks on these fields, so it could recommend the cheapest fare described by another fare's terms.

## Fix

Once `recomputeSourceEconomics` names the cheapest provider, if that provider is the source currently being folded, its offer-specific fields are copied onto the accumulated result. Each source is folded exactly once and a non-cheapest fold is skipped, so the fields always belong to whichever source owns the headline price, regardless of fold order.

Flight fields now carried with the cheapest source: `SelfConnect`, `FareType`, `Warnings`, `CarryOnIncluded`, `CheckedBagsIncluded`, `ComparablePrice`, `ComparableBreakdown`, `Confidence`.

Ground fields: `PriceMax`, `Amenities`, `SeatsLeft`, `Confidence`.

Physical-identity fields (legs, duration, stops, emissions, transfers) are left alone. They are identical across deduplicated sources by construction.

## Tests

Adds offline regression tests in `internal/models/resolve_test.go` covering baggage, self-connect, fare-type plus warnings, comparable price, nil-confidence overwrite, fold-order independence, and the ground mirror. Each asserts the field travels with the cheapest source and that provenance (`Sources`) is preserved.

Every new test fails against the pre-fix code and passes with the fix. The old code happened to be correct only when the cheapest source was folded first; the order-independence test covers the middle and last cases it got wrong.

`internal/models` coverage: 89.1%. Verified locally with `go test -race` on Go 1.26.5.

## Follow-up

A separate defect in `FlightIdentityKey` (two distinct flights with missing carrier data on the same route and time can collapse into one, dropping a real option) is noted for a follow-up ticket. Out of scope here.
