### PR TITLE
Make cheapest-source currency selection order-independent

### DIFF
--- a/internal/models/resolve.go
+++ b/internal/models/resolve.go
@@ -97,27 +97,72 @@ func GroundIdentityKey(r GroundRoute) string {
 		"|" + strings.Join(ops, ",")
 }
 
+// dominantCurrency selects the currency for headline cheapest computation
+// in an order-independent way: the currency with the highest number of
+// Price>0 sources (most-represented). Ties are broken by the
+// lexicographically smallest uppercased currency code (not first-seen order).
+// Currency grouping is case-insensitive; the returned string is taken from
+// a source's Currency value (as-is) to preserve existing casing style in results.
+func dominantCurrency(sources []PriceSource) string {
+	if len(sources) == 0 {
+		return ""
+	}
+	count := map[string]int{}
+	orig := map[string]string{} // upper -> a source's original Currency for that group
+	for _, s := range sources {
+		if s.Price <= 0 {
+			continue
+		}
+		u := strings.ToUpper(strings.TrimSpace(s.Currency))
+		if u == "" {
+			continue
+		}
+		count[u]++
+		if _, ok := orig[u]; !ok {
+			orig[u] = s.Currency
+		}
+	}
+	if len(count) == 0 {
+		return ""
+	}
+	maxC := 0
+	for _, c := range count {
+		if c > maxC {
+			maxC = c
+		}
+	}
+	var best []string
+	for u, c := range count {
+		if c == maxC {
+			best = append(best, u)
+		}
+	}
+	sort.Strings(best)
+	chosenU := best[0]
+	if o, ok := orig[chosenU]; ok && o != "" {
+		return o
+	}
+	return chosenU
+}
+
 // recomputeSourceEconomics sets the headline price to the cheapest source and
 // fills Savings (dearest - cheapest) and the cheapest provider name. To avoid a
 // false "cheapest" across currencies, comparison is restricted to sources that
-// share the currency of the first priced source; differently-priced-currency
+// share the (now deterministically chosen) currency; differently-currency
 // sources are kept in Sources but excluded from the min/savings math.
 func recomputeSourceEconomics(sources []PriceSource) (cheapest float64, currency, cheapestProvider, bookingURL string, savings float64) {
 	if len(sources) == 0 {
 		return 0, "", "", "", 0
 	}
-	// Pick the comparison currency: the first source with a positive price.
-	cmpCur := ""
-	for _, s := range sources {
-		if s.Price > 0 {
-			cmpCur = s.Currency
-			break
-		}
-	}
+	cmpCur := dominantCurrency(sources)
+	// Use case-insensitive compare for the group (per spec); return values
+	// come from the actual min source's fields (as-is).
+	cmpU := strings.ToUpper(strings.TrimSpace(cmpCur))
 	minIdx := -1
 	var maxPrice float64
 	for i, s := range sources {
-		if s.Price <= 0 || s.Currency != cmpCur {
+		su := strings.ToUpper(strings.TrimSpace(s.Currency))
+		if s.Price <= 0 || su != cmpU {
 			continue
 		}
 		if minIdx == -1 || s.Price < sources[minIdx].Price {

--- a/internal/models/resolve_test.go
+++ b/internal/models/resolve_test.go
@@ -404,3 +404,92 @@ func TestFlightIdentityKey_CarrierlessFallback(t *testing.T) {
 		// Full shape roughly: KL1001@...|ams>lhr@...-...
 	})
 }
+
+// TestResolveFlightSources_HeadlineDeterministicAcrossOrder proves that
+// recomputeSourceEconomics (via ResolveFlightSources) selects the headline
+// currency deterministically (most-represented, lex tie-break) independent
+// of provider slice order. Same physical itinerary, reversed order must
+// produce identical Price/Currency/CheapestSource/Savings.
+func TestResolveFlightSources_HeadlineDeterministicAcrossOrder(t *testing.T) {
+	leg := []FlightLeg{{AirlineCode: "AF", FlightNumber: "1234", DepartureTime: "2026-06-01T08:00:00Z"}}
+	// Same two sources, different currencies, counts 1 each.
+	srcEUR := FlightResult{Price: 210, Currency: "EUR", Provider: "kiwi", Legs: leg}
+	srcUSD := FlightResult{Price: 119, Currency: "USD", Provider: "skiplagged", Legs: leg}
+
+	orderA := []FlightResult{srcEUR, srcUSD} // EUR first
+	orderB := []FlightResult{srcUSD, srcEUR} // USD first
+
+	ra := ResolveFlightSources(orderA)[0]
+	rb := ResolveFlightSources(orderB)[0]
+
+	if ra.Price != rb.Price || ra.Currency != rb.Currency || ra.CheapestSource != rb.CheapestSource || ra.Savings != rb.Savings {
+		t.Errorf("headlines differ by order: A(price=%v cur=%s prov=%s sav=%v) B(price=%v cur=%s prov=%s sav=%v)",
+			ra.Price, ra.Currency, ra.CheapestSource, ra.Savings,
+			rb.Price, rb.Currency, rb.CheapestSource, rb.Savings)
+	}
+
+	// Tie (1 EUR, 1 USD) -> lex smallest "EUR" wins. Savings=0 (no same-currency pair).
+	if ra.Currency != "EUR" || ra.Price != 210 || ra.Savings != 0 {
+		t.Errorf("tie lex pick wrong: got cur=%s price=%v sav=%v want EUR/210/0", ra.Currency, ra.Price, ra.Savings)
+	}
+	if len(ra.Sources) != 2 || len(rb.Sources) != 2 {
+		t.Errorf("expected both sources retained, got A:%d B:%d", len(ra.Sources), len(rb.Sources))
+	}
+}
+
+// TestResolveGroundSources_HeadlineDeterministicAcrossOrder is the ground mirror.
+func TestResolveGroundSources_HeadlineDeterministicAcrossOrder(t *testing.T) {
+	mk := func(provider string, price float64, cur string) GroundRoute {
+		return GroundRoute{
+			Provider:  provider,
+			Type:      "train",
+			Price:     price,
+			Currency:  cur,
+			Departure: GroundStop{City: "Paris", Station: "Gare de Lyon", Time: "2026-06-01T10:00:00Z"},
+			Arrival:   GroundStop{City: "Lyon", Station: "Part-Dieu", Time: "2026-06-01T12:00:00Z"},
+			Legs:      []GroundLeg{{Provider: "sncf", Type: "train"}},
+		}
+	}
+	srcEUR := mk("trainline", 210, "EUR")
+	srcUSD := mk("sncf", 119, "USD")
+
+	orderA := []GroundRoute{srcEUR, srcUSD}
+	orderB := []GroundRoute{srcUSD, srcEUR}
+
+	ra := ResolveGroundSources(orderA)[0]
+	rb := ResolveGroundSources(orderB)[0]
+
+	if ra.Price != rb.Price || ra.Currency != rb.Currency || ra.CheapestSource != rb.CheapestSource || ra.Savings != rb.Savings {
+		t.Errorf("ground headlines differ by order: A(price=%v cur=%s prov=%s sav=%v) B(price=%v cur=%s prov=%s sav=%v)",
+			ra.Price, ra.Currency, ra.CheapestSource, ra.Savings,
+			rb.Price, rb.Currency, rb.CheapestSource, rb.Savings)
+	}
+
+	if ra.Currency != "EUR" || ra.Price != 210 || ra.Savings != 0 {
+		t.Errorf("ground tie lex pick wrong: got cur=%s price=%v sav=%v want EUR/210/0", ra.Currency, ra.Price, ra.Savings)
+	}
+	if len(ra.Sources) != 2 || len(rb.Sources) != 2 {
+		t.Errorf("expected both ground sources retained, got A:%d B:%d", len(ra.Sources), len(rb.Sources))
+	}
+}
+
+// TestResolveFlightSources_DominantCurrencyMajority proves most-represented
+// currency wins even when it is not first in slice.
+func TestResolveFlightSources_DominantCurrencyMajority(t *testing.T) {
+	leg := []FlightLeg{{AirlineCode: "AF", FlightNumber: "1234", DepartureTime: "2026-06-01T08:00:00Z"}}
+	// Two USD, one EUR — USD must win regardless of order.
+	s1 := FlightResult{Price: 100, Currency: "USD", Provider: "a", Legs: leg}
+	s2 := FlightResult{Price: 110, Currency: "USD", Provider: "b", Legs: leg}
+	s3 := FlightResult{Price: 120, Currency: "EUR", Provider: "c", Legs: leg}
+
+	// Shuffled orders
+	for _, order := range [][]FlightResult{{s3, s1, s2}, {s1, s3, s2}, {s2, s3, s1}} {
+		r := ResolveFlightSources(order)[0]
+		if r.Currency != "USD" || r.Price != 100 {
+			t.Errorf("majority failed for order %v: got cur=%s price=%v want USD/100", providers(order), r.Currency, r.Price)
+		}
+		if r.Savings != 10 {
+			t.Errorf("majority savings=%v want 10 (110-100 within USD)", r.Savings)
+		}
+	}
+}


### PR DESCRIPTION
## What

When several providers return the same physical flight or train, trvl collapses them into one result and picks a headline cheapest price. When those sources quote in different currencies, the comparison currency was chosen from the first priced source in the slice. Provider merge order is not stable, so the same itinerary could yield a different headline price, currency, and provider depending on ordering.

## Change

`recomputeSourceEconomics` now selects the comparison currency via `dominantCurrency`: the most-represented currency among priced sources, with ties broken by the lexicographically smallest code rather than first-seen order. The selection is deterministic regardless of source order and independent of Go map iteration order. The helper is shared by the flight and ground fold paths, so one change covers both.

The existing rule that we never compare cheapest across currencies is retained: sources in other currencies stay in `Sources` but are excluded from the min/savings math. No new dependencies; `internal/models` stays dependency-free.

## Tests

- Order-independence for flights and ground: the same two mixed-currency sources in both orders now produce identical headline price, currency, provider, and savings. These fail on the pre-change code (verified by stashing the fix) and pass after.
- Majority case: three sources across shuffled orders resolve to the most-represented currency deterministically.
- Pre-existing cross-currency and fare-attribute tests continue to pass.

## Verification

- `go build ./...`
- `go vet ./internal/models/`
- `staticcheck ./internal/models/`
- `go test -race ./internal/models/`

All green locally.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>