### PR TITLE
ground: rank ground routes by comparable price across currencies

### DIFF
--- a/internal/ground/search.go
+++ b/internal/ground/search.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/MikkoParkkola/trvl/internal/breaker"
 	"github.com/MikkoParkkola/trvl/internal/cache"
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/searchctx"
 	"golang.org/x/sync/singleflight"
@@ -141,6 +142,96 @@ func providerEnabled(name string, include, exclude []string) bool {
 		}
 	}
 	return false
+}
+
+// currencyConverter converts amount from->to, returning the converted amount
+// and a non-empty status/ok signal. Injected so unit tests never hit the network.
+type currencyConverter func(ctx context.Context, amount float64, from, to string) (converted float64, ok bool)
+
+// normalizeGroundCurrencies best-effort converts every route's price into the
+// target currency for comparable ranking. On success it mutates Price+Currency
+// to the target AND sets ComparablePrice. On failure it leaves the route in its
+// original currency and ComparablePrice stays 0 (=> incomparable).
+func normalizeGroundCurrencies(ctx context.Context, routes []models.GroundRoute, target string, conv currencyConverter) {
+	tU := strings.ToUpper(strings.TrimSpace(target))
+	if tU == "" || conv == nil {
+		return
+	}
+	for i := range routes {
+		r := &routes[i]
+		if r.Price <= 0 {
+			continue
+		}
+		cU := strings.ToUpper(strings.TrimSpace(r.Currency))
+		if cU == tU {
+			r.ComparablePrice = r.Price // already in target
+			continue
+		}
+		if converted, ok := conv(ctx, r.Price, r.Currency, target); ok && converted > 0 {
+			r.Price = converted
+			r.Currency = target
+			r.ComparablePrice = converted
+		}
+		// else: leave as-is, ComparablePrice=0 => incomparable tail
+	}
+}
+
+// sortGroundRoutes performs the stable cross-currency comparable-price sort
+// (used by search and directly by unit tests for determinism verification).
+func sortGroundRoutes(routes []models.GroundRoute) {
+	sort.SliceStable(routes, func(i, j int) bool {
+		a, b := routes[i], routes[j]
+		ac, bc := a.ComparablePrice > 0, b.ComparablePrice > 0
+		if ac != bc {
+			return ac
+		}
+		if ac && bc {
+			pa := a.PriceForRanking()
+			pb := b.PriceForRanking()
+			ra, rb := pa > 0, pb > 0
+			if ra != rb {
+				return ra
+			}
+			if ra && pa != pb {
+				return pa < pb
+			}
+		} else {
+			au, bu := strings.ToUpper(strings.TrimSpace(a.Currency)), strings.ToUpper(strings.TrimSpace(b.Currency))
+			if au != bu {
+				return au < bu
+			}
+			pa, pb := a.Price, b.Price
+			ra, rb := pa > 0, pb > 0
+			if ra != rb {
+				return ra
+			}
+			if ra && pa != pb {
+				return pa < pb
+			}
+		}
+		if a.Duration != b.Duration {
+			return a.Duration < b.Duration
+		}
+		if a.Departure.Time != b.Departure.Time {
+			return a.Departure.Time < b.Departure.Time
+		}
+		if a.Arrival.Time != b.Arrival.Time {
+			return a.Arrival.Time < b.Arrival.Time
+		}
+		if a.Provider != b.Provider {
+			return a.Provider < b.Provider
+		}
+		if a.BookingURL != b.BookingURL {
+			return a.BookingURL < b.BookingURL
+		}
+		if a.Transfers != b.Transfers {
+			return a.Transfers < b.Transfers
+		}
+		if a.Type != b.Type {
+			return a.Type < b.Type
+		}
+		return false
+	})
 }
 
 // SearchByName searches all providers for ground transport between two cities
@@ -587,6 +678,32 @@ func searchByNameCore(ctx context.Context, from, to, date string, opts SearchOpt
 	// stable JSON output (and stable tests).
 	sort.Slice(statuses, func(i, j int) bool { return statuses[i].ID < statuses[j].ID })
 
+	// Normalize currencies for truthful cross-currency ranking BEFORE filter
+	// (so MaxPrice uses comparable numbers) and BEFORE resolve. Target mirrors
+	// the flights derivation (opts.Currency if set, else first currency observed
+	// from raw results). Never hardcodes EUR here.
+	target := strings.TrimSpace(opts.Currency)
+	if target == "" {
+		for _, r := range allRoutes {
+			if c := strings.TrimSpace(r.Currency); c != "" {
+				target = c
+				break
+			}
+		}
+	}
+	if target != "" {
+		conv := func(ctx context.Context, amount float64, from, to string) (float64, bool) {
+			amt, status := destinations.ConvertCurrency(ctx, amount, from, to)
+			// Faithful adaptation of ConvertCurrency + flights normalize convention:
+			// success when returned status matches the requested to-currency and amt > 0.
+			if amt > 0 && strings.EqualFold(strings.TrimSpace(status), strings.TrimSpace(to)) {
+				return amt, true
+			}
+			return amt, false
+		}
+		normalizeGroundCurrencies(ctx, allRoutes, target, conv)
+	}
+
 	// Filter/deduplicate in one pass while preserving the current semantics:
 	// unavailable routes are removed first, then duplicate routes are suppressed
 	// before MaxPrice and Type filters are applied.
@@ -596,10 +713,8 @@ func searchByNameCore(ctx context.Context, from, to, date string, opts SearchOpt
 	// one route carrying every provider as a PriceSource (cheapest headline).
 	allRoutes = models.ResolveGroundSources(allRoutes)
 
-	// Sort by price
-	sort.Slice(allRoutes, func(i, j int) bool {
-		return allRoutes[i].Price < allRoutes[j].Price
-	})
+	// Sort by comparable price (cross-currency truthful). See sortGroundRoutes.
+	sortGroundRoutes(allRoutes)
 
 	annotateGroundConfidence(allRoutes, time.Now())
 

--- a/internal/ground/search_helpers_test.go
+++ b/internal/ground/search_helpers_test.go
@@ -1,6 +1,8 @@
 package ground
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
@@ -160,5 +162,169 @@ func TestFilterGroundRoutes(t *testing.T) {
 	}
 	if filtered[0].Price != 19 {
 		t.Fatalf("expected filtered route price 19, got %v", filtered[0].Price)
+	}
+}
+
+// ============================================================
+// normalizeGroundCurrencies + sortGroundRoutes cross-currency tests
+// All use stub converters (never real destinations.ConvertCurrency).
+// ============================================================
+
+func makeGroundRoute(provider, curr string, price float64, depTime, arrTime string) models.GroundRoute {
+	return models.GroundRoute{
+		Provider: provider,
+		Type:     "bus",
+		Price:    price,
+		Currency: curr,
+		Duration: 120,
+		Departure: models.GroundStop{
+			City: "Origin",
+			Time: depTime,
+		},
+		Arrival: models.GroundStop{
+			City: "Dest",
+			Time: arrTime,
+		},
+		Legs:       []models.GroundLeg{{Type: "bus", Provider: provider}},
+		BookingURL: "https://example.com/" + provider,
+	}
+}
+
+func TestNormalizeGroundCurrencies_MixedSuccess_Ranking(t *testing.T) {
+	// 110 EUR vs 119 USD; stub makes 119 USD convert to ~109.48 EUR.
+	// After norm+sort the USD-converted must rank #1 (the raw numeric trap).
+	routes := []models.GroundRoute{
+		makeGroundRoute("flix", "EUR", 110, "2026-07-01T08:00", "2026-07-01T10:00"),
+		makeGroundRoute("regio", "USD", 119, "2026-07-01T09:00", "2026-07-01T11:00"),
+	}
+	conv := func(ctx context.Context, amount float64, from, to string) (float64, bool) {
+		if strings.EqualFold(from, "USD") && strings.EqualFold(to, "EUR") {
+			return amount * 0.92, true // 119 * 0.92 = 109.48 < 110
+		}
+		return 0, false
+	}
+	normalizeGroundCurrencies(context.Background(), routes, "EUR", conv)
+	// resolve not strictly needed (distinct keys), but run for fidelity
+	routes = models.ResolveGroundSources(routes)
+	sortGroundRoutes(routes)
+
+	if len(routes) != 2 {
+		t.Fatalf("got %d routes", len(routes))
+	}
+	// first should be the (converted) cheaper USD one, now in EUR
+	if routes[0].Currency != "EUR" || routes[0].ComparablePrice <= 0 {
+		t.Errorf("first route should be normalized EUR with ComparablePrice set: %+v", routes[0])
+	}
+	if routes[0].PriceForRanking() >= routes[1].PriceForRanking() {
+		t.Errorf("expected converted USD route cheaper for ranking: got %.2f then %.2f",
+			routes[0].PriceForRanking(), routes[1].PriceForRanking())
+	}
+	// the originally 119 now shows converted price
+	if routes[0].PriceForRanking() > 110 {
+		t.Errorf("converted price should be <110, got %v", routes[0].PriceForRanking())
+	}
+}
+
+func TestNormalizeGroundCurrencies_FXUnavailable_IncomparableTail(t *testing.T) {
+	// Stub refuses all FX; target EUR routes get Comparable, others stay raw.
+	// Sort must put target-curr group first, then tail grouped by curr code (alpha) then price.
+	routes := []models.GroundRoute{
+		makeGroundRoute("p1", "USD", 50, "2026-07-01T08:00", "2026-07-01T10:00"),
+		makeGroundRoute("p2", "EUR", 120, "2026-07-01T09:00", "2026-07-01T11:00"),
+		makeGroundRoute("p3", "GBP", 90, "2026-07-01T10:00", "2026-07-01T12:00"),
+		makeGroundRoute("p4", "EUR", 95, "2026-07-01T07:00", "2026-07-01T09:00"),
+	}
+	conv := func(ctx context.Context, amount float64, from, to string) (float64, bool) {
+		return 0, false // FX unavailable
+	}
+	normalizeGroundCurrencies(context.Background(), routes, "EUR", conv)
+	routes = models.ResolveGroundSources(routes)
+	sortGroundRoutes(routes)
+
+	if len(routes) != 4 {
+		t.Fatalf("got %d", len(routes))
+	}
+	// first two should be the EUR ones (comparable), sorted by price 95 then 120
+	if routes[0].Currency != "EUR" || routes[0].ComparablePrice == 0 || routes[0].PriceForRanking() != 95 {
+		t.Errorf("first should be EUR 95 comparable: %+v", routes[0])
+	}
+	if routes[1].Currency != "EUR" || routes[1].PriceForRanking() != 120 {
+		t.Errorf("second should be EUR 120: %+v", routes[1])
+	}
+	// then incomparable tail: GBP (alpha before USD) then the USD
+	if routes[2].Currency != "GBP" {
+		t.Errorf("third should be GBP group start, got %q", routes[2].Currency)
+	}
+	if routes[3].Currency != "USD" {
+		t.Errorf("fourth should be USD, got %q", routes[3].Currency)
+	}
+	// ensure no cross-curr numeric lie: the raw 50 USD must NOT be first (it is in tail)
+	if routes[0].Price == 50 || routes[0].Currency == "USD" {
+		t.Error("raw foreign cheap price incorrectly ranked before target-currency group")
+	}
+}
+
+func TestNormalizeGroundCurrencies_PermutationIndependence(t *testing.T) {
+	// Different input order must yield identical final order after norm+resolve+sort.
+	base := []models.GroundRoute{
+		makeGroundRoute("a", "EUR", 100, "2026-07-01T08:00", "2026-07-01T10:00"),
+		makeGroundRoute("b", "USD", 80, "2026-07-01T09:00", "2026-07-01T11:00"),
+		makeGroundRoute("c", "EUR", 90, "2026-07-01T07:00", "2026-07-01T09:00"),
+	}
+	conv := func(ctx context.Context, amount float64, from, to string) (float64, bool) {
+		if strings.EqualFold(from, "USD") && strings.EqualFold(to, "EUR") {
+			return amount * 0.9, true // 72 EUR
+		}
+		return amount, strings.EqualFold(from, to)
+	}
+
+	// process original order
+	r1 := append([]models.GroundRoute(nil), base...)
+	normalizeGroundCurrencies(context.Background(), r1, "EUR", conv)
+	r1 = models.ResolveGroundSources(r1)
+	sortGroundRoutes(r1)
+
+	// reversed input order
+	r2 := append([]models.GroundRoute(nil), base[2], base[1], base[0])
+	normalizeGroundCurrencies(context.Background(), r2, "EUR", conv)
+	r2 = models.ResolveGroundSources(r2)
+	sortGroundRoutes(r2)
+
+	if len(r1) != len(r2) {
+		t.Fatalf("len differ %d vs %d", len(r1), len(r2))
+	}
+	for i := range r1 {
+		if r1[i].Provider != r2[i].Provider ||
+			r1[i].PriceForRanking() != r2[i].PriceForRanking() ||
+			r1[i].Currency != r2[i].Currency {
+			t.Errorf("order mismatch at %d: %+v vs %+v", i, r1[i], r2[i])
+		}
+	}
+}
+
+func TestNormalizeGroundCurrencies_MaxPriceRespectsNormalization(t *testing.T) {
+	// A route at raw 50 "USD" that converts to 125 "EUR" must be excluded by MaxPrice=100 (in target).
+	// A route at 80 EUR (stays) must survive.
+	routes := []models.GroundRoute{
+		makeGroundRoute("cheapraw", "USD", 50, "2026-07-01T08:00", "2026-07-01T10:00"),
+		makeGroundRoute("normal", "EUR", 80, "2026-07-01T09:00", "2026-07-01T11:00"),
+	}
+	conv := func(ctx context.Context, amount float64, from, to string) (float64, bool) {
+		if strings.EqualFold(from, "USD") && strings.EqualFold(to, "EUR") {
+			return 125.0, true // expensive after conversion
+		}
+		return amount, true
+	}
+	normalizeGroundCurrencies(context.Background(), routes, "EUR", conv)
+
+	opts := SearchOptions{MaxPrice: 100, Currency: "EUR"}
+	filtered := filterGroundRoutes(routes, opts)
+	// note: we normalize before filter in real path; here we simulate the state after norm
+
+	if len(filtered) != 1 || filtered[0].Provider != "normal" {
+		t.Fatalf("expected only the EUR 80 to survive MaxPrice after norm, got %+v", filtered)
+	}
+	if filtered[0].Price > 100 {
+		t.Error("surviving route should be under 100")
 	}
 }

--- a/internal/models/ground.go
+++ b/internal/models/ground.go
@@ -44,6 +44,11 @@ type GroundRoute struct {
 	Price      float64     `json:"price"`
 	PriceMax   float64     `json:"price_max,omitempty"` // RegioJet gives price ranges
 	Currency   string      `json:"currency"`
+	// ComparablePrice is the price converted to a common target currency for
+	// cross-currency ranking and MaxPrice filtering (and for PriceForRanking).
+	// Set by the normalize pass in ground search when conversion succeeds.
+	// 0 means "use raw Price" (incomparable across currencies).
+	ComparablePrice float64 `json:"comparable_price,omitempty"`
 	Duration   int         `json:"duration_minutes"`
 	Departure  GroundStop  `json:"departure"`
 	Arrival    GroundStop  `json:"arrival"`
@@ -96,4 +101,13 @@ type GroundLeg struct {
 	Arrival   GroundStop `json:"arrival"`
 	Duration  int        `json:"duration_minutes"`
 	Amenities []string   `json:"amenities,omitempty"`
+}
+
+// PriceForRanking returns the normalized comparable price when available,
+// falling back to the raw Price. Used for cross-currency-safe ranking.
+func (r GroundRoute) PriceForRanking() float64 {
+	if r.ComparablePrice > 0 {
+		return r.ComparablePrice
+	}
+	return r.Price
 }

--- a/internal/models/resolve.go
+++ b/internal/models/resolve.go
@@ -238,6 +238,7 @@ func foldGroundSource(dst *GroundRoute, src GroundRoute) {
 			dst.Amenities = src.Amenities
 			dst.SeatsLeft = src.SeatsLeft
 			dst.Confidence = src.Confidence
+			dst.ComparablePrice = src.ComparablePrice
 		}
 	}
 	dst.CheapestSource = prov


### PR DESCRIPTION
## What

Ground search ranked the whole result list by raw `.Price` and ignored currency. A route quoted at 119 USD sorted ahead of one at 110 EUR because 119 is the smaller number, even though the two were never compared as currencies. That ordering decides the top result the traveler sees, so the "cheapest" label could point at a route that actually costs more once the exchange rate is applied.

This adds a normalization pass that converts each route into the target currency before filtering and ranking, following the pattern flights already use (`ComparablePrice` / `PriceForRanking`).

## How

- `GroundRoute` gains a `ComparablePrice` field and a `PriceForRanking()` accessor that falls back to raw `Price` when no comparable value is set. `internal/models` stays stdlib-only.
- `normalizeGroundCurrencies` (in `internal/ground`) converts each route to the target currency via `internal/destinations.ConvertCurrency`, injected as a `currencyConverter` func so unit tests never touch the network. On success it sets `Price`, `Currency`, and `ComparablePrice`. When conversion is unavailable the route keeps its own currency and `ComparablePrice` stays 0.
- The target currency is `opts.Currency` when set, otherwise the first observed currency. It is never hardcoded to EUR.
- The pass runs before `filterGroundRoutes` and `ResolveGroundSources`. That also fixes the `MaxPrice` filter, which previously compared raw amounts across currencies.
- `sortGroundRoutes` replaces the old raw `sort.Slice`. Comparable routes rank first by comparable price. Routes that could not be converted are grouped by currency code and then by raw price, so the sort never compares two different currencies as plain numbers. A tiebreaker chain (duration, departure, arrival, provider, booking URL, transfers, type) keeps the order total and permutation-independent.
- `foldGroundSource` propagates `ComparablePrice` onto the collapsed headline.

## Tests

Four table tests in `internal/ground`, all using stub converters (offline, deterministic):

1. Mixed EUR/USD input, stub converts USD to EUR: the genuinely-cheaper-in-target route ranks first.
2. Conversion unavailable: comparable routes precede the incomparable tail, and the tail is grouped by currency then price.
3. Shuffled input produces identical output ordering.
4. `MaxPrice` filter applied on normalized values.

## Verification

`go build ./...`, `go vet`, `staticcheck ./...`, and `go test -race ./internal/ground/... ./internal/models/...` all pass on Go 1.26.5.
