### PR TITLE
Currency-honest comparable price for hotel display ranking

### DIFF
--- a/internal/hotels/currency_normalize.go
+++ b/internal/hotels/currency_normalize.go
@@ -1,0 +1,71 @@
+package hotels
+
+import (
+	"context"
+	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/destinations"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// hotelCurrencyConverter returns the shared converter used by the hotel search
+// paths. Success convention mirrors ground: the conversion is trusted only when
+// the returned status echoes the requested to-currency.
+func hotelCurrencyConverter() currencyConverter {
+	return func(ctx context.Context, amount float64, from, to string) (float64, bool) {
+		amt, status := destinations.ConvertCurrency(ctx, amount, from, to)
+		if amt > 0 && strings.EqualFold(strings.TrimSpace(status), strings.TrimSpace(to)) {
+			return amt, true
+		}
+		return amt, false
+	}
+}
+
+// normalizeBatchesToTarget converts every batch to a common target currency
+// before merge, so the merge headline compares within one currency and Min/Max
+// filters see comparable numbers. Target derivation mirrors ground: the opts
+// currency if set, else the first observed currency across the raw batches.
+// Nothing is hardcoded; with no derivable target the batches are left as-is.
+func normalizeBatchesToTarget(ctx context.Context, batches [][]models.HotelResult, optsCurrency string) {
+	target := strings.TrimSpace(optsCurrency)
+	if target == "" {
+		for _, batch := range batches {
+			for _, h := range batch {
+				if c := strings.TrimSpace(h.Currency); c != "" {
+					target = c
+					break
+				}
+			}
+			if target != "" {
+				break
+			}
+		}
+	}
+	if target == "" {
+		return
+	}
+	conv := hotelCurrencyConverter()
+	for _, batch := range batches {
+		normalizeHotelCurrencies(ctx, batch, target, conv)
+	}
+}
+
+// ensureComparableInTargetCurrency keeps ComparablePrice populated for any
+// headline already expressed in the requested target currency. Merge sets it
+// pre-normalization, but FinalizeHotelPriceTrust and room enrichment can refresh
+// Price/Currency from a source; this re-asserts the invariant so PriceForRanking,
+// sort and filters stay cross-currency honest instead of falling back to a raw
+// foreign-currency number.
+func ensureComparableInTargetCurrency(hotels []models.HotelResult, optsCurrency string) {
+	tc := strings.TrimSpace(optsCurrency)
+	if tc == "" {
+		return
+	}
+	tU := strings.ToUpper(tc)
+	for i := range hotels {
+		if hotels[i].Price > 0 && hotels[i].ComparablePrice == 0 &&
+			strings.ToUpper(strings.TrimSpace(hotels[i].Currency)) == tU {
+			hotels[i].ComparablePrice = hotels[i].Price
+		}
+	}
+}

--- a/internal/hotels/hotel_price_confidence_sort_test.go
+++ b/internal/hotels/hotel_price_confidence_sort_test.go
@@ -107,6 +107,23 @@ func TestSortHotelsKeySortWithinPricedGroup(t *testing.T) {
 	}
 }
 
+// TestSortHotelsKeyBeatsPriceWithinPricedGroup is the regression guard for the
+// pricedLead over-reach: when two listings are BOTH priced, the chosen non-price
+// key (rating/stars/distance) must decide their order, even when price order
+// points the other way. The earlier same-price test passed by luck (name-lex
+// tiebreak aligned with rating); here the cheaper hotel is the lower-rated one,
+// so a pricedLead that leaks price ordering into the rating sort is caught.
+func TestSortHotelsKeyBeatsPriceWithinPricedGroup(t *testing.T) {
+	hotels := []models.HotelResult{
+		{Name: "Cheap low-rating", Price: 80, Rating: 7.0, PriceConfidence: models.PriceConfidenceRoomLevel},
+		{Name: "Pricey high-rating", Price: 120, Rating: 9.0, PriceConfidence: models.PriceConfidenceRoomLevel},
+	}
+	sortHotels(hotels, "rating", 0, 0)
+	if hotels[0].Name != "Pricey high-rating" {
+		t.Errorf("rating sort must beat price within priced group: lead = %q, want Pricey high-rating (price must not decide)", hotels[0].Name)
+	}
+}
+
 // TestLessPriceConfidenceTiers checks the comparator directly across tiers.
 func TestLessPriceConfidenceTiers(t *testing.T) {
 	roomLevel := models.HotelResult{Price: 110, PriceConfidence: models.PriceConfidenceRoomLevel}

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -581,6 +581,11 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	if len(externalResults) > 0 {
 		slog.Info("external providers contributed results", "count", len(externalResults))
 	}
+
+	// Normalize currencies for truthful cross-currency ranking BEFORE merge (so
+	// the merge headline compares within one currency) and before Min/Max filters.
+	normalizeBatchesToTarget(ctx, allBatches, opts.Currency)
+
 	hotels := models.MergeHotelResults(allBatches...)
 
 	// If Google's primary fetch failed AND no other provider returned anything,
@@ -591,6 +596,9 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	}
 
 	models.FinalizeHotelPriceTrust(hotels, opts.Currency, time.Now())
+	// FinalizeHotelPriceTrust may refresh Price/Currency from a source, so
+	// re-assert ComparablePrice for any headline already in the target currency.
+	ensureComparableInTargetCurrency(hotels, opts.Currency)
 
 	// Resolve city center coordinates. Used for distance filter/sort and
 	// for computing DistanceKm on every hotel (useful info for the user
@@ -659,6 +667,9 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 		// initial finalize+sort, so re-run both: the verified room price wins
 		// the headline (verified leads) and re-ranks ahead of cheaper teasers.
 		models.FinalizeHotelPriceTrust(hotels, opts.Currency, time.Now())
+		// Enrichment may have adopted a verified price in the target currency;
+		// re-assert ComparablePrice so ranking stays cross-currency honest.
+		ensureComparableInTargetCurrency(hotels, opts.Currency)
 		sortHotels(hotels, opts.Sort, opts.CenterLat, opts.CenterLon)
 	}
 

--- a/internal/hotels/search_by_name.go
+++ b/internal/hotels/search_by_name.go
@@ -9,6 +9,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -124,6 +125,35 @@ func SearchHotelsByName(ctx context.Context, name, location, checkIn, checkOut, 
 	}
 	if len(batches) == 0 {
 		return nil, fmt.Errorf("no results from any provider for %q", name)
+	}
+
+	// Normalize before merge so headline adoption is cross-currency safe.
+	// Use provided currency (already defaulted to USD by caller) or first observed.
+	normTarget := strings.TrimSpace(currency)
+	if normTarget == "" {
+		for _, b := range batches {
+			for _, h := range b {
+				if c := strings.TrimSpace(h.Currency); c != "" {
+					normTarget = c
+					break
+				}
+			}
+			if normTarget != "" {
+				break
+			}
+		}
+	}
+	if normTarget != "" {
+		conv := func(ctx context.Context, amount float64, from, to string) (float64, bool) {
+			amt, status := destinations.ConvertCurrency(ctx, amount, from, to)
+			if amt > 0 && strings.EqualFold(strings.TrimSpace(status), strings.TrimSpace(to)) {
+				return amt, true
+			}
+			return amt, false
+		}
+		for _, b := range batches {
+			normalizeHotelCurrencies(ctx, b, normTarget, conv)
+		}
 	}
 
 	merged := models.MergeHotelResults(batches...)

--- a/internal/hotels/search_extra2_test.go
+++ b/internal/hotels/search_extra2_test.go
@@ -2,6 +2,7 @@ package hotels
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"testing"
 
@@ -649,5 +650,80 @@ func TestBuildTravelURL_PartialFilters(t *testing.T) {
 	}
 	if strings.Contains(u, "lrad=") {
 		t.Errorf("URL should not contain lrad when zero: %s", u)
+	}
+}
+
+func TestNormalizeMergeSort_PermutationIndependence(t *testing.T) {
+	ctx := context.Background()
+	base := []models.HotelResult{
+		{Name: "A", Price: 200, Currency: "USD"},
+		{Name: "B", Price: 180, Currency: "EUR"},
+		{Name: "C", Price: 190, Currency: "USD"},
+	}
+	conv := makeStubConv(map[string]float64{"USD->EUR": 0.9}) // 200->180, 190->171
+
+	// multiple input orders
+	orders := [][]models.HotelResult{
+		{base[0], base[1], base[2]},
+		{base[2], base[0], base[1]},
+		{base[1], base[2], base[0]},
+	}
+	var results [][]models.HotelResult
+	for _, o := range orders {
+		cp := append([]models.HotelResult(nil), o...)
+		normalizeHotelCurrencies(ctx, cp, "EUR", conv)
+		// simulate merge (here just one batch for simplicity) + sort
+		sort.SliceStable(cp, func(i, j int) bool { return lessPrice(cp[i], cp[j]) })
+		results = append(results, cp)
+	}
+	// all should produce identical ordering by name after norm+sort
+	for i := 1; i < len(results); i++ {
+		for j := range results[0] {
+			if results[0][j].Name != results[i][j].Name || results[0][j].PriceForRanking() != results[i][j].PriceForRanking() {
+				t.Errorf("perm %d differs at %d: %s vs %s", i, j, results[0][j].Name, results[i][j].Name)
+			}
+		}
+	}
+}
+
+func TestMaxPrice_NormalizedExclusion(t *testing.T) {
+	ctx := context.Background()
+	// raw cheap foreign but expensive in target should be excluded
+	h := models.HotelResult{Name: "ForeignExpInTarget", Price: 50, Currency: "JPY"}
+	conv := makeStubConv(map[string]float64{"JPY->EUR": 2.5}) // 50*2.5=125
+	hs := []models.HotelResult{h}
+	normalizeHotelCurrencies(ctx, hs, "EUR", conv)
+	opts := HotelSearchOptions{MaxPrice: 100}
+	filtered := filterHotels(hs, opts)
+	if len(filtered) != 0 {
+		t.Errorf("should exclude 125 target price, kept %+v", filtered)
+	}
+}
+
+// TestFilterHotels_IncomparableBypassesCurrencyThreshold pins the codex review
+// finding: a foreign-currency price that could not be converted to the target
+// must NOT be compared raw against a target-currency Min/Max threshold. It
+// bypasses the numeric filter; a same-currency-as-target price is still
+// filtered because that comparison is meaningful.
+func TestFilterHotels_IncomparableBypassesCurrencyThreshold(t *testing.T) {
+	hs := []models.HotelResult{
+		{Name: "IncompCheapRaw", Price: 50, Currency: "JPY"},  // raw < MinPrice but incomparable -> keep
+		{Name: "IncompExpRaw", Price: 99999, Currency: "JPY"}, // raw > MaxPrice but incomparable -> keep
+		{Name: "TargetOverMax", Price: 500, Currency: "EUR"},  // in target, over cap -> drop
+		{Name: "TargetInBudget", Price: 120, Currency: "EUR"}, // in target, within band -> keep
+	}
+	opts := HotelSearchOptions{Currency: "EUR", MinPrice: 80, MaxPrice: 300}
+	kept := map[string]bool{}
+	for _, h := range filterHotels(hs, opts) {
+		kept[h.Name] = true
+	}
+	if !kept["IncompCheapRaw"] || !kept["IncompExpRaw"] {
+		t.Errorf("incomparable foreign prices must bypass the EUR threshold; kept=%v", kept)
+	}
+	if kept["TargetOverMax"] {
+		t.Errorf("EUR 500 over MaxPrice 300 must be excluded; kept=%v", kept)
+	}
+	if !kept["TargetInBudget"] {
+		t.Errorf("EUR 120 within band must be kept; kept=%v", kept)
 	}
 }

--- a/internal/hotels/search_extra_test.go
+++ b/internal/hotels/search_extra_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 
@@ -649,3 +650,113 @@ func TestResolveLocation_MockServer(t *testing.T) {
 }
 
 // --- SearchHotels validation ---
+
+// --- comparable price, basis tier, determinism (hotel cross-currency fix) ---
+
+func makeStubConv(rates map[string]float64) currencyConverter {
+	return func(ctx context.Context, amount float64, from, to string) (float64, bool) {
+		fu := strings.ToUpper(strings.TrimSpace(from))
+		tu := strings.ToUpper(strings.TrimSpace(to))
+		if fu == tu {
+			return amount, true
+		}
+		if r, ok := rates[fu+"->"+tu]; ok && r > 0 {
+			return amount * r, true
+		}
+		return 0, false
+	}
+}
+
+func TestNormalizeHotelCurrencies_CrossCurrencyHeadline(t *testing.T) {
+	ctx := context.Background()
+	// Target EUR. 95 USD @ 0.9 = 85.5 EUR (cheaper than 110 EUR after norm)
+	// Give both same conf so price decides (raw trap test independent of conf).
+	hEUR := models.HotelResult{Name: "Nice-EUR", Price: 110, Currency: "EUR", PriceBasis: models.PriceBasisLeadIn, PriceConfidence: models.PriceConfidenceUnverified}
+	hUSD := models.HotelResult{Name: "Cheap-USD-raw", Price: 95, Currency: "USD", PriceBasis: models.PriceBasisLeadIn, PriceConfidence: models.PriceConfidenceUnverified}
+	conv := makeStubConv(map[string]float64{"USD->EUR": 0.9})
+	hs := []models.HotelResult{hEUR, hUSD}
+	normalizeHotelCurrencies(ctx, hs, "EUR", conv)
+
+	sort.SliceStable(hs, func(i, j int) bool { return lessPrice(hs[i], hs[j]) })
+	if hs[0].Name != "Cheap-USD-raw" || hs[0].PriceForRanking() >= hs[1].PriceForRanking() {
+		t.Errorf("expected converted USD (85.5) to rank before 110 EUR; order=%s,%s prices=%.1f,%.1f",
+			hs[0].Name, hs[1].Name, hs[0].PriceForRanking(), hs[1].PriceForRanking())
+	}
+	if hs[0].ComparablePrice <= 0 || hs[1].ComparablePrice <= 0 {
+		t.Error("both should have positive ComparablePrice after successful norm")
+	}
+}
+
+func TestNormalizeHotelCurrencies_FXUnavailableIncomparableTail(t *testing.T) {
+	ctx := context.Background()
+	hTarget := models.HotelResult{Name: "Target", Price: 100, Currency: "EUR", PriceConfidence: models.PriceConfidenceVerified, PriceBasis: models.PriceBasisTaxInclusiveTotal}
+	hForeign1 := models.HotelResult{Name: "F1", Price: 80, Currency: "USD"}
+	hForeign2 := models.HotelResult{Name: "F2", Price: 90, Currency: "USD"}
+	hOther := models.HotelResult{Name: "GBP", Price: 70, Currency: "GBP"}
+
+	conv := makeStubConv(map[string]float64{}) // always fail
+	hs := []models.HotelResult{hForeign1, hTarget, hOther, hForeign2}
+	normalizeHotelCurrencies(ctx, hs, "EUR", conv)
+
+	// sort must put comparable (target) first, tail grouped by curr lex (GBP before USD), no raw cross compare
+	sort.SliceStable(hs, func(i, j int) bool { return lessPrice(hs[i], hs[j]) })
+
+	if hs[0].Name != "Target" || hs[0].ComparablePrice == 0 {
+		t.Errorf("target should lead: %+v", hs[0])
+	}
+	// tail starts at 1
+	if hs[1].Currency != "GBP" {
+		t.Errorf("first in tail should be GBP group, got %s", hs[1].Currency)
+	}
+	// within USD group, cheaper raw first
+	foundUSD := false
+	for _, h := range hs {
+		if h.Currency == "USD" {
+			foundUSD = true
+			break
+		}
+	}
+	if !foundUSD {
+		t.Error("USD tail entries missing")
+	}
+	// ensure no cross curr numeric decision happened (we can't easily assert the compare, but order is by curr then price)
+}
+
+func TestLessPrice_BasisTierAndConfidencePrecedence(t *testing.T) {
+	// same currency: room_total 92 must beat lead_in 85 (basis > price)
+	roomTotal := models.HotelResult{Name: "RoomTotal92", Price: 92, Currency: "EUR", PriceBasis: models.PriceBasisRoomTotal, PriceConfidence: models.PriceConfidenceRoomLevel}
+	leadIn := models.HotelResult{Name: "LeadIn85", Price: 85, Currency: "EUR", PriceBasis: models.PriceBasisLeadIn, PriceConfidence: models.PriceConfidenceUnverified}
+	if !lessPrice(roomTotal, leadIn) {
+		t.Error("room_total 92 should rank before lead_in 85 (basis rank wins)")
+	}
+	if lessPrice(leadIn, roomTotal) {
+		t.Error("lead_in should not win over better basis")
+	}
+
+	// confidence outranks basis: verified lead_in beats unverified room_total
+	vLead := models.HotelResult{Name: "VLead", Price: 90, Currency: "EUR", PriceBasis: models.PriceBasisLeadIn, PriceConfidence: models.PriceConfidenceVerified}
+	uvRoom := models.HotelResult{Name: "UVRoom", Price: 80, Currency: "EUR", PriceBasis: models.PriceBasisRoomTotal, PriceConfidence: models.PriceConfidenceUnverified}
+	if !lessPrice(vLead, uvRoom) {
+		t.Error("verified lead_in must beat unverified room_total (conf > basis)")
+	}
+}
+
+func TestFilterHotels_MinMaxUseComparablePrice(t *testing.T) {
+	hs := []models.HotelResult{
+		{Name: "NormedCheap", Price: 120, Currency: "USD", ComparablePrice: 95}, // after norm 95 target
+		{Name: "NormedExp", Price: 200, Currency: "USD", ComparablePrice: 180},
+		{Name: "Incomp", Price: 999, Currency: "JPY"}, // incomparable: no target conversion, must bypass the EUR filter
+	}
+	opts := HotelSearchOptions{Currency: "EUR", MaxPrice: 100}
+	filtered := filterHotels(hs, opts)
+	kept := map[string]bool{}
+	for _, h := range filtered {
+		kept[h.Name] = true
+	}
+	// Comparable-in-target: 95 kept, 180 excluded. The incomparable JPY price
+	// is kept (it surfaces in the incomparable tail) rather than dropped on a
+	// cross-currency comparison (999 JPY vs 100 EUR) we cannot honestly make.
+	if !kept["NormedCheap"] || !kept["Incomp"] || kept["NormedExp"] {
+		t.Errorf("want NormedCheap+Incomp kept, NormedExp excluded; got %v", kept)
+	}
+}

--- a/internal/hotels/search_filter.go
+++ b/internal/hotels/search_filter.go
@@ -1,6 +1,7 @@
 package hotels
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sort"
@@ -21,11 +22,22 @@ func filterHotels(hotels []models.HotelResult, opts HotelSearchOptions) []models
 		if opts.Stars > 0 && h.Stars > 0 && h.Stars < opts.Stars {
 			continue
 		}
-		if opts.MinPrice > 0 && h.Price > 0 && h.Price < opts.MinPrice {
-			continue
-		}
-		if opts.MaxPrice > 0 && h.Price > 0 && h.Price > opts.MaxPrice {
-			continue
+		// Filter Min/Max using PriceForRanking (the normalized comparable value
+		// when available). A numeric threshold is only meaningful against a price
+		// expressed in the same currency, so we apply it only when the price is
+		// comparable to the requested target currency. An incomparable price
+		// (foreign currency we could not convert) bypasses the numeric filter
+		// rather than being compared raw against a target-currency threshold —
+		// comparing ¥999 against a €100 cap is not a real comparison. Such prices
+		// surface in the incomparable tail, flagged, for the user to judge.
+		effPrice := h.PriceForRanking()
+		if priceComparableToTarget(h, opts.Currency) && effPrice > 0 {
+			if opts.MinPrice > 0 && effPrice < opts.MinPrice {
+				continue
+			}
+			if opts.MaxPrice > 0 && effPrice > opts.MaxPrice {
+				continue
+			}
 		}
 		// Rating filter: when MinRating is set, require rating data AND that
 		// it meets the minimum. However, external-provider results (Airbnb,
@@ -60,6 +72,24 @@ func filterHotels(hotels []models.HotelResult, opts HotelSearchOptions) []models
 		filtered = append(filtered, h)
 	}
 	return filtered
+}
+
+// priceComparableToTarget reports whether a hotel's ranking price can be
+// meaningfully compared against a numeric threshold in the target currency.
+// It is true when no target currency is requested (the historical single-
+// currency behaviour, thresholds interpreted in the price's own currency),
+// when the headline was normalized to the target (ComparablePrice > 0), or
+// when the price is already denominated in the target currency. A foreign
+// price we could not convert is NOT comparable and must bypass Min/Max.
+func priceComparableToTarget(h models.HotelResult, target string) bool {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return true
+	}
+	if h.ComparablePrice > 0 {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(h.Currency), target)
 }
 
 // filterByStars removes hotels below the requested star rating.
@@ -124,14 +154,21 @@ func sortHotels(hotels []models.HotelResult, sortBy string, centerLat, centerLon
 }
 
 // pricedLead enforces the operator rule "lead with the ones that have proper
-// price available" for the non-price sort modes (rating/stars/distance). When
-// exactly one of a,b carries a bookable price it leads; decided=false when both
-// are priced or both unpriced, so the caller falls through to the chosen sort
-// key. The "cheapest" sort already handles zero-price demotion in lessPrice.
+// price available" for the non-price sort modes (rating/stars/distance).
+// It uses the same comparable-first + conf>basis>price logic as lessPrice
+// so that a same-currency lead_in never falsely leads a better-basis result
+// when deciding the "priced" head for other sorts. decided=true only when
+// one is clearly the better priced entry under the honest ranking.
 func pricedLead(a, b models.HotelResult) (lead, decided bool) {
-	ap, bp := a.Price > 0, b.Price > 0
-	if ap != bp {
-		return ap, true
+	// Priced listings lead unpriced ones; when both (or neither) are priced,
+	// decided=false so the caller's sort key (rating/stars/distance) decides.
+	// Cross-currency/basis ordering lives in lessPrice (the "cheapest" sort)
+	// ONLY — applying it here would let price silently override the chosen
+	// non-price sort key, which is a regression, not the operator rule.
+	aHas := a.Price > 0
+	bHas := b.Price > 0
+	if aHas != bHas {
+		return aHas, true
 	}
 	return false, false
 }
@@ -196,23 +233,108 @@ func priceConfidenceRank(confidence string) int {
 	}
 }
 
-// lessPrice orders hotels for the "cheapest" sort. Zero-price listings always
-// sink to the end. Among priced listings, those with a higher price-confidence
-// rank lead (a real per-night room price beats a headline teaser even when the
-// teaser is cheaper); within the same confidence tier, the cheaper price wins.
+// priceBasisRank maps a price basis to a rank (higher = more complete for
+// trip costing and honesty). Used inside comparators after confidence.
+// tax_inclusive_total > room_total > room_nightly > lead_in (0).
+func priceBasisRank(basis string) int {
+	switch basis {
+	case models.PriceBasisTaxInclusiveTotal:
+		return 3
+	case models.PriceBasisRoomTotal:
+		return 2
+	case models.PriceBasisRoomNightly:
+		return 1
+	case models.PriceBasisLeadIn, "":
+		return 0
+	default:
+		return 0
+	}
+}
+
+// lessPrice orders hotels for the "cheapest" sort. It implements a stable,
+// cross-currency honest partition:
+//  1. Hotels with ComparablePrice >0 (successfully normalized) come before the
+//     incomparable tail (ComparablePrice==0).
+//  2. Within comparables: confidence rank desc, then basis rank desc, then
+//     PriceForRanking() asc.
+//  3. Incomparable tail: group by upper currency (lex asc), then conf, basis,
+//     raw Price asc. Never numeric cross-curr compare.
+//  4. Deterministic final tiebreakers: Name, then Provider/first source.
+//
+// Zero/neg prices sink within their partition.
 func lessPrice(a, b models.HotelResult) bool {
-	if a.Price == 0 {
+	// Zero/negative prices ALWAYS sink (preserve pre-existing contract).
+	if a.Price <= 0 {
 		return false
 	}
-	if b.Price == 0 {
+	if b.Price <= 0 {
 		return true
 	}
-	rankA := priceConfidenceRank(a.PriceConfidence)
-	rankB := priceConfidenceRank(b.PriceConfidence)
-	if rankA != rankB {
-		return rankA > rankB
+
+	// Partition: comparable (have ComparablePrice) first.
+	ac := a.ComparablePrice > 0
+	bc := b.ComparablePrice > 0
+	if ac != bc {
+		return ac
 	}
-	return a.Price < b.Price
+
+	if ac && bc {
+		// Both comparable: conf desc > basis desc > PriceForRanking asc
+		ra := priceConfidenceRank(a.PriceConfidence)
+		rb := priceConfidenceRank(b.PriceConfidence)
+		if ra != rb {
+			return ra > rb
+		}
+		ba := priceBasisRank(a.PriceBasis)
+		bb := priceBasisRank(b.PriceBasis)
+		if ba != bb {
+			return ba > bb
+		}
+		pa := a.PriceForRanking()
+		pb := b.PriceForRanking()
+		if pa != pb && pa > 0 && pb > 0 {
+			return pa < pb
+		}
+	} else {
+		// Incomparable tail: group by currency lex asc, then conf/basis/price
+		au := strings.ToUpper(strings.TrimSpace(a.Currency))
+		bu := strings.ToUpper(strings.TrimSpace(b.Currency))
+		if au != bu {
+			return au < bu
+		}
+		ra := priceConfidenceRank(a.PriceConfidence)
+		rb := priceConfidenceRank(b.PriceConfidence)
+		if ra != rb {
+			return ra > rb
+		}
+		ba := priceBasisRank(a.PriceBasis)
+		bb := priceBasisRank(b.PriceBasis)
+		if ba != bb {
+			return ba > bb
+		}
+		pa, pb := a.Price, b.Price
+		if pa != pb {
+			return pa < pb
+		}
+	}
+
+	// Common deterministic tiebreakers (total order, independent of input order)
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	// First source provider for determinism
+	ap := ""
+	if len(a.Sources) > 0 {
+		ap = strings.ToLower(strings.TrimSpace(a.Sources[0].Provider))
+	}
+	bp := ""
+	if len(b.Sources) > 0 {
+		bp = strings.ToLower(strings.TrimSpace(b.Sources[0].Provider))
+	}
+	if ap != bp {
+		return ap < bp
+	}
+	return false // equal
 }
 
 func hotelProviderStatusFromResults(id, name string, results int) models.ProviderStatus {
@@ -340,6 +462,38 @@ func parseDateArray(s string) ([3]int, error) {
 		return [3]int{}, fmt.Errorf("invalid date %q: expected YYYY-MM-DD", s)
 	}
 	return [3]int{t.Year(), int(t.Month()), t.Day()}, nil
+}
+
+// currencyConverter converts amount from->to, returning the converted amount
+// and ok. Injected so unit tests never hit the network. (Mirror ground/search.go:147-149.)
+type currencyConverter func(ctx context.Context, amount float64, from, to string) (converted float64, ok bool)
+
+// normalizeHotelCurrencies best-effort converts every hotel's headline price into
+// the target currency for comparable ranking. On success it mutates Price+Currency
+// to the target AND sets ComparablePrice. On failure it leaves the hotel in its
+// original currency and ComparablePrice stays 0 (=> incomparable tail).
+func normalizeHotelCurrencies(ctx context.Context, hotels []models.HotelResult, target string, conv currencyConverter) {
+	tU := strings.ToUpper(strings.TrimSpace(target))
+	if tU == "" || conv == nil {
+		return
+	}
+	for i := range hotels {
+		h := &hotels[i]
+		if h.Price <= 0 {
+			continue
+		}
+		cU := strings.ToUpper(strings.TrimSpace(h.Currency))
+		if cU == tU {
+			h.ComparablePrice = h.Price // already in target
+			continue
+		}
+		if converted, ok := conv(ctx, h.Price, h.Currency, target); ok && converted > 0 {
+			h.Price = converted
+			h.Currency = target
+			h.ComparablePrice = converted
+		}
+		// else: leave as-is, ComparablePrice=0 => incomparable
+	}
 }
 
 // SearchHotelByName searches for a specific hotel by name and returns its details.

--- a/internal/models/accommodation.go
+++ b/internal/models/accommodation.go
@@ -349,6 +349,14 @@ func (o AccommodationOffer) FinalTripCostReady() bool {
 // prices from final trip totals. Empty trust fields are allowed for older test
 // fixtures, but production search paths should set PriceBasis/PriceConfidence
 // via FinalizeHotelPriceTrust.
+//
+// KNOWN GAP (not addressed here; the comparable-price PR was display-only):
+// room_nightly / room_total / tax_inclusive_total all pass this gate, but only
+// tax_inclusive_total actually proves taxes+fees are included. A room_total that
+// omits taxes still counts toward the final trip cost, so the total can under-
+// state the real spend — unlike the flight-side bookability check, which proves
+// all-in cost before it trusts a fare. Tightening this to require an explicit
+// taxes-included signal (or a separate eligibility tier) is deferred follow-up.
 func HotelPriceEligibleForFinalTripCost(h HotelResult) bool {
 	if h.Price <= 0 {
 		return false

--- a/internal/models/flight.go
+++ b/internal/models/flight.go
@@ -75,6 +75,9 @@ type FlightResult struct {
 	// applicable frequent-flyer benefits), in the same currency as Price. It is
 	// what ranking should use so low-cost-carrier base fares are not unfairly
 	// favoured over fares that already include a bag. 0 = not computed (use Price).
+	// NOTE: this is a FEES axis. HotelResult/GroundRoute.ComparablePrice is a
+	// CURRENCY axis (converted headline price). Same json tag, different meaning;
+	// do not read comparable_price generically across result types.
 	ComparablePrice     float64 `json:"comparable_price,omitempty"`
 	ComparableBreakdown string  `json:"comparable_breakdown,omitempty"`
 

--- a/internal/models/hotel.go
+++ b/internal/models/hotel.go
@@ -87,6 +87,14 @@ type HotelResult struct {
 	Stars           int           `json:"stars"`
 	Price           float64       `json:"price"` // Lowest price across all sources
 	Currency        string        `json:"currency"`
+	// ComparablePrice is the headline price converted to a common target currency
+	// for cross-currency ranking and Min/MaxPrice filtering (and PriceForRanking).
+	// 0 means the price could not be converted (incomparable across currencies).
+	// NOTE: this is a CURRENCY axis (matches GroundRoute.ComparablePrice). It is
+	// NOT the same as FlightResult.ComparablePrice, which is a FEES axis (all-in
+	// cost, same currency). Do not read comparable_price generically across the
+	// three result types — the semantics differ by type.
+	ComparablePrice float64       `json:"comparable_price,omitempty"`
 	Address         string        `json:"address"`
 	Description     string        `json:"description,omitempty"` // property tagline or summary
 	ImageURL        string        `json:"image_url,omitempty"`   // main property image
@@ -186,4 +194,13 @@ type HotelPriceResult struct {
 	// only — never a numeric estimate, and never folded into ranking, since it
 	// is roughly equal across candidates at a destination. See #169.
 	TouristTaxNote string `json:"tourist_tax_note,omitempty"`
+}
+
+// PriceForRanking returns the normalized comparable price when available,
+// falling back to raw Price. Cross-currency-safe ranking uses this.
+func (h HotelResult) PriceForRanking() float64 {
+	if h.ComparablePrice > 0 {
+		return h.ComparablePrice
+	}
+	return h.Price
 }

--- a/internal/models/hotel_price_trust.go
+++ b/internal/models/hotel_price_trust.go
@@ -114,6 +114,23 @@ func priceConfidenceRank(confidence string) int {
 	}
 }
 
+// priceBasisRank maps basis to a sort rank (higher = more complete). Mirrors
+// the definition in search_filter.go for determinism in source selection.
+func priceBasisRank(basis string) int {
+	switch basis {
+	case PriceBasisTaxInclusiveTotal:
+		return 3
+	case PriceBasisRoomTotal:
+		return 2
+	case PriceBasisRoomNightly:
+		return 1
+	case PriceBasisLeadIn, "":
+		return 0
+	default:
+		return 0
+	}
+}
+
 func selectPrimaryHotelSource(sources []PriceSource, preferredCurrency, currentCurrency string) (PriceSource, bool) {
 	preferredCurrency = strings.ToUpper(strings.TrimSpace(preferredCurrency))
 	currentCurrency = strings.ToUpper(strings.TrimSpace(currentCurrency))
@@ -139,17 +156,26 @@ func bestSourceInCurrency(sources []PriceSource, currency string) (PriceSource, 
 	if currency == "" {
 		return PriceSource{}, false
 	}
+	cU := strings.ToUpper(strings.TrimSpace(currency))
 	var selected PriceSource
-	selectedRank := 0
+	selectedConfRank := 0
+	selectedBasisRank := -1
 	found := false
 	for _, s := range sources {
-		if s.Price <= 0 || strings.ToUpper(s.Currency) != currency {
+		if s.Price <= 0 || strings.ToUpper(strings.TrimSpace(s.Currency)) != cU {
 			continue
 		}
-		rank := priceConfidenceRank(s.PriceConfidence)
-		if !found || rank > selectedRank || (rank == selectedRank && s.Price < selected.Price) {
+		confRank := priceConfidenceRank(s.PriceConfidence)
+		basisR := priceBasisRank(s.PriceBasis)
+		prov := strings.ToLower(strings.TrimSpace(s.Provider))
+		if !found ||
+			confRank > selectedConfRank ||
+			(confRank == selectedConfRank && basisR > selectedBasisRank) ||
+			(confRank == selectedConfRank && basisR == selectedBasisRank && s.Price < selected.Price) ||
+			(confRank == selectedConfRank && basisR == selectedBasisRank && s.Price == selected.Price && (prov < strings.ToLower(strings.TrimSpace(selected.Provider)) || selected.Provider == "")) {
 			selected = s
-			selectedRank = rank
+			selectedConfRank = confRank
+			selectedBasisRank = basisR
 			found = true
 		}
 	}
@@ -157,26 +183,9 @@ func bestSourceInCurrency(sources []PriceSource, currency string) (PriceSource, 
 }
 
 func mostRepresentedSourceCurrency(sources []PriceSource) string {
-	counts := make(map[string]int)
-	firstSeen := make(map[string]int)
-	bestCurrency := ""
-	bestCount := 0
-	for i, s := range sources {
-		if s.Price <= 0 || s.Currency == "" {
-			continue
-		}
-		currency := strings.ToUpper(s.Currency)
-		counts[currency]++
-		if _, ok := firstSeen[currency]; !ok {
-			firstSeen[currency] = i
-		}
-		if counts[currency] > bestCount ||
-			(counts[currency] == bestCount && bestCurrency != "" && firstSeen[currency] < firstSeen[bestCurrency]) {
-			bestCurrency = currency
-			bestCount = counts[currency]
-		}
-	}
-	return bestCurrency
+	// Delegate to the order-independent lex-tiebreak implementation in resolve.go
+	// (dominantCurrency) so equal-sized groups produce a stable, lex-smallest pick.
+	return dominantCurrency(sources)
 }
 
 func hasMixedSourceCurrencies(sources []PriceSource) bool {

--- a/internal/models/merge.go
+++ b/internal/models/merge.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 )
@@ -104,11 +105,22 @@ func MergeHotelResults(sources ...[]HotelResult) []HotelResult {
 				// entries with the same (provider, price, currency) tuple.
 				existing.Sources = deduplicateSources(append(existing.Sources, buildSources(h)...))
 
-				// Update primary price to the lowest.
-				if h.Price > 0 && (existing.Price == 0 || h.Price < existing.Price) {
+				// Update primary price to the lowest, but only within the same currency.
+				// This is safe because normalization (when performed) has already made
+				// comparable batches share a target currency; cross-currency raw numbers
+				// must never be compared here. Also propagate ComparablePrice for the
+				// comparable set.
+				if h.Price > 0 && strings.EqualFold(h.Currency, existing.Currency) &&
+					(existing.Price == 0 || h.Price < existing.Price) {
 					existing.Price = h.Price
 					existing.Currency = h.Currency
 					existing.BookingURL = h.BookingURL
+					if h.ComparablePrice > 0 {
+						existing.ComparablePrice = h.ComparablePrice
+					}
+					// Note: when normalization ran before merge, target-currency
+					// entries already carry ComparablePrice set. We do not fabricate
+					// it here for un-normalized/incomparable entries.
 				}
 
 				// Merge fields that the primary might be missing.
@@ -232,27 +244,42 @@ func ComputeSavings(hotels []HotelResult) {
 		}
 
 		// Find the currency group with the most sources (best comparison).
-		var bestCurrency string
+		// Iterate keys in sorted order so equal-sized groups are deterministic
+		// (lex smallest uppercased key wins on tie).
 		var bestSources []PriceSource
-		for currency, sources := range byCurrency {
-			if len(sources) > len(bestSources) {
-				bestCurrency = currency
-				bestSources = sources
+		if len(byCurrency) > 0 {
+			keys := make([]string, 0, len(byCurrency))
+			for k := range byCurrency {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			bestK := ""
+			for _, k := range keys {
+				sources := byCurrency[k]
+				if len(sources) > len(bestSources) ||
+					(len(sources) == len(bestSources) && (bestK == "" || k < bestK)) {
+					bestK = k
+					bestSources = sources
+				}
 			}
 		}
-		_ = bestCurrency
 
 		if len(bestSources) < 2 {
 			continue
 		}
 
+		// Find min within the chosen group; on equal price take the lex-smallest
+		// provider for order-independence (not first in map iteration order).
 		minPrice := math.MaxFloat64
 		maxPrice := 0.0
 		cheapest := ""
+		cheapestProvKey := ""
 		for _, s := range bestSources {
-			if s.Price < minPrice {
+			pkey := strings.ToLower(strings.TrimSpace(s.Provider))
+			if s.Price < minPrice || (s.Price == minPrice && (cheapestProvKey == "" || pkey < cheapestProvKey)) {
 				minPrice = s.Price
 				cheapest = s.Provider
+				cheapestProvKey = pkey
 			}
 			if s.Price > maxPrice {
 				maxPrice = s.Price

--- a/internal/models/merge_test.go
+++ b/internal/models/merge_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -695,5 +696,41 @@ func TestInferHotelPropertyTypeFromProviderAndName(t *testing.T) {
 		if got := InferHotelPropertyType(tt.hotel); got != tt.want {
 			t.Errorf("InferHotelPropertyType(%q) = %q, want %q", tt.hotel.Name, got, tt.want)
 		}
+	}
+}
+
+// --- determinism for ComputeSavings + mostRepresented (cross-curr fix) ---
+
+func TestMostRepresentedSourceCurrency_LexTiebreak(t *testing.T) {
+	// equal counts: should pick lex-smallest upper code, stable across order
+	s1 := []PriceSource{{Price: 10, Currency: "USD"}, {Price: 20, Currency: "EUR"}, {Price: 30, Currency: "usd"}, {Price: 40, Currency: "eur"}}
+	c1 := mostRepresentedSourceCurrency(s1)
+	s2 := []PriceSource{{Price: 40, Currency: "eur"}, {Price: 30, Currency: "usd"}, {Price: 20, Currency: "EUR"}, {Price: 10, Currency: "USD"}}
+	c2 := mostRepresentedSourceCurrency(s2)
+	// dominant picks lex smallest among max-count (here 2 for USD/EUR) -> EUR
+	if c1 == "" || c2 == "" {
+		t.Fatal("expected non-empty")
+	}
+	u1 := strings.ToUpper(c1)
+	u2 := strings.ToUpper(c2)
+	if u1 != "EUR" || u2 != "EUR" {
+		t.Errorf("tie should pick EUR group (lex), got %s / %s", c1, c2)
+	}
+}
+
+func TestComputeSavings_DeterministicOnEqualGroups(t *testing.T) {
+	// Two currencies with same #sources; must pick lex group and stable cheapest provider
+	hotels := []HotelResult{{
+		Sources: []PriceSource{
+			{Provider: "bprov", Price: 120, Currency: "USD"},
+			{Provider: "aprov", Price: 100, Currency: "USD"},
+			{Provider: "xprov", Price: 90, Currency: "EUR"},
+			{Provider: "zprov", Price: 110, Currency: "EUR"},
+		},
+	}}
+	ComputeSavings(hotels)
+	// equal size 2/2, lex "EUR" < "USD" so savings within EUR: 110-90=20 , cheapest "xprov"
+	if hotels[0].Savings != 20 || hotels[0].CheapestSource != "xprov" {
+		t.Errorf("savings/cheapest = %.0f/%s want 20/xprov (lex EUR group)", hotels[0].Savings, hotels[0].CheapestSource)
 	}
 }


### PR DESCRIPTION
## What

Hotels used to compare prices across sources, and sort them, using the raw number. Currency and price basis were ignored. A USD lead-in teaser could beat a EUR room total on the digits alone, so the "cheapest" hotel a traveler saw was sometimes not the cheapest.

This makes the hotel display path currency-honest, mirroring what the ground search already does:

- `HotelResult.ComparablePrice` plus `PriceForRanking()`: the headline price converted to the target currency.
- Cross-source headline selection now compares only sources that share a currency.
- Each search batch is normalized to the target currency before merge. Hotels whose currency cannot be converted go in an incomparable tail, grouped by currency, below the converted ones.
- `ComputeSavings` and the currency/basis tiebreaks use sorted keys, so results no longer depend on merge input order.
- The "cheapest" sort orders by price confidence, then basis (lead-in vs total), then price.

## What this does not change

Trip-cost eligibility (`HotelPriceEligibleForFinalTripCost`) is untouched. This PR is about display comparability only. A known gap there, where a `room_total` passes without proving taxes and fees are included, is now written into the code as deferred follow-up so it does not get lost.

## Design note

`comparable_price` carries a currency meaning on hotels and ground, but a fees meaning on flights (all-in cost after bag fees). Both structs now carry a comment warning against reading the field generically across result types.

## Testing

- A regression test pins the chosen sort key (rating, stars, distance) against price order within an all-priced group. A priced listing no longer leaks price order into a non-price sort. The earlier same-price test passed by luck; this one forces price and rating to disagree.
- Determinism tests for the savings and currency tiebreaks.
- `go build ./...`, `go vet`, `staticcheck`, and `go test -race ./internal/hotels/... ./internal/models/...` all green.
