### PR TITLE
trip: currency-honest trip totals (needs_price_verification gate)

### DIFF
--- a/internal/trip/cost.go
+++ b/internal/trip/cost.go
@@ -210,7 +210,18 @@ func assembleTripCost(ctx context.Context, result *TripCostResult, requestedCurr
 	}
 
 	applyTripCostCurrencyAndTotals(ctx, result, requestedCurrency, nights, guests, destinations.ConvertCurrency)
-	result.Error = formatTripCostError(errors, result.Success)
+	// Compose conversion-failure marker with any search errors. When currency
+	// honesty forces !success we still surface the search error text (using
+	// partial-failure form when price data was present) without clobber.
+	if result.Error != "" {
+		usePartial := len(errors) > 0 && (result.Flights.Outbound > 0 || result.Flights.Return > 0 || result.Hotels.PerNight > 0 || result.Hotels.Total > 0)
+		searchErr := formatTripCostError(errors, usePartial)
+		if searchErr != "" {
+			result.Error = result.Error + "; " + searchErr
+		}
+	} else {
+		result.Error = formatTripCostError(errors, result.Success)
+	}
 }
 
 type tripCostCurrencyConverter func(context.Context, float64, string, string) (float64, string)
@@ -235,57 +246,100 @@ func applyTripCostCurrencyAndTotals(
 	flightCurrency := result.Flights.Currency
 	hotelCurrency := result.Hotels.Currency
 
+	var currencyFailures []string
 	if targetCurrency != "" {
 		if result.Flights.Outbound > 0 {
-			result.Flights.Outbound, result.Flights.Currency = convertedTripCostAmount(
+			amt, cur := convertedTripCostAmount(
 				ctx,
 				result.Flights.Outbound,
 				flightCurrency,
 				targetCurrency,
 				convert,
 			)
+			result.Flights.Outbound = amt
+			result.Flights.Currency = cur
+			if cur != targetCurrency {
+				currencyFailures = append(currencyFailures, fmt.Sprintf("flight price in %s could not be converted to %s", flightCurrency, targetCurrency))
+			}
 		}
 		if result.Flights.Return > 0 {
-			result.Flights.Return, result.Flights.Currency = convertedTripCostAmount(
+			amt, cur := convertedTripCostAmount(
 				ctx,
 				result.Flights.Return,
 				flightCurrency,
 				targetCurrency,
 				convert,
 			)
+			result.Flights.Return = amt
+			result.Flights.Currency = cur
+			if cur != targetCurrency {
+				currencyFailures = append(currencyFailures, fmt.Sprintf("flight price in %s could not be converted to %s", flightCurrency, targetCurrency))
+			}
 		}
 		if result.Hotels.PerNight > 0 {
-			result.Hotels.PerNight, result.Hotels.Currency = convertedTripCostAmount(
+			amt, cur := convertedTripCostAmount(
 				ctx,
 				result.Hotels.PerNight,
 				hotelCurrency,
 				targetCurrency,
 				convert,
 			)
+			result.Hotels.PerNight = amt
+			result.Hotels.Currency = cur
+			if cur != targetCurrency {
+				currencyFailures = append(currencyFailures, fmt.Sprintf("hotel price in %s could not be converted to %s", hotelCurrency, targetCurrency))
+			}
 		}
 		if result.Hotels.Total > 0 {
-			result.Hotels.Total, result.Hotels.Currency = convertedTripCostAmount(
+			amt, cur := convertedTripCostAmount(
 				ctx,
 				result.Hotels.Total,
 				hotelCurrency,
 				targetCurrency,
 				convert,
 			)
+			result.Hotels.Total = amt
+			result.Hotels.Currency = cur
+			if cur != targetCurrency {
+				currencyFailures = append(currencyFailures, fmt.Sprintf("hotel price in %s could not be converted to %s", hotelCurrency, targetCurrency))
+			}
 		}
+	}
+
+	// Set claimed currency only when no conversion failures (keeps existing
+	// behavior when target=="").
+	if targetCurrency != "" && len(currencyFailures) == 0 {
 		result.Currency = targetCurrency
+	} else if targetCurrency != "" {
+		result.Currency = ""
 	}
 
 	// Flights are per person, hotels are per room.
 	flightPerPerson := result.Flights.Outbound + result.Flights.Return
 	flightTotal := flightPerPerson * float64(guests)
-	result.Total = flightTotal + result.Hotels.Total
+	computedTotal := flightTotal + result.Hotels.Total
 
-	if result.Total > 0 {
+	if len(currencyFailures) == 0 && computedTotal > 0 {
+		result.Total = computedTotal
 		result.Success = true
 		result.PerPerson = result.Total / float64(guests)
 		if nights > 0 {
 			result.PerDay = result.Total / float64(nights)
 		}
+	} else {
+		result.Total = 0
+	}
+
+	if len(currencyFailures) > 0 {
+		seen := map[string]bool{}
+		var uniq []string
+		for _, f := range currencyFailures {
+			if !seen[f] {
+				seen[f] = true
+				uniq = append(uniq, f)
+			}
+		}
+		result.Error = "needs_price_verification: " + strings.Join(uniq, "; ")
 	}
 }
 
@@ -320,7 +374,7 @@ func cheapestHotel(htls []models.HotelResult) models.HotelResult {
 		if !models.HotelPriceEligibleForFinalTripCost(h) {
 			continue
 		}
-		if best.Price <= 0 || h.Price < best.Price {
+		if best.Price <= 0 || h.PriceForRanking() < best.PriceForRanking() {
 			best = h
 		}
 	}

--- a/internal/trip/cost_test.go
+++ b/internal/trip/cost_test.go
@@ -3,6 +3,7 @@ package trip
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
@@ -530,5 +531,142 @@ func TestApplyTripCostCurrencyAndTotals_UsesAvailableCurrencyWhenUnrequested(t *
 	}
 	if result.Total != 270 {
 		t.Errorf("total = %v, want 270", result.Total)
+	}
+}
+
+// ============================================================
+// Currency honesty tests for applyTripCostCurrencyAndTotals (conversion failure)
+// ============================================================
+
+func TestApplyTripCostCurrencyAndTotals_MixedCurrencyFlightFailsToConvert(t *testing.T) {
+	// Flight in JPY, stub fails convert (returns orig amount + from), hotel EUR succeeds.
+	result := &TripCostResult{
+		Flights: FlightCost{
+			Outbound: 100,
+			Return:   120,
+			Currency: "JPY",
+		},
+		Hotels: HotelCost{
+			PerNight: 50,
+			Total:    100,
+			Currency: "EUR",
+		},
+		Nights: 2,
+	}
+
+	applyTripCostCurrencyAndTotals(
+		context.Background(),
+		result,
+		"EUR",
+		2,
+		1,
+		func(_ context.Context, amount float64, from, to string) (float64, string) {
+			if from == to || to == "" {
+				return amount, from
+			}
+			if from == "EUR" && to == "EUR" {
+				return amount, "EUR"
+			}
+			// JPY to EUR: simulate unknown rate -> return orig, from (as destinations.ConvertCurrency does)
+			return amount, from
+		},
+	)
+
+	if result.Success {
+		t.Fatal("expected Success==false when a component could not be converted to target")
+	}
+	if !strings.Contains(result.Error, "needs_price_verification") {
+		t.Errorf("error = %q, want contains 'needs_price_verification'", result.Error)
+	}
+	if strings.Contains(result.Error, "EUR") && strings.Contains(result.Error, "JPY") {
+		// at least the example phrasing
+	}
+	// Total must not be a clean sum presented as EUR (we zero it on dishonesty)
+	if result.Total != 0 {
+		t.Errorf("Total = %v, want 0 (no clean total when not all in target)", result.Total)
+	}
+	if result.Currency != "" {
+		t.Errorf("Currency = %q, want empty (not falsely claiming EUR)", result.Currency)
+	}
+	// per-component left intact with real currencies
+	if result.Flights.Outbound != 100 || result.Flights.Currency != "JPY" {
+		t.Errorf("flight kept as 100 JPY, got %v %s", result.Flights.Outbound, result.Flights.Currency)
+	}
+	if result.Hotels.Total != 100 || result.Hotels.Currency != "EUR" {
+		t.Errorf("hotel kept as 100 EUR, got %v %s", result.Hotels.Total, result.Hotels.Currency)
+	}
+}
+
+func TestApplyTripCostCurrencyAndTotals_AllComponentsConvertSuccessfully(t *testing.T) {
+	result := &TripCostResult{
+		Flights: FlightCost{
+			Outbound: 150,
+			Return:   300,
+			Currency: "JPY",
+		},
+		Hotels: HotelCost{
+			PerNight: 50,
+			Total:    100,
+			Currency: "EUR",
+		},
+		Nights: 2,
+	}
+
+	applyTripCostCurrencyAndTotals(
+		context.Background(),
+		result,
+		"EUR",
+		2,
+		1,
+		func(_ context.Context, amount float64, from, to string) (float64, string) {
+			if from == to || to == "" {
+				return amount, from
+			}
+			if from == "JPY" && to == "EUR" {
+				return amount / 150, "EUR" // fake rate: 150JPY=1EUR
+			}
+			if from == "EUR" && to == "EUR" {
+				return amount, "EUR"
+			}
+			return amount, from
+		},
+	)
+
+	if !result.Success {
+		t.Fatal("expected Success==true when all convert to target")
+	}
+	if result.Currency != "EUR" {
+		t.Errorf("currency = %q, want EUR", result.Currency)
+	}
+	// Outbound 150/150=1, return 300/150=2, hotel 100; total per person flights 3 + hotel 100 = 103
+	if result.Total != 103 {
+		t.Errorf("total = %v, want 103 (sum of converted amounts)", result.Total)
+	}
+}
+
+func TestCheapestHotel_UsesPriceForRankingAcrossCurrencies(t *testing.T) {
+	// Both must be eligible per HotelPriceEligibleForFinalTripCost rules.
+	// Use explicit valid basis/conf so fixtures are production-like.
+	htls := []models.HotelResult{
+		{
+			Price:           15000,
+			Currency:        "JPY",
+			Name:            "CheapInComparable JPY",
+			ComparablePrice: 90,
+			PriceBasis:      models.PriceBasisRoomTotal,
+			PriceConfidence: models.PriceConfidenceRoomLevel,
+		},
+		{
+			Price:           100,
+			Currency:        "EUR",
+			Name:            "EUR ExpensiveOnComparable",
+			ComparablePrice: 100,
+			PriceBasis:      models.PriceBasisRoomTotal,
+			PriceConfidence: models.PriceConfidenceRoomLevel,
+		},
+	}
+	best := cheapestHotel(htls)
+	if best.Name != "CheapInComparable JPY" {
+		t.Errorf("cheapestHotel picked %q, want the JPY one (PriceForRanking 90 < 100)", best.Name)
 	}
 }

--- a/internal/trip/cost_test.go
+++ b/internal/trip/cost_test.go
@@ -578,8 +578,8 @@ func TestApplyTripCostCurrencyAndTotals_MixedCurrencyFlightFailsToConvert(t *tes
 	if !strings.Contains(result.Error, "needs_price_verification") {
 		t.Errorf("error = %q, want contains 'needs_price_verification'", result.Error)
 	}
-	if strings.Contains(result.Error, "EUR") && strings.Contains(result.Error, "JPY") {
-		// at least the example phrasing
+	if !strings.Contains(result.Error, "EUR") || !strings.Contains(result.Error, "JPY") {
+		t.Errorf("error = %q, want it to name both the source (JPY) and target (EUR) currencies", result.Error)
 	}
 	// Total must not be a clean sum presented as EUR (we zero it on dishonesty)
 	if result.Total != 0 {


### PR DESCRIPTION
## What

Trip-cost totals now refuse to present a mixed-currency sum as an honest all-in figure. Follow-through on #484 (which made hotel display comparability currency-honest); this closes the decision half — the total an assistant quotes for "what will this trip cost?"

## Why

destinations.ConvertCurrency returns (amount, from) with no error when a rate is missing (internal/destinations/currency.go:126-127). applyTripCostCurrencyAndTotals set result.Currency to the target and summed result.Total unconditionally, so a failed conversion left one component in its source currency while the headline total was labelled the target currency. Total = JPY_flight + EUR_hotel, stamped EUR.

## Change

- If any priced component does not reach the target currency after conversion: Success=false, Total=0 (no misleading headline), Currency cleared, and a needs_price_verification marker naming the unconverted component(s). Component amounts and their real currencies are preserved for callers. Composes with existing partial-failure search-error text.
- When every component converts, behaviour is unchanged.
- cheapestHotel ranks by PriceForRanking() (comparable price when set) instead of raw Price, so a mixed-currency eligible set no longer picks a nominally smaller foreign number.
- cheapestFlight intentionally untouched — flights have no comparable-price layer yet (separate follow-up).

## Tests (offline, deterministic, stub converter)

- mixed-currency flight-convert failure gives not-Success plus needs_price_verification marker
- all-components-convert happy path gives Success, Currency equals target, exact sum preserved
- cheapestHotel picks the comparably-cheaper hotel across currencies

## Gate

gofmt clean, go build, go vet, staticcheck, and go test -race on internal/trip and internal/models all green locally (Go 1.26.5).

Generated with Claude Code
