### PR TITLE
fix(trip): rank cheapest flight within majority-currency cohort

### DIFF
--- a/internal/trip/cost.go
+++ b/internal/trip/cost.go
@@ -137,15 +137,17 @@ func CalculateTripCost(ctx context.Context, input TripCostInput) (*TripCostResul
 	go func() {
 		defer wg.Done()
 		outResult, outErr = flights.SearchFlightsWithClient(ctx, client, input.Origin, input.Destination, input.DepartDate, flights.SearchOptions{
-			SortBy: models.SortCheapest,
-			Adults: 1,
+			SortBy:   models.SortCheapest,
+			Adults:   1,
+			Currency: input.Currency,
 		})
 	}()
 	go func() {
 		defer wg.Done()
 		retResult, retErr = flights.SearchFlightsWithClient(ctx, client, input.Destination, input.Origin, input.ReturnDate, flights.SearchOptions{
-			SortBy: models.SortCheapest,
-			Adults: 1,
+			SortBy:   models.SortCheapest,
+			Adults:   1,
+			Currency: input.Currency,
 		})
 	}()
 	go func() {
@@ -356,11 +358,34 @@ func formatTripCostError(errors []string, partial bool) string {
 	return joined
 }
 
-// cheapestFlight returns the flight with the lowest positive price.
+// cheapestFlight returns the lowest-priced flight within the most common
+// currency cohort. normalizeFlightCurrencies (search.go) rewrites successfully
+// converted flights to the session/requested currency, so the largest
+// same-currency bucket is the comparable set; conversion-failure stragglers
+// left in a foreign currency are excluded so a nominally-small foreign number
+// can't win the ranking on raw magnitude alone.
 func cheapestFlight(flts []models.FlightResult) models.FlightResult {
-	best := flts[0]
-	for _, f := range flts[1:] {
-		if f.Price > 0 && (best.Price <= 0 || f.Price < best.Price) {
+	// Tally currencies among positive-price entries and pick the most frequent.
+	// Ties resolve to the first currency to reach the max count (slice order),
+	// keeping selection deterministic.
+	counts := make(map[string]int)
+	cohort, cohortCount := "", 0
+	for _, f := range flts {
+		if f.Price <= 0 {
+			continue
+		}
+		counts[f.Currency]++
+		if counts[f.Currency] > cohortCount {
+			cohortCount, cohort = counts[f.Currency], f.Currency
+		}
+	}
+	if cohortCount == 0 {
+		// No positive-price entry; preserve prior behavior.
+		return flts[0]
+	}
+	var best models.FlightResult
+	for _, f := range flts {
+		if f.Price > 0 && f.Currency == cohort && (best.Price <= 0 || f.Price < best.Price) {
 			best = f
 		}
 	}

--- a/internal/trip/cost_test.go
+++ b/internal/trip/cost_test.go
@@ -89,6 +89,50 @@ func TestCheapestFlight_SkipsZero(t *testing.T) {
 	}
 }
 
+// TestCheapestFlight_PicksMinWithinMajorityCurrency verifies that ranking stays
+// inside the majority currency cohort: a nominally-large foreign straggler that
+// normalizeFlightCurrencies could not convert must not be compared on raw
+// magnitude against the comparable (majority-currency) flights.
+func TestCheapestFlight_PicksMinWithinMajorityCurrency(t *testing.T) {
+	flts := []models.FlightResult{
+		{Price: 100, Currency: "EUR"},
+		{Price: 90, Currency: "EUR"},
+		{Price: 500, Currency: "JPY"}, // unconverted straggler, ignored
+	}
+	best := cheapestFlight(flts)
+	if best.Price != 90 || best.Currency != "EUR" {
+		t.Errorf("cheapestFlight = %v %s, want 90 EUR", best.Price, best.Currency)
+	}
+}
+
+// TestCheapestFlight_AllSameCurrency_UnchangedBehavior confirms no regression on
+// the common case where every candidate shares one currency.
+func TestCheapestFlight_AllSameCurrency_UnchangedBehavior(t *testing.T) {
+	flts := []models.FlightResult{
+		{Price: 300, Currency: "EUR"},
+		{Price: 150, Currency: "EUR"},
+		{Price: 220, Currency: "EUR"},
+	}
+	best := cheapestFlight(flts)
+	if best.Price != 150 {
+		t.Errorf("cheapestFlight = %v, want 150", best.Price)
+	}
+}
+
+// TestCheapestFlight_SingleStragglerIgnored verifies a lone minority-currency
+// entry is excluded from the comparison even when its raw number is smallest.
+func TestCheapestFlight_SingleStragglerIgnored(t *testing.T) {
+	flts := []models.FlightResult{
+		{Price: 200, Currency: "USD"},
+		{Price: 150, Currency: "USD"},
+		{Price: 100, Currency: "GBP"}, // minority straggler, ignored
+	}
+	best := cheapestFlight(flts)
+	if best.Price != 150 || best.Currency != "USD" {
+		t.Errorf("cheapestFlight = %v %s, want 150 USD", best.Price, best.Currency)
+	}
+}
+
 func TestCheapestHotel(t *testing.T) {
 	htls := []models.HotelResult{
 		{Price: 120, Currency: "EUR", Name: "Hotel A"},


### PR DESCRIPTION
## What

`cheapestFlight` ranked raw `f.Price` across currencies. When a candidate list spans currencies, that picks the nominally-smaller foreign number rather than the actually-cheapest fare after conversion. That flight's headline price then flows into the trip-cost total, so the wrong flight defeats the currency-honest totals gate that shipped in #485.

## Fix

Two parts, smallest honest diff:

1. **Cohort-safe selection.** `normalizeFlightCurrencies` already rewrites successfully-converted fares to the session/requested currency and leaves conversion-failure stragglers in their native currency. So the largest same-currency bucket is the comparable set. `cheapestFlight` now ranks `min(Price)` strictly within the most-frequent currency cohort; ties resolve to first-seen for determinism, and foreign stragglers are excluded rather than compared on raw magnitude.
2. **Currency asymmetry.** The cost-path flight searches omitted `Currency: input.Currency` while the hotel search passed it. Added it to both flight searches so normalization targets the user's requested currency and the cohort is the right one.

No signature change, no converter dependency, no new model field. Headline `Price` ranking is preserved so selection stays consistent with the total `assembleTripCost` sums.

## Tests

Three new cohort tests (majority-currency min, all-same-currency no-regression, single-straggler-ignored). Existing single-currency tests unchanged.

## Gate

`gofmt -l internal/trip` empty · `go build ./...` · `go vet ./internal/trip/...` · `staticcheck ./internal/trip/...` exit 0 · `go test -race ./internal/trip/... ./internal/models/... ./internal/flights/...` all pass.
