### PR TITLE
multimodal: price every leg in one target currency

### DIFF
--- a/cmd/trvl/multimodal_plan.go
+++ b/cmd/trvl/multimodal_plan.go
@@ -11,6 +11,7 @@ import (
 
 func multimodalPlanCmd() *cobra.Command {
 	var allowBrowserFallbacks bool
+	var currency string
 
 	cmd := &cobra.Command{
 		Use:     "multimodal FROM TO DATE",
@@ -40,7 +41,7 @@ Examples:
 			from, to, date := args[0], args[1], args[2]
 
 			planner := multimodal.NewPlanner(allowBrowserFallbacks)
-			plan, err := planner.Plan(cmd.Context(), from, to, date)
+			plan, err := planner.Plan(cmd.Context(), from, to, date, currency)
 			if err != nil {
 				return err
 			}
@@ -58,6 +59,7 @@ Examples:
 	}
 
 	cmd.Flags().BoolVar(&allowBrowserFallbacks, "allow-browser-fallbacks", false, "Allow browser/cookie-assisted Rome2Rio discovery + ground leg pricing")
+	cmd.Flags().StringVar(&currency, "currency", "", "Target currency for all legs (e.g. EUR, GBP); defaults to EUR. Keeps flight and ground prices comparable.")
 	return cmd
 }
 

--- a/internal/multimodal/composer.go
+++ b/internal/multimodal/composer.go
@@ -60,6 +60,10 @@ type LegSpec struct {
 	From string
 	To   string
 	Date string
+	// Currency is the single target currency every leg of the plan is priced in,
+	// so flight and ground legs are comparable and itinerary totals can be ranked
+	// honestly. Empty falls back to each provider's own default.
+	Currency string
 }
 
 // PricedLeg is one leg of an assembled itinerary after pricing (or estimation).
@@ -160,7 +164,7 @@ func (p *Planner) planTimeout() time.Duration {
 // for from→to on date. It never returns a nil Plan on a non-empty query; a
 // discovery failure or an empty discovery degrades to an empty (but described)
 // plan rather than an error so callers can always render something honest.
-func (p *Planner) Plan(ctx context.Context, from, to, date string) (*Plan, error) {
+func (p *Planner) Plan(ctx context.Context, from, to, date, currency string) (*Plan, error) {
 	plan := &Plan{From: from, To: to, Date: date}
 	if strings.TrimSpace(from) == "" || strings.TrimSpace(to) == "" || strings.TrimSpace(date) == "" {
 		plan.Error = "from, to, and date are required"
@@ -169,6 +173,11 @@ func (p *Planner) Plan(ctx context.Context, from, to, date string) (*Plan, error
 	if p.Discover == nil || p.Price == nil {
 		plan.Error = "multimodal planner is not configured"
 		return plan, nil
+	}
+	// One target currency for every leg so flight and ground prices are comparable
+	// and itinerary totals rank honestly. Default matches the ground search default.
+	if strings.TrimSpace(currency) == "" {
+		currency = "EUR"
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, p.planTimeout())
@@ -195,7 +204,7 @@ func (p *Planner) Plan(ctx context.Context, from, to, date string) (*Plan, error
 			"priced the "+itoa(len(routes))+" most promising of "+itoa(plan.Discovered)+" discovered chains")
 	}
 
-	itineraries := p.priceRoutes(ctx, from, to, date, routes)
+	itineraries := p.priceRoutes(ctx, from, to, date, currency, routes)
 	plan.Priced = len(itineraries)
 
 	rankItineraries(itineraries)
@@ -225,7 +234,7 @@ func (p *Planner) Plan(ctx context.Context, from, to, date string) (*Plan, error
 // priceRoutes prices every leg of every route with bounded parallelism, then
 // assembles each route into an itinerary. A route whose legs all fail to price
 // (and which has no indicative range to estimate from) is dropped with no panic.
-func (p *Planner) priceRoutes(ctx context.Context, from, to, date string, routes []models.GroundRoute) []Itinerary {
+func (p *Planner) priceRoutes(ctx context.Context, from, to, date, currency string, routes []models.GroundRoute) []Itinerary {
 	sem := make(chan struct{}, maxParallelLegs)
 	var mu sync.Mutex
 	out := make([]Itinerary, 0, len(routes))
@@ -234,6 +243,9 @@ func (p *Planner) priceRoutes(ctx context.Context, from, to, date string, routes
 	for i := range routes {
 		route := routes[i]
 		specs := legSpecsForRoute(route, from, to, date)
+		for j := range specs {
+			specs[j].Currency = currency // one target currency for every leg
+		}
 		priced := make([]PricedLeg, len(specs))
 		var legWG sync.WaitGroup
 		for j := range specs {

--- a/internal/multimodal/composer_test.go
+++ b/internal/multimodal/composer_test.go
@@ -305,11 +305,11 @@ func TestProductionSeamsAndPurePickers(t *testing.T) {
 		{Price: 200, Currency: ""},
 		{Price: 300, ComparablePrice: 180, Currency: "EUR", Provider: "google"},
 		{Price: 190, Currency: "EUR", Provider: "kiwi"},
-	})
+	}, "")
 	if !ok || bestFlight.Provider != "google" {
 		t.Fatalf("cheapestFlight = %#v/%v", bestFlight, ok)
 	}
-	if _, ok := cheapestFlight([]models.FlightResult{{Price: 0, Currency: "EUR"}}); ok {
+	if _, ok := cheapestFlight([]models.FlightResult{{Price: 0, Currency: "EUR"}}, ""); ok {
 		t.Fatal("empty priced flight set should not produce a cheapest flight")
 	}
 
@@ -318,11 +318,11 @@ func TestProductionSeamsAndPurePickers(t *testing.T) {
 		{Price: 40, Currency: ""},
 		{Price: 55, Currency: "EUR", Provider: "flixbus"},
 		{Price: 45, Currency: "EUR", Provider: "sncf"},
-	})
+	}, "")
 	if !ok || bestRoute.Provider != "sncf" {
 		t.Fatalf("cheapestRoute = %#v/%v", bestRoute, ok)
 	}
-	if _, ok := cheapestRoute([]models.GroundRoute{{Price: 0, Currency: "EUR"}}); ok {
+	if _, ok := cheapestRoute([]models.GroundRoute{{Price: 0, Currency: "EUR"}}, ""); ok {
 		t.Fatal("empty priced route set should not produce a cheapest route")
 	}
 
@@ -398,7 +398,7 @@ func TestCheapestSelectorsExcludeForeignStragglers(t *testing.T) {
 		{Price: 60, Currency: "EUR", Provider: "eur-cheap"},
 		{Price: 90, Currency: "EUR", Provider: "eur-dear"},
 		{Price: 5, Currency: "GBP", Provider: "gbp-straggler"},
-	})
+	}, "")
 	if !ok || best.Provider != "eur-cheap" {
 		t.Fatalf("cheapestFlight picked %#v/%v; want eur-cheap (GBP straggler must not win)", best, ok)
 	}
@@ -407,8 +407,45 @@ func TestCheapestSelectorsExcludeForeignStragglers(t *testing.T) {
 		{Price: 45, Currency: "EUR", Provider: "eur-cheap"},
 		{Price: 70, Currency: "EUR", Provider: "eur-dear"},
 		{Price: 3, Currency: "GBP", Provider: "gbp-straggler"},
-	})
+	}, "")
 	if !ok || route.Provider != "eur-cheap" {
 		t.Fatalf("cheapestRoute picked %#v/%v; want eur-cheap (GBP straggler must not win)", route, ok)
+	}
+}
+
+// TestCheapestSelectorsPreferTargetCurrency proves the second honesty guarantee:
+// when the plan's target currency is present only as a minority (a provider mostly
+// returned another currency), the selector still ranks within the target cohort so
+// the leg stays in the requested currency instead of being repriced into whatever
+// the provider returned most of. The dominant-currency fallback only applies when
+// the target is absent.
+func TestCheapestSelectorsPreferTargetCurrency(t *testing.T) {
+	// GBP dominates (two entries) but the plan targets EUR, present as one entry.
+	// Prefer must pick the EUR entry, not the cheaper-looking dominant GBP fare.
+	best, ok := cheapestFlight([]models.FlightResult{
+		{Price: 40, Currency: "GBP", Provider: "gbp-cheap"},
+		{Price: 50, Currency: "GBP", Provider: "gbp-dear"},
+		{Price: 70, Currency: "EUR", Provider: "eur-target"},
+	}, "EUR")
+	if !ok || best.Provider != "eur-target" {
+		t.Fatalf("cheapestFlight picked %#v/%v; want eur-target (target currency must win over dominant GBP)", best, ok)
+	}
+
+	route, ok := cheapestRoute([]models.GroundRoute{
+		{Price: 30, Currency: "GBP", Provider: "gbp-cheap"},
+		{Price: 35, Currency: "GBP", Provider: "gbp-dear"},
+		{Price: 55, Currency: "EUR", Provider: "eur-target"},
+	}, "EUR")
+	if !ok || route.Provider != "eur-target" {
+		t.Fatalf("cheapestRoute picked %#v/%v; want eur-target (target currency must win over dominant GBP)", route, ok)
+	}
+
+	// When the target is absent, fall back to the dominant cohort.
+	fallback, ok := cheapestFlight([]models.FlightResult{
+		{Price: 40, Currency: "GBP", Provider: "gbp-cheap"},
+		{Price: 50, Currency: "GBP", Provider: "gbp-dear"},
+	}, "EUR")
+	if !ok || fallback.Provider != "gbp-cheap" {
+		t.Fatalf("cheapestFlight fallback picked %#v/%v; want gbp-cheap (dominant cohort when target absent)", fallback, ok)
 	}
 }

--- a/internal/multimodal/composer_test.go
+++ b/internal/multimodal/composer_test.go
@@ -58,7 +58,7 @@ func TestPlan_TwoLegChain_SummedRealPrice(t *testing.T) {
 	}
 	p := plannerWith(discoverFixed(r), pricer.price)
 
-	plan, err := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	plan, err := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01", "EUR")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestPlan_RankByTrueTotal(t *testing.T) {
 	}
 	p := plannerWith(discoverFixed(expensive, cheap), pricer.price)
 
-	plan, _ := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	plan, _ := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01", "EUR")
 	if len(plan.Itineraries) != 2 {
 		t.Fatalf("expected 2 itineraries, got %d", len(plan.Itineraries))
 	}
@@ -121,7 +121,7 @@ func TestPlan_EstimateFallback_WhenLegUnpriceable(t *testing.T) {
 	}
 	p := plannerWith(discoverFixed(r), pricer.price)
 
-	plan, _ := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	plan, _ := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01", "EUR")
 	if len(plan.Itineraries) != 1 {
 		t.Fatalf("expected 1 itinerary, got %d", len(plan.Itineraries))
 	}
@@ -157,7 +157,7 @@ func TestPlan_EstimateFallback_WhenLegUnpriceable(t *testing.T) {
 
 func TestPlan_EmptyDiscovery_Graceful(t *testing.T) {
 	p := plannerWith(discoverFixed(), fakePricer{}.price)
-	plan, err := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	plan, err := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01", "EUR")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestPlan_DiscoveryError_Degrades(t *testing.T) {
 		return nil, context.DeadlineExceeded
 	}
 	p := plannerWith(disc, fakePricer{}.price)
-	plan, err := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	plan, err := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01", "EUR")
 	if err != nil {
 		t.Fatalf("discovery error must degrade, not propagate: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestPlan_HackAnnotation_OnCheapest(t *testing.T) {
 		return &models.HackSaving{Type: "multimodal_skip_flight", Savings: 20, Price: 110, NaivePrice: naive, Currency: cur}
 	}
 
-	plan, _ := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	plan, _ := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01", "EUR")
 	if len(plan.Itineraries) != 1 || plan.Itineraries[0].HackSaving == nil {
 		t.Fatalf("expected a hack saving annotated on the cheapest itinerary")
 	}
@@ -214,7 +214,7 @@ func TestPlan_HackAnnotation_OnCheapest(t *testing.T) {
 
 func TestPlan_MissingArgs(t *testing.T) {
 	p := plannerWith(discoverFixed(), fakePricer{}.price)
-	plan, _ := p.Plan(context.Background(), "", "London", "2026-07-01")
+	plan, _ := p.Plan(context.Background(), "", "London", "2026-07-01", "EUR")
 	if plan.Error == "" {
 		t.Errorf("expected an error for missing origin")
 	}
@@ -375,7 +375,7 @@ func TestPlan_BoundsLargeDiscoverySet(t *testing.T) {
 		"train": {Price: 20, Currency: "EUR"},
 	}.price)
 
-	plan, err := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01")
+	plan, err := p.Plan(context.Background(), "Helsinki", "London", "2026-07-01", "EUR")
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -384,5 +384,31 @@ func TestPlan_BoundsLargeDiscoverySet(t *testing.T) {
 	}
 	if len(plan.Notes) == 0 {
 		t.Fatalf("expected truncation note for large discovery set")
+	}
+}
+
+// TestCheapestSelectorsExcludeForeignStragglers proves the currency-cohort honesty
+// fix: a nominally-small fare in a minority currency must not win over the cheapest
+// fare in the dominant cohort. Without cohort ranking, the raw numeric minimum would
+// pick the foreign straggler and lie about which option is actually cheapest.
+func TestCheapestSelectorsExcludeForeignStragglers(t *testing.T) {
+	// GBP 5 is nominally the smallest number but is a lone straggler; the EUR cohort
+	// (two entries) is dominant and its cheapest real fare is EUR 60.
+	best, ok := cheapestFlight([]models.FlightResult{
+		{Price: 60, Currency: "EUR", Provider: "eur-cheap"},
+		{Price: 90, Currency: "EUR", Provider: "eur-dear"},
+		{Price: 5, Currency: "GBP", Provider: "gbp-straggler"},
+	})
+	if !ok || best.Provider != "eur-cheap" {
+		t.Fatalf("cheapestFlight picked %#v/%v; want eur-cheap (GBP straggler must not win)", best, ok)
+	}
+
+	route, ok := cheapestRoute([]models.GroundRoute{
+		{Price: 45, Currency: "EUR", Provider: "eur-cheap"},
+		{Price: 70, Currency: "EUR", Provider: "eur-dear"},
+		{Price: 3, Currency: "GBP", Provider: "gbp-straggler"},
+	})
+	if !ok || route.Provider != "eur-cheap" {
+		t.Fatalf("cheapestRoute picked %#v/%v; want eur-cheap (GBP straggler must not win)", route, ok)
 	}
 }

--- a/internal/multimodal/pricing.go
+++ b/internal/multimodal/pricing.go
@@ -77,7 +77,7 @@ func priceFlightLeg(ctx context.Context, spec LegSpec) (PricedLeg, bool) {
 	if !ok {
 		return PricedLeg{}, false
 	}
-	res, err := flights.SearchFlights(ctx, origin, dest, spec.Date, flights.SearchOptions{NoHacks: true})
+	res, err := flights.SearchFlights(ctx, origin, dest, spec.Date, flights.SearchOptions{NoHacks: true, Currency: spec.Currency})
 	if err != nil || res == nil || !res.Success {
 		return PricedLeg{}, false
 	}
@@ -115,6 +115,7 @@ func priceGroundLeg(ctx context.Context, spec LegSpec, allowBrowser bool) (Price
 	opts := ground.SearchOptions{
 		NoHacks:               true,
 		AllowBrowserFallbacks: allowBrowser,
+		Currency:              spec.Currency, // price this leg in the plan's target currency
 		// Rome2Rio is the DISCOVERY source; its prices are indicative ranges, not
 		// confirmed fares. Excluding it from per-leg pricing keeps a "real" leg
 		// price honest (a bookable provider only) and avoids a redundant Cloudflare
@@ -202,11 +203,21 @@ func resolveAirport(place string) (string, bool) {
 	return "", false
 }
 
+// cheapestFlight returns the lowest-ranking-price flight within the most common
+// currency cohort. Ranking a nominal minimum across mixed currencies would let a
+// nominally-small foreign fare win dishonestly, so stragglers in a minority
+// currency are excluded rather than compared. Mirrors internal/trip cost ranking.
 func cheapestFlight(fs []models.FlightResult) (models.FlightResult, bool) {
+	cohort := dominantCurrency(len(fs), func(i int) (string, bool) {
+		return fs[i].Currency, fs[i].PriceForRanking() > 0
+	})
+	if cohort == "" {
+		return models.FlightResult{}, false
+	}
 	var best models.FlightResult
 	found := false
 	for _, f := range fs {
-		if f.PriceForRanking() <= 0 || f.Currency == "" {
+		if f.PriceForRanking() <= 0 || f.Currency != cohort {
 			continue
 		}
 		if !found || f.PriceForRanking() < best.PriceForRanking() {
@@ -216,11 +227,19 @@ func cheapestFlight(fs []models.FlightResult) (models.FlightResult, bool) {
 	return best, found
 }
 
+// cheapestRoute returns the lowest-price ground route within the most common
+// currency cohort, for the same honesty reason as cheapestFlight.
 func cheapestRoute(rs []models.GroundRoute) (models.GroundRoute, bool) {
+	cohort := dominantCurrency(len(rs), func(i int) (string, bool) {
+		return rs[i].Currency, rs[i].Price > 0
+	})
+	if cohort == "" {
+		return models.GroundRoute{}, false
+	}
 	var best models.GroundRoute
 	found := false
 	for _, r := range rs {
-		if r.Price <= 0 || r.Currency == "" {
+		if r.Price <= 0 || r.Currency != cohort {
 			continue
 		}
 		if !found || r.Price < best.Price {
@@ -228,6 +247,27 @@ func cheapestRoute(rs []models.GroundRoute) (models.GroundRoute, bool) {
 		}
 	}
 	return best, found
+}
+
+// dominantCurrency returns the most frequently occurring currency among the n
+// entries whose (currency, priced) pair reports priced==true and a non-empty
+// currency. Ties resolve to the first currency to reach the max count, keeping
+// selection deterministic across slice order. Returns "" when nothing qualifies.
+func dominantCurrency(n int, at func(i int) (currency string, priced bool)) string {
+	counts := make(map[string]int)
+	best := ""
+	bestN := 0
+	for i := 0; i < n; i++ {
+		cur, priced := at(i)
+		if !priced || cur == "" {
+			continue
+		}
+		counts[cur]++
+		if counts[cur] > bestN {
+			best, bestN = cur, counts[cur]
+		}
+	}
+	return best
 }
 
 func flightProvider(f models.FlightResult) string {

--- a/internal/multimodal/pricing.go
+++ b/internal/multimodal/pricing.go
@@ -81,7 +81,7 @@ func priceFlightLeg(ctx context.Context, spec LegSpec) (PricedLeg, bool) {
 	if err != nil || res == nil || !res.Success {
 		return PricedLeg{}, false
 	}
-	best, ok := cheapestFlight(res.Flights)
+	best, ok := cheapestFlight(res.Flights, spec.Currency)
 	if !ok {
 		return PricedLeg{}, false
 	}
@@ -131,7 +131,7 @@ func priceGroundLeg(ctx context.Context, spec LegSpec, allowBrowser bool) (Price
 	if err != nil || res == nil || !res.Success {
 		return PricedLeg{}, false
 	}
-	best, ok := cheapestRoute(res.Routes)
+	best, ok := cheapestRoute(res.Routes, spec.Currency)
 	if !ok {
 		return PricedLeg{}, false
 	}
@@ -203,12 +203,15 @@ func resolveAirport(place string) (string, bool) {
 	return "", false
 }
 
-// cheapestFlight returns the lowest-ranking-price flight within the most common
-// currency cohort. Ranking a nominal minimum across mixed currencies would let a
-// nominally-small foreign fare win dishonestly, so stragglers in a minority
-// currency are excluded rather than compared. Mirrors internal/trip cost ranking.
-func cheapestFlight(fs []models.FlightResult) (models.FlightResult, bool) {
-	cohort := dominantCurrency(len(fs), func(i int) (string, bool) {
+// cheapestFlight returns the lowest-ranking-price flight within a single currency
+// cohort. It prefers the target currency (prefer) when at least one priced flight
+// is quoted in it, so a provider that returns the target only as a minority is
+// still honoured; otherwise it falls back to the most common currency. Ranking a
+// nominal minimum across mixed currencies would let a nominally-small foreign fare
+// win dishonestly, so stragglers outside the cohort are excluded rather than
+// compared. Mirrors internal/trip cost ranking.
+func cheapestFlight(fs []models.FlightResult, prefer string) (models.FlightResult, bool) {
+	cohort := cohortCurrency(prefer, len(fs), func(i int) (string, bool) {
 		return fs[i].Currency, fs[i].PriceForRanking() > 0
 	})
 	if cohort == "" {
@@ -227,10 +230,11 @@ func cheapestFlight(fs []models.FlightResult) (models.FlightResult, bool) {
 	return best, found
 }
 
-// cheapestRoute returns the lowest-price ground route within the most common
-// currency cohort, for the same honesty reason as cheapestFlight.
-func cheapestRoute(rs []models.GroundRoute) (models.GroundRoute, bool) {
-	cohort := dominantCurrency(len(rs), func(i int) (string, bool) {
+// cheapestRoute returns the lowest-price ground route within a single currency
+// cohort, preferring the target currency, for the same honesty reason as
+// cheapestFlight.
+func cheapestRoute(rs []models.GroundRoute, prefer string) (models.GroundRoute, bool) {
+	cohort := cohortCurrency(prefer, len(rs), func(i int) (string, bool) {
 		return rs[i].Currency, rs[i].Price > 0
 	})
 	if cohort == "" {
@@ -247,6 +251,22 @@ func cheapestRoute(rs []models.GroundRoute) (models.GroundRoute, bool) {
 		}
 	}
 	return best, found
+}
+
+// cohortCurrency picks the currency the cheapest-selector should rank within. A
+// non-empty prefer wins whenever at least one priced entry is quoted in it, so a
+// leg is kept in the plan's target currency rather than silently repriced into
+// whatever a provider happened to return most of. When prefer is empty or absent
+// from the priced entries, it falls back to the most common currency.
+func cohortCurrency(prefer string, n int, at func(i int) (currency string, priced bool)) string {
+	if prefer != "" {
+		for i := 0; i < n; i++ {
+			if cur, priced := at(i); priced && cur == prefer {
+				return prefer
+			}
+		}
+	}
+	return dominantCurrency(n, at)
 }
 
 // dominantCurrency returns the most frequently occurring currency among the n

--- a/mcp/tools_multimodal.go
+++ b/mcp/tools_multimodal.go
@@ -94,9 +94,10 @@ func handlePlanMultimodal(ctx context.Context, args map[string]any, elicit Elici
 		return nil, nil, fmt.Errorf("from, to, and date are required")
 	}
 	allowBrowser := argBool(args, "allow_browser_fallbacks", false)
+	currency := argString(args, "currency")
 
 	planner := multimodal.NewPlanner(allowBrowser)
-	plan, err := planner.Plan(ctx, from, to, date)
+	plan, err := planner.Plan(ctx, from, to, date, currency)
 	if err != nil {
 		return nil, nil, toolExecutionError("Multimodal plan", err)
 	}


### PR DESCRIPTION
## What this changes

Multimodal itineraries mix a flight leg with ground legs, and each leg was priced by whatever currency its provider happened to return. Ranking then sorted the raw totals. If a flight came back in one currency and a bus in another, a nominally small foreign fare could sort ahead of a genuinely cheaper option, so a fly-vs-ground comparison could be ranked wrong.

This threads one target currency through the whole plan:

- `Plan` takes a `currency` argument, defaults it to EUR (the same default the ground search already used), and stamps it on every `LegSpec`.
- The flight and ground pricers pass that currency to their searches, so each provider is asked to quote in it.
- Leg selection stays inside one currency cohort. `cheapestFlight` and `cheapestRoute` rank within the target currency when a priced candidate is quoted in it, and fall back to the most common returned currency only when the target is absent. Minority-currency stragglers are skipped rather than compared.

The two surfaces that already advertised a currency now honour it: the `plan_multimodal` MCP tool read a `currency` argument it previously dropped, and the CLI gains a `--currency` flag.

## Why the two commits

The first commit adds the cohort. The second responds to a review point: the most-common-currency cohort keeps a candidate list self-consistent, but a provider that ignores the requested currency could leave the target as a minority, and the dominant cohort would then reprice the leg into whatever the provider returned most of. Preferring the target currency closes that gap. The itinerary assembler already refuses to sum a leg whose currency differs from the headline (it demotes and discloses it), so no wrong total could ship either way; this just keeps more legs in the requested currency instead of demoting them to estimates.

## Known residual

An all-estimate itinerary can still carry mixed currencies if Rome2Rio returns different currencies for a city pair. That path predates this change and is rare; every real priced leg is now uniform.

## Tests

- `TestCheapestSelectorsExcludeForeignStragglers` — a minority foreign fare must not win the cohort.
- `TestCheapestSelectorsPreferTargetCurrency` — target-in-minority wins, dominant cohort used only when the target is absent.
- Existing cheapest-selector and Plan tests updated for the new signatures.

Local gate: `gofmt`, `go build ./...`, `go vet`, `staticcheck`, and `go test -race ./internal/multimodal/...` all clean.
