### PR TITLE
multimodal: convert foreign legs at a reference rate instead of excluding them

### DIFF
--- a/internal/multimodal/assemble.go
+++ b/internal/multimodal/assemble.go
@@ -1,6 +1,8 @@
 package multimodal
 
 import (
+	"context"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -58,8 +60,11 @@ func legSpecsForRoute(route models.GroundRoute, from, to, date string) []LegSpec
 // Currency discipline (mirrors flights round-trip composition): legs are summed
 // only in a single currency. The headline currency is the first real priced
 // leg's currency, falling back to the route's indicative currency. A real leg in
-// a different currency cannot be summed honestly, so it is demoted to an
-// estimate with a warning rather than fabricating a converted total.
+// a different currency is first offered to convert (via the injected converter)
+// into the headline currency at a reference rate, disclosing the original quote;
+// only when that conversion is unavailable is the leg demoted to an estimate
+// (never a fabricated converted total). A nil converter keeps the conservative
+// exclusion for every foreign leg.
 //
 // Estimate fallback: any leg that could not be priced (or was demoted) shares
 // the route's indicative remainder — max(0, indicativeLow - realSum) split
@@ -67,11 +72,12 @@ func legSpecsForRoute(route models.GroundRoute, from, to, date string) []LegSpec
 //
 // Returns ok=false when the route yields neither a real nor an indicative total
 // (nothing honest to show).
-func assembleItinerary(route models.GroundRoute, from, to, date string, legs []PricedLeg) (Itinerary, bool) {
+func assembleItinerary(ctx context.Context, convert CurrencyConverter, route models.GroundRoute, from, to, date string, legs []PricedLeg) (Itinerary, bool) {
 	currency := headlineCurrency(legs, route.Currency)
 
 	realSum := 0.0
 	unpriced := 0
+	converted := false
 	for i := range legs {
 		l := &legs[i]
 		if !l.Estimated && l.Price > 0 && l.Currency == currency {
@@ -79,7 +85,25 @@ func assembleItinerary(route models.GroundRoute, from, to, date string, legs []P
 			continue
 		}
 		if !l.Estimated && l.Price > 0 && l.Currency != currency {
-			// Real fare in a non-matching currency: cannot be summed honestly.
+			// Real fare in a foreign currency. Prefer an honest reference-rate
+			// conversion into the headline currency so the leg is compared and
+			// summed rather than silently discarded; preserve the original quote
+			// and disclose the conversion. Fall back to the conservative
+			// demote-to-estimate only when conversion is unavailable.
+			if convert != nil {
+				if conv, cur := convert(ctx, l.Price, l.Currency, currency); cur == currency && conv > 0 {
+					conv = round2(conv)
+					l.OriginalPrice = l.Price
+					l.OriginalCurrency = l.Currency
+					l.Detail = strings.TrimSpace(l.Detail + fmt.Sprintf(" (converted from %.2f %s at a reference rate; not a checkout-final rate)", l.Price, l.Currency))
+					l.Price = conv
+					l.Currency = currency
+					realSum += conv
+					converted = true
+					continue
+				}
+			}
+			// Conversion unavailable: cannot be summed honestly.
 			l.Estimated = true
 			l.Detail = strings.TrimSpace(l.Detail + " (priced in " + l.Currency + "; not summed)")
 		}
@@ -136,6 +160,9 @@ func assembleItinerary(route models.GroundRoute, from, to, date string, legs []P
 
 	if estimated {
 		warnings = append(warnings, "total includes an estimate: one or more legs use Rome2Rio's indicative price, not a confirmed fare — verify before booking")
+	}
+	if converted {
+		warnings = append(warnings, "total includes a leg converted at a reference exchange rate (not a checkout-final rate); card fees and spreads may change the amount actually charged")
 	}
 	if route.Type != "" {
 		// Preserve discovery risk caveats if the route carried any amenity/notes.

--- a/internal/multimodal/composer.go
+++ b/internal/multimodal/composer.go
@@ -80,6 +80,13 @@ type PricedLeg struct {
 	Provider   string `json:"provider"`
 	BookingURL string `json:"booking_url,omitempty"`
 	Detail     string `json:"detail,omitempty"`
+	// OriginalPrice and OriginalCurrency preserve a foreign leg's own fare when
+	// the assembler converts it into the itinerary's headline currency at a
+	// reference rate. They are zero/empty unless a conversion happened, so the
+	// original quote is never lost and a caller can recompute the applied rate
+	// (Price / OriginalPrice). Disclosure of the conversion also lands in Detail.
+	OriginalPrice    float64 `json:"original_price,omitempty"`
+	OriginalCurrency string  `json:"original_currency,omitempty"`
 }
 
 // Itinerary is an end-to-end multimodal journey with a single true total.
@@ -126,13 +133,23 @@ type LegPricer func(ctx context.Context, spec LegSpec) (PricedLeg, bool)
 // Returns nil when no genuinely cheaper option exists. Optional (may be nil).
 type HackAnnotator func(ctx context.Context, from, to, date string, naivePrice float64, currency string) *models.HackSaving
 
+// CurrencyConverter converts amount from one currency to another, returning the
+// converted amount and the resulting currency. It mirrors
+// destinations.ConvertCurrency: on an unknown rate it returns the amount in the
+// ORIGINAL currency (result currency != target), which the assembler reads as
+// "conversion unavailable" and keeps the conservative exclusion. Optional (may
+// be nil): a nil converter leaves foreign legs excluded from the sum rather than
+// normalised.
+type CurrencyConverter func(ctx context.Context, amount float64, from, to string) (float64, string)
+
 // Planner composes multimodal itineraries from injected seams. The zero value is
 // not usable; construct via NewPlanner (production) or set the seams directly
 // (tests).
 type Planner struct {
 	Discover       Discoverer
 	Price          LegPricer
-	Hacks          HackAnnotator // optional
+	Hacks          HackAnnotator     // optional
+	Convert        CurrencyConverter // optional; nil = foreign legs excluded from the sum, not normalised
 	AllowBrowser   bool
 	MaxItineraries int
 	LegTimeout     time.Duration
@@ -272,7 +289,7 @@ func (p *Planner) priceRoutes(ctx context.Context, from, to, date, currency stri
 		go func(r models.GroundRoute, legs *[]PricedLeg, wgLeg *sync.WaitGroup) {
 			defer wg.Done()
 			wgLeg.Wait()
-			if it, ok := assembleItinerary(r, from, to, date, *legs); ok {
+			if it, ok := assembleItinerary(ctx, p.Convert, r, from, to, date, *legs); ok {
 				mu.Lock()
 				out = append(out, it)
 				mu.Unlock()

--- a/internal/multimodal/composer_test.go
+++ b/internal/multimodal/composer_test.go
@@ -2,6 +2,7 @@ package multimodal
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
@@ -226,7 +227,8 @@ func TestAssemble_CurrencyMismatchDemotesToEstimate(t *testing.T) {
 		{Mode: "ferry", Price: 40, Currency: "EUR"},
 		{Mode: "fly", Price: 100, Currency: "GBP"}, // mismatched real fare
 	}
-	it, ok := assembleItinerary(r, "Helsinki", "London", "2026-07-01", legs)
+	// nil converter → conservative exclusion (the pre-lever#4 behaviour).
+	it, ok := assembleItinerary(context.Background(), nil, r, "Helsinki", "London", "2026-07-01", legs)
 	if !ok {
 		t.Fatal("expected an assembled itinerary")
 	}
@@ -239,6 +241,79 @@ func TestAssemble_CurrencyMismatchDemotesToEstimate(t *testing.T) {
 	// remainder = 200 - 40 = 160 on the demoted fly leg → total 200.
 	if it.TotalPrice != 200 {
 		t.Errorf("expected total 200, got %v", it.TotalPrice)
+	}
+}
+
+func TestAssemble_ConvertsForeignLegWithDisclosure(t *testing.T) {
+	r := route2("ferry", "Hub", "fly", "Helsinki", "London", 200, "EUR")
+	legs := []PricedLeg{
+		{Mode: "ferry", Price: 40, Currency: "EUR"},
+		{Mode: "fly", Price: 100, Currency: "GBP"}, // foreign real fare
+	}
+	// Stub converter: GBP->EUR at 0.90, everything else "unavailable" (returns the
+	// original currency, mirroring destinations.ConvertCurrency). NEVER calls the
+	// real converter.
+	convert := func(_ context.Context, amount float64, from, to string) (float64, string) {
+		if from == "GBP" && to == "EUR" {
+			return amount * 0.90, "EUR"
+		}
+		return amount, from
+	}
+	it, ok := assembleItinerary(context.Background(), convert, r, "Helsinki", "London", "2026-07-01", legs)
+	if !ok {
+		t.Fatal("expected an assembled itinerary")
+	}
+	// GBP 100 -> EUR 90, summed with the EUR 40 ferry leg -> 130. No estimate.
+	if it.Estimated {
+		t.Errorf("a converted real leg must not demote the itinerary to estimated")
+	}
+	if it.Currency != "EUR" {
+		t.Errorf("headline currency should be EUR, got %q", it.Currency)
+	}
+	if it.TotalPrice != 130 {
+		t.Errorf("expected converted total 40 + 90 = 130, got %v", it.TotalPrice)
+	}
+	fly := it.Legs[1]
+	if fly.Currency != "EUR" || fly.Price != 90 {
+		t.Errorf("fly leg should be normalised to EUR 90, got %s %v", fly.Currency, fly.Price)
+	}
+	if fly.OriginalCurrency != "GBP" || fly.OriginalPrice != 100 {
+		t.Errorf("original GBP 100 must be preserved, got %s %v", fly.OriginalCurrency, fly.OriginalPrice)
+	}
+	if !strings.Contains(fly.Detail, "converted from 100.00 GBP") {
+		t.Errorf("leg detail must disclose the conversion, got %q", fly.Detail)
+	}
+	foundWarn := false
+	for _, w := range it.Warnings {
+		if strings.Contains(w, "reference exchange rate") {
+			foundWarn = true
+		}
+	}
+	if !foundWarn {
+		t.Errorf("itinerary must warn that a reference rate (not checkout-final) was used, got %v", it.Warnings)
+	}
+}
+
+func TestAssemble_NilConverterExcludesForeignLeg(t *testing.T) {
+	r := route2("ferry", "Hub", "fly", "Helsinki", "London", 200, "EUR")
+	legs := []PricedLeg{
+		{Mode: "ferry", Price: 40, Currency: "EUR"},
+		{Mode: "fly", Price: 100, Currency: "GBP"},
+	}
+	// Converter present but reports the pair unavailable -> conservative exclusion,
+	// identical to the nil path.
+	convert := func(_ context.Context, amount float64, from, _ string) (float64, string) {
+		return amount, from
+	}
+	it, ok := assembleItinerary(context.Background(), convert, r, "Helsinki", "London", "2026-07-01", legs)
+	if !ok {
+		t.Fatal("expected an assembled itinerary")
+	}
+	if !it.Estimated {
+		t.Errorf("an unconvertible foreign leg must demote to estimate")
+	}
+	if it.Legs[1].OriginalCurrency != "" {
+		t.Errorf("no conversion happened; original fields must stay empty, got %q", it.Legs[1].OriginalCurrency)
 	}
 }
 

--- a/internal/multimodal/pricing.go
+++ b/internal/multimodal/pricing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/ground"
 	"github.com/MikkoParkkola/trvl/internal/hacks"
@@ -24,6 +25,7 @@ func NewPlanner(allowBrowser bool) *Planner {
 		Discover:     ground.SearchRome2Rio,
 		Price:        productionLegPricer(allowBrowser),
 		Hacks:        productionHackAnnotator,
+		Convert:      destinations.ConvertCurrency,
 		AllowBrowser: allowBrowser,
 	}
 }


### PR DESCRIPTION
## What

The multimodal itinerary assembler used to demote any real leg priced in a
currency other than the itinerary headline to an estimate, labelled "priced in
X; not summed". Honest, but it threw away a real fare rather than using it. This
PR converts that leg into the headline currency at a cached reference rate,
sums it, and discloses the conversion.

This is the next step after PRs #485, #486 and #487, which established the rule
that a raw foreign-currency number never wins a cheapest-or-ranking decision.
Exclusion was the safe move while conversion was untrusted. With a cached,
no-key rate available, transparent conversion is the honest completion of that
work.

## How

`assembleItinerary` takes an optional `CurrencyConverter` seam. For a real leg
whose currency differs from the headline:

- try to convert it into the headline currency;
- on success, preserve the original amount and currency on the leg
  (`OriginalPrice`, `OriginalCurrency`), record the conversion in the leg
  detail, and add an itinerary warning that a reference rate was used;
- on an unknown rate, keep the previous demote-to-estimate behaviour.

The converter mirrors `destinations.ConvertCurrency`: when it cannot find a
rate it returns the amount in the original currency, which the assembler reads
as "no rate available". A nil converter (the zero value, used by every existing
unit test) keeps the old exclusion exactly. Production wires the real cached
converter through `NewPlanner`.

## Honesty

The applied rate is a reference rate, not a checkout-final one. Card fees and
spreads can change what is actually charged, so:

- the original quote is never lost (recompute the applied rate as
  `Price / OriginalPrice`);
- the leg detail says "converted from N X at a reference rate; not a
  checkout-final rate";
- the itinerary warns the reader that a reference rate was used.

## Tests

Two new tests use a stubbed converter and never call the real
`ConvertCurrency`. One asserts a GBP leg is converted to EUR, summed, disclosed
and warned. One asserts an unconvertible leg still demotes to an estimate.
Existing tests are unchanged in behaviour: they pass a nil converter and keep
the exclusion path.

`gofmt`, `go build ./...`, `go vet`, `staticcheck` and `go test -race
./internal/multimodal/...` all pass locally.

## Follow-up

Surface the FX source and timestamp onto the leg for a fuller audit trail, and
extend the same converter seam to the single-currency trip cost path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
