### PR TITLE
pricefeed: rank cheapest provider within a single currency cohort

### DIFF
--- a/internal/pricefeed/pricefeed.go
+++ b/internal/pricefeed/pricefeed.go
@@ -212,12 +212,45 @@ func optionURLs(r hotels.RoomType) []string {
 	return out
 }
 
-// CheapestProvider returns the lowest positive-priced provider, or a zero value.
+// CheapestProvider returns the lowest positive-priced provider within a single
+// currency cohort — the most common currency among priced providers — or a zero
+// value. Ranking a nominal minimum across mixed currencies would let a
+// nominally-small foreign price win dishonestly (100 JPY beating 90 EUR just
+// because 100 < 90 is false economics), so providers outside the dominant cohort
+// are excluded rather than compared. When no provider carries a currency it falls
+// back to the lowest positive price. Mirrors the cohort rule already enforced in
+// internal/multimodal and internal/trip.
 func CheapestProvider(providers []models.ProviderPrice) models.ProviderPrice {
+	cohort := dominantProviderCurrency(providers)
 	var best models.ProviderPrice
 	for _, p := range providers {
-		if p.Price > 0 && (best.Price == 0 || p.Price < best.Price) {
+		if p.Price <= 0 {
+			continue
+		}
+		if cohort != "" && p.Currency != cohort {
+			continue
+		}
+		if best.Price == 0 || p.Price < best.Price {
 			best = p
+		}
+	}
+	return best
+}
+
+// dominantProviderCurrency returns the most frequently occurring non-empty
+// currency among positive-priced providers, with a deterministic first-seen
+// tie-break, or "" when none carry a currency.
+func dominantProviderCurrency(providers []models.ProviderPrice) string {
+	counts := make(map[string]int)
+	best := ""
+	bestN := 0
+	for _, p := range providers {
+		if p.Price <= 0 || p.Currency == "" {
+			continue
+		}
+		counts[p.Currency]++
+		if counts[p.Currency] > bestN {
+			best, bestN = p.Currency, counts[p.Currency]
 		}
 	}
 	return best

--- a/internal/pricefeed/pricefeed_test.go
+++ b/internal/pricefeed/pricefeed_test.go
@@ -145,3 +145,18 @@ func TestCheapestProvider(t *testing.T) {
 		t.Fatalf("want 150, got %v", got.Price)
 	}
 }
+
+// TestCheapestProvider_ExcludesForeignCohort proves a nominally-smaller foreign
+// price cannot win across currencies: with two EUR providers and one JPY, the
+// dominant EUR cohort is ranked and the 5 JPY quote is excluded rather than
+// compared against 80 EUR.
+func TestCheapestProvider_ExcludesForeignCohort(t *testing.T) {
+	got := CheapestProvider([]models.ProviderPrice{
+		{Provider: "a", Price: 90, Currency: "EUR"},
+		{Provider: "b", Price: 80, Currency: "EUR"},
+		{Provider: "c", Price: 5, Currency: "JPY"},
+	})
+	if got.Price != 80 || got.Currency != "EUR" {
+		t.Fatalf("want 80 EUR (JPY excluded), got %v %s", got.Price, got.Currency)
+	}
+}


### PR DESCRIPTION
## What

`CheapestProvider` in `internal/pricefeed` selected the lowest nominal price across all providers without regard to currency. A provider quoting 5 JPY would beat one quoting 80 EUR because 5 is less than 80, which is a meaningless comparison. This function feeds the MCP price-signal tool, so the bad comparison reached users.

This change selects the dominant currency cohort (the most common currency among priced providers, with a first-seen tie-break) and ranks only within it. Providers in other currencies are excluded from the comparison rather than measured against it. When no provider carries a currency, the function keeps its prior lowest-price behavior, so currency-less callers and the existing all-EUR test see no change.

## Why

Levers 1 through 4 established the cross-currency honesty contract in the flight/ground selectors, itinerary composition, and FX normalization. The price-signal surface was still comparing raw numbers across currencies. Closing that gap keeps the "cheapest" label honest wherever it appears, which is a prerequisite for later work that explains or attests a ranking: an explanation attached to a dishonest sort is itself dishonest.

The rule mirrors the cohort logic already used in `internal/multimodal` and `internal/trip`, kept as a small local helper rather than a shared abstraction until a third surface needs it.

## Test

`TestCheapestProvider_ExcludesForeignCohort`: two EUR providers (90, 80) and one JPY provider (5). The result is 80 EUR, proving the nominally smaller JPY quote is excluded rather than picked. The existing `TestCheapestProvider` (all-EUR) still passes unchanged.

Local gates: gofmt clean, `go build ./...`, `go vet`, `staticcheck`, and `go test -race ./internal/pricefeed/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
