### PR TITLE
mcp: report cohort-honest cheapest hotel provider

### DIFF
--- a/mcp/tools_hotels.go
+++ b/mcp/tools_hotels.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/pricefeed"
 	"github.com/MikkoParkkola/trvl/internal/pricesignal"
 	"github.com/MikkoParkkola/trvl/internal/profile"
 )
@@ -304,13 +305,7 @@ func handleHotelPrices(ctx context.Context, args map[string]any, elicit ElicitFu
 
 	summary := fmt.Sprintf("Found %d booking providers for hotel %s (%s to %s).",
 		len(result.Providers), hotelID, checkIn, checkOut)
-	if len(result.Providers) > 0 {
-		cheapest := result.Providers[0]
-		for _, p := range result.Providers[1:] {
-			if p.Price > 0 && p.Price < cheapest.Price {
-				cheapest = p
-			}
-		}
+	if cheapest := pricefeed.CheapestProvider(result.Providers); cheapest.Price > 0 {
 		summary += fmt.Sprintf(" Cheapest: %s %.0f via %s.", cheapest.Currency, cheapest.Price, cheapest.Provider)
 	}
 


### PR DESCRIPTION
## What

`handleHotelPrices` builds a one-line summary that names the cheapest booking
provider. It did that with an inline scan for the numerically smallest `Price`
across `result.Providers`. Google's partner matrix parses a currency per
provider, so that set can hold Booking in EUR next to Agoda in another currency.
A nominally smaller foreign quote could then be labelled "cheapest" against a
larger home-currency one, which is the exact cross-currency error the pricefeed
cohort guard was written to prevent.

This routes the summary through `pricefeed.CheapestProvider`, which picks the
lowest price inside the dominant currency cohort and skips other-currency
quotes. The duplicated scan goes away (net −5 lines). The full provider list is
still returned in the structured payload, so nothing is hidden from the caller;
only the superlative label changes from a possibly false claim to an honest one.

## Scope

One file, one handler. The flight and date-grid selectors are single-currency by
construction and are left untouched. The cross-hotel and per-room selectors mix
currencies differently and need their own cohort adapters, so they are deferred
to separate slices rather than forced through this one.

## Tests

Behaviour is `pricefeed.CheapestProvider`, already covered by
`TestCheapestProvider_ExcludesForeignCohort`. No new MCP test: there is no
summary-string seam to assert against without a fetch-mock refactor that costs
more than the label is worth.

Local verification: `go build`, `go vet`, `gofmt` clean; `staticcheck ./mcp/`
clean; `go test -race ./internal/pricefeed/` and `go test -race ./mcp/` both
pass (the mcp race suite needs ~20 min on this machine, so it runs under an
extended timeout locally; CI's default ceiling holds on faster runners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
