### PR TITLE
tripwindow: normalize flight+hotel into EUR before summing, ranking, budget-filtering

### DIFF
--- a/internal/tripwindow/total_currency_test.go
+++ b/internal/tripwindow/total_currency_test.go
@@ -1,0 +1,82 @@
+package tripwindow
+
+import (
+	"context"
+	"testing"
+)
+
+// stubConverter converts to EUR using a fixed rate table. It mirrors the real
+// destinations.ConvertCurrency failure contract: on an unknown currency it
+// returns the original amount and the *source* currency (conversion did not
+// happen), so callers must check the returned currency to know it succeeded.
+func stubConverter(rates map[string]float64) currencyConverter {
+	return func(_ context.Context, amount float64, from, to string) (float64, string) {
+		if from == to || from == "" || to == "" || amount == 0 {
+			return amount, to
+		}
+		if to != "EUR" {
+			return amount, from // this stub only reaches EUR
+		}
+		r, ok := rates[from]
+		if !ok || r == 0 {
+			return amount, from // can't convert
+		}
+		return amount * r, "EUR"
+	}
+}
+
+// TestNormalizeTripTotalEUR_SameCurrency: both legs already EUR -> plain sum.
+func TestNormalizeTripTotalEUR_SameCurrency(t *testing.T) {
+	conv := stubConverter(nil)
+	total, cur := normalizeTripTotalEUR(context.Background(), conv, 200, "EUR", 300, "EUR")
+	if cur != "EUR" || total != 500 {
+		t.Fatalf("same-currency sum: got %v %s, want 500 EUR", total, cur)
+	}
+}
+
+// TestNormalizeTripTotalEUR_ConvertsForeignHotel: flight EUR, hotel GBP with a
+// live rate -> both normalized to EUR before summation (the honest total).
+func TestNormalizeTripTotalEUR_ConvertsForeignHotel(t *testing.T) {
+	conv := stubConverter(map[string]float64{"GBP": 1.16})
+	total, cur := normalizeTripTotalEUR(context.Background(), conv, 200, "EUR", 450, "GBP")
+	if cur != "EUR" {
+		t.Fatalf("currency: got %s, want EUR", cur)
+	}
+	if want := 200.0 + 450.0*1.16; total != want {
+		t.Fatalf("converted total: got %v, want %v", total, want)
+	}
+}
+
+// TestNormalizeTripTotalEUR_RefusesUnconvertibleMix is the core anti-lie
+// regression: flight EUR 200 + hotel GBP 450 with NO available GBP rate must
+// NOT be summed into a franken-total labelled EUR. Since a nonzero component
+// cannot be brought into EUR, the honest answer is "unknown" (0, "") — which
+// makes the window sort last and escape the EUR budget filter rather than
+// silently admit an over-budget or mis-ranked trip.
+func TestNormalizeTripTotalEUR_RefusesUnconvertibleMix(t *testing.T) {
+	conv := stubConverter(nil) // GBP has no rate -> conversion fails
+	total, cur := normalizeTripTotalEUR(context.Background(), conv, 200, "EUR", 450, "GBP")
+	if total != 0 || cur != "" {
+		t.Fatalf("unconvertible mix must be refused: got %v %q, want 0 \"\"", total, cur)
+	}
+}
+
+// TestNormalizeTripTotalEUR_ZeroComponentDoesNotBlock: a component priced 0
+// (search failed for that leg) contributes nothing and never triggers refusal;
+// the other, convertible leg still yields an honest EUR total.
+func TestNormalizeTripTotalEUR_ZeroComponentDoesNotBlock(t *testing.T) {
+	conv := stubConverter(map[string]float64{"USD": 0.92})
+	total, cur := normalizeTripTotalEUR(context.Background(), conv, 0, "", 500, "USD")
+	if cur != "EUR" || total != 500*0.92 {
+		t.Fatalf("zero flight + convertible hotel: got %v %s, want %v EUR", total, cur, 500*0.92)
+	}
+}
+
+// TestNormalizeTripTotalEUR_ForeignFlightConverts: flight USD converts, hotel 0.
+func TestNormalizeTripTotalEUR_ForeignFlightConverts(t *testing.T) {
+	conv := stubConverter(map[string]float64{"USD": 0.92})
+	total, cur := normalizeTripTotalEUR(context.Background(), conv, 500, "USD", 0, "")
+	if cur != "EUR" || total != 500*0.92 {
+		t.Fatalf("convertible flight + zero hotel: got %v %s, want %v EUR", total, cur, 500*0.92)
+	}
+}

--- a/internal/tripwindow/total_currency_test.go
+++ b/internal/tripwindow/total_currency_test.go
@@ -28,7 +28,7 @@ func stubConverter(rates map[string]float64) currencyConverter {
 // TestNormalizeTripTotalEUR_SameCurrency: both legs already EUR -> plain sum.
 func TestNormalizeTripTotalEUR_SameCurrency(t *testing.T) {
 	conv := stubConverter(nil)
-	total, cur := normalizeTripTotalEUR(context.Background(), conv, 200, "EUR", 300, "EUR")
+	total, _, _, cur := normalizeTripTotalEUR(context.Background(), conv, 200, "EUR", 300, "EUR")
 	if cur != "EUR" || total != 500 {
 		t.Fatalf("same-currency sum: got %v %s, want 500 EUR", total, cur)
 	}
@@ -38,12 +38,20 @@ func TestNormalizeTripTotalEUR_SameCurrency(t *testing.T) {
 // live rate -> both normalized to EUR before summation (the honest total).
 func TestNormalizeTripTotalEUR_ConvertsForeignHotel(t *testing.T) {
 	conv := stubConverter(map[string]float64{"GBP": 1.16})
-	total, cur := normalizeTripTotalEUR(context.Background(), conv, 200, "EUR", 450, "GBP")
+	total, flightEUR, hotelEUR, cur := normalizeTripTotalEUR(context.Background(), conv, 200, "EUR", 450, "GBP")
 	if cur != "EUR" {
 		t.Fatalf("currency: got %s, want EUR", cur)
 	}
 	if want := 200.0 + 450.0*1.16; total != want {
 		t.Fatalf("converted total: got %v, want %v", total, want)
+	}
+	// Components must be the converted EUR amounts, not the native quotes, so
+	// the response never labels a GBP hotel price as EUR.
+	if flightEUR != 200.0 {
+		t.Fatalf("flight component: got %v, want 200 (already EUR)", flightEUR)
+	}
+	if want := 450.0 * 1.16; hotelEUR != want {
+		t.Fatalf("hotel component: got %v, want %v (converted to EUR)", hotelEUR, want)
 	}
 }
 
@@ -55,9 +63,13 @@ func TestNormalizeTripTotalEUR_ConvertsForeignHotel(t *testing.T) {
 // silently admit an over-budget or mis-ranked trip.
 func TestNormalizeTripTotalEUR_RefusesUnconvertibleMix(t *testing.T) {
 	conv := stubConverter(nil) // GBP has no rate -> conversion fails
-	total, cur := normalizeTripTotalEUR(context.Background(), conv, 200, "EUR", 450, "GBP")
+	total, flightEUR, hotelEUR, cur := normalizeTripTotalEUR(context.Background(), conv, 200, "EUR", 450, "GBP")
 	if total != 0 || cur != "" {
 		t.Fatalf("unconvertible mix must be refused: got %v %q, want 0 \"\"", total, cur)
+	}
+	// A refused total must not leak partial component amounts either.
+	if flightEUR != 0 || hotelEUR != 0 {
+		t.Fatalf("refused mix must zero components: got flight=%v hotel=%v, want 0 0", flightEUR, hotelEUR)
 	}
 }
 
@@ -66,7 +78,7 @@ func TestNormalizeTripTotalEUR_RefusesUnconvertibleMix(t *testing.T) {
 // the other, convertible leg still yields an honest EUR total.
 func TestNormalizeTripTotalEUR_ZeroComponentDoesNotBlock(t *testing.T) {
 	conv := stubConverter(map[string]float64{"USD": 0.92})
-	total, cur := normalizeTripTotalEUR(context.Background(), conv, 0, "", 500, "USD")
+	total, _, _, cur := normalizeTripTotalEUR(context.Background(), conv, 0, "", 500, "USD")
 	if cur != "EUR" || total != 500*0.92 {
 		t.Fatalf("zero flight + convertible hotel: got %v %s, want %v EUR", total, cur, 500*0.92)
 	}
@@ -75,7 +87,7 @@ func TestNormalizeTripTotalEUR_ZeroComponentDoesNotBlock(t *testing.T) {
 // TestNormalizeTripTotalEUR_ForeignFlightConverts: flight USD converts, hotel 0.
 func TestNormalizeTripTotalEUR_ForeignFlightConverts(t *testing.T) {
 	conv := stubConverter(map[string]float64{"USD": 0.92})
-	total, cur := normalizeTripTotalEUR(context.Background(), conv, 500, "USD", 0, "")
+	total, _, _, cur := normalizeTripTotalEUR(context.Background(), conv, 500, "USD", 0, "")
 	if cur != "EUR" || total != 500*0.92 {
 		t.Fatalf("convertible flight + zero hotel: got %v %s, want %v EUR", total, cur, 500*0.92)
 	}

--- a/internal/tripwindow/total_currency_test.go
+++ b/internal/tripwindow/total_currency_test.go
@@ -2,6 +2,7 @@ package tripwindow
 
 import (
 	"context"
+	"math"
 	"testing"
 )
 
@@ -90,5 +91,27 @@ func TestNormalizeTripTotalEUR_ForeignFlightConverts(t *testing.T) {
 	total, _, _, cur := normalizeTripTotalEUR(context.Background(), conv, 500, "USD", 0, "")
 	if cur != "EUR" || total != 500*0.92 {
 		t.Fatalf("convertible flight + zero hotel: got %v %s, want %v EUR", total, cur, 500*0.92)
+	}
+}
+
+// TestNormalizeTripTotalEUR_RefusesNonFinite: a converter that yields NaN or
+// +Inf (corrupt/overflowing rate) must be refused, not summed. A non-finite
+// total would slip past the eur<=0 guard, bypass the budget filter, corrupt the
+// ascending-price ranking, and break JSON encoding of the whole MCP response.
+func TestNormalizeTripTotalEUR_RefusesNonFinite(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rate float64
+	}{
+		{"NaN", math.NaN()},
+		{"PosInf", math.Inf(1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conv := stubConverter(map[string]float64{"XXX": tc.rate})
+			total, flightEUR, hotelEUR, cur := normalizeTripTotalEUR(context.Background(), conv, 200, "EUR", 100, "XXX")
+			if total != 0 || cur != "" || flightEUR != 0 || hotelEUR != 0 {
+				t.Fatalf("non-finite %s rate must be refused: got total=%v flight=%v hotel=%v cur=%q, want all zero", tc.name, total, flightEUR, hotelEUR, cur)
+			}
+		})
 	}
 }

--- a/internal/tripwindow/total_currency_test.go
+++ b/internal/tripwindow/total_currency_test.go
@@ -94,6 +94,19 @@ func TestNormalizeTripTotalEUR_ForeignFlightConverts(t *testing.T) {
 	}
 }
 
+// TestNormalizeTripTotalEUR_RefusesUnknownCurrency: a positive leg cost with an
+// empty currency must be refused, not silently counted as EUR. The real
+// ConvertCurrency returns (amount, "EUR") for an empty source currency (it
+// treats "" as a no-op), so without an explicit guard an unknown-currency
+// amount would be relabelled EUR — the exact mislabelling this file prevents.
+func TestNormalizeTripTotalEUR_RefusesUnknownCurrency(t *testing.T) {
+	conv := stubConverter(nil)
+	total, flightEUR, hotelEUR, cur := normalizeTripTotalEUR(context.Background(), conv, 200, "EUR", 100, "")
+	if total != 0 || cur != "" || flightEUR != 0 || hotelEUR != 0 {
+		t.Fatalf("positive cost with empty currency must be refused: got total=%v flight=%v hotel=%v cur=%q, want all zero", total, flightEUR, hotelEUR, cur)
+	}
+}
+
 // TestNormalizeTripTotalEUR_RefusesNonFinite: a converter that yields NaN or
 // +Inf (corrupt/overflowing rate) must be refused, not summed. A non-finite
 // total would slip past the eur<=0 guard, bypass the budget filter, corrupt the

--- a/internal/tripwindow/tripwindow.go
+++ b/internal/tripwindow/tripwindow.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/models"
@@ -138,6 +139,7 @@ func Find(ctx context.Context, in Input) ([]Candidate, error) {
 		flightCost float64
 		hotelCost  float64
 		hotelName  string
+		hotelCurr  string
 		curr       string
 	}
 	results := make([]priceResult, len(candidates))
@@ -164,7 +166,7 @@ func Find(ctx context.Context, in Input) ([]Candidate, error) {
 			retDate := c.end.Format(dateLayout)
 
 			var flightCost, hotelCost float64
-			var curr, hotelName string
+			var curr, hotelName, hotelCurr string
 
 			// Determine flight budget cap from preferences.
 			var flightBudget float64
@@ -181,11 +183,11 @@ func Find(ctx context.Context, in Input) ([]Candidate, error) {
 			}()
 			go func() {
 				defer sub.Done()
-				hotelCost, hotelName = cheapestHotel(ctx, dest, depDate, retDate, c.nights, prefs)
+				hotelCost, hotelName, hotelCurr = cheapestHotel(ctx, dest, depDate, retDate, c.nights, prefs)
 			}()
 			sub.Wait()
 
-			results[i] = priceResult{i, flightCost, hotelCost, hotelName, curr}
+			results[i] = priceResult{i, flightCost, hotelCost, hotelName, hotelCurr, curr}
 		}()
 	}
 	wg.Wait()
@@ -194,13 +196,17 @@ func Find(ctx context.Context, in Input) ([]Candidate, error) {
 	var out []Candidate
 	for i, c := range candidates {
 		pr := results[i]
-		total := pr.flightCost + pr.hotelCost
+		// Normalize flight + hotel into one currency (EUR, matching Input.BudgetEUR)
+		// before summing, filtering, and ranking. A leg that cannot be brought into
+		// EUR yields an unknown total (0, "") rather than a fabricated mixed-currency
+		// sum, so the window sorts last and escapes the budget filter.
+		total, totalCurr := normalizeTripTotalEUR(ctx, destinations.ConvertCurrency, pr.flightCost, pr.curr, pr.hotelCost, pr.hotelCurr)
 		if in.BudgetEUR > 0 && total > 0 && total > in.BudgetEUR {
 			continue
 		}
 
 		overlaps := overlapsAny(c.start, c.end, preferred)
-		reasoning := buildReasoning(c.start, c.end, c.nights, total, pr.curr, overlaps)
+		reasoning := buildReasoning(c.start, c.end, c.nights, total, totalCurr, overlaps)
 
 		out = append(out, Candidate{
 			Start:             c.start.Format(dateLayout),
@@ -210,7 +216,7 @@ func Find(ctx context.Context, in Input) ([]Candidate, error) {
 			FlightCost:        pr.flightCost,
 			HotelCost:         pr.hotelCost,
 			HotelName:         pr.hotelName,
-			Currency:          pr.curr,
+			Currency:          totalCurr,
 			OverlapsPreferred: overlaps,
 			Reasoning:         reasoning,
 		})
@@ -271,9 +277,44 @@ func overlapsAny(start, end time.Time, ivs []parsedInterval) bool {
 // cheapestHotel searches for the cheapest qualifying hotel at the destination
 // for the given check-in/check-out dates, applying preferences filters. Returns
 // (total_for_stay, hotel_name). Returns (0, "") on any error.
-func cheapestHotel(ctx context.Context, dest, checkIn, checkOut string, nights int, prefs *preferences.Preferences) (float64, string) {
-	if dest == "" || checkIn == "" || checkOut == "" || nights <= 0 {
+// currencyConverter converts amount from one currency to another, returning the
+// converted amount and the currency actually produced. On failure it returns a
+// currency other than the requested target (mirrors destinations.ConvertCurrency,
+// which returns the source currency when no rate is available).
+type currencyConverter func(ctx context.Context, amount float64, from, to string) (float64, string)
+
+// normalizeTripTotalEUR sums a flight and a hotel cost in EUR, converting foreign
+// legs via convert. Target is EUR to match Input.BudgetEUR. A leg priced 0
+// contributes nothing. A leg priced >0 that cannot be brought into EUR makes the
+// whole total unknown (0, "") — the window is never shown a fabricated
+// mixed-currency total, sorts last, and escapes the EUR budget filter. Returns
+// (totalEUR, "EUR") when at least one leg is priced and every priced leg reached
+// EUR.
+func normalizeTripTotalEUR(ctx context.Context, convert currencyConverter, flightCost float64, flightCurr string, hotelCost float64, hotelCurr string) (float64, string) {
+	legs := [...]struct {
+		cost float64
+		curr string
+	}{{flightCost, flightCurr}, {hotelCost, hotelCurr}}
+	total := 0.0
+	for _, leg := range legs {
+		if leg.cost <= 0 {
+			continue
+		}
+		eur, cur := convert(ctx, leg.cost, leg.curr, "EUR")
+		if cur != "EUR" || eur <= 0 {
+			return 0, "" // this leg cannot be summed honestly
+		}
+		total += eur
+	}
+	if total <= 0 {
 		return 0, ""
+	}
+	return total, "EUR"
+}
+
+func cheapestHotel(ctx context.Context, dest, checkIn, checkOut string, nights int, prefs *preferences.Preferences) (float64, string, string) {
+	if dest == "" || checkIn == "" || checkOut == "" || nights <= 0 {
+		return 0, "", ""
 	}
 
 	hotelLocation := models.ResolveHotelCity(dest)
@@ -297,7 +338,7 @@ func cheapestHotel(ctx context.Context, dest, checkIn, checkOut string, nights i
 
 	result, err := hotels.SearchHotels(ctx, hotelLocation, opts)
 	if err != nil || result == nil || !result.Success || len(result.Hotels) == 0 {
-		return 0, ""
+		return 0, "", ""
 	}
 
 	filtered := result.Hotels
@@ -305,9 +346,13 @@ func cheapestHotel(ctx context.Context, dest, checkIn, checkOut string, nights i
 		filtered = preferences.FilterHotels(filtered, hotelLocation, prefs)
 	}
 	if len(filtered) == 0 {
-		return 0, ""
+		return 0, "", ""
 	}
 
+	// ponytail: min-by-raw-price can pick a cheaper foreign hotel over a pricier
+	// local one across mixed currencies; the caller normalizes the chosen price to
+	// EUR, so the total stays honest, but cross-currency hotel *selection* is a
+	// follow-up (compare by ComparablePrice cohort like pricefeed.CheapestHotel).
 	cheapest := filtered[0]
 	for _, h := range filtered[1:] {
 		if h.Price > 0 && h.Price < cheapest.Price {
@@ -315,9 +360,9 @@ func cheapestHotel(ctx context.Context, dest, checkIn, checkOut string, nights i
 		}
 	}
 	if cheapest.Price <= 0 {
-		return 0, ""
+		return 0, "", ""
 	}
-	return cheapest.Price * float64(nights), cheapest.Name
+	return cheapest.Price * float64(nights), cheapest.Name, cheapest.Currency
 }
 
 // cheapestFlightWithBudget returns the cheapest round-trip price and currency

--- a/internal/tripwindow/tripwindow.go
+++ b/internal/tripwindow/tripwindow.go
@@ -11,6 +11,7 @@ package tripwindow
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -296,8 +297,8 @@ func normalizeTripTotalEUR(ctx context.Context, convert currencyConverter, fligh
 			return 0, true
 		}
 		eur, cur := convert(ctx, cost, curr, "EUR")
-		if cur != "EUR" || eur <= 0 {
-			return 0, false // cannot express this leg in EUR
+		if cur != "EUR" || eur <= 0 || math.IsInf(eur, 0) || math.IsNaN(eur) {
+			return 0, false // cannot express this leg in EUR (unconvertible or non-finite)
 		}
 		return eur, true
 	}
@@ -307,7 +308,7 @@ func normalizeTripTotalEUR(ctx context.Context, convert currencyConverter, fligh
 		return 0, 0, 0, ""
 	}
 	sum := fEUR + hEUR
-	if sum <= 0 {
+	if sum <= 0 || math.IsInf(sum, 0) || math.IsNaN(sum) {
 		return 0, 0, 0, ""
 	}
 	return sum, fEUR, hEUR, "EUR"

--- a/internal/tripwindow/tripwindow.go
+++ b/internal/tripwindow/tripwindow.go
@@ -200,7 +200,7 @@ func Find(ctx context.Context, in Input) ([]Candidate, error) {
 		// before summing, filtering, and ranking. A leg that cannot be brought into
 		// EUR yields an unknown total (0, "") rather than a fabricated mixed-currency
 		// sum, so the window sorts last and escapes the budget filter.
-		total, totalCurr := normalizeTripTotalEUR(ctx, destinations.ConvertCurrency, pr.flightCost, pr.curr, pr.hotelCost, pr.hotelCurr)
+		total, flightEUR, hotelEUR, totalCurr := normalizeTripTotalEUR(ctx, destinations.ConvertCurrency, pr.flightCost, pr.curr, pr.hotelCost, pr.hotelCurr)
 		if in.BudgetEUR > 0 && total > 0 && total > in.BudgetEUR {
 			continue
 		}
@@ -213,8 +213,8 @@ func Find(ctx context.Context, in Input) ([]Candidate, error) {
 			End:               c.end.Format(dateLayout),
 			Nights:            c.nights,
 			EstimatedCost:     total,
-			FlightCost:        pr.flightCost,
-			HotelCost:         pr.hotelCost,
+			FlightCost:        flightEUR,
+			HotelCost:         hotelEUR,
 			HotelName:         pr.hotelName,
 			Currency:          totalCurr,
 			OverlapsPreferred: overlaps,
@@ -283,33 +283,34 @@ func overlapsAny(start, end time.Time, ivs []parsedInterval) bool {
 // which returns the source currency when no rate is available).
 type currencyConverter func(ctx context.Context, amount float64, from, to string) (float64, string)
 
-// normalizeTripTotalEUR sums a flight and a hotel cost in EUR, converting foreign
-// legs via convert. Target is EUR to match Input.BudgetEUR. A leg priced 0
-// contributes nothing. A leg priced >0 that cannot be brought into EUR makes the
-// whole total unknown (0, "") — the window is never shown a fabricated
-// mixed-currency total, sorts last, and escapes the EUR budget filter. Returns
-// (totalEUR, "EUR") when at least one leg is priced and every priced leg reached
-// EUR.
-func normalizeTripTotalEUR(ctx context.Context, convert currencyConverter, flightCost float64, flightCurr string, hotelCost float64, hotelCurr string) (float64, string) {
-	legs := [...]struct {
-		cost float64
-		curr string
-	}{{flightCost, flightCurr}, {hotelCost, hotelCurr}}
-	total := 0.0
-	for _, leg := range legs {
-		if leg.cost <= 0 {
-			continue
+// normalizeTripTotalEUR converts a flight and a hotel cost into EUR (the currency
+// Input.BudgetEUR is denominated in) via convert, returning the EUR total and each
+// leg's EUR amount so the caller can expose consistent, honestly-labelled
+// components. A leg priced 0 contributes nothing. A leg priced >0 that cannot be
+// brought into EUR makes the whole result unknown (all zeros, "") — the window is
+// never shown a fabricated mixed-currency total, sorts last, and escapes the EUR
+// budget filter. Returns (totalEUR, flightEUR, hotelEUR, "EUR") on success.
+func normalizeTripTotalEUR(ctx context.Context, convert currencyConverter, flightCost float64, flightCurr string, hotelCost float64, hotelCurr string) (total, flightEUR, hotelEUR float64, currency string) {
+	toEUR := func(cost float64, curr string) (float64, bool) {
+		if cost <= 0 {
+			return 0, true
 		}
-		eur, cur := convert(ctx, leg.cost, leg.curr, "EUR")
+		eur, cur := convert(ctx, cost, curr, "EUR")
 		if cur != "EUR" || eur <= 0 {
-			return 0, "" // this leg cannot be summed honestly
+			return 0, false // cannot express this leg in EUR
 		}
-		total += eur
+		return eur, true
 	}
-	if total <= 0 {
-		return 0, ""
+	fEUR, okF := toEUR(flightCost, flightCurr)
+	hEUR, okH := toEUR(hotelCost, hotelCurr)
+	if !okF || !okH {
+		return 0, 0, 0, ""
 	}
-	return total, "EUR"
+	sum := fEUR + hEUR
+	if sum <= 0 {
+		return 0, 0, 0, ""
+	}
+	return sum, fEUR, hEUR, "EUR"
 }
 
 func cheapestHotel(ctx context.Context, dest, checkIn, checkOut string, nights int, prefs *preferences.Preferences) (float64, string, string) {

--- a/internal/tripwindow/tripwindow.go
+++ b/internal/tripwindow/tripwindow.go
@@ -296,6 +296,9 @@ func normalizeTripTotalEUR(ctx context.Context, convert currencyConverter, fligh
 		if cost <= 0 {
 			return 0, true
 		}
+		if curr == "" {
+			return 0, false // positive cost with unknown currency: ConvertCurrency would stamp it "EUR", so refuse rather than mislabel
+		}
 		eur, cur := convert(ctx, cost, curr, "EUR")
 		if cur != "EUR" || eur <= 0 || math.IsInf(eur, 0) || math.IsNaN(eur) {
 			return 0, false // cannot express this leg in EUR (unconvertible or non-finite)

--- a/internal/tripwindow/tripwindow_coverage_test.go
+++ b/internal/tripwindow/tripwindow_coverage_test.go
@@ -253,7 +253,7 @@ func TestBuildReasoning_AllCases(t *testing.T) {
 func TestCheapestHotel_EmptyDestination(t *testing.T) {
 	t.Parallel()
 	// Empty dest causes immediate (0, "") return without any HTTP call.
-	price, name := cheapestHotel(context.Background(), "", "2026-05-01", "2026-05-05", 4, nil)
+	price, name, _ := cheapestHotel(context.Background(), "", "2026-05-01", "2026-05-05", 4, nil)
 	if price != 0 || name != "" {
 		t.Errorf("expected (0, '') for empty dest, got (%v, %q)", price, name)
 	}
@@ -261,7 +261,7 @@ func TestCheapestHotel_EmptyDestination(t *testing.T) {
 
 func TestCheapestHotel_EmptyCheckIn(t *testing.T) {
 	t.Parallel()
-	price, name := cheapestHotel(context.Background(), "PRG", "", "2026-05-05", 4, nil)
+	price, name, _ := cheapestHotel(context.Background(), "PRG", "", "2026-05-05", 4, nil)
 	if price != 0 || name != "" {
 		t.Errorf("expected (0, '') for empty checkIn, got (%v, %q)", price, name)
 	}
@@ -269,7 +269,7 @@ func TestCheapestHotel_EmptyCheckIn(t *testing.T) {
 
 func TestCheapestHotel_EmptyCheckOut(t *testing.T) {
 	t.Parallel()
-	price, name := cheapestHotel(context.Background(), "PRG", "2026-05-01", "", 4, nil)
+	price, name, _ := cheapestHotel(context.Background(), "PRG", "2026-05-01", "", 4, nil)
 	if price != 0 || name != "" {
 		t.Errorf("expected (0, '') for empty checkOut, got (%v, %q)", price, name)
 	}
@@ -277,7 +277,7 @@ func TestCheapestHotel_EmptyCheckOut(t *testing.T) {
 
 func TestCheapestHotel_ZeroNights(t *testing.T) {
 	t.Parallel()
-	price, name := cheapestHotel(context.Background(), "PRG", "2026-05-01", "2026-05-05", 0, nil)
+	price, name, _ := cheapestHotel(context.Background(), "PRG", "2026-05-01", "2026-05-05", 0, nil)
 	if price != 0 || name != "" {
 		t.Errorf("expected (0, '') for zero nights, got (%v, %q)", price, name)
 	}

--- a/internal/tripwindow/tripwindow_extra_test.go
+++ b/internal/tripwindow/tripwindow_extra_test.go
@@ -249,7 +249,7 @@ func TestCheapestFlightWithBudget_NegativeBudget(t *testing.T) {
 
 func TestCheapestHotel_NegativeNights(t *testing.T) {
 	t.Parallel()
-	price, name := cheapestHotel(context.Background(), "PRG", "2026-05-01", "2026-05-05", -1, nil)
+	price, name, _ := cheapestHotel(context.Background(), "PRG", "2026-05-01", "2026-05-05", -1, nil)
 	if price != 0 || name != "" {
 		t.Errorf("expected (0, '') for negative nights, got (%v, %q)", price, name)
 	}


### PR DESCRIPTION
## What

The trip-window search (`trvl when`) sums a flight quote and a hotel quote to rank candidate windows and filter them against a budget. When those two quotes were in different currencies, it summed the raw numbers and labelled the total with the flight's currency. A €200 flight plus a £450 hotel became "€650" — a number that is simply wrong, and one that then drove ranking and the budget cutoff.

This normalizes both legs to EUR before summing, ranking, or budget-filtering, and refuses to invent a total it cannot compute honestly.

## How

`normalizeTripTotalEUR` now converts each leg to EUR first:

- Both legs convert cleanly → honest EUR total, ranked and filtered normally.
- A leg has a positive cost that cannot be brought into EUR (no rate, unknown/empty source currency, or a non-finite conversion result) → the whole window is refused: it returns the existing `(0, "")` "unknown" sentinel, so it sorts last and skips the budget filter rather than presenting a fabricated price.
- A leg priced 0 (that search leg found nothing) contributes nothing and never triggers a refusal.

The `FlightCost` / `HotelCost` components in the response are now the converted EUR amounts, so a GBP hotel price is never displayed with a EUR label.

## Why refuse instead of guess

A wrong total here is worse than no total: it corrupts the ranking and can push an over-budget trip under the cutoff (or the reverse). "Unknown, sorted last" is honest; "€650" for a mixed-currency pair is not.

## Edge cases covered by tests

- Same-currency sum, foreign-hotel conversion, foreign-flight conversion
- Unconvertible mix refused, with components zeroed (no partial leak)
- Zero-priced leg does not block a convertible partner
- Positive cost with empty source currency refused (the converter treats `""` as a EUR no-op, which would otherwise relabel an unknown amount as euros)
- Non-finite conversion (`NaN`, `+Inf`) refused, so a corrupt rate can't slip past the budget filter, break the price ranking, or crash JSON encoding of the response

## Verification

- `go build ./...`, `go vet`, `staticcheck`, `gofmt` all clean
- `go test -race ./internal/tripwindow/` green
- Reviewed for currency-honesty regressions across the trip-window path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
