### PR TITLE
hacks: guard split-ticket savings against mixed-currency arithmetic

### DIFF
--- a/internal/hacks/helpers.go
+++ b/internal/hacks/helpers.go
@@ -33,6 +33,28 @@ func minFlightPrice(r *models.FlightSearchResult) float64 {
 	return min
 }
 
+// minFlightPriceWithCurrency returns the cheapest positive price AND the
+// Currency of THAT SAME flight (not Flights[0]). Returns (0, "") if none.
+func minFlightPriceWithCurrency(r *models.FlightSearchResult) (float64, string) {
+	if r == nil || !r.Success {
+		return 0, ""
+	}
+	min := math.MaxFloat64
+	var currency string
+	found := false
+	for _, f := range r.Flights {
+		if f.Price > 0 && f.Price < min {
+			min = f.Price
+			currency = f.Currency
+			found = true
+		}
+	}
+	if !found {
+		return 0, ""
+	}
+	return min, currency
+}
+
 // flightCurrency returns the currency of the first flight result, or a fallback.
 func flightCurrency(r *models.FlightSearchResult, fallback string) string {
 	if r == nil || !r.Success || len(r.Flights) == 0 {

--- a/internal/hacks/split.go
+++ b/internal/hacks/split.go
@@ -3,9 +3,14 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/MikkoParkkola/trvl/internal/flights"
 )
+
+// splitSearchFunc is the flight search seam (overridable in tests). Mirrors the
+// backToBackSearchFunc / railFlyFlightSearcher house pattern.
+var splitSearchFunc = flights.SearchFlights
 
 // detectSplit compares a round-trip ticket against the sum of two separate
 // one-way tickets (one each direction, potentially different airlines).
@@ -16,37 +21,51 @@ func detectSplit(ctx context.Context, in DetectorInput) []Hack {
 		return nil
 	}
 
-	// Round-trip price.
-	rtResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{
+	// Round-trip price + the currency of the exact flight that set the price.
+	rtResult, err := splitSearchFunc(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{
 		ReturnDate: in.ReturnDate,
 	})
-	if err != nil || !rtResult.Success || len(rtResult.Flights) == 0 {
+	if err != nil || rtResult == nil || !rtResult.Success || len(rtResult.Flights) == 0 {
 		return nil
 	}
-	rtPrice := minFlightPrice(rtResult)
+	rtPrice, rtCur := minFlightPriceWithCurrency(rtResult)
 	if rtPrice <= 0 {
 		return nil
 	}
 
 	// Cheapest one-way outbound.
-	owOutResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
-	if err != nil || !owOutResult.Success || len(owOutResult.Flights) == 0 {
+	owOutResult, err := splitSearchFunc(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
+	if err != nil || owOutResult == nil || !owOutResult.Success || len(owOutResult.Flights) == 0 {
 		return nil
 	}
-	owOutPrice := minFlightPrice(owOutResult)
+	owOutPrice, owOutCur := minFlightPriceWithCurrency(owOutResult)
 	if owOutPrice <= 0 {
 		return nil
 	}
 
 	// Cheapest one-way return.
-	owRetResult, err := flights.SearchFlights(ctx, in.Destination, in.Origin, in.ReturnDate, flights.SearchOptions{})
-	if err != nil || !owRetResult.Success || len(owRetResult.Flights) == 0 {
+	owRetResult, err := splitSearchFunc(ctx, in.Destination, in.Origin, in.ReturnDate, flights.SearchOptions{})
+	if err != nil || owRetResult == nil || !owRetResult.Success || len(owRetResult.Flights) == 0 {
 		return nil
 	}
-	owRetPrice := minFlightPrice(owRetResult)
+	owRetPrice, owRetCur := minFlightPriceWithCurrency(owRetResult)
 	if owRetPrice <= 0 {
 		return nil
 	}
+
+	// Currency honesty: the split saving sums two one-way prices and subtracts
+	// them from a round-trip price — three independently searched numbers. Only
+	// emit a saving if all three priced flights are in the same, known currency.
+	// Otherwise the "Saves X" headline would be arithmetic across currencies
+	// wearing a single label — refuse rather than lie. (Empty currency is never
+	// inferred to EUR; that is treated as unknown and refused.)
+	rtCur = strings.ToUpper(strings.TrimSpace(rtCur))
+	owOutCur = strings.ToUpper(strings.TrimSpace(owOutCur))
+	owRetCur = strings.ToUpper(strings.TrimSpace(owRetCur))
+	if rtCur == "" || owOutCur == "" || owRetCur == "" || rtCur != owOutCur || rtCur != owRetCur {
+		return nil
+	}
+	currency := rtCur
 
 	splitTotal := owOutPrice + owRetPrice
 	savings := rtPrice - splitTotal
@@ -55,8 +74,6 @@ func detectSplit(ctx context.Context, in DetectorInput) []Hack {
 	if savings < 15 {
 		return nil
 	}
-
-	currency := flightCurrency(rtResult, in.currency())
 
 	return []Hack{{
 		Type:     "split",

--- a/internal/hacks/split.go
+++ b/internal/hacks/split.go
@@ -59,10 +59,17 @@ func detectSplit(ctx context.Context, in DetectorInput) []Hack {
 	// Otherwise the "Saves X" headline would be arithmetic across currencies
 	// wearing a single label — refuse rather than lie. (Empty currency is never
 	// inferred to EUR; that is treated as unknown and refused.)
+	//
+	// The Savings is also subtracted from in.NaivePrice by BestSaving, so it must
+	// match in.Currency (the baseline fare's currency) too — otherwise a EUR
+	// saving would be deducted from a USD baseline and mislabeled downstream.
 	rtCur = strings.ToUpper(strings.TrimSpace(rtCur))
 	owOutCur = strings.ToUpper(strings.TrimSpace(owOutCur))
 	owRetCur = strings.ToUpper(strings.TrimSpace(owRetCur))
-	if rtCur == "" || owOutCur == "" || owRetCur == "" || rtCur != owOutCur || rtCur != owRetCur {
+	baseCur := strings.ToUpper(strings.TrimSpace(in.Currency))
+	if rtCur == "" || owOutCur == "" || owRetCur == "" ||
+		rtCur != owOutCur || rtCur != owRetCur ||
+		baseCur == "" || rtCur != baseCur {
 		return nil
 	}
 	currency := rtCur

--- a/internal/hacks/split.go
+++ b/internal/hacks/split.go
@@ -53,26 +53,20 @@ func detectSplit(ctx context.Context, in DetectorInput) []Hack {
 		return nil
 	}
 
-	// Currency honesty: the split saving sums two one-way prices and subtracts
-	// them from a round-trip price — three independently searched numbers. Only
-	// emit a saving if all three priced flights are in the same, known currency.
-	// Otherwise the "Saves X" headline would be arithmetic across currencies
-	// wearing a single label — refuse rather than lie. (Empty currency is never
-	// inferred to EUR; that is treated as unknown and refused.)
-	//
-	// The Savings is also subtracted from in.NaivePrice by BestSaving, so it must
-	// match in.Currency (the baseline fare's currency) too — otherwise a EUR
-	// saving would be deducted from a USD baseline and mislabeled downstream.
+	// Emit only when the baseline currency is known and every searched fare is
+	// in that same currency. Comparing each leg against a non-empty baseCur
+	// covers the empty-currency case too (empty != a known currency), so no
+	// separate empty checks are needed. baseCur is also what BestSaving
+	// subtracts the saving from, so matching it prevents a cross-currency,
+	// mislabeled total downstream. Empty currency is unknown, never EUR.
 	rtCur = strings.ToUpper(strings.TrimSpace(rtCur))
 	owOutCur = strings.ToUpper(strings.TrimSpace(owOutCur))
 	owRetCur = strings.ToUpper(strings.TrimSpace(owRetCur))
 	baseCur := strings.ToUpper(strings.TrimSpace(in.Currency))
-	if rtCur == "" || owOutCur == "" || owRetCur == "" ||
-		rtCur != owOutCur || rtCur != owRetCur ||
-		baseCur == "" || rtCur != baseCur {
+	if baseCur == "" || rtCur != baseCur || owOutCur != baseCur || owRetCur != baseCur {
 		return nil
 	}
-	currency := rtCur
+	currency := baseCur
 
 	splitTotal := owOutPrice + owRetPrice
 	savings := rtPrice - splitTotal

--- a/internal/hacks/split_test.go
+++ b/internal/hacks/split_test.go
@@ -48,6 +48,7 @@ func TestDetectSplit_currencyMismatch_returnsNil(t *testing.T) {
 		Destination: "BCN",
 		Date:        "2026-07-01",
 		ReturnDate:  "2026-07-08",
+		Currency:    "EUR",
 	})
 	if len(hacks) != 0 {
 		t.Errorf("expected 0 hacks for currency mismatch, got %d", len(hacks))
@@ -70,6 +71,7 @@ func TestDetectSplit_allEmptyCurrency_returnsNil(t *testing.T) {
 		Destination: "BCN",
 		Date:        "2026-07-01",
 		ReturnDate:  "2026-07-08",
+		Currency:    "EUR",
 	})
 	if len(hacks) != 0 {
 		t.Errorf("expected 0 hacks when all currencies empty, got %d", len(hacks))
@@ -131,6 +133,7 @@ func TestDetectSplit_cheapestFlightCurrencyMismatch_returnsNil(t *testing.T) {
 		Destination: "BCN",
 		Date:        "2026-07-01",
 		ReturnDate:  "2026-07-08",
+		Currency:    "EUR",
 	})
 	if len(hacks) != 0 {
 		t.Errorf("expected 0 hacks for cheapest-flight currency mismatch, got %d", len(hacks))

--- a/internal/hacks/split_test.go
+++ b/internal/hacks/split_test.go
@@ -56,14 +56,18 @@ func TestDetectSplit_currencyMismatch_returnsNil(t *testing.T) {
 }
 
 func TestDetectSplit_allEmptyCurrency_returnsNil(t *testing.T) {
+	// Every searched fare AND the baseline currency empty -> unknown -> refuse.
+	// Isolates the baseCur=="" guard: with all four empty, the equality checks
+	// ("" == "") would pass, so only the empty-baseline check prevents emitting
+	// a saving in an unknown currency.
 	withSplitMockSearch(t, func(_ context.Context, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
 		if opts.ReturnDate != "" {
-			return splitMakeResult(200, ""), nil
+			return splitMakeResult(300, ""), nil
 		}
 		if origin == "HEL" && dest == "BCN" {
-			return splitMakeResult(85, ""), nil
+			return splitMakeResult(100, ""), nil
 		}
-		return splitMakeResult(85, ""), nil
+		return splitMakeResult(100, ""), nil
 	})
 
 	hacks := detectSplit(context.Background(), DetectorInput{
@@ -71,7 +75,7 @@ func TestDetectSplit_allEmptyCurrency_returnsNil(t *testing.T) {
 		Destination: "BCN",
 		Date:        "2026-07-01",
 		ReturnDate:  "2026-07-08",
-		Currency:    "EUR",
+		Currency:    "",
 	})
 	if len(hacks) != 0 {
 		t.Errorf("expected 0 hacks when all currencies empty, got %d", len(hacks))

--- a/internal/hacks/split_test.go
+++ b/internal/hacks/split_test.go
@@ -92,6 +92,7 @@ func TestDetectSplit_positiveControl_emitsWithVerifiedCurrency(t *testing.T) {
 		Destination: "BCN",
 		Date:        "2026-07-01",
 		ReturnDate:  "2026-07-08",
+		Currency:    "EUR",
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 hack, got %d", len(hacks))
@@ -152,8 +153,35 @@ func TestDetectSplit_belowThreshold_returnsNil(t *testing.T) {
 		Destination: "BCN",
 		Date:        "2026-07-01",
 		ReturnDate:  "2026-07-08",
+		Currency:    "EUR",
 	})
 	if len(hacks) != 0 {
 		t.Errorf("expected 0 hacks for savings below threshold, got %d", len(hacks))
+	}
+}
+
+func TestDetectSplit_baselineCurrencyMismatch_returnsNil(t *testing.T) {
+	// All three searched fares agree (EUR), but the naive baseline (in.Currency)
+	// is USD. BestSaving subtracts Savings from NaivePrice, so an EUR saving
+	// against a USD baseline would be a cross-currency lie -> refuse.
+	withSplitMockSearch(t, func(_ context.Context, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+		if opts.ReturnDate != "" {
+			return splitMakeResult(300, "EUR"), nil
+		}
+		if origin == "HEL" && dest == "BCN" {
+			return splitMakeResult(100, "EUR"), nil
+		}
+		return splitMakeResult(100, "EUR"), nil
+	})
+
+	hacks := detectSplit(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-07-01",
+		ReturnDate:  "2026-07-08",
+		Currency:    "USD",
+	})
+	if len(hacks) != 0 {
+		t.Errorf("expected 0 hacks when baseline currency differs, got %d", len(hacks))
 	}
 }

--- a/internal/hacks/split_test.go
+++ b/internal/hacks/split_test.go
@@ -114,12 +114,14 @@ func TestDetectSplit_positiveControl_emitsWithVerifiedCurrency(t *testing.T) {
 func TestDetectSplit_cheapestFlightCurrencyMismatch_returnsNil(t *testing.T) {
 	// Result whose Flights[0] is EUR but the cheapest flight is USD must be
 	// read as USD (proves minFlightPriceWithCurrency uses the min flight's
-	// currency, not [0]). This drives a currency mismatch -> nil.
+	// currency, not [0]). Numbers chosen so the buggy [0]=EUR path would clear
+	// the savings threshold and emit (250 rt - 200 ow = 50) — the test only
+	// passes because the correct USD read drives a currency mismatch -> nil.
 	withSplitMockSearch(t, func(_ context.Context, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
 		if opts.ReturnDate != "" {
 			return splitMakeMulti([]models.FlightResult{
-				{Price: 250, Currency: "EUR"},
-				{Price: 200, Currency: "USD"},
+				{Price: 300, Currency: "EUR"},
+				{Price: 250, Currency: "USD"},
 			}), nil
 		}
 		if origin == "HEL" && dest == "BCN" && date == "2026-07-01" {

--- a/internal/hacks/split_test.go
+++ b/internal/hacks/split_test.go
@@ -1,0 +1,159 @@
+package hacks
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func splitMakeResult(price float64, currency string) *models.FlightSearchResult {
+	return &models.FlightSearchResult{
+		Success: true,
+		Flights: []models.FlightResult{{Price: price, Currency: currency}},
+	}
+}
+
+func splitMakeMulti(fls []models.FlightResult) *models.FlightSearchResult {
+	return &models.FlightSearchResult{
+		Success: true,
+		Flights: fls,
+	}
+}
+
+func withSplitMockSearch(t *testing.T, fn func(context.Context, string, string, string, flights.SearchOptions) (*models.FlightSearchResult, error)) {
+	t.Helper()
+	original := splitSearchFunc
+	splitSearchFunc = fn
+	t.Cleanup(func() { splitSearchFunc = original })
+}
+
+func TestDetectSplit_currencyMismatch_returnsNil(t *testing.T) {
+	// RED core: rt EUR 200, owOut USD 85, owRet USD 85 → detectSplit returns nil
+	// (would have lied "Saves EUR 30" before the fix).
+	withSplitMockSearch(t, func(_ context.Context, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+		if opts.ReturnDate != "" {
+			return splitMakeResult(200, "EUR"), nil
+		}
+		if origin == "HEL" && dest == "BCN" {
+			return splitMakeResult(85, "USD"), nil
+		}
+		return splitMakeResult(85, "USD"), nil
+	})
+
+	hacks := detectSplit(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-07-01",
+		ReturnDate:  "2026-07-08",
+	})
+	if len(hacks) != 0 {
+		t.Errorf("expected 0 hacks for currency mismatch, got %d", len(hacks))
+	}
+}
+
+func TestDetectSplit_allEmptyCurrency_returnsNil(t *testing.T) {
+	withSplitMockSearch(t, func(_ context.Context, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+		if opts.ReturnDate != "" {
+			return splitMakeResult(200, ""), nil
+		}
+		if origin == "HEL" && dest == "BCN" {
+			return splitMakeResult(85, ""), nil
+		}
+		return splitMakeResult(85, ""), nil
+	})
+
+	hacks := detectSplit(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-07-01",
+		ReturnDate:  "2026-07-08",
+	})
+	if len(hacks) != 0 {
+		t.Errorf("expected 0 hacks when all currencies empty, got %d", len(hacks))
+	}
+}
+
+func TestDetectSplit_positiveControl_emitsWithVerifiedCurrency(t *testing.T) {
+	withSplitMockSearch(t, func(_ context.Context, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+		if opts.ReturnDate != "" {
+			return splitMakeResult(300, "EUR"), nil
+		}
+		if origin == "HEL" && dest == "BCN" {
+			return splitMakeResult(100, "EUR"), nil
+		}
+		return splitMakeResult(100, "EUR"), nil
+	})
+
+	hacks := detectSplit(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-07-01",
+		ReturnDate:  "2026-07-08",
+	})
+	if len(hacks) != 1 {
+		t.Fatalf("expected 1 hack, got %d", len(hacks))
+	}
+	h := hacks[0]
+	if h.Currency != "EUR" {
+		t.Errorf("expected EUR, got %q", h.Currency)
+	}
+	if h.Savings != 100 {
+		t.Errorf("expected savings 100, got %.0f", h.Savings)
+	}
+	if !strings.Contains(h.Description, "EUR") {
+		t.Errorf("description should contain EUR, got: %s", h.Description)
+	}
+}
+
+func TestDetectSplit_cheapestFlightCurrencyMismatch_returnsNil(t *testing.T) {
+	// Result whose Flights[0] is EUR but the cheapest flight is USD must be
+	// read as USD (proves minFlightPriceWithCurrency uses the min flight's
+	// currency, not [0]). This drives a currency mismatch -> nil.
+	withSplitMockSearch(t, func(_ context.Context, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+		if opts.ReturnDate != "" {
+			return splitMakeMulti([]models.FlightResult{
+				{Price: 250, Currency: "EUR"},
+				{Price: 200, Currency: "USD"},
+			}), nil
+		}
+		if origin == "HEL" && dest == "BCN" && date == "2026-07-01" {
+			return splitMakeResult(100, "EUR"), nil
+		}
+		return splitMakeResult(100, "EUR"), nil
+	})
+
+	hacks := detectSplit(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-07-01",
+		ReturnDate:  "2026-07-08",
+	})
+	if len(hacks) != 0 {
+		t.Errorf("expected 0 hacks for cheapest-flight currency mismatch, got %d", len(hacks))
+	}
+}
+
+func TestDetectSplit_belowThreshold_returnsNil(t *testing.T) {
+	withSplitMockSearch(t, func(_ context.Context, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+		if opts.ReturnDate != "" {
+			return splitMakeResult(300, "EUR"), nil
+		}
+		if origin == "HEL" && dest == "BCN" {
+			return splitMakeResult(145, "EUR"), nil
+		}
+		return splitMakeResult(145, "EUR"), nil
+	})
+
+	hacks := detectSplit(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-07-01",
+		ReturnDate:  "2026-07-08",
+	})
+	if len(hacks) != 0 {
+		t.Errorf("expected 0 hacks for savings below threshold, got %d", len(hacks))
+	}
+}

--- a/internal/hacks/split_test.go
+++ b/internal/hacks/split_test.go
@@ -31,16 +31,17 @@ func withSplitMockSearch(t *testing.T, fn func(context.Context, string, string, 
 }
 
 func TestDetectSplit_currencyMismatch_returnsNil(t *testing.T) {
-	// RED core: rt EUR 200, owOut USD 85, owRet USD 85 → detectSplit returns nil
-	// (would have lied "Saves EUR 30" before the fix).
+	// Only the outbound one-way differs (USD) from the EUR rt+baseline+return.
+	// Isolates the owOutCur!=baseCur clause: numbers emit if that check is
+	// dropped (300 rt - 200 ow = 100 saving).
 	withSplitMockSearch(t, func(_ context.Context, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
 		if opts.ReturnDate != "" {
-			return splitMakeResult(200, "EUR"), nil
+			return splitMakeResult(300, "EUR"), nil
 		}
 		if origin == "HEL" && dest == "BCN" {
-			return splitMakeResult(85, "USD"), nil
+			return splitMakeResult(100, "USD"), nil
 		}
-		return splitMakeResult(85, "USD"), nil
+		return splitMakeResult(100, "EUR"), nil
 	})
 
 	hacks := detectSplit(context.Background(), DetectorInput{
@@ -51,7 +52,31 @@ func TestDetectSplit_currencyMismatch_returnsNil(t *testing.T) {
 		Currency:    "EUR",
 	})
 	if len(hacks) != 0 {
-		t.Errorf("expected 0 hacks for currency mismatch, got %d", len(hacks))
+		t.Errorf("expected 0 hacks for outbound currency mismatch, got %d", len(hacks))
+	}
+}
+
+func TestDetectSplit_returnCurrencyMismatch_returnsNil(t *testing.T) {
+	// Only the return one-way differs (USD). Isolates owRetCur!=baseCur.
+	withSplitMockSearch(t, func(_ context.Context, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+		if opts.ReturnDate != "" {
+			return splitMakeResult(300, "EUR"), nil
+		}
+		if origin == "HEL" && dest == "BCN" {
+			return splitMakeResult(100, "EUR"), nil
+		}
+		return splitMakeResult(100, "USD"), nil
+	})
+
+	hacks := detectSplit(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-07-01",
+		ReturnDate:  "2026-07-08",
+		Currency:    "EUR",
+	})
+	if len(hacks) != 0 {
+		t.Errorf("expected 0 hacks for return currency mismatch, got %d", len(hacks))
 	}
 }
 


### PR DESCRIPTION
## What this fixes

`detectSplit` compares a round-trip fare against two one-way fares and reports the difference as a saving. The saving flowed into `BestSaving`, which computes `NaivePrice(baseline) - savings`. Nothing checked that the round-trip, both one-ways, and the baseline were all in the same currency. A round-trip priced in EUR against one-ways priced in USD produced a number like "Saves EUR 30" that mixed two currencies and misled the user.

## The approach

Guard and skip, no conversion. A split saving is emitted only when:

1. the baseline currency (`in.Currency`) is known and non-empty, and
2. the round-trip fare, the cheapest outbound one-way, and the cheapest return one-way are all in that same currency.

An empty currency is treated as unknown and never assumed to be EUR. Currency is read from the exact minimum-priced flight (via `minFlightPriceWithCurrency`), not `Flights[0]`, so a cheap USD fare hidden behind a EUR first result is still read correctly.

## Why the guard is four clauses

```go
if baseCur == "" || rtCur != baseCur || owOutCur != baseCur || owRetCur != baseCur {
    return nil
}
```

Each clause covers a distinct failure: unknown baseline, and each of the three fares disagreeing with it. They are behaviourally equivalent to "all four equal one non-empty currency", but written out so every clause is independently testable.

## Testing

Each clause has a dedicated test that fails if that clause is removed. Verified with mutation testing against the committed baseline: dropping any one of the four clauses turns exactly one test red, and the full suite is green unmodified.

- `allEmptyCurrency` isolates the empty-baseline clause (all fares empty, so the equality checks would pass).
- `cheapestFlightCurrencyMismatch` isolates the round-trip clause and proves the currency comes from the price-setting flight, not the first result.
- `currencyMismatch` (outbound-only USD) and `returnCurrencyMismatch` (return-only USD) isolate the two one-way clauses.
- `positiveControl` confirms a valid same-currency saving still emits.
- `belowThreshold` confirms suppression there is the 15-unit threshold, not the currency guard.
- `baselineCurrencyMismatch` covers fares agreeing with each other but disagreeing with the baseline.

Local gate: `go build`, `go vet`, `gofmt`, `staticcheck`, and `-race` tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
