### PR TITLE
hacks: display cross-currency travel-hack legs in one honest currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   convert every leg into your requested display currency before they compare
   or combine prices. A suggestion whose leg cannot be honestly converted is
   dropped rather than shown with a misleading figure.
+- **Estimated ground fares are now labelled as such.** When a ferry or ground
+  leg falls back to trvl's built-in fare estimate because no live provider quote
+  is available, the ferry-positioning and multimodal routes mark it "(estimated
+  fare)" in the description, so a modelled number is no longer indistinguishable
+  from a real quote.
 - **Wrong cheapest flight in mixed-currency combos.** Flight-combo and
   back-to-back savings picked the numerically smallest raw fare and only then
   converted it, so a fare that merely looked cheaper in a stronger currency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-07-13
+
+### Fixed
+
+- **Cross-currency display honesty across every hack detector.** When you
+  searched in a currency other than EUR, several detectors showed a
+  EUR-denominated number wearing your currency's label (for example a "£19"
+  ferry fare that was really €19). Positioning, open-jaw, flight-combo,
+  back-to-back, ferry-positioning, the multimodal routes, rail-competition,
+  accommodation-split, departure-tax, error-fare, and night-transport now
+  convert every leg into your requested display currency before they compare
+  or combine prices. A suggestion whose leg cannot be honestly converted is
+  dropped rather than shown with a misleading figure.
+- **Wrong cheapest flight in mixed-currency combos.** Flight-combo and
+  back-to-back savings picked the numerically smallest raw fare and only then
+  converted it, so a fare that merely looked cheaper in a stronger currency
+  (90 GBP) could beat a genuinely cheaper one (100 USD). Prices are now
+  converted first and the minimum taken in the target currency.
+- **Wizz Air self-heal no longer bleeds across hosts.** A discovered API
+  version healed against a test or override host is scoped to that host
+  instead of overwriting the shared production version, so concurrent
+  searches can't force each other's discovered version.
+- **Native round-trips retained through truncation** (#472, #473): a
+  window-compliant native round-trip is kept when results are trimmed rather
+  than displaced by a cheaper non-compliant option.
+
+### Changed
+
+- Hack detectors take their flight and ground searches through a per-call
+  `SearchOverride` seam on `SearchOptions`/`DetectorInput` instead of mutable
+  package globals (#478), making the offline test suite deterministic and
+  race-free.
+- `DetectAll` checks the context before dispatching detectors, so a cancelled
+  or timed-out request stops instead of leaking live provider calls.
+
 ## [1.19.1] - 2026-07-10
 
 ### Fixed

--- a/docs/currency-review-findings.md
+++ b/docs/currency-review-findings.md
@@ -1,0 +1,56 @@
+# Cross-model review findings (codex/gpt-5.6-sol) — currency honesty sweep
+
+Reviewer: codex `gpt-5.6-sol`. Reviewed: 2026-07-13. Gate: no branch merges to
+lever11 until its BLOCKERs+MAJORs are fixed and re-reviewed clean by codex.
+
+## RF — inline rail_fly (commit 2292a54, MINE)
+- [BLOCKER] rail_fly.go:181 — inconvertible rail leg keeps foreign currency but
+  its cost is subtracted from target-denominated savings + labelled target.
+- [BLOCKER] rail_fly_bundle.go:75 & :186 — bundle sums target flight + unconverted
+  rail cost, labels mixed total as flight currency.
+- [MAJOR] rail_fly_test.go:580 — test checks only labels; never verifies converted
+  arithmetic or the failed-conversion drop.
+STATUS: fixing inline this session (my own code).
+
+## C — worktree-agent-a72b5bd61b7d22fe9 (5 detectors)
+- [BLOCKER] error_fare.go:157 — NaivePrice already in requested currency, converted
+  AGAIN from EUR. Wrong for every non-EUR request.
+- [BLOCKER] night_transport.go:55 — overwrites r.Currency with target without
+  converting/verifying. Reject routes whose returned currency differs.
+- [MAJOR] rail_competition.go:121 — NaivePrice double-converted from EUR.
+- [MAJOR] accommodation_split.go:194 — minSavingsEUR compared to target-currency
+  savings; convert threshold first.
+- [MAJOR] accommodation_split.go:318 — hotel Currency never checked vs requested.
+- [MAJOR] departure_tax.go:124 — Savings is gross tax but text says "minus
+  transport"; must subtract convGround.
+- [MINOR] error_fare_test.go:181 — only EUR + unconvertible XXX; no valid non-EUR case.
+
+## B — worktree-agent-a4e242c0a9b4c4733 (back-to-back/positioning/open-jaw/combo)
+- [MAJOR] flight_combo.go:121 — cheapestFlightPriceInCurrency picks cheapest raw
+  fare BEFORE conversion; mixed-currency can pick wrong flight. Convert then min.
+- [MAJOR] open_jaw.go:14 & positioning.go:80 — mutable package-level search hooks
+  unsynchronized; parallel test/detector race. (Note: E's DI refactor is the fix pattern.)
+- [MAJOR] flight_combo_test.go:104 — no successful cross-currency test verifying
+  converted amounts.
+- [MINOR] positioning_test.go:109 — "inconvertible ground" test never exercises one.
+
+## E — worktree-agent-a5c9cd49f837d79c7 (time-window/native-RT/DI)
+- [MAJOR] roundtrip_native.go:371 — replacing retained result with cheaper later
+  native fare breaks documented sorted order. Re-sort or insert in place.
+- [MAJOR] wizzair_selfheal.go:161 — per-call host override mutates process-global
+  wizzVersion; concurrent different-host searches cross-contaminate. (Agent scoped
+  this OUT; codex disagrees — scope healed version by host.)
+- [MAJOR] roundtrip_retain_test.go:34 — fixture not actually sorted (290 after 310),
+  masking the order bug.
+- [MINOR] roundtrip_retain_test.go:16 — all-EUR fixtures; no cross-currency case.
+
+## D — worktree-agent-a282842898a867cef (test-only)
+- [MAJOR x2] split_test.go:225 & multimodal_return_split_test.go:432 — assert only
+  Hack.Currency, never the rendered numeric price/savings. Non-blocking (D only adds
+  coverage) but the added tests should assert amounts too.
+
+## Cross-cutting root cause (biggest potential)
+Multiple detectors treat NaivePrice / provider prices as EUR and convert FROM EUR
+to target, when the value is ALREADY in the requested currency. Fix once, verify
+across ALL detectors with a non-EUR sweep test. VERIFY NaivePrice denomination in
+DetectorInput before mass-editing.

--- a/docs/currency-review-findings.md
+++ b/docs/currency-review-findings.md
@@ -154,3 +154,18 @@ Reviewer: codex gpt-5.6-sol, one runner subagent per branch (relays codex verdic
     the DetectAll branch (2491e91) fixes; C's worktree predates that merge, so they clear
     on lever11 post-merge. Confirmed pre-existing on base 6fdbb13 via git stash. codex
     round-4 review of 9b45942+fc84d96 DISPATCHED.
+
+## Merge status (2026-07-13, lever11)
+
+- MERGED into lever11 (each --no-ff): E (worktree-agent-a5c9cd49f837d79c7), DetectAll
+  (worktree-agent-a0782756f2ea57762), C (worktree-agent-a72b5bd61b7d22fe9). All three
+  merged clean, no conflicts. currency.go seam now on lever11.
+- codex round-4 on C's 9b45942+fc84d96: currency dimension CLEAN (thresholds target-
+  denominated, all conversions via seam, accommodation test offline, no new mixing). Its
+  lone CHANGES-REQUIRED blocker was the DetectAll ctx issue (hacks.go:370) — resolved by
+  the DetectAll merge. Confirmed: post-merge `go test ./internal/hacks/ -race -count=1`
+  = ok 32.6s (the two TestDetectAll_* failures now pass).
+- PENDING: B (worktree-agent-a4e242c0a9b4c4733) — 4-detector fix agent running; must
+  rebase onto lever11 (currency.go now exists there) then codex review before merge.
+- REMAINING before v1.20.0: B merge + cross-detector non-EUR sweep test + full-repo DoD
+  (go test ./... -race, staticcheck ./..., govulncheck, coverage>=80%) + release.

--- a/docs/currency-review-findings.md
+++ b/docs/currency-review-findings.md
@@ -49,6 +49,23 @@ STATUS: fixing inline this session (my own code).
   Hack.Currency, never the rendered numeric price/savings. Non-blocking (D only adds
   coverage) but the added tests should assert amounts too.
 
+## G — DetectAll context-honoring + live-call leak (found via self-review, pre-existing)
+Discovered 2026-07-13 running `go test ./internal/hacks/ -race` on lever11 base.
+- [BLOCKER] internal/hacks/benchmark_test.go:207 TestDetectAll_CancelledContext and
+  :233 TestDetectAll_DeadlineExceeded FAIL: DetectAll with an already-cancelled /
+  1ms-deadline context takes ~820ms (expected <500ms). DetectAll does not check
+  ctx.Err() before dispatching detectors, so live provider calls (skiplagged,
+  wizzair, rome2rio, agoda, spotahome, ferryhopper, wunderflats) still fire.
+- [LOCK VIOLATION] the default (non-live-env) hacks suite makes real network calls
+  via DetectAll → non-deterministic; skiplagged 429s (self-inflicted rate-limit)
+  push elapsed over the 500ms bar. LOCK: default suite must be offline/deterministic.
+- Root fix: DetectAll must short-circuit on ctx.Err() before/inside the dispatch
+  loop so a cancelled/expired context returns promptly and issues no provider calls.
+  This also makes the two context tests deterministic + offline.
+- Likely CI-green today (CI egress to these hosts fast-fails <500ms); real bug is
+  masked by environment. Separate from the currency theme; fixed in its own branch.
+STATUS: dispatched dedicated fix agent (own worktree off lever11), codex re-review after.
+
 ## Cross-cutting root cause (biggest potential)
 Multiple detectors treat NaivePrice / provider prices as EUR and convert FROM EUR
 to target, when the value is ALREADY in the requested currency. Fix once, verify

--- a/docs/currency-review-findings.md
+++ b/docs/currency-review-findings.md
@@ -3,6 +3,29 @@
 Reviewer: codex `gpt-5.6-sol`. Reviewed: 2026-07-13. Gate: no branch merges to
 lever11 until its BLOCKERs+MAJORs are fixed and re-reviewed clean by codex.
 
+## Release gate — FULL-REPO DoD compliance (BLOCKING, operator directive 2026-07-13)
+
+The codebase is expected to be DoD-compliant AT ALL TIMES, not just at tag time.
+Every branch merge into lever11 AND the v1.20.0 tag are gated on the ENTIRE trvl
+tree passing DoD, not merely the touched detectors:
+
+- §3 static / 0-bug: `GOTOOLCHAIN=go1.26.5 go vet ./...` + `staticcheck ./...` +
+  `govulncheck ./...` clean repo-wide (zero errors = stop-the-line).
+- §4/§6 testing+regression: `GOTOOLCHAIN=go1.26.5 go test ./... -race -count=1` green
+  on the full tree; NEW tests exist AND pass; coverage >=80% (`make test-coverage`).
+- H1-H11 hygiene: no orphans / dead code / duplicate fns; `internal/hacks/currency.go`
+  seam consolidated (single declaration, not per-branch dupes); findings doc tracked.
+- §5 locks: default suite offline+deterministic (the LOCK codex caught C violating);
+  `internal/models` import direction intact; MCP 2025-11-25 unbroken.
+- §1/§12 evidence+review: cross-model codex review clean on every branch; AC pass/fail
+  + gate verdicts posted to the release issue before close.
+- D22-D30: supply-chain audit at merge; no secrets; no default API keys.
+
+A red ANYWHERE in `./...` (including pre-existing violations in untouched packages
+surfaced by the full pass) blocks the merge/release and is fixed in THIS release,
+never merged over.
+
+
 ## RF — inline rail_fly (commit 2292a54, MINE)
 - [BLOCKER] rail_fly.go:181 — inconvertible rail leg keeps foreign currency but
   its cost is subtracted from target-denominated savings + labelled target.
@@ -71,3 +94,63 @@ Multiple detectors treat NaivePrice / provider prices as EUR and convert FROM EU
 to target, when the value is ALREADY in the requested currency. Fix once, verify
 across ALL detectors with a non-EUR sweep test. VERIFY NaivePrice denomination in
 DetectorInput before mass-editing.
+
+## Codex re-review verdicts (2026-07-13, round 2)
+
+Reviewer: codex gpt-5.6-sol, one runner subagent per branch (relays codex verdict only).
+
+- **E (5e9ec46/c49fe5c/4f94424)** — VERDICT: CLEAN. All 4 findings RESOLVED
+  (re-sort via compareFlightPrices; wizz healed-version scoped per-host under mutex;
+  fixtures genuinely ascending + assertPriceSorted; cross-currency incl XXX covered).
+  No new issues; codex ran focused -race, passed. MERGE-READY.
+- **C (8fa2886)** — VERDICT: CHANGES-REQUIRED. 6/7 findings RESOLVED (error_fare
+  double-convert, night_transport currency reject, rail_competition, accommodation_split
+  x2, departure_tax net-of-transport all fixed). NOT-RESOLVED: #7 error_fare needs an
+  injectable conversion-rate seam for a deterministic non-EUR regression test. NEW MAJOR:
+  TestDetectDepartureTax_nonEURTarget is network-dependent (calls prod ConvertCurrency for
+  both execution + expectation) — LOCK violation. FIX IN PROGRESS: seam impl agent
+  (convertCurrency package var, mirrors railGroundSearcher) + deterministic fake-rate tests
+  for error_fare + departure_tax. Re-review after.
+  - SEAM DONE @9b33255: convertCurrency package var; all 7 call sites routed; deterministic
+    fake-rate tests for error_fare (no-double-conversion) + departure_tax; bonus: fixed a
+    genuinely-live suppressed-test that warmed the shared rate cache. Offline green, -race PASS.
+  - FOLLOW-UP DONE @6fdbb13: inconvertible-currency tests in night_transport_test.go +
+    rail_competition_test.go now inject never-convert fake seam; both 0.00s offline, -race PASS.
+  - PENDING: codex final re-review of full C stack (8fa2886->9b33255->6fdbb13) dispatched.
+- **DetectAll (2491e91)** — VERDICT: CLEAN. Prompt nil-return on pre-cancelled ctx
+  (hacks.go:344); concurrent ctx.Err safe; all 3 callers compile unchanged + handle nil
+  slices; no nil-deref. codex ran -race -count=10 on both target tests + mcp/cmd pkgs, PASS.
+  MERGE-READY.
+- **B (redo)** — 5 commits landed green (positioning/open_jaw/back_to_back/flight_combo
+  + cheapestFlightPriceInCurrency-in-target + SearchOverride plumbing replacing racy
+  pkg-global search vars). Audit of B surfaced 4 MORE detectors with the same
+  currency-mixing defect (ferry_positioning, multimodal_positioning,
+  multimodal_open_jaw_ground, multimodal_skip_flight) + the fact that
+  internal/ground.SearchOptions lacks a SearchOverride seam. Fix agent dispatched into
+  B's worktree (convert-before-arithmetic + drop-on-inconvertible, ground override seam,
+  offline tests). codex review of the full B stack pending after that lands.
+
+## Codex re-review verdicts (2026-07-13, round 3)
+
+- **C final (8fa2886->9b33255->6fdbb13)** — VERDICT: CHANGES-REQUIRED. Confirmed
+  RESOLVED: GBP seam test proves NaivePrice stays GBP 20 + correct Savings/Currency;
+  seam defaults to destinations.ConvertCurrency (behavior-preserving); seam-mutating
+  tests restore sequentially, -race clean. STILL OPEN:
+  (1) LOCK VIOLATION — accommodation_split inconvertible-currency test still invokes the
+  live default converter (~0.57s observed = real network call); must inject the
+  never-convert fake seam like night_transport/rail_competition.
+  (2) NEW MAJOR — detectErrorFare compares target-currency NaivePrice against unconverted
+  EUR thresholds (floorEUR/errorThreshold/flashThreshold), so non-EUR targets (JPY etc.)
+  misclassify and mis-discount; must convert thresholds into target before comparison.
+  FIX IN PROGRESS: dedicated agent in C's worktree (threshold conversion via seam +
+  fake-seam offline accommodation test + non-EUR error_fare regression). Re-review after.
+  - FIX LANDED: 9b45942 (detectErrorFare converts floorEUR/typicalEUR into target via
+    seam BEFORE comparing target-denominated NaivePrice; discount uses converted
+    dispTypical; EUR unchanged via from==to short-circuit) + fc84d96 (accommodation_split
+    inconvertible test injects never-convert fake seam, offline). New test
+    TestDetectErrorFare_nonEURTarget_JPY_classifiesCorrectly (EUR->JPY@130). Scoped -race
+    run: 20 tests PASS @0.00s, no network WARN. NOTE: full-package run still fails
+    TestDetectAll_CancelledContext/_DeadlineExceeded — these are the SAME live-timing tests
+    the DetectAll branch (2491e91) fixes; C's worktree predates that merge, so they clear
+    on lever11 post-merge. Confirmed pre-existing on base 6fdbb13 via git stash. codex
+    round-4 review of 9b45942+fc84d96 DISPATCHED.

--- a/docs/currency-review-findings.md
+++ b/docs/currency-review-findings.md
@@ -169,3 +169,18 @@ Reviewer: codex gpt-5.6-sol, one runner subagent per branch (relays codex verdic
   rebase onto lever11 (currency.go now exists there) then codex review before merge.
 - REMAINING before v1.20.0: B merge + cross-detector non-EUR sweep test + full-repo DoD
   (go test ./... -race, staticcheck ./..., govulncheck, coverage>=80%) + release.
+
+## B redo landed + round-1 codex dispatched (2026-07-13)
+- B redo committed b39f69a (on f482228): 4 detectors fixed (ferry_positioning,
+  multimodal_positioning, multimodal_open_jaw_ground, multimodal_skip_flight) convert-
+  before-arithmetic + drop-on-inconvertible; currency_honesty_test.go (8 offline tests
+  0.00s); ground GroundSearchOverride seam already existed; staticcheck clean.
+- MERGE WRINKLE: B built its OWN internal/hacks/currency.go with extra helpers
+  (convertCurrencyFn, cheapestFlightPriceInTarget, groundLegPriceInTarget); lever11 now
+  has C's simpler currency.go (var convertCurrency = destinations.ConvertCurrency). MERGE
+  WILL CONFLICT on currency.go -> resolve by UNION (single convertCurrency var + B's
+  helpers), then re-run full hacks+ground -race + staticcheck.
+- codex round-1 review of B stack (1024877^..b39f69a) DISPATCHED (agent ace76cf7).
+- ORDER: await codex-clean B -> merge B into lever11 (resolve currency.go union) ->
+  cross-detector non-EUR sweep test -> full-repo DoD (go test ./... -race, staticcheck
+  ./..., govulncheck, coverage>=80%) -> release v1.20.0.

--- a/internal/flights/alliance_probe_test.go
+++ b/internal/flights/alliance_probe_test.go
@@ -2,11 +2,13 @@ package flights
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/testutil"
 )
 
@@ -47,6 +49,9 @@ func TestAllianceProbe(t *testing.T) {
 		defer cancel()
 		res, err := SearchFlightsWithClient(ctx, client, "HEL", "LHR", searchDate, baseOpts)
 		if err != nil {
+			if errors.Is(err, models.ErrRateLimited) {
+				t.Skipf("baseline rate-limited/challenged upstream (not a wire-format drift): %v", err)
+			}
 			t.Fatalf("baseline search failed: %v", err)
 		}
 		baseline = res.Count

--- a/internal/flights/filter.go
+++ b/internal/flights/filter.go
@@ -2,6 +2,7 @@ package flights
 
 import (
 	"strings"
+	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -20,19 +21,52 @@ import (
 //
 // The function never mutates the input slice and always returns a valid
 // (possibly empty) slice.
+//
+// This is a thin backward-compatible wrapper over FilterFlightsByTimeWindow with
+// a zero tolerance: every flight outside the window is hard-dropped, so the
+// returned set is exactly the flights inside the window (legacy semantics).
 func FilterFlightsByTimePreference(flights []models.FlightResult, earliest, latest string) []models.FlightResult {
 	if earliest == "" && latest == "" {
 		return flights
 	}
+	kept, _, _ := FilterFlightsByTimeWindow(flights, earliest, latest, 0)
+	return kept
+}
 
-	out := make([]models.FlightResult, 0, len(flights))
+// FilterFlightsByTimeWindow partitions flights by how their directional departure
+// time(s) relate to the SOFT [earliest, latest] window, with a tolerance of
+// hardFloorMinutes:
+//
+//   - kept          — every flight that is NOT hard-dropped, in input order. This
+//     is the set callers should carry forward; it is the union of the flights
+//     fully inside the window and the soft-penalised near-misses.
+//   - softPenalised — the subset of kept whose worst directional departure falls
+//     OUTSIDE the window but within hardFloorMinutes of it (a near-miss). These
+//     are surfaced separately so a caller can down-rank them.
+//   - hardDropped    — flights whose worst directional departure falls MORE than
+//     hardFloorMinutes outside the window. These are excluded from kept.
+//
+// hardFloorMinutes == 0 reproduces the legacy hard cutoff: any departure outside
+// the window is hard-dropped and softPenalised is always empty. Bounds are
+// "HH:MM" 24-hour strings; an empty bound means no constraint on that side. The
+// function never mutates the input slice and always returns valid (possibly
+// empty, non-nil) slices.
+func FilterFlightsByTimeWindow(flights []models.FlightResult, earliest, latest string, hardFloorMinutes int) (kept, softPenalised, hardDropped []models.FlightResult) {
+	kept = make([]models.FlightResult, 0, len(flights))
+	softPenalised = make([]models.FlightResult, 0)
+	hardDropped = make([]models.FlightResult, 0)
 	for _, f := range flights {
-		if !directionalDeparturesInWindow(f, earliest, latest) {
-			continue
+		switch timeWindowClass(f, earliest, latest, hardFloorMinutes) {
+		case 2:
+			hardDropped = append(hardDropped, f)
+		case 1:
+			kept = append(kept, f)
+			softPenalised = append(softPenalised, f)
+		default:
+			kept = append(kept, f)
 		}
-		out = append(out, f)
 	}
-	return out
+	return kept, softPenalised, hardDropped
 }
 
 // FilterFlightsByBudget drops flights whose price exceeds maxPrice.
@@ -147,6 +181,71 @@ func directionalDeparturesInWindow(f models.FlightResult, earliest, latest strin
 		}
 	}
 	return true
+}
+
+// timeWindowClass classifies a flight against the SOFT [earliest, latest] window
+// with a tolerance of hardFloorMinutes, returning:
+//
+//	0 — every checked directional departure is inside the window
+//	1 — at least one departure is outside the window but within the tolerance
+//	    (a soft near-miss; the flight is kept but should be down-ranked)
+//	2 — at least one departure is more than the tolerance outside the window
+//	    (a hard miss; the flight should be dropped)
+//
+// The worst (largest) deviation across the checked directional departures wins,
+// so a flight is only class 0 when BOTH its outbound and return starts are inside
+// the window. A flight with no parseable departure times is class 0 (kept), which
+// preserves the legacy "keep when we cannot tell" behaviour.
+func timeWindowClass(f models.FlightResult, earliest, latest string, hardFloorMinutes int) int {
+	if earliest == "" && latest == "" {
+		return 0
+	}
+	worst := 0
+	for _, t := range collectDirectionalDepTimes(f) {
+		dev := windowDeviationMinutes(t, earliest, latest)
+		if dev <= 0 {
+			continue
+		}
+		class := 1
+		if dev > hardFloorMinutes {
+			class = 2
+		}
+		if class > worst {
+			worst = class
+		}
+	}
+	return worst
+}
+
+// windowDeviationMinutes returns how many minutes the "HH:MM" time t falls
+// outside the [earliest, latest] window (0 when inside, or when t cannot be
+// parsed — an unparseable time never triggers a penalty). Bounds are optional.
+func windowDeviationMinutes(t, earliest, latest string) int {
+	tm, ok := clockToMinutes(t)
+	if !ok {
+		return 0
+	}
+	if earliest != "" {
+		if em, ok := clockToMinutes(earliest); ok && tm < em {
+			return em - tm
+		}
+	}
+	if latest != "" {
+		if lm, ok := clockToMinutes(latest); ok && tm > lm {
+			return tm - lm
+		}
+	}
+	return 0
+}
+
+// clockToMinutes parses an "HH:MM" 24-hour string into minutes-since-midnight.
+// Returns ok=false for any malformed input.
+func clockToMinutes(hhmm string) (int, bool) {
+	tm, err := time.Parse("15:04", hhmm)
+	if err != nil {
+		return 0, false
+	}
+	return tm.Hour()*60 + tm.Minute(), true
 }
 
 // collectDirectionalDepTimes returns the HH:MM strings for the legs that

--- a/internal/flights/filter_window_test.go
+++ b/internal/flights/filter_window_test.go
@@ -1,0 +1,115 @@
+package flights
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func leg(dt string) models.FlightLeg { return models.FlightLeg{DepartureTime: dt} }
+
+// #473: with a non-zero tolerance, a departure just outside the window is kept
+// but flagged as a soft near-miss; one far outside is hard-dropped.
+func TestFilterFlightsByTimeWindow_SoftAndHard(t *testing.T) {
+	flts := []models.FlightResult{
+		{Price: 100, Legs: []models.FlightLeg{leg("2026-06-15T08:00")}}, // inside [06:00,22:00]
+		{Price: 200, Legs: []models.FlightLeg{leg("2026-06-15T05:45")}}, // 15 min before -> soft (tol 30)
+		{Price: 300, Legs: []models.FlightLeg{leg("2026-06-15T22:20")}}, // 20 min after  -> soft (tol 30)
+		{Price: 400, Legs: []models.FlightLeg{leg("2026-06-15T04:00")}}, // 120 min before -> hard drop
+	}
+	kept, soft, hard := FilterFlightsByTimeWindow(flts, "06:00", "22:00", 30)
+
+	if len(kept) != 3 {
+		t.Fatalf("kept: expected 3, got %d (%+v)", len(kept), kept)
+	}
+	if kept[0].Price != 100 || kept[1].Price != 200 || kept[2].Price != 300 {
+		t.Errorf("kept order/prices wrong: got [%.0f %.0f %.0f]", kept[0].Price, kept[1].Price, kept[2].Price)
+	}
+	if len(soft) != 2 || soft[0].Price != 200 || soft[1].Price != 300 {
+		t.Errorf("soft: expected [200 300], got %+v", soft)
+	}
+	if len(hard) != 1 || hard[0].Price != 400 {
+		t.Errorf("hard: expected [400], got %+v", hard)
+	}
+}
+
+// #473: tolerance boundary is inclusive — a departure exactly hardFloor minutes
+// outside is a soft near-miss, one minute further is hard-dropped.
+func TestFilterFlightsByTimeWindow_ToleranceBoundary(t *testing.T) {
+	flts := []models.FlightResult{
+		{Price: 1, Legs: []models.FlightLeg{leg("2026-06-15T05:30")}}, // exactly 30 before -> soft
+		{Price: 2, Legs: []models.FlightLeg{leg("2026-06-15T05:29")}}, // 31 before -> hard
+	}
+	kept, soft, hard := FilterFlightsByTimeWindow(flts, "06:00", "22:00", 30)
+	if len(kept) != 1 || kept[0].Price != 1 {
+		t.Errorf("kept: expected [1], got %+v", kept)
+	}
+	if len(soft) != 1 || soft[0].Price != 1 {
+		t.Errorf("soft: expected [1], got %+v", soft)
+	}
+	if len(hard) != 1 || hard[0].Price != 2 {
+		t.Errorf("hard: expected [2], got %+v", hard)
+	}
+}
+
+// #473: zero tolerance reproduces the legacy hard cutoff, and the
+// FilterFlightsByTimePreference wrapper returns exactly the kept set.
+func TestFilterFlightsByTimeWindow_ZeroToleranceIsLegacy(t *testing.T) {
+	flts := []models.FlightResult{
+		{Price: 100, Legs: []models.FlightLeg{leg("2026-06-15T05:59")}}, // 1 min before -> dropped
+		{Price: 200, Legs: []models.FlightLeg{leg("2026-06-15T06:00")}}, // edge -> inside
+		{Price: 300, Legs: []models.FlightLeg{leg("2026-06-15T14:00")}}, // inside
+	}
+	kept, soft, hard := FilterFlightsByTimeWindow(flts, "06:00", "22:00", 0)
+	if len(kept) != 2 || kept[0].Price != 200 || kept[1].Price != 300 {
+		t.Errorf("kept: expected [200 300], got %+v", kept)
+	}
+	if len(soft) != 0 {
+		t.Errorf("soft: expected none at zero tolerance, got %+v", soft)
+	}
+	if len(hard) != 1 || hard[0].Price != 100 {
+		t.Errorf("hard: expected [100], got %+v", hard)
+	}
+
+	// Wrapper parity: same input through the legacy entry point.
+	wrap := FilterFlightsByTimePreference(flts, "06:00", "22:00")
+	if len(wrap) != len(kept) {
+		t.Fatalf("wrapper returned %d, kept was %d", len(wrap), len(kept))
+	}
+	for i := range wrap {
+		if wrap[i].Price != kept[i].Price {
+			t.Errorf("wrapper[%d]=%.0f, kept[%d]=%.0f", i, wrap[i].Price, i, kept[i].Price)
+		}
+	}
+}
+
+// #473: the return (inbound) leg is subject to the same tolerance — an early
+// inbound within tolerance is soft, beyond it is hard-dropped.
+func TestFilterFlightsByTimeWindow_ReturnLeg(t *testing.T) {
+	flts := []models.FlightResult{
+		{
+			Price: 500,
+			Legs: []models.FlightLeg{
+				{Direction: "outbound", DepartureTime: "2026-07-01T11:00"},
+				{Direction: "inbound", DepartureTime: "2026-07-08T09:40"}, // 20 min before 10:00 -> soft
+			},
+		},
+		{
+			Price: 600,
+			Legs: []models.FlightLeg{
+				{Direction: "outbound", DepartureTime: "2026-07-01T11:00"},
+				{Direction: "inbound", DepartureTime: "2026-07-08T07:00"}, // 180 min before -> hard
+			},
+		},
+	}
+	kept, soft, hard := FilterFlightsByTimeWindow(flts, "10:00", "", 30)
+	if len(kept) != 1 || kept[0].Price != 500 {
+		t.Errorf("kept: expected [500], got %+v", kept)
+	}
+	if len(soft) != 1 || soft[0].Price != 500 {
+		t.Errorf("soft: expected [500], got %+v", soft)
+	}
+	if len(hard) != 1 || hard[0].Price != 600 {
+		t.Errorf("hard: expected [600], got %+v", hard)
+	}
+}

--- a/internal/flights/filters_probe_test.go
+++ b/internal/flights/filters_probe_test.go
@@ -3,11 +3,13 @@ package flights
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/testutil"
 )
 
@@ -45,6 +47,9 @@ func TestFiltersProbe(t *testing.T) {
 		defer cancel()
 		res, err := SearchFlightsWithClient(ctx, client, "HEL", "LHR", searchDate, baseOpts)
 		if err != nil {
+			if errors.Is(err, models.ErrRateLimited) {
+				t.Skipf("baseline rate-limited/challenged upstream (not a wire-format drift): %v", err)
+			}
 			t.Fatalf("baseline search failed: %v", err)
 		}
 		t.Logf("Baseline (SearchFlightsWithClient): %d flights", res.Count)

--- a/internal/flights/kiwi_roundtrip_probe_test.go
+++ b/internal/flights/kiwi_roundtrip_probe_test.go
@@ -2,9 +2,12 @@ package flights
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
 // TestProbeKiwiRoundTrip hits live Kiwi with a round-trip request (returnDate
@@ -32,6 +35,9 @@ func TestProbeKiwiRoundTrip(t *testing.T) {
 	results, err := SearchKiwiFlights(ctx, origin, destination, dep, "EUR", opts)
 	t.Logf("SearchKiwiFlights(returnDate=%s) -> %d results, err=%v", ret, len(results), err)
 	if err != nil {
+		if errors.Is(err, models.ErrRateLimited) {
+			t.Skipf("kiwi round-trip rate-limited/503 upstream (not a wire-format drift): %v", err)
+		}
 		t.Fatalf("kiwi round-trip request failed: %v", err)
 	}
 	for i, f := range results {

--- a/internal/flights/policy.go
+++ b/internal/flights/policy.go
@@ -30,7 +30,15 @@ func ApplySharedFlightPolicy(result *models.FlightSearchResult, prefs *preferenc
 	if !skipBudgetPref {
 		result.Flights = FilterFlightsByBudget(result.Flights, prefs.BudgetFlightMax)
 	}
-	result.Flights = FilterFlightsByTimePreference(result.Flights, prefs.FlightTimeEarliest, prefs.FlightTimeLatest)
+	// #473: split the time-of-day window into a SOFT window plus a hard-floor
+	// tolerance. Flights just outside the window are KEPT (near-misses) rather
+	// than silently dropped; only flights beyond the tolerance are removed. The
+	// near-misses are down-ranked by the scoring factor
+	// FactorTimeHardFloorCompliance, so the honest set is surfaced without a
+	// synthetic provider status muddying the raw provider counts.
+	kept, _, _ := FilterFlightsByTimeWindow(
+		result.Flights, prefs.FlightTimeEarliest, prefs.FlightTimeLatest, prefs.FlightTimeHardFloor)
+	result.Flights = kept
 	result.Flights = AdjustBagAllowance(result.Flights, prefs.FrequentFlyerPrograms)
 
 	// #469: inject concrete, bookable hack-derived candidates (e.g. rail+fly

--- a/internal/flights/providers_concurrent.go
+++ b/internal/flights/providers_concurrent.go
@@ -133,7 +133,7 @@ func runWizzairProvider(ctx context.Context, client *batchexec.Client, origin, d
 		slog.Warn("wizzair flight search failed", "origin", origin, "destination", destination, "date", date, "error", err)
 		// wizzairFailureStatus renders a typed, actionable status; a 404
 		// version-rotation gets a WIZZ_VERSION_ROTATED fix hint.
-		return providerOutcome{err: err, status: wizzairFailureStatus(err)}
+		return providerOutcome{err: err, status: wizzairFailureStatus(opts.wizzBaseHost(), err)}
 	}
 	return providerOutcome{flights: flights, succeeded: true, status: models.ProviderStatus{
 		ID:      "wizzair",

--- a/internal/flights/roundtrip.go
+++ b/internal/flights/roundtrip.go
@@ -143,7 +143,13 @@ func searchRoundTripComposed(ctx context.Context, client *batchexec.Client, orig
 		merged = append(merged, composed...)
 		sortFlightResults(merged, opts.SortBy)
 		if len(merged) > roundTripMaxResults {
-			merged = merged[:roundTripMaxResults]
+			// #472: window-aware truncation — keep the cheapest window-compliant
+			// native round-trip even if it falls beyond the price cutoff, so the
+			// post-search time-window filter still has a compliant native fare to
+			// surface instead of falling back to composed multi-stops. When no
+			// departure-time window is requested at the search layer this is a
+			// plain cheapest-max truncation.
+			merged = retainCompliantNativeRoundTrip(merged, opts.DepartAfter, opts.DepartBefore, roundTripMaxResults)
 			truncated = true
 		}
 		composed = merged

--- a/internal/flights/roundtrip_native.go
+++ b/internal/flights/roundtrip_native.go
@@ -337,6 +337,55 @@ func searchAFKLMNativeRoundTrip(ctx context.Context, origin, destination, date, 
 	return native, []models.ProviderStatus{st}
 }
 
+// retainCompliantNativeRoundTrip truncates a merged round-trip candidate list
+// (already sorted cheapest-first by the caller) to at most max entries, but
+// guarantees the cheapest window-compliant native round-trip survives the cut
+// even when it would otherwise fall beyond the price cutoff.
+//
+// This addresses #472: the pre-filter truncation runs BEFORE the departure-time
+// window filter. When the cheapest native round-trips violate the window and the
+// only compliant native fare is pricier (beyond the cutoff), truncation discards
+// it, so the later window filter drops the cheap non-compliant fares and leaves
+// only composed multi-stops — the user loses the preferred-carrier product. By
+// retaining the cheapest compliant native fare here, that fare is still present
+// for the window filter to keep and rank.
+//
+// Compliance uses the same directional-departure window check as the post-search
+// filter (earliest/latest are "HH:MM"; an empty bound means no constraint on that
+// side). When the window is unset, no native fare is compliant, nothing is
+// truncated, or a compliant native fare already survives, this is a plain
+// cheapest-max truncation. The retained fare replaces the last (most expensive)
+// kept slot so the length is unchanged. The input slice is not mutated.
+func retainCompliantNativeRoundTrip(merged []models.FlightResult, earliest, latest string, max int) []models.FlightResult {
+	if max <= 0 || len(merged) <= max {
+		return merged
+	}
+	head := merged[:max]
+	if earliest == "" && latest == "" {
+		return head
+	}
+	for _, f := range head {
+		if isCompliantNativeRoundTrip(f, earliest, latest) {
+			return head // a compliant native fare already survives
+		}
+	}
+	for i := max; i < len(merged); i++ {
+		if isCompliantNativeRoundTrip(merged[i], earliest, latest) {
+			out := make([]models.FlightResult, max)
+			copy(out, head)
+			out[max-1] = merged[i] // swap into the last (cheapest-displaced) slot
+			return out
+		}
+	}
+	return head
+}
+
+// isCompliantNativeRoundTrip reports whether f is a genuine native round-trip
+// fare (FareRoundTrip) whose directional departures all fall inside the window.
+func isCompliantNativeRoundTrip(f models.FlightResult, earliest, latest string) bool {
+	return f.FareType == models.FareRoundTrip && directionalDeparturesInWindow(f, earliest, latest)
+}
+
 // nativeRoundTripCurrency picks the currency to normalise native round-trip fares
 // to, so they rank against the composed pairs in one currency: the caller's
 // explicit currency if set, else the currency the composed pairs are already in,

--- a/internal/flights/roundtrip_native.go
+++ b/internal/flights/roundtrip_native.go
@@ -347,8 +347,11 @@ func searchAFKLMNativeRoundTrip(ctx context.Context, origin, destination, date, 
 // filter (earliest/latest are "HH:MM"; an empty bound means no constraint on that
 // side). When the window is unset, no native fare is compliant, nothing is
 // truncated, or a compliant native fare already survives, this is a plain
-// cheapest-max truncation. The retained fare replaces the last (most expensive)
-// kept slot so the length is unchanged. The input slice is not mutated.
+// cheapest-max truncation. The retained fare displaces the most expensive kept
+// slot, then the kept slice is re-sorted cheapest-first so the returned list
+// stays in the same sorted order the caller (and downstream ranking/truncation)
+// expects — a raw swap into the last slot would otherwise leave the displaced
+// fare out of price order. The input slice is not mutated.
 func retainCompliantNativeRoundTrip(merged []models.FlightResult, earliest, latest string, max int) []models.FlightResult {
 	if max <= 0 || len(merged) <= max {
 		return merged
@@ -366,7 +369,10 @@ func retainCompliantNativeRoundTrip(merged []models.FlightResult, earliest, late
 		if isCompliantNativeRoundTrip(merged[i], earliest, latest) {
 			out := make([]models.FlightResult, max)
 			copy(out, head)
-			out[max-1] = merged[i] // swap into the last (cheapest-displaced) slot
+			out[max-1] = merged[i] // displace the most expensive kept slot
+			sort.SliceStable(out, func(a, b int) bool {
+				return compareFlightPrices(out[a].PriceForRanking(), out[b].PriceForRanking()) < 0
+			})
 			return out
 		}
 	}

--- a/internal/flights/roundtrip_native.go
+++ b/internal/flights/roundtrip_native.go
@@ -13,17 +13,6 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
-// afklmNewProvider is the constructor used to opportunistically include
-// AFKLM native round-trips in the default merge. It is overridden in tests
-// to inject a pre-configured provider (via NewProviderWithClient) without
-// depending on real credentials or network for credential resolution.
-var afklmNewProvider = afklm.NewProvider
-
-// afklmTestFlights is a test seam (prod code never sets it) allowing
-// deterministic injection of AFKLM results for testing default-merge
-// inclusion without cross-package client construction.
-var afklmTestFlights []models.FlightResult
-
 // searchNativeRoundTrip queries providers that price a return trip as a single
 // native fare (Skiplagged today) and returns only genuine round-trip itineraries
 // (FareRoundTrip, both legs present). It is rate-conscious: the composer has
@@ -271,8 +260,8 @@ func searchKiwiNativeRoundTrip(ctx context.Context, client *batchexec.Client, or
 // full both-leg round-trips when ReturnDate is supplied.
 func searchAFKLMNativeRoundTrip(ctx context.Context, origin, destination, date, returnDate string, opts SearchOptions) ([]models.FlightResult, []models.ProviderStatus) {
 	// test seam: synthetic results (used by unit tests for deterministic AFKLM merge coverage)
-	if len(afklmTestFlights) > 0 {
-		native := append([]models.FlightResult(nil), afklmTestFlights...)
+	if len(opts.afklmTestFlights) > 0 {
+		native := append([]models.FlightResult(nil), opts.afklmTestFlights...)
 		target := nativeRoundTripCurrency(opts, nil, nil)
 		normalizeFlightCurrencies(ctx, native, target, destinations.ConvertCurrency)
 		return native, []models.ProviderStatus{{
@@ -286,7 +275,11 @@ func searchAFKLMNativeRoundTrip(ctx context.Context, origin, destination, date, 
 		return nil, nil
 	}
 
-	p, err := afklmNewProvider()
+	newProvider := opts.afklmNewProvider
+	if newProvider == nil {
+		newProvider = afklm.NewProvider // production default
+	}
+	p, err := newProvider()
 	if errors.Is(err, afklm.ErrNoCredential) {
 		return nil, nil // silent, zero latency, zero user signal
 	}

--- a/internal/flights/roundtrip_retain_test.go
+++ b/internal/flights/roundtrip_retain_test.go
@@ -7,9 +7,13 @@ import (
 )
 
 func nativeRT(price float64, outDep, inDep string) models.FlightResult {
+	return nativeRTCur(price, "EUR", outDep, inDep)
+}
+
+func nativeRTCur(price float64, currency, outDep, inDep string) models.FlightResult {
 	return models.FlightResult{
 		Price:    price,
-		Currency: "EUR",
+		Currency: currency,
 		FareType: models.FareRoundTrip,
 		Legs: []models.FlightLeg{
 			{Direction: "outbound", DepartureTime: outDep},
@@ -19,43 +23,64 @@ func nativeRT(price float64, outDep, inDep string) models.FlightResult {
 }
 
 func composedRT(price float64, stops int) models.FlightResult {
+	return composedRTCur(price, "EUR", stops)
+}
+
+func composedRTCur(price float64, currency string, stops int) models.FlightResult {
 	return models.FlightResult{
 		Price:    price,
-		Currency: "EUR",
+		Currency: currency,
 		Stops:    stops,
 		FareType: models.FareSplitTickets,
 		Legs:     []models.FlightLeg{{Direction: "outbound", DepartureTime: "2026-07-21T08:00"}},
 	}
 }
 
+// assertPriceSorted fails the test if results is not cheapest-first per
+// compareFlightPrices/PriceForRanking — the invariant every caller of
+// retainCompliantNativeRoundTrip relies on, and the one #472's fixtures used
+// to violate silently (masking the order-corruption bug the sort now fixes).
+func assertPriceSorted(t *testing.T, label string, results []models.FlightResult) {
+	t.Helper()
+	for i := 1; i < len(results); i++ {
+		if compareFlightPrices(results[i-1].PriceForRanking(), results[i].PriceForRanking()) > 0 {
+			t.Errorf("%s: not price-sorted at index %d: %.0f before %.0f", label, i, results[i-1].PriceForRanking(), results[i].PriceForRanking())
+		}
+	}
+}
+
 // #472: the cheapest window-compliant native round-trip is retained through
 // truncation even when it is priced beyond the cutoff, displacing the most
-// expensive kept slot — so it survives for the later window filter.
+// expensive kept slot — so it survives for the later window filter. The
+// displaced-in fare must not corrupt the cheapest-first order of the result.
 func TestRetainCompliantNativeRoundTrip_RetainsBeyondCutoff(t *testing.T) {
 	merged := []models.FlightResult{
 		nativeRT(263, "2026-07-21T11:00", "2026-07-25T07:00"), // cheapest, return 07:00 -> non-compliant
 		nativeRT(274, "2026-07-21T09:45", "2026-07-25T07:00"), // non-compliant
 		composedRT(300, 2),
 		composedRT(310, 1),
-		nativeRT(290, "2026-07-21T10:15", "2026-07-25T13:55"), // compliant, but pricier -> beyond cutoff
+		nativeRT(340, "2026-07-21T10:15", "2026-07-25T13:55"), // compliant, priciest -> beyond cutoff
 	}
+	assertPriceSorted(t, "fixture", merged)
+
 	got := retainCompliantNativeRoundTrip(merged, "10:00", "", 4)
+	assertPriceSorted(t, "result", got)
 	if len(got) != 4 {
 		t.Fatalf("expected 4, got %d", len(got))
 	}
-	// The compliant €290 fare must be present despite being the 5th cheapest.
+	// The compliant €340 fare must be present despite being the 5th cheapest.
 	found := false
 	for _, f := range got {
-		if f.Price == 290 {
+		if f.Price == 340 {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("compliant native RT (290) was truncated away: %+v", got)
+		t.Errorf("compliant native RT (340) was truncated away: %+v", got)
 	}
 	// It should occupy the displaced last slot; the €310 composed leaves.
-	if got[3].Price != 290 {
-		t.Errorf("expected 290 in last slot, got %.0f", got[3].Price)
+	if got[3].Price != 340 {
+		t.Errorf("expected 340 in last slot, got %.0f", got[3].Price)
 	}
 }
 
@@ -67,7 +92,10 @@ func TestRetainCompliantNativeRoundTrip_AlreadyPresent(t *testing.T) {
 		composedRT(300, 2),
 		composedRT(310, 1),
 	}
+	assertPriceSorted(t, "fixture", merged)
+
 	got := retainCompliantNativeRoundTrip(merged, "10:00", "", 2)
+	assertPriceSorted(t, "result", got)
 	if len(got) != 2 || got[0].Price != 263 || got[1].Price != 300 {
 		t.Errorf("expected plain truncation [263,300], got %+v", got)
 	}
@@ -76,25 +104,102 @@ func TestRetainCompliantNativeRoundTrip_AlreadyPresent(t *testing.T) {
 // #472: with no departure-time window, retention is a plain cheapest-max cut.
 func TestRetainCompliantNativeRoundTrip_NoWindow(t *testing.T) {
 	merged := []models.FlightResult{
+		nativeRT(290, "2026-07-21T05:00", "2026-07-25T05:00"),
 		composedRT(300, 2),
 		composedRT(310, 1),
-		nativeRT(290, "2026-07-21T05:00", "2026-07-25T05:00"),
 	}
+	assertPriceSorted(t, "fixture", merged)
+
 	got := retainCompliantNativeRoundTrip(merged, "", "", 2)
-	if len(got) != 2 || got[0].Price != 300 || got[1].Price != 310 {
-		t.Errorf("no window: expected [300,310], got %+v", got)
+	assertPriceSorted(t, "result", got)
+	if len(got) != 2 || got[0].Price != 290 || got[1].Price != 300 {
+		t.Errorf("no window: expected [290,300], got %+v", got)
 	}
 }
 
 // #472: nothing to retain when no native fare is window-compliant -> plain cut.
+// The non-compliant native is priced above the cutoff (320) so the fixture
+// stays genuinely sorted while still exercising the "candidate exists beyond
+// the cut but fails the window check" path.
 func TestRetainCompliantNativeRoundTrip_NoneCompliant(t *testing.T) {
 	merged := []models.FlightResult{
 		composedRT(300, 2),
 		composedRT(310, 1),
-		nativeRT(290, "2026-07-21T11:00", "2026-07-25T07:00"), // return 07:00 -> non-compliant
+		nativeRT(320, "2026-07-21T11:00", "2026-07-25T07:00"), // return 07:00 -> non-compliant
 	}
+	assertPriceSorted(t, "fixture", merged)
+
 	got := retainCompliantNativeRoundTrip(merged, "10:00", "", 2)
+	assertPriceSorted(t, "result", got)
 	if len(got) != 2 || got[0].Price != 300 || got[1].Price != 310 {
 		t.Errorf("none compliant: expected plain [300,310], got %+v", got)
+	}
+}
+
+// #472 defect #4: every fixture above used EUR, so displacement/re-sort logic
+// could scramble a Price/Currency pairing (e.g. relabel a swapped-in fare with
+// the wrong currency) without any test catching it. This fare represents a
+// native round-trip that normalizeFlightCurrencies successfully converted to
+// the search's target currency before this function ever sees it — Price and
+// Currency must survive the displacement swap and the following re-sort as a
+// matched pair.
+func TestRetainCompliantNativeRoundTrip_MixedCurrencyConvertedFareKeepsPairing(t *testing.T) {
+	merged := []models.FlightResult{
+		nativeRT(263, "2026-07-21T11:00", "2026-07-25T07:00"), // non-compliant
+		nativeRT(274, "2026-07-21T09:45", "2026-07-25T07:00"), // non-compliant
+		composedRT(300, 2),
+		composedRT(310, 1),
+		// originally quoted ~370 USD; normalizeFlightCurrencies converted it to
+		// 340 EUR before merge — represented here as its post-conversion state.
+		nativeRTCur(340, "EUR", "2026-07-21T10:15", "2026-07-25T13:55"),
+	}
+	assertPriceSorted(t, "fixture", merged)
+
+	got := retainCompliantNativeRoundTrip(merged, "10:00", "", 4)
+	assertPriceSorted(t, "result", got)
+	if len(got) != 4 {
+		t.Fatalf("expected 4, got %d", len(got))
+	}
+	if got[3].Price != 340 || got[3].Currency != "EUR" {
+		t.Errorf("converted fare must keep its Price/Currency pairing, got price=%.0f currency=%q", got[3].Price, got[3].Currency)
+	}
+	for _, f := range got[:3] {
+		if f.Currency != "EUR" {
+			t.Errorf("unrelated entry (price=%.0f) picked up the wrong currency %q; displacement must not cross-contaminate", f.Price, f.Currency)
+		}
+	}
+}
+
+// #472 defect #4: normalizeFlightCurrencies leaves Price and Currency
+// untouched when conversion fails (documented fallback contract). This fare
+// simulates that failure — an unrecognised code that never got converted to
+// the search's target currency. retainCompliantNativeRoundTrip must carry it
+// through honestly: the numeric price must never be silently relabeled to a
+// different currency, and it must not bleed its currency onto neighbours.
+func TestRetainCompliantNativeRoundTrip_InconvertibleFareStaysHonest(t *testing.T) {
+	merged := []models.FlightResult{
+		nativeRT(263, "2026-07-21T11:00", "2026-07-25T07:00"), // non-compliant
+		nativeRT(274, "2026-07-21T09:45", "2026-07-25T07:00"), // non-compliant
+		composedRT(300, 2),
+		composedRT(310, 1),
+		// conversion to the target currency failed (unsupported/unknown code);
+		// Price and Currency were left exactly as quoted, per the documented
+		// fallback contract.
+		nativeRTCur(450, "XXX", "2026-07-21T10:15", "2026-07-25T13:55"),
+	}
+	assertPriceSorted(t, "fixture", merged)
+
+	got := retainCompliantNativeRoundTrip(merged, "10:00", "", 4)
+	assertPriceSorted(t, "result", got)
+	if len(got) != 4 {
+		t.Fatalf("expected 4, got %d", len(got))
+	}
+	if got[3].Price != 450 || got[3].Currency != "XXX" {
+		t.Errorf("inconvertible fare must keep its original price+currency untouched, got price=%.0f currency=%q", got[3].Price, got[3].Currency)
+	}
+	for _, f := range got[:3] {
+		if f.Currency != "EUR" {
+			t.Errorf("unrelated entry (price=%.0f) picked up the inconvertible currency %q; displacement must not cross-contaminate", f.Price, f.Currency)
+		}
 	}
 }

--- a/internal/flights/roundtrip_retain_test.go
+++ b/internal/flights/roundtrip_retain_test.go
@@ -1,0 +1,100 @@
+package flights
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func nativeRT(price float64, outDep, inDep string) models.FlightResult {
+	return models.FlightResult{
+		Price:    price,
+		Currency: "EUR",
+		FareType: models.FareRoundTrip,
+		Legs: []models.FlightLeg{
+			{Direction: "outbound", DepartureTime: outDep},
+			{Direction: "inbound", DepartureTime: inDep},
+		},
+	}
+}
+
+func composedRT(price float64, stops int) models.FlightResult {
+	return models.FlightResult{
+		Price:    price,
+		Currency: "EUR",
+		Stops:    stops,
+		FareType: models.FareSplitTickets,
+		Legs:     []models.FlightLeg{{Direction: "outbound", DepartureTime: "2026-07-21T08:00"}},
+	}
+}
+
+// #472: the cheapest window-compliant native round-trip is retained through
+// truncation even when it is priced beyond the cutoff, displacing the most
+// expensive kept slot — so it survives for the later window filter.
+func TestRetainCompliantNativeRoundTrip_RetainsBeyondCutoff(t *testing.T) {
+	merged := []models.FlightResult{
+		nativeRT(263, "2026-07-21T11:00", "2026-07-25T07:00"), // cheapest, return 07:00 -> non-compliant
+		nativeRT(274, "2026-07-21T09:45", "2026-07-25T07:00"), // non-compliant
+		composedRT(300, 2),
+		composedRT(310, 1),
+		nativeRT(290, "2026-07-21T10:15", "2026-07-25T13:55"), // compliant, but pricier -> beyond cutoff
+	}
+	got := retainCompliantNativeRoundTrip(merged, "10:00", "", 4)
+	if len(got) != 4 {
+		t.Fatalf("expected 4, got %d", len(got))
+	}
+	// The compliant €290 fare must be present despite being the 5th cheapest.
+	found := false
+	for _, f := range got {
+		if f.Price == 290 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("compliant native RT (290) was truncated away: %+v", got)
+	}
+	// It should occupy the displaced last slot; the €310 composed leaves.
+	if got[3].Price != 290 {
+		t.Errorf("expected 290 in last slot, got %.0f", got[3].Price)
+	}
+}
+
+// #472: when a compliant native round-trip already survives the cut, the list is
+// a plain cheapest-max truncation (no displacement).
+func TestRetainCompliantNativeRoundTrip_AlreadyPresent(t *testing.T) {
+	merged := []models.FlightResult{
+		nativeRT(263, "2026-07-21T11:00", "2026-07-25T12:00"), // compliant, cheapest
+		composedRT(300, 2),
+		composedRT(310, 1),
+	}
+	got := retainCompliantNativeRoundTrip(merged, "10:00", "", 2)
+	if len(got) != 2 || got[0].Price != 263 || got[1].Price != 300 {
+		t.Errorf("expected plain truncation [263,300], got %+v", got)
+	}
+}
+
+// #472: with no departure-time window, retention is a plain cheapest-max cut.
+func TestRetainCompliantNativeRoundTrip_NoWindow(t *testing.T) {
+	merged := []models.FlightResult{
+		composedRT(300, 2),
+		composedRT(310, 1),
+		nativeRT(290, "2026-07-21T05:00", "2026-07-25T05:00"),
+	}
+	got := retainCompliantNativeRoundTrip(merged, "", "", 2)
+	if len(got) != 2 || got[0].Price != 300 || got[1].Price != 310 {
+		t.Errorf("no window: expected [300,310], got %+v", got)
+	}
+}
+
+// #472: nothing to retain when no native fare is window-compliant -> plain cut.
+func TestRetainCompliantNativeRoundTrip_NoneCompliant(t *testing.T) {
+	merged := []models.FlightResult{
+		composedRT(300, 2),
+		composedRT(310, 1),
+		nativeRT(290, "2026-07-21T11:00", "2026-07-25T07:00"), // return 07:00 -> non-compliant
+	}
+	got := retainCompliantNativeRoundTrip(merged, "10:00", "", 2)
+	if len(got) != 2 || got[0].Price != 300 || got[1].Price != 310 {
+		t.Errorf("none compliant: expected plain [300,310], got %+v", got)
+	}
+}

--- a/internal/flights/roundtrip_test.go
+++ b/internal/flights/roundtrip_test.go
@@ -392,7 +392,8 @@ func TestComposedProviderLabel(t *testing.T) {
 
 // --- AFKLM opportunistic in default RT merge (credential = enable) + no-cred silent + tag correctness ---
 
-// (var afklmTestFlights lives in roundtrip.go as package-level seam)
+// (AFKLM constructor + synthetic-flight seams are injected via SearchOptions:
+// opts.afklmNewProvider / opts.afklmTestFlights — no package-level globals)
 
 func TestSearchRoundTrip_DefaultMerge_IncludesAFKLMWhenCredential(t *testing.T) {
 	sample := models.FlightResult{
@@ -402,21 +403,17 @@ func TestSearchRoundTrip_DefaultMerge_IncludesAFKLMWhenCredential(t *testing.T) 
 			{DepartureAirport: models.AirportInfo{Code: "PRG"}, ArrivalAirport: models.AirportInfo{Code: "AMS"}, DepartureTime: "2026-05-22T20:55", Direction: "inbound"},
 		},
 	}
-	origF := afklmTestFlights
-	afklmTestFlights = []models.FlightResult{sample}
-	defer func() { afklmTestFlights = origF }()
-
-	// stub NewProvider too (seam takes precedence inside search func)
-	origNew := afklmNewProvider
-	afklmNewProvider = func() (*afklm.AFKLMProvider, error) { return nil, nil }
-	defer func() { afklmNewProvider = origNew }()
-
 	body := makeTestFlightBody(t)
 	ts := makeTestFlightServer(t, 200, body)
 	defer ts.Close()
 	bx := batchexec.NewTestClient(ts.URL)
 
-	res, err := SearchFlightsWithClient(context.Background(), bx, "AMS", "PRG", "2026-05-15", SearchOptions{ReturnDate: "2026-05-22"})
+	res, err := SearchFlightsWithClient(context.Background(), bx, "AMS", "PRG", "2026-05-15", SearchOptions{
+		ReturnDate:       "2026-05-22",
+		afklmTestFlights: []models.FlightResult{sample},
+		// stub NewProvider too (seam takes precedence inside search func)
+		afklmNewProvider: func() (*afklm.AFKLMProvider, error) { return nil, nil },
+	})
 	if err != nil {
 		t.Fatalf("default RT must succeed: %v", err)
 	}
@@ -433,20 +430,15 @@ func TestSearchRoundTrip_DefaultMerge_IncludesAFKLMWhenCredential(t *testing.T) 
 }
 
 func TestSearchRoundTrip_DefaultMerge_SilentSkipNoCredential(t *testing.T) {
-	origNew := afklmNewProvider
-	afklmNewProvider = func() (*afklm.AFKLMProvider, error) { return nil, afklm.ErrNoCredential }
-	defer func() { afklmNewProvider = origNew }()
-
-	origF := afklmTestFlights
-	afklmTestFlights = nil
-	defer func() { afklmTestFlights = origF }()
-
 	body := makeTestFlightBody(t)
 	ts := makeTestFlightServer(t, 200, body)
 	defer ts.Close()
 	bx := batchexec.NewTestClient(ts.URL)
 
-	res, err := SearchFlightsWithClient(context.Background(), bx, "HEL", "NRT", "2026-06-15", SearchOptions{ReturnDate: "2026-06-22"})
+	res, err := SearchFlightsWithClient(context.Background(), bx, "HEL", "NRT", "2026-06-15", SearchOptions{
+		ReturnDate:       "2026-06-22",
+		afklmNewProvider: func() (*afklm.AFKLMProvider, error) { return nil, afklm.ErrNoCredential },
+	})
 	if err != nil {
 		t.Fatalf("no-cred must not fail the merge: %v", err)
 	}
@@ -485,15 +477,9 @@ func TestSearchRoundTrip_DefaultMerge_SilentSkipDailyQuota(t *testing.T) {
 
 	p := afklm.NewProviderWithClient(cli)
 
-	origNew := afklmNewProvider
-	afklmNewProvider = func() (*afklm.AFKLMProvider, error) { return p, nil }
-	defer func() { afklmNewProvider = origNew }()
-
-	origF := afklmTestFlights
-	afklmTestFlights = nil
-	defer func() { afklmTestFlights = origF }()
-
-	flights, statuses := searchAFKLMNativeRoundTrip(context.Background(), "AMS", "PRG", "2026-08-01", "2026-08-08", SearchOptions{})
+	flights, statuses := searchAFKLMNativeRoundTrip(context.Background(), "AMS", "PRG", "2026-08-01", "2026-08-08", SearchOptions{
+		afklmNewProvider: func() (*afklm.AFKLMProvider, error) { return p, nil },
+	})
 	if flights != nil || statuses != nil {
 		t.Errorf("searchAFKLMNativeRoundTrip must return nil,nil on daily quota (like ErrNoCredential); got %d/%d", len(flights), len(statuses))
 	}
@@ -504,27 +490,22 @@ func TestSearchRoundTrip_DefaultMerge_SilentSkipDailyQuota(t *testing.T) {
 // fans multiple origins, AFKLM default-merge path issues at most 1 seam call
 // (hence at most 1 query) thanks to the primary-only + seam-suppression logic.
 func TestSearchMultiAirport_Spread_AFKLMAtMostOnePerLogicalSearch(t *testing.T) {
-	origNew := afklmNewProvider
-	defer func() { afklmNewProvider = origNew }()
-
 	var calls int32
-	afklmNewProvider = func() (*afklm.AFKLMProvider, error) {
-		atomic.AddInt32(&calls, 1)
-		// Return non-NoCredential err so searchAFKLM skips without calling SearchFlights on a nil p
-		// and without network.
-		return nil, fmt.Errorf("afklm test: no real call")
-	}
-
-	origF := afklmTestFlights
-	afklmTestFlights = nil
-	defer func() { afklmTestFlights = origF }()
 
 	// RT + multiple origins exercises the spread + primary AFKLM restriction.
 	// Other providers fan normally; AFKLM must not.
 	// Use short ctx so parallel sub-searches (google etc) fail fast instead of hanging on net.
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
-	opts := SearchOptions{ReturnDate: "2026-07-10"}
+	opts := SearchOptions{
+		ReturnDate: "2026-07-10",
+		afklmNewProvider: func() (*afklm.AFKLMProvider, error) {
+			atomic.AddInt32(&calls, 1)
+			// Return non-NoCredential err so searchAFKLM skips without calling SearchFlights on a nil p
+			// and without network.
+			return nil, fmt.Errorf("afklm test: no real call")
+		},
+	}
 	_, err := SearchMultiAirport(ctx, []string{"HEL", "AMS"}, []string{"BCN"}, "2026-07-01", opts)
 	if err != nil {
 		// SearchMultiAirport itself does not error on provider failures (they are silent-skipped).
@@ -548,21 +529,18 @@ func TestSearchMultiAirport_Spread_AFKLMAtMostOnePerLogicalSearch(t *testing.T) 
 // primary pair) even under concurrency — fanout subs stay suppressed. With N
 // concurrent SearchMultiAirport calls the seam count must equal N, not N×combos.
 func TestSearchMultiAirport_ConcurrentRoundTrips_NoDataRace(t *testing.T) {
-	origNew := afklmNewProvider
-	defer func() { afklmNewProvider = origNew }()
 	var seamCalls int32
-	// Non-network stub so the primary AFKLM read resolves without credentials/net.
-	afklmNewProvider = func() (*afklm.AFKLMProvider, error) {
-		atomic.AddInt32(&seamCalls, 1)
-		return nil, afklm.ErrNoCredential
-	}
-	origF := afklmTestFlights
-	afklmTestFlights = nil
-	defer func() { afklmTestFlights = origF }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
-	opts := SearchOptions{ReturnDate: "2026-07-10"}
+	opts := SearchOptions{
+		ReturnDate: "2026-07-10",
+		// Non-network stub so the primary AFKLM read resolves without credentials/net.
+		afklmNewProvider: func() (*afklm.AFKLMProvider, error) {
+			atomic.AddInt32(&seamCalls, 1)
+			return nil, afklm.ErrNoCredential
+		},
+	}
 
 	const n = 4
 	var wg sync.WaitGroup

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -16,6 +16,7 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/cache"
 	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/fareintel"
+	"github.com/MikkoParkkola/trvl/internal/flights/afklm"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/searchctx"
 	"golang.org/x/sync/singleflight"
@@ -97,6 +98,24 @@ type SearchOptions struct {
 	// mutated package global (which raced under concurrent SearchMultiAirport
 	// calls). Unexported: internal fanout control, not a user-facing knob.
 	suppressAFKLM bool
+
+	// Dependency-injection seams (unexported: test-only wiring, not user knobs).
+	// They replace the mutable package-level globals that tests previously
+	// swapped in place — swapping a shared global races the moment two searches
+	// run concurrently (the exact class of bug PR #476/#477 fixed for AFKLM).
+	// Threading them through the per-call SearchOptions gives each search its own
+	// isolated wiring, so there is no shared mutable provider seam left to race.
+	//
+	// afklmNewProvider overrides the AFKLM constructor used by the native
+	// round-trip merge; nil falls back to afklm.NewProvider (production default).
+	afklmNewProvider func() (*afklm.AFKLMProvider, error)
+	// afklmTestFlights injects synthetic AFKLM round-trip results so the
+	// default-merge inclusion can be exercised without a real client or network.
+	afklmTestFlights []models.FlightResult
+	// wizzHost / transaviaHost override the provider base URL (tests point them
+	// at an httptest server). Empty means the real production host.
+	wizzHost      string
+	transaviaHost string
 }
 
 // defaults fills in zero-value fields with sensible defaults.

--- a/internal/flights/search.go
+++ b/internal/flights/search.go
@@ -97,7 +97,24 @@ type SearchOptions struct {
 	// mutated package global (which raced under concurrent SearchMultiAirport
 	// calls). Unexported: internal fanout control, not a user-facing knob.
 	suppressAFKLM bool
+
+	// SearchOverride replaces the real flight search for this single call.
+	// Nil (the default) runs the production search. This is the same
+	// dependency-injection pattern used for the AFKLM/Wizz Air/Transavia
+	// seams above (see commit "inject provider and host seams through
+	// SearchOptions"), extended to the top-level search entry point so
+	// callers in OTHER packages — today internal/hacks' positioning and
+	// open-jaw detectors — can inject synthetic results for tests without
+	// mutating a shared package-level function variable. Each call carries
+	// its own override value, so concurrent detector/test calls never race
+	// on shared mutable state the way the old package-level var did.
+	SearchOverride SearchFunc
 }
+
+// SearchFunc matches the signature of SearchFlights. It is the type of
+// SearchOptions.SearchOverride and lets external packages inject a
+// replacement search implementation per call.
+type SearchFunc func(ctx context.Context, origin, destination, date string, opts SearchOptions) (*models.FlightSearchResult, error)
 
 // defaults fills in zero-value fields with sensible defaults.
 func (o *SearchOptions) defaults() {
@@ -153,6 +170,14 @@ func canonicalStringSlice(values []string) string {
 // SearchFlightsWithClient is like SearchFlights but accepts a pre-built client,
 // useful for reusing connections across multiple requests.
 func SearchFlightsWithClient(ctx context.Context, client *batchexec.Client, origin, destination, date string, opts SearchOptions) (*models.FlightSearchResult, error) {
+	// A per-call override takes over entirely, bypassing validation, caching,
+	// and every provider — the same contract the old package-level function
+	// variables in internal/hacks gave test callers, but carried as ordinary
+	// call data instead of shared mutable state. See SearchOptions.SearchOverride.
+	if opts.SearchOverride != nil {
+		return opts.SearchOverride(ctx, origin, destination, date, opts)
+	}
+
 	opts.defaults()
 
 	if origin == "" || destination == "" || date == "" {

--- a/internal/flights/transavia.go
+++ b/internal/flights/transavia.go
@@ -42,8 +42,19 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// transaviaHost is overridable in tests (httptest server).
-var transaviaHost = "https" + "://" + "api.transavia.com"
+// transaviaDefaultHost is the production base URL. Tests override it per-call
+// via SearchOptions.transaviaHost (see (SearchOptions).transaviaBaseHost),
+// rather than swapping a shared package global that would race across searches.
+const transaviaDefaultHost = "https" + "://" + "api.transavia.com"
+
+// transaviaBaseHost returns the Transavia base URL for this search: the per-call
+// test override when set, else the production host.
+func (o SearchOptions) transaviaBaseHost() string {
+	if o.transaviaHost != "" {
+		return o.transaviaHost
+	}
+	return transaviaDefaultHost
+}
 
 var (
 	transaviaLimiter = rate.NewLimiter(rate.Every(500*time.Millisecond), 1)
@@ -124,7 +135,7 @@ func SearchTransavia(ctx context.Context, origin, destination, date, currency st
 	q.Set("originDepartureDate", depDate)
 	q.Set("adultCount", fmt.Sprintf("%d", max(opts.Adults, 1)))
 	q.Set("directFlight", "true")
-	reqURL := transaviaHost + "/v1/flightoffers/?" + q.Encode()
+	reqURL := opts.transaviaBaseHost() + "/v1/flightoffers/?" + q.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {

--- a/internal/flights/transavia_test.go
+++ b/internal/flights/transavia_test.go
@@ -36,11 +36,8 @@ func TestSearchTransavia_MapsOffers(t *testing.T) {
 	defer srv.Close()
 
 	t.Setenv("TRANSAVIA_API_KEY", "test-key")
-	orig := transaviaHost
-	transaviaHost = srv.URL
-	defer func() { transaviaHost = orig }()
 
-	out, err := SearchTransavia(context.Background(), "AMS", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	out, err := SearchTransavia(context.Background(), "AMS", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1, transaviaHost: srv.URL})
 	if err != nil {
 		t.Fatalf("SearchTransavia error: %v", err)
 	}
@@ -90,11 +87,8 @@ func TestSearchTransavia_Unauthorized(t *testing.T) {
 	defer srv.Close()
 
 	t.Setenv("TRANSAVIA_API_KEY", "bad-key")
-	orig := transaviaHost
-	transaviaHost = srv.URL
-	defer func() { transaviaHost = orig }()
 
-	_, err := SearchTransavia(context.Background(), "AMS", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	_, err := SearchTransavia(context.Background(), "AMS", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1, transaviaHost: srv.URL})
 	if err == nil {
 		t.Fatal("want error on 401, got nil")
 	}

--- a/internal/flights/wizzair.go
+++ b/internal/flights/wizzair.go
@@ -112,8 +112,19 @@ const wizzDefaultVersion = "29.4.0"
 // WIZZAIR_API_VERSION takes precedence at request time via wizzResolvedVersion.
 var wizzVersion = wizzDefaultVersion
 
-// wizzHost is overridable in tests (httptest server).
-var wizzHost = "https" + "://" + "be.wizzair.com"
+// wizzDefaultHost is the production base URL. Tests override it per-call via
+// SearchOptions.wizzHost (see (SearchOptions).wizzBaseHost), rather than
+// swapping a shared package global that would race across concurrent searches.
+const wizzDefaultHost = "https" + "://" + "be.wizzair.com"
+
+// wizzBaseHost returns the Wizz base URL for this search: the per-call test
+// override when set, else the production host.
+func (o SearchOptions) wizzBaseHost() string {
+	if o.wizzHost != "" {
+		return o.wizzHost
+	}
+	return wizzDefaultHost
+}
 
 var (
 	wizzLimiter = rate.NewLimiter(rate.Every(500*time.Millisecond), 1)
@@ -131,8 +142,8 @@ func wizzResolvedVersion() string {
 	return wizzVersion
 }
 
-func wizzTimetableURL() string {
-	return wizzHost + "/" + wizzResolvedVersion() + "/Api/search/timetable"
+func wizzTimetableURL(host string) string {
+	return host + "/" + wizzResolvedVersion() + "/Api/search/timetable"
 }
 
 type wizzFlightLeg struct {
@@ -225,8 +236,9 @@ func SearchWizzair(ctx context.Context, origin, destination, date, currency stri
 	if currency == "" {
 		currency = "EUR"
 	}
+	host := opts.wizzBaseHost()
 	// Adopt a previously-healed version (if any) before the first request.
-	wizzMaybeLoadCache()
+	wizzMaybeLoadCache(host)
 	if err := wizzLimiter.Wait(ctx); err != nil {
 		return nil, err
 	}
@@ -253,15 +265,15 @@ func SearchWizzair(ctx context.Context, origin, destination, date, currency stri
 	// past an already-working version (we'd otherwise treat the healed version as
 	// the stale one and probe its successors).
 	used := wizzResolvedVersion()
-	results, err := wizzSearchOnce(ctx, payload, date, currency)
+	results, err := wizzSearchOnce(ctx, host, payload, date, currency)
 	// Self-heal on a version rotation: discover the new version, swap it in, and
 	// retry once. The retry IS the end-to-end verification — it only succeeds if
 	// the discovered version actually serves a priced timetable response.
 	if errors.Is(err, ErrWizzVersionRotated) && wizzHealEnabled() {
-		if newV, ok := wizzHeal(ctx, used); ok && newV != used {
+		if newV, ok := wizzHeal(ctx, host, used); ok && newV != used {
 			slog.Warn("wizzair self-healed API version after rotation", "from", used, "to", newV)
 			if werr := wizzLimiter.Wait(ctx); werr == nil {
-				results, err = wizzSearchOnce(ctx, payload, date, currency)
+				results, err = wizzSearchOnce(ctx, host, payload, date, currency)
 			}
 		}
 	}
@@ -271,8 +283,8 @@ func SearchWizzair(ctx context.Context, origin, destination, date, currency stri
 // wizzSearchOnce performs one timetable request at the currently-resolved
 // version and maps the response. A rotated version surfaces as
 // ErrWizzVersionRotated (404) for the caller to optionally heal and retry.
-func wizzSearchOnce(ctx context.Context, payload []byte, date, currency string) ([]models.FlightResult, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, wizzTimetableURL(), bytes.NewReader(payload))
+func wizzSearchOnce(ctx context.Context, host string, payload []byte, date, currency string) ([]models.FlightResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, wizzTimetableURL(host), bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("wizzair: build request: %w", err)
 	}

--- a/internal/flights/wizzair.go
+++ b/internal/flights/wizzair.go
@@ -131,19 +131,25 @@ var (
 	wizzClient  = &http.Client{Timeout: 25 * time.Second}
 )
 
-// wizzResolvedVersion returns the API version to use, preferring the env
-// override so operators can react to a rotation without a redeploy.
-func wizzResolvedVersion() string {
+// wizzResolvedVersion returns the API version to use for host, preferring the
+// env override so operators can react to a rotation without a redeploy. The
+// version is scoped by host: the production host (wizzDefaultHost) reads the
+// shared wizzVersion global (self-healed and persisted across restarts); any
+// other host (a per-call SearchOptions.wizzHost override) reads its own healed
+// entry when one exists, else falls back to wizzVersion as the starting point —
+// so a heal against that host can never be observed by, or overwrite, a
+// concurrent search against a different host.
+func wizzResolvedVersion(host string) string {
 	if v := strings.TrimSpace(os.Getenv("WIZZAIR_API_VERSION")); v != "" {
 		return v
 	}
 	wizzVersionMu.RLock()
 	defer wizzVersionMu.RUnlock()
-	return wizzVersion
+	return wizzLockedVersion(host)
 }
 
 func wizzTimetableURL(host string) string {
-	return host + "/" + wizzResolvedVersion() + "/Api/search/timetable"
+	return host + "/" + wizzResolvedVersion(host) + "/Api/search/timetable"
 }
 
 type wizzFlightLeg struct {
@@ -200,9 +206,9 @@ type wizzValidationError struct {
 //
 // The (bounded, whitespace-collapsed) body is echoed into the message so an
 // operator can see exactly what Wizz said without re-running with a capture.
-func classifyWizzStatus(status int, body []byte) error {
+func classifyWizzStatus(host string, status int, body []byte) error {
 	if status == http.StatusNotFound {
-		return fmt.Errorf("wizzair: tried API version %q: %w", wizzResolvedVersion(), ErrWizzVersionRotated)
+		return fmt.Errorf("wizzair: tried API version %q: %w", wizzResolvedVersion(host), ErrWizzVersionRotated)
 	}
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) > 0 && trimmed[0] == '{' {
@@ -264,7 +270,7 @@ func SearchWizzair(ctx context.Context, origin, destination, date, currency stri
 	// concurrent heal between the failure and the heal call can't make us walk
 	// past an already-working version (we'd otherwise treat the healed version as
 	// the stale one and probe its successors).
-	used := wizzResolvedVersion()
+	used := wizzResolvedVersion(host)
 	results, err := wizzSearchOnce(ctx, host, payload, date, currency)
 	// Self-heal on a version rotation: discover the new version, swap it in, and
 	// retry once. The retry IS the end-to-end verification — it only succeeds if
@@ -306,7 +312,7 @@ func wizzSearchOnce(ctx context.Context, host string, payload []byte, date, curr
 		// bot-walls (non-JSON 4xx). The search continues and returns other
 		// providers' results regardless of which typed error we surface here.
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
-		return nil, classifyWizzStatus(resp.StatusCode, errBody)
+		return nil, classifyWizzStatus(host, resp.StatusCode, errBody)
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
 	if err != nil {
@@ -390,14 +396,17 @@ func wizzDisplayTime(s string) string {
 	return s
 }
 
-// wizzairFailureStatus maps a SearchWizzair error to a typed ProviderStatus.
-// A version-rotation 404 (ErrWizzVersionRotated) renders an actionable status
-// carrying a typed FixHintCode and a hint naming the WIZZAIR_API_VERSION env
-// override plus the last-known-good version, so an operator or orchestrating LLM
-// can restore the provider without a code change. All other errors fall through
-// to the standard classification (timeout vs failed). This helper is pure so it
-// can be unit-tested offline, independent of the live aggregate search.
-func wizzairFailureStatus(err error) models.ProviderStatus {
+// wizzairFailureStatus maps a SearchWizzair error to a typed ProviderStatus. The
+// host names which base URL this attempt used, so the version echoed in the
+// rotation fix hint reflects that host's own resolved version rather than
+// another concurrent search's. A version-rotation 404 (ErrWizzVersionRotated)
+// renders an actionable status carrying a typed FixHintCode and a hint naming
+// the WIZZAIR_API_VERSION env override plus the last-known-good version, so an
+// operator or orchestrating LLM can restore the provider without a code change.
+// All other errors fall through to the standard classification (timeout vs
+// failed). This helper is pure so it can be unit-tested offline, independent of
+// the live aggregate search.
+func wizzairFailureStatus(host string, err error) models.ProviderStatus {
 	st := models.ProviderStatus{
 		ID:     "wizzair",
 		Name:   "Wizz Air",
@@ -408,7 +417,7 @@ func wizzairFailureStatus(err error) models.ProviderStatus {
 		st.FixHintCode = "WIZZ_VERSION_ROTATED"
 		st.FixHint = fmt.Sprintf(
 			"Wizz API version path rotated; set WIZZAIR_API_VERSION=<current> to restore (tried %q; last-known-good: %s)",
-			wizzResolvedVersion(), wizzDefaultVersion,
+			wizzResolvedVersion(host), wizzDefaultVersion,
 		)
 	}
 	if errors.Is(err, ErrWizzBlocked) {

--- a/internal/flights/wizzair_probe_test.go
+++ b/internal/flights/wizzair_probe_test.go
@@ -36,7 +36,7 @@ func TestWizzairProbe(t *testing.T) {
 		// reports the actionable status rather than red-flagging a transport bug.
 		switch {
 		case errors.Is(err, ErrWizzVersionRotated):
-			st := wizzairFailureStatus(err)
+			st := wizzairFailureStatus(wizzDefaultHost, err)
 			t.Logf("Wizz API version rotated (expected, actionable): code=%s hint=%q",
 				st.FixHintCode, st.FixHint)
 			if st.FixHintCode != "WIZZ_VERSION_ROTATED" {
@@ -44,7 +44,7 @@ func TestWizzairProbe(t *testing.T) {
 			}
 			return
 		case errors.Is(err, ErrWizzBlocked):
-			st := wizzairFailureStatus(err)
+			st := wizzairFailureStatus(wizzDefaultHost, err)
 			t.Logf("Wizz edge-blocked this IP (expected from datacenter/CI; honest typed status): code=%s hint=%q err=%v",
 				st.FixHintCode, st.FixHint, err)
 			if st.FixHintCode != "WIZZ_BLOCKED" {
@@ -52,7 +52,7 @@ func TestWizzairProbe(t *testing.T) {
 			}
 			return
 		case errors.Is(err, ErrWizzRejected):
-			st := wizzairFailureStatus(err)
+			st := wizzairFailureStatus(wizzDefaultHost, err)
 			t.Logf("Wizz declined the route (validationCodes; honest typed status): code=%s hint=%q err=%v",
 				st.FixHintCode, st.FixHint, err)
 			if st.FixHintCode != "WIZZ_MARKET_REJECTED" {

--- a/internal/flights/wizzair_selfheal.go
+++ b/internal/flights/wizzair_selfheal.go
@@ -44,9 +44,17 @@ const wizzBrowserUA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537
 
 var (
 	// wizzVersionMu guards concurrent reads (wizzResolvedVersion) and heal-time
-	// writes of wizzVersion, so the aggregate's parallel provider goroutines stay
-	// race-free under -race.
+	// writes of wizzVersion and wizzHostVersions, so the aggregate's parallel
+	// provider goroutines stay race-free under -race.
 	wizzVersionMu sync.RWMutex
+	// wizzHostVersions holds healed versions for non-production host overrides
+	// (tests, or any explicit SearchOptions.wizzHost), keyed by host. A heal
+	// against a non-production host writes here instead of the shared
+	// wizzVersion global, so a search against one host can never heal-and-force
+	// its discovered version onto a concurrent search against a different host.
+	// The production host (wizzDefaultHost) always uses wizzVersion directly, so
+	// production behaviour and on-disk persistence are unaffected.
+	wizzHostVersions map[string]string
 	// wizzHealCacheOnce loads the on-disk cached version exactly once per process.
 	wizzHealCacheOnce sync.Once
 	// wizzHealLimiter throttles discovery probes so a rotation can't burst the edge.
@@ -148,21 +156,54 @@ func wizzVersionNewer(a, b string) bool {
 // caller arriving after another goroutine already healed gets the new version.
 // Returns ("", false) when no candidate in range is live (caller keeps the typed
 // rotation error — graceful degradation preserved).
+//
+// The healed version is scoped to host: a production-host (wizzDefaultHost) heal
+// updates the shared wizzVersion global and persists to disk, exactly as before.
+// A heal against any other host (a per-call SearchOptions.wizzHost override) only
+// ever writes wizzHostVersions[host] — it can never mutate the global, so a
+// concurrent search against a different host (production or another override)
+// cannot be healed onto a version that was only verified live against this one.
 func wizzHeal(ctx context.Context, host, stale string) (string, bool) {
 	wizzVersionMu.Lock()
 	defer wizzVersionMu.Unlock()
-	if wizzVersion != stale {
-		return wizzVersion, true // another goroutine already healed
+	if cur := wizzLockedVersion(host); cur != stale {
+		return cur, true // another goroutine already healed
 	}
 	for _, c := range wizzNextCandidates(stale) {
 		_ = wizzHealLimiter.Wait(ctx)
 		if wizzProbeVersion(ctx, host, c) == "live" {
-			wizzVersion = c
-			wizzPersistVersion(host, c)
+			wizzSetLockedVersion(host, c)
 			return c, true
 		}
 	}
 	return "", false
+}
+
+// wizzLockedVersion returns the currently-known version for host. Callers must
+// hold wizzVersionMu (read or write lock).
+func wizzLockedVersion(host string) string {
+	if !wizzRealHost(host) {
+		if v, ok := wizzHostVersions[host]; ok {
+			return v
+		}
+	}
+	return wizzVersion
+}
+
+// wizzSetLockedVersion records a newly-healed version for host. Callers must
+// hold wizzVersionMu for writing. Only the production host updates the shared
+// global and on-disk cache; any other host is scoped to wizzHostVersions so it
+// can never leak into production or into a different host override.
+func wizzSetLockedVersion(host, v string) {
+	if wizzRealHost(host) {
+		wizzVersion = v
+		wizzPersistVersion(host, v)
+		return
+	}
+	if wizzHostVersions == nil {
+		wizzHostVersions = make(map[string]string)
+	}
+	wizzHostVersions[host] = v
 }
 
 type wizzVersionCache struct {

--- a/internal/flights/wizzair_selfheal.go
+++ b/internal/flights/wizzair_selfheal.go
@@ -63,15 +63,15 @@ func wizzHealEnabled() bool {
 	return os.Getenv("WIZZAIR_NO_AUTOHEAL") != "1"
 }
 
-// wizzRealHost reports whether requests target the real Wizz host (not an
-// httptest server). Cache load/persist only happen against the real host so unit
-// tests stay hermetic.
-func wizzRealHost() bool { return wizzHost == "https"+"://"+"be.wizzair.com" }
+// wizzRealHost reports whether host targets the real Wizz host (not an httptest
+// server). Cache load/persist only happen against the real host so unit tests
+// stay hermetic.
+func wizzRealHost(host string) bool { return host == wizzDefaultHost }
 
 // wizzProbeVersion classifies a version path via the asset/culture oracle:
 // "absent" (404), "live" (200/405), or "inconclusive" (transient/edge/transport).
-func wizzProbeVersion(ctx context.Context, v string) string {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wizzHost+"/"+v+"/Api/asset/culture", nil)
+func wizzProbeVersion(ctx context.Context, host, v string) string {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, host+"/"+v+"/Api/asset/culture", nil)
 	if err != nil {
 		return "inconclusive"
 	}
@@ -148,7 +148,7 @@ func wizzVersionNewer(a, b string) bool {
 // caller arriving after another goroutine already healed gets the new version.
 // Returns ("", false) when no candidate in range is live (caller keeps the typed
 // rotation error — graceful degradation preserved).
-func wizzHeal(ctx context.Context, stale string) (string, bool) {
+func wizzHeal(ctx context.Context, host, stale string) (string, bool) {
 	wizzVersionMu.Lock()
 	defer wizzVersionMu.Unlock()
 	if wizzVersion != stale {
@@ -156,9 +156,9 @@ func wizzHeal(ctx context.Context, stale string) (string, bool) {
 	}
 	for _, c := range wizzNextCandidates(stale) {
 		_ = wizzHealLimiter.Wait(ctx)
-		if wizzProbeVersion(ctx, c) == "live" {
+		if wizzProbeVersion(ctx, host, c) == "live" {
 			wizzVersion = c
-			wizzPersistVersion(c)
+			wizzPersistVersion(host, c)
 			return c, true
 		}
 	}
@@ -181,8 +181,8 @@ func wizzCachePath() (string, bool) {
 // wizzPersistVersion best-effort writes the discovered version so a restart skips
 // rediscovery. No-op against a test host or on any I/O error (caching is an
 // optimisation, never load-bearing).
-func wizzPersistVersion(v string) {
-	if !wizzRealHost() {
+func wizzPersistVersion(host, v string) {
+	if !wizzRealHost(host) {
 		return
 	}
 	path, ok := wizzCachePath()
@@ -200,12 +200,12 @@ func wizzPersistVersion(v string) {
 // wizzMaybeLoadCache loads a previously-healed version once per process, so a
 // fresh run starts from the last-known-live version rather than the (possibly
 // stale) compiled-in default. Skipped under a test host or an operator pin.
-func wizzMaybeLoadCache() {
+func wizzMaybeLoadCache(host string) {
 	wizzHealCacheOnce.Do(func() {
 		// Skip under a test host or whenever healing is off (operator pin or
 		// WIZZAIR_NO_AUTOHEAL): the opt-out must fully restore fail-clean and must
 		// not silently adopt a previously-cached healed version.
-		if !wizzRealHost() || !wizzHealEnabled() {
+		if !wizzRealHost(host) || !wizzHealEnabled() {
 			return
 		}
 		path, ok := wizzCachePath()

--- a/internal/flights/wizzair_selfheal_test.go
+++ b/internal/flights/wizzair_selfheal_test.go
@@ -47,13 +47,10 @@ func TestWizzProbeVersion(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	orig := wizzHost
-	wizzHost = srv.URL
-	defer func() { wizzHost = orig }()
 
 	cases := map[string]string{"29.4.0": "live", "29.3.0": "absent", "29.9.9": "inconclusive"}
 	for v, want := range cases {
-		if got := wizzProbeVersion(context.Background(), v); got != want {
+		if got := wizzProbeVersion(context.Background(), srv.URL, v); got != want {
 			t.Errorf("probe(%s) = %q, want %q", v, got, want)
 		}
 	}
@@ -88,14 +85,13 @@ func TestSearchWizzair_SelfHealsOnRotation(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origHost, origVer := wizzHost, wizzVersion
-	wizzHost = srv.URL
+	origVer := wizzVersion
 	wizzVersion = stale
-	defer func() { wizzHost, wizzVersion = origHost, origVer }()
+	defer func() { wizzVersion = origVer }()
 	t.Setenv("WIZZAIR_API_VERSION", "") // no operator pin
 	t.Setenv("WIZZAIR_NO_AUTOHEAL", "") // healing enabled
 
-	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})
 	if err != nil {
 		t.Fatalf("self-heal search should succeed, got error: %v", err)
 	}
@@ -120,13 +116,12 @@ func TestSearchWizzair_NoHealWhenPinned(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origHost, origVer := wizzHost, wizzVersion
-	wizzHost = srv.URL
+	origVer := wizzVersion
 	wizzVersion = "10.1.0"
-	defer func() { wizzHost, wizzVersion = origHost, origVer }()
+	defer func() { wizzVersion = origVer }()
 	t.Setenv("WIZZAIR_API_VERSION", "29.3.0") // operator pin -> healing disabled
 
-	_, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	_, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})
 	if err == nil {
 		t.Fatal("want rotation error when pinned, got nil")
 	}

--- a/internal/flights/wizzair_selfheal_test.go
+++ b/internal/flights/wizzair_selfheal_test.go
@@ -98,7 +98,7 @@ func TestSearchWizzair_SelfHealsOnRotation(t *testing.T) {
 	if len(out) != 1 {
 		t.Fatalf("want 1 result after self-heal, got %d", len(out))
 	}
-	if got := wizzResolvedVersion(); got != live {
+	if got := wizzResolvedVersion(srv.URL); got != live {
 		t.Errorf("version after heal = %q, want %q", got, live)
 	}
 }

--- a/internal/flights/wizzair_selfheal_test.go
+++ b/internal/flights/wizzair_selfheal_test.go
@@ -8,10 +8,20 @@ import (
 	"testing"
 )
 
+// setWizzVersionForTest sets the shared wizzVersion under the write lock so test
+// assignments don't race locked production readers (wizzResolvedVersion) or
+// leaked timeout-drain goroutines. Returns the previous value for restore.
+func setWizzVersionForTest(v string) string {
+	wizzVersionMu.Lock()
+	defer wizzVersionMu.Unlock()
+	old := wizzVersion
+	wizzVersion = v // setWizzVersionForTest: sole sanctioned locked writer
+	return old
+}
+
 // TestWizzNextCandidates checks the rotation-walk order: next minors first
 // (the common rotation), then patches, then the next majors.
-func TestWizzNextCandidates(t *testing.T) {
-	got := wizzNextCandidates("29.3.0")
+func TestWizzNextCandidates(t *testing.T) {	got := wizzNextCandidates("29.3.0")
 	if len(got) == 0 {
 		t.Fatal("no candidates generated")
 	}
@@ -85,9 +95,8 @@ func TestSearchWizzair_SelfHealsOnRotation(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origVer := wizzVersion
-	wizzVersion = stale
-	defer func() { wizzVersion = origVer }()
+	origVer := setWizzVersionForTest(stale)
+	defer setWizzVersionForTest(origVer)
 	t.Setenv("WIZZAIR_API_VERSION", "") // no operator pin
 	t.Setenv("WIZZAIR_NO_AUTOHEAL", "") // healing enabled
 
@@ -116,9 +125,8 @@ func TestSearchWizzair_NoHealWhenPinned(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origVer := wizzVersion
-	wizzVersion = "10.1.0"
-	defer func() { wizzVersion = origVer }()
+	origVer := setWizzVersionForTest("10.1.0")
+	defer setWizzVersionForTest(origVer)
 	t.Setenv("WIZZAIR_API_VERSION", "29.3.0") // operator pin -> healing disabled
 
 	_, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})

--- a/internal/flights/wizzair_test.go
+++ b/internal/flights/wizzair_test.go
@@ -24,9 +24,8 @@ func TestWizzDefaultVersionWellFormed(t *testing.T) {
 	}
 	// Snapshot/restore the runtime version var: other tests in suite may have
 	// self-healed it to a newer value; this test must validate the *default const*.
-	orig := wizzVersion
-	wizzVersion = wizzDefaultVersion
-	defer func() { wizzVersion = orig }()
+	orig := setWizzVersionForTest(wizzDefaultVersion)
+	defer setWizzVersionForTest(orig)
 	if got := wizzTimetableURL(wizzDefaultHost); !strings.Contains(got, "/"+wizzDefaultVersion+"/Api/") {
 		t.Fatalf("wizzTimetableURL() = %q, expected to contain /%s/Api/", got, wizzDefaultVersion)
 	}
@@ -56,9 +55,8 @@ func TestSearchWizzair_MapsFlight(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origVer := wizzVersion
-	wizzVersion = "10.1.0"
-	defer func() { wizzVersion = origVer }()
+	origVer := setWizzVersionForTest("10.1.0")
+	defer setWizzVersionForTest(origVer)
 
 	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})
 	if err != nil {
@@ -91,9 +89,8 @@ func TestSearchWizzair_MapsFlight(t *testing.T) {
 }
 
 func TestWizzResolvedVersion_EnvOverride(t *testing.T) {
-	orig := wizzVersion
-	wizzVersion = "10.1.0"
-	defer func() { wizzVersion = orig }()
+	orig := setWizzVersionForTest("10.1.0")
+	defer setWizzVersionForTest(orig)
 
 	t.Setenv("WIZZAIR_API_VERSION", "")
 	if got := wizzResolvedVersion(wizzDefaultHost); got != "10.1.0" {
@@ -106,9 +103,8 @@ func TestWizzResolvedVersion_EnvOverride(t *testing.T) {
 }
 
 func TestWizzTimetableURL_IncludesVersion(t *testing.T) {
-	orig := wizzVersion
-	wizzVersion = "10.1.0"
-	defer func() { wizzVersion = orig }()
+	orig := setWizzVersionForTest("10.1.0")
+	defer setWizzVersionForTest(orig)
 	t.Setenv("WIZZAIR_API_VERSION", "")
 	got := wizzTimetableURL(wizzDefaultHost)
 	want := wizzDefaultHost + "/10.1.0/Api/search/timetable"
@@ -144,9 +140,8 @@ func TestSearchWizzair_404_VersionRotated(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origVer := wizzVersion
-	wizzVersion = "10.1.0"
-	defer func() { wizzVersion = origVer }()
+	origVer := setWizzVersionForTest("10.1.0")
+	defer setWizzVersionForTest(origVer)
 	t.Setenv("WIZZAIR_API_VERSION", "")
 
 	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})
@@ -169,9 +164,8 @@ func TestSearchWizzair_404_VersionRotated(t *testing.T) {
 // error into an actionable ProviderStatus with the typed FixHintCode and a hint
 // naming the env override and last-known-good version. Pure / offline.
 func TestWizzairFailureStatus_TypedActionable(t *testing.T) {
-	orig := wizzVersion
-	wizzVersion = "10.1.0"
-	defer func() { wizzVersion = orig }()
+	orig := setWizzVersionForTest("10.1.0")
+	defer setWizzVersionForTest(orig)
 	t.Setenv("WIZZAIR_API_VERSION", "")
 
 	rotated := fmt.Errorf("wizzair: tried API version %q: %w", "10.1.0", ErrWizzVersionRotated)
@@ -227,9 +221,8 @@ func TestSearchWizzair_EnvOverrideRestores(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origVer := wizzVersion
-	wizzVersion = "10.1.0" // stale default would 404
-	defer func() { wizzVersion = origVer }()
+	origVer := setWizzVersionForTest("10.1.0") // stale default would 404
+	defer setWizzVersionForTest(origVer)
 
 	// Without the override: stale default 404s -> rotation sentinel.
 	t.Setenv("WIZZAIR_API_VERSION", "")
@@ -261,9 +254,8 @@ func TestSearchWizzair_LiveFixture_Parses(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origVer := wizzVersion
-	wizzVersion = "29.3.0"
-	defer func() { wizzVersion = origVer }()
+	origVer := setWizzVersionForTest("29.3.0")
+	defer setWizzVersionForTest(origVer)
 	t.Setenv("WIZZAIR_API_VERSION", "")
 
 	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-08-04", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})
@@ -314,9 +306,8 @@ func TestSearchWizzair_400_InvalidMarket(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origVer := wizzVersion
-	wizzVersion = "29.3.0"
-	defer func() { wizzVersion = origVer }()
+	origVer := setWizzVersionForTest("29.3.0")
+	defer setWizzVersionForTest(origVer)
 	t.Setenv("WIZZAIR_API_VERSION", "")
 
 	out, err := SearchWizzair(context.Background(), "BUD", "JFK", "2026-08-04", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})
@@ -350,9 +341,8 @@ func TestSearchWizzair_400_EdgeBlocked(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origVer := wizzVersion
-	wizzVersion = "29.3.0"
-	defer func() { wizzVersion = origVer }()
+	origVer := setWizzVersionForTest("29.3.0")
+	defer setWizzVersionForTest(origVer)
 	t.Setenv("WIZZAIR_API_VERSION", "")
 
 	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-08-04", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})

--- a/internal/flights/wizzair_test.go
+++ b/internal/flights/wizzair_test.go
@@ -27,7 +27,7 @@ func TestWizzDefaultVersionWellFormed(t *testing.T) {
 	orig := wizzVersion
 	wizzVersion = wizzDefaultVersion
 	defer func() { wizzVersion = orig }()
-	if got := wizzTimetableURL(); !strings.Contains(got, "/"+wizzDefaultVersion+"/Api/") {
+	if got := wizzTimetableURL(wizzDefaultHost); !strings.Contains(got, "/"+wizzDefaultVersion+"/Api/") {
 		t.Fatalf("wizzTimetableURL() = %q, expected to contain /%s/Api/", got, wizzDefaultVersion)
 	}
 }
@@ -56,12 +56,11 @@ func TestSearchWizzair_MapsFlight(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origHost, origVer := wizzHost, wizzVersion
-	wizzHost = srv.URL
+	origVer := wizzVersion
 	wizzVersion = "10.1.0"
-	defer func() { wizzHost, wizzVersion = origHost, origVer }()
+	defer func() { wizzVersion = origVer }()
 
-	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})
 	if err != nil {
 		t.Fatalf("SearchWizzair error: %v", err)
 	}
@@ -111,8 +110,8 @@ func TestWizzTimetableURL_IncludesVersion(t *testing.T) {
 	wizzVersion = "10.1.0"
 	defer func() { wizzVersion = orig }()
 	t.Setenv("WIZZAIR_API_VERSION", "")
-	got := wizzTimetableURL()
-	want := wizzHost + "/10.1.0/Api/search/timetable"
+	got := wizzTimetableURL(wizzDefaultHost)
+	want := wizzDefaultHost + "/10.1.0/Api/search/timetable"
 	if got != want {
 		t.Errorf("url = %q, want %q", got, want)
 	}
@@ -145,13 +144,12 @@ func TestSearchWizzair_404_VersionRotated(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origHost, origVer := wizzHost, wizzVersion
-	wizzHost = srv.URL
+	origVer := wizzVersion
 	wizzVersion = "10.1.0"
-	defer func() { wizzHost, wizzVersion = origHost, origVer }()
+	defer func() { wizzVersion = origVer }()
 	t.Setenv("WIZZAIR_API_VERSION", "")
 
-	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})
 	if err == nil {
 		t.Fatal("want error on 404, got nil")
 	}
@@ -229,20 +227,19 @@ func TestSearchWizzair_EnvOverrideRestores(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origHost, origVer := wizzHost, wizzVersion
-	wizzHost = srv.URL
+	origVer := wizzVersion
 	wizzVersion = "10.1.0" // stale default would 404
-	defer func() { wizzHost, wizzVersion = origHost, origVer }()
+	defer func() { wizzVersion = origVer }()
 
 	// Without the override: stale default 404s -> rotation sentinel.
 	t.Setenv("WIZZAIR_API_VERSION", "")
-	if _, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1}); !errors.Is(err, ErrWizzVersionRotated) {
+	if _, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL}); !errors.Is(err, ErrWizzVersionRotated) {
 		t.Fatalf("stale default: err = %v, want ErrWizzVersionRotated", err)
 	}
 
 	// With the override: request path carries the good version -> results.
 	t.Setenv("WIZZAIR_API_VERSION", goodVersion)
-	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1})
+	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-07-07", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})
 	if err != nil {
 		t.Fatalf("override should restore provider, got err: %v", err)
 	}
@@ -264,13 +261,12 @@ func TestSearchWizzair_LiveFixture_Parses(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origHost, origVer := wizzHost, wizzVersion
-	wizzHost = srv.URL
+	origVer := wizzVersion
 	wizzVersion = "29.3.0"
-	defer func() { wizzHost, wizzVersion = origHost, origVer }()
+	defer func() { wizzVersion = origVer }()
 	t.Setenv("WIZZAIR_API_VERSION", "")
 
-	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-08-04", "EUR", SearchOptions{Adults: 1})
+	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-08-04", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})
 	if err != nil {
 		t.Fatalf("SearchWizzair error: %v", err)
 	}
@@ -318,13 +314,12 @@ func TestSearchWizzair_400_InvalidMarket(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origHost, origVer := wizzHost, wizzVersion
-	wizzHost = srv.URL
+	origVer := wizzVersion
 	wizzVersion = "29.3.0"
-	defer func() { wizzHost, wizzVersion = origHost, origVer }()
+	defer func() { wizzVersion = origVer }()
 	t.Setenv("WIZZAIR_API_VERSION", "")
 
-	out, err := SearchWizzair(context.Background(), "BUD", "JFK", "2026-08-04", "EUR", SearchOptions{Adults: 1})
+	out, err := SearchWizzair(context.Background(), "BUD", "JFK", "2026-08-04", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})
 	if err == nil {
 		t.Fatal("want error on 400 validationCodes, got nil")
 	}
@@ -355,13 +350,12 @@ func TestSearchWizzair_400_EdgeBlocked(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origHost, origVer := wizzHost, wizzVersion
-	wizzHost = srv.URL
+	origVer := wizzVersion
 	wizzVersion = "29.3.0"
-	defer func() { wizzHost, wizzVersion = origHost, origVer }()
+	defer func() { wizzVersion = origVer }()
 	t.Setenv("WIZZAIR_API_VERSION", "")
 
-	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-08-04", "EUR", SearchOptions{Adults: 1})
+	out, err := SearchWizzair(context.Background(), "BUD", "BCN", "2026-08-04", "EUR", SearchOptions{Adults: 1, wizzHost: srv.URL})
 	if err == nil {
 		t.Fatal("want error on non-JSON 400, got nil")
 	}

--- a/internal/flights/wizzair_test.go
+++ b/internal/flights/wizzair_test.go
@@ -96,11 +96,11 @@ func TestWizzResolvedVersion_EnvOverride(t *testing.T) {
 	defer func() { wizzVersion = orig }()
 
 	t.Setenv("WIZZAIR_API_VERSION", "")
-	if got := wizzResolvedVersion(); got != "10.1.0" {
+	if got := wizzResolvedVersion(wizzDefaultHost); got != "10.1.0" {
 		t.Errorf("default version = %q, want 10.1.0", got)
 	}
 	t.Setenv("WIZZAIR_API_VERSION", "27.5.0")
-	if got := wizzResolvedVersion(); got != "27.5.0" {
+	if got := wizzResolvedVersion(wizzDefaultHost); got != "27.5.0" {
 		t.Errorf("env-override version = %q, want 27.5.0", got)
 	}
 }
@@ -175,7 +175,7 @@ func TestWizzairFailureStatus_TypedActionable(t *testing.T) {
 	t.Setenv("WIZZAIR_API_VERSION", "")
 
 	rotated := fmt.Errorf("wizzair: tried API version %q: %w", "10.1.0", ErrWizzVersionRotated)
-	st := wizzairFailureStatus(rotated)
+	st := wizzairFailureStatus(wizzDefaultHost, rotated)
 
 	if st.ID != "wizzair" || st.Name != "Wizz Air" {
 		t.Errorf("bad identity: %+v", st)
@@ -200,7 +200,7 @@ func TestWizzairFailureStatus_TypedActionable(t *testing.T) {
 // TestWizzairFailureStatus_GenericError checks a non-rotation error gets no
 // version-rotation fix hint (no false actionability).
 func TestWizzairFailureStatus_GenericError(t *testing.T) {
-	st := wizzairFailureStatus(errors.New("wizzair: decode: boom"))
+	st := wizzairFailureStatus(wizzDefaultHost, errors.New("wizzair: decode: boom"))
 	if st.FixHintCode != "" {
 		t.Errorf("fix_hint_code = %q, want empty for generic error", st.FixHintCode)
 	}
@@ -332,7 +332,7 @@ func TestSearchWizzair_400_InvalidMarket(t *testing.T) {
 	if !strings.Contains(err.Error(), "InvalidMarket") {
 		t.Errorf("error %q should echo the validationCodes", err)
 	}
-	st := wizzairFailureStatus(err)
+	st := wizzairFailureStatus(srv.URL, err)
 	if st.FixHintCode != "WIZZ_MARKET_REJECTED" {
 		t.Errorf("fix_hint_code = %q, want WIZZ_MARKET_REJECTED", st.FixHintCode)
 	}
@@ -368,7 +368,7 @@ func TestSearchWizzair_400_EdgeBlocked(t *testing.T) {
 	if !strings.Contains(err.Error(), "CloudFront") {
 		t.Errorf("error %q should echo the edge body snippet", err)
 	}
-	st := wizzairFailureStatus(err)
+	st := wizzairFailureStatus(srv.URL, err)
 	if st.FixHintCode != "WIZZ_BLOCKED" {
 		t.Errorf("fix_hint_code = %q, want WIZZ_BLOCKED", st.FixHintCode)
 	}
@@ -394,7 +394,7 @@ func TestClassifyWizzStatus_Table(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err := classifyWizzStatus(c.status, []byte(c.body))
+			err := classifyWizzStatus(wizzDefaultHost, c.status, []byte(c.body))
 			if !errors.Is(err, c.want) {
 				t.Fatalf("classifyWizzStatus(%d, %q) = %v, want errors.Is %v", c.status, c.body, err, c.want)
 			}

--- a/internal/ground/search.go
+++ b/internal/ground/search.go
@@ -122,7 +122,20 @@ type SearchOptions struct {
 	// cheaper synthesized option (multimodal, cross-border rail, …) in
 	// result.HackSaving. Set NoHacks to run a pure naive search.
 	NoHacks bool
+
+	// SearchOverride replaces the real ground-transport search for this single
+	// call. Nil (the default) runs the production search. Mirrors
+	// flights.SearchOptions.SearchOverride: callers in other packages — today
+	// internal/hacks' positioning/ferry/open-jaw-ground detectors — inject a
+	// synthetic result per call, so tests never depend on live providers and
+	// concurrent calls never race on shared mutable state.
+	SearchOverride SearchFunc
 }
+
+// SearchFunc matches the signature of SearchByName. It is the type of
+// SearchOptions.SearchOverride and lets external packages inject a
+// replacement ground-search implementation per call.
+type SearchFunc func(ctx context.Context, from, to, date string, opts SearchOptions) (*models.GroundSearchResult, error)
 
 // providerEnabled reports whether a provider should run given an optional
 // allow-list (include; empty means all) and a deny-list (exclude, which always
@@ -237,6 +250,13 @@ func sortGroundRoutes(routes []models.GroundRoute) {
 // SearchByName searches all providers for ground transport between two cities
 // given by name. Resolves city names to provider-specific IDs automatically.
 func SearchByName(ctx context.Context, from, to, date string, opts SearchOptions) (*models.GroundSearchResult, error) {
+	// A per-call override takes over entirely, bypassing defaults, caching,
+	// and every provider — the same contract flights.SearchOptions.SearchOverride
+	// gives test callers. See SearchOptions.SearchOverride.
+	if opts.SearchOverride != nil {
+		return opts.SearchOverride(ctx, from, to, date, opts)
+	}
+
 	if opts.Currency == "" {
 		opts.Currency = "EUR"
 	}

--- a/internal/ground/search_override_test.go
+++ b/internal/ground/search_override_test.go
@@ -1,0 +1,59 @@
+package ground
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// TestSearchByNameSearchOverride pins the per-call SearchOverride seam added
+// for the cross-currency hack detectors: when set, SearchByName must return the
+// override's result verbatim and must not touch providers, defaults, or the
+// cache. A cancelled context proves no real search ran (the production path
+// would observe the cancellation; the override ignores it).
+func TestSearchByNameSearchOverride(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var gotFrom, gotTo, gotDate string
+	sentinel := &models.GroundSearchResult{
+		Success: true,
+		Count:   1,
+		Routes:  []models.GroundRoute{{Provider: "test", Type: "bus", Price: 42, Currency: "EUR"}},
+	}
+	opts := SearchOptions{
+		SearchOverride: func(_ context.Context, from, to, date string, _ SearchOptions) (*models.GroundSearchResult, error) {
+			gotFrom, gotTo, gotDate = from, to, date
+			return sentinel, nil
+		},
+	}
+
+	res, err := SearchByName(ctx, "Helsinki", "Tallinn", "2026-06-01", opts)
+	if err != nil {
+		t.Fatalf("override path returned error: %v", err)
+	}
+	if res != sentinel {
+		t.Fatalf("SearchByName did not return the override result; got %+v", res)
+	}
+	if gotFrom != "Helsinki" || gotTo != "Tallinn" || gotDate != "2026-06-01" {
+		t.Errorf("override received wrong args: from=%q to=%q date=%q", gotFrom, gotTo, gotDate)
+	}
+}
+
+// TestSearchByNameNoOverrideStillRuns guards the nil-default branch: with no
+// override the call proceeds into the normal path (here short-circuited by a
+// cancelled context) rather than panicking or mis-dispatching.
+func TestSearchByNameNoOverrideStillRuns(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// No SearchOverride set. The production path runs; with a cancelled context
+	// it must return without panicking. We assert only that it does not panic
+	// and yields a non-nil result or an error — either is a valid production
+	// outcome, unlike the override branch which is deterministic.
+	res, err := SearchByName(ctx, "Helsinki", "Tallinn", "2026-06-01", SearchOptions{})
+	if err == nil && res == nil {
+		t.Fatal("nil-override path returned nil result and nil error")
+	}
+}

--- a/internal/hacks/accommodation_split.go
+++ b/internal/hacks/accommodation_split.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
@@ -76,7 +75,7 @@ func DetectAccommodationSplit(ctx context.Context, in AccommodationSplitInput) [
 	// before doing any hotel search. If we can't honestly convert it,
 	// suppress the whole detector rather than mix EUR moving costs into a
 	// non-EUR total.
-	movingCost, mcur := destinations.ConvertCurrency(ctx, movingCostEUR, "EUR", currency)
+	movingCost, mcur := convertCurrency(ctx, movingCostEUR, "EUR", currency)
 	if mcur != currency {
 		return nil
 	}
@@ -85,7 +84,7 @@ func DetectAccommodationSplit(ctx context.Context, in AccommodationSplitInput) [
 	// too — comparing a target-currency net saving against a raw EUR number
 	// would pass/fail the threshold on the wrong scale for every non-EUR
 	// target.
-	minSavings, scur := destinations.ConvertCurrency(ctx, minSavingsEUR, "EUR", currency)
+	minSavings, scur := convertCurrency(ctx, minSavingsEUR, "EUR", currency)
 	if scur != currency {
 		return nil
 	}

--- a/internal/hacks/accommodation_split.go
+++ b/internal/hacks/accommodation_split.go
@@ -81,6 +81,15 @@ func DetectAccommodationSplit(ctx context.Context, in AccommodationSplitInput) [
 		return nil
 	}
 
+	// Convert the fixed EUR minimum-saving threshold into the target currency
+	// too — comparing a target-currency net saving against a raw EUR number
+	// would pass/fail the threshold on the wrong scale for every non-EUR
+	// target.
+	minSavings, scur := destinations.ConvertCurrency(ctx, minSavingsEUR, "EUR", currency)
+	if scur != currency {
+		return nil
+	}
+
 	// Load user preferences for hotel filtering.
 	prefs, _ := preferences.Load()
 
@@ -92,7 +101,7 @@ func DetectAccommodationSplit(ctx context.Context, in AccommodationSplitInput) [
 	baselineTotal := baseline.Price * float64(totalNights)
 
 	// 2. Find the best split (2-way first, 3-way if MaxSplits >= 3).
-	best := findBestSplit(ctx, in, checkIn, totalNights, currency, movingCost, baselineTotal, prefs)
+	best := findBestSplit(ctx, in, checkIn, totalNights, currency, movingCost, minSavings, baselineTotal, prefs)
 	if best == nil {
 		return nil
 	}
@@ -117,6 +126,7 @@ func findBestSplit(
 	totalNights int,
 	currency string,
 	movingCost float64,
+	minSavings float64,
 	baselineTotal float64,
 	prefs *preferences.Preferences,
 ) *Hack {
@@ -191,7 +201,7 @@ func findBestSplit(
 
 	// Net savings after moving costs are already baked into best.totalCost.
 	netSavings := baselineTotal - best.totalCost
-	if netSavings < minSavingsEUR {
+	if netSavings < minSavings {
 		return nil
 	}
 	if best.totalCost > baselineTotal*minSavingsRatio {
@@ -307,12 +317,19 @@ func searchBestHotel(ctx context.Context, city, checkIn, checkOut string, guests
 		return nil
 	}
 
-	// Return cheapest with a valid price.
+	// Return cheapest with a valid price that is actually denominated in the
+	// requested currency. A hotel priced in something else would silently
+	// corrupt the split-cost sum and get mislabeled with the wrong currency,
+	// so skip it and keep looking rather than trust it.
 	for _, h := range filtered {
-		if h.Price > 0 {
-			hCopy := h
-			return &hCopy
+		if h.Price <= 0 {
+			continue
 		}
+		if h.Currency != "" && !strings.EqualFold(h.Currency, currency) {
+			continue
+		}
+		hCopy := h
+		return &hCopy
 	}
 	return nil
 }

--- a/internal/hacks/accommodation_split.go
+++ b/internal/hacks/accommodation_split.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
@@ -52,7 +53,7 @@ func DetectAccommodationSplit(ctx context.Context, in AccommodationSplitInput) [
 	if in.Guests <= 0 {
 		in.Guests = 2
 	}
-	currency := in.Currency
+	currency := strings.ToUpper(strings.TrimSpace(in.Currency))
 	if currency == "" {
 		currency = "EUR"
 	}
@@ -71,6 +72,15 @@ func DetectAccommodationSplit(ctx context.Context, in AccommodationSplitInput) [
 		return nil
 	}
 
+	// Convert the fixed EUR per-move friction cost into the target currency
+	// before doing any hotel search. If we can't honestly convert it,
+	// suppress the whole detector rather than mix EUR moving costs into a
+	// non-EUR total.
+	movingCost, mcur := destinations.ConvertCurrency(ctx, movingCostEUR, "EUR", currency)
+	if mcur != currency {
+		return nil
+	}
+
 	// Load user preferences for hotel filtering.
 	prefs, _ := preferences.Load()
 
@@ -82,7 +92,7 @@ func DetectAccommodationSplit(ctx context.Context, in AccommodationSplitInput) [
 	baselineTotal := baseline.Price * float64(totalNights)
 
 	// 2. Find the best split (2-way first, 3-way if MaxSplits >= 3).
-	best := findBestSplit(ctx, in, checkIn, totalNights, currency, baselineTotal, prefs)
+	best := findBestSplit(ctx, in, checkIn, totalNights, currency, movingCost, baselineTotal, prefs)
 	if best == nil {
 		return nil
 	}
@@ -106,6 +116,7 @@ func findBestSplit(
 	checkIn time.Time,
 	totalNights int,
 	currency string,
+	movingCost float64,
 	baselineTotal float64,
 	prefs *preferences.Preferences,
 ) *Hack {
@@ -157,12 +168,12 @@ func findBestSplit(
 			}
 
 			moves := len(j.splitPoints)
-			movingCost := float64(moves) * movingCostEUR
+			jobMovingCost := float64(moves) * movingCost
 			totalCost := 0.0
 			for _, s := range segments {
 				totalCost += s.TotalCost
 			}
-			totalCost += movingCost
+			totalCost += jobMovingCost
 
 			mu.Lock()
 			defer mu.Unlock()
@@ -187,7 +198,7 @@ func findBestSplit(
 		return nil
 	}
 
-	return buildAccommodationHack(in.City, best.segments, best.moves, netSavings, baselineTotal, currency)
+	return buildAccommodationHack(in.City, best.segments, best.moves, netSavings, baselineTotal, movingCost, currency)
 }
 
 // evaluateSplit searches for the cheapest hotel for each segment defined by
@@ -307,7 +318,7 @@ func searchBestHotel(ctx context.Context, city, checkIn, checkOut string, guests
 }
 
 // buildAccommodationHack assembles the Hack from evaluated segments.
-func buildAccommodationHack(city string, segments []splitSegment, moves int, netSavings, baselineTotal float64, currency string) *Hack {
+func buildAccommodationHack(city string, segments []splitSegment, moves int, netSavings, baselineTotal, movingCost float64, currency string) *Hack {
 	n := len(segments)
 	propertiesWord := "properties"
 	if n == 2 {
@@ -344,7 +355,7 @@ func buildAccommodationHack(city string, segments []splitSegment, moves int, net
 		currency, roundSavings(splitCost), currency, roundSavings(baselineTotal),
 	))
 	if moves > 0 {
-		moveCost := float64(moves) * movingCostEUR
+		moveCost := float64(moves) * movingCost
 		if moves == 1 {
 			steps = append(steps, fmt.Sprintf("Move between hotels on %s (~%s %.0f taxi)", formatDate(segments[0].CheckOut), currency, moveCost))
 		} else {

--- a/internal/hacks/accommodation_split_test.go
+++ b/internal/hacks/accommodation_split_test.go
@@ -64,7 +64,7 @@ func TestBuildAccommodationHack_twoSegments(t *testing.T) {
 	}
 	// Baseline: 49/night × 7 = 343; moving costs: 1 × 15 = 15; split: 135 + 152 + 15 = 302; savings = 343 - 302 = 41
 	// (below 50 threshold — we test the struct assembly regardless)
-	hack := buildAccommodationHack("Prague", segments, 1, 100, 402, "EUR")
+	hack := buildAccommodationHack("Prague", segments, 1, 100, 402, 15, "EUR")
 
 	if hack == nil {
 		t.Fatal("expected non-nil hack")
@@ -97,7 +97,7 @@ func TestBuildAccommodationHack_threeSegments(t *testing.T) {
 		{Hotel: makeHotel("B", 35), CheckIn: "2026-04-15", CheckOut: "2026-04-17", Nights: 2, TotalCost: 70},
 		{Hotel: makeHotel("C", 30), CheckIn: "2026-04-17", CheckOut: "2026-04-19", Nights: 2, TotalCost: 60},
 	}
-	hack := buildAccommodationHack("Prague", segments, 2, 150, 400, "EUR")
+	hack := buildAccommodationHack("Prague", segments, 2, 150, 400, 15, "EUR")
 	if hack == nil {
 		t.Fatal("expected non-nil hack")
 	}
@@ -142,6 +142,52 @@ func TestDetectAccommodationSplit_tooShortStay(t *testing.T) {
 	}
 }
 
+// TestDetectAccommodationSplit_nonEURTarget_suppressedWhenInconvertible proves
+// case (b): a non-EUR target currency that can't be honestly converted (XXX
+// is the ISO 4217 "no currency" placeholder — it will never appear in a
+// real exchange-rate table) suppresses the whole detector before any hotel
+// search runs, rather than mixing the EUR-denominated moving-cost constant
+// into a mislabeled total. Deterministic — no live network required (the
+// currency check runs before baseline hotel search).
+func TestDetectAccommodationSplit_nonEURTarget_suppressedWhenInconvertible(t *testing.T) {
+	in := AccommodationSplitInput{
+		City:     "Prague",
+		CheckIn:  "2026-04-12",
+		CheckOut: "2026-04-19",
+		Currency: "XXX",
+	}
+	got := DetectAccommodationSplit(context.Background(), in)
+	if got != nil {
+		t.Errorf("expected nil for inconvertible target currency, got %v", got)
+	}
+}
+
+// TestDetectAccommodationSplit_eurTarget_labelsEURAndConverts proves cases
+// (a) and (c): EUR passes through untouched (the EUR->EUR moving-cost
+// conversion short-circuits, no network) and, when the live hotel search
+// actually surfaces a split hack, its Currency matches the target. Gated
+// behind TRVL_TEST_LIVE_INTEGRATIONS since DetectAccommodationSplit needs a
+// live hotel search to produce a hack at all — the default suite must stay
+// deterministic and offline (see TestBoundaryDates above for the same
+// pattern in this file).
+func TestDetectAccommodationSplit_eurTarget_labelsEURAndConverts(t *testing.T) {
+	if os.Getenv("TRVL_TEST_LIVE_INTEGRATIONS") == "" {
+		t.Skip("skipping live-API test; set TRVL_TEST_LIVE_INTEGRATIONS=1 to run")
+	}
+	in := AccommodationSplitInput{
+		City:     "Prague",
+		CheckIn:  "2026-04-12",
+		CheckOut: "2026-04-19",
+		Currency: "EUR",
+	}
+	hacks := DetectAccommodationSplit(context.Background(), in)
+	for _, h := range hacks {
+		if h.Currency != "EUR" {
+			t.Errorf("Currency = %q, want EUR", h.Currency)
+		}
+	}
+}
+
 // TestMinSavingsFilter verifies the EUR 50 minimum net savings filter.
 func TestMinSavingsFilter(t *testing.T) {
 	// Net savings below 50 must not produce a hack.
@@ -156,7 +202,7 @@ func TestMinSavingsFilter(t *testing.T) {
 	}
 	// Sanity-check via buildAccommodationHack (it does NOT apply the threshold —
 	// that's the responsibility of findBestSplit). We verify the values are correct.
-	hack := buildAccommodationHack("Prague", segments, 1, netSavings, baseline, "EUR")
+	hack := buildAccommodationHack("Prague", segments, 1, netSavings, baseline, 15, "EUR")
 	if hack.Savings != roundSavings(netSavings) {
 		t.Errorf("Savings = %v, want %v", hack.Savings, roundSavings(netSavings))
 	}
@@ -285,7 +331,7 @@ func TestHackType(t *testing.T) {
 			{Hotel: makeHotel("X", 100), CheckIn: "2026-04-12", CheckOut: "2026-04-16", Nights: 4, TotalCost: 400},
 			{Hotel: makeHotel("Y", 80), CheckIn: "2026-04-16", CheckOut: "2026-04-19", Nights: 3, TotalCost: 240},
 		},
-		1, 60, 700, "EUR",
+		1, 60, 700, 15, "EUR",
 	)
 	if hack.Type != "accommodation_split" {
 		t.Errorf("Type = %q, want accommodation_split", hack.Type)
@@ -314,7 +360,7 @@ func TestStepContainsHotelName(t *testing.T) {
 		{Hotel: makeHotel("Grand Hyatt", 120), CheckIn: "2026-04-12", CheckOut: "2026-04-15", Nights: 3, TotalCost: 360},
 		{Hotel: makeHotel("Budget Inn", 55), CheckIn: "2026-04-15", CheckOut: "2026-04-19", Nights: 4, TotalCost: 220},
 	}
-	hack := buildAccommodationHack("Berlin", segments, 1, 200, 760, "EUR")
+	hack := buildAccommodationHack("Berlin", segments, 1, 200, 760, 15, "EUR")
 	found := false
 	for _, s := range hack.Steps {
 		if containsSubstring(s, "Grand Hyatt") {
@@ -335,7 +381,7 @@ func TestCitationsNonEmpty(t *testing.T) {
 		{Hotel: hotel, CheckIn: "2026-04-12", CheckOut: "2026-04-15", Nights: 3, TotalCost: 150},
 		{Hotel: makeHotel("B", 40), CheckIn: "2026-04-15", CheckOut: "2026-04-19", Nights: 4, TotalCost: 160},
 	}
-	hack := buildAccommodationHack("Paris", segments, 1, 100, 410, "EUR")
+	hack := buildAccommodationHack("Paris", segments, 1, 100, 410, 15, "EUR")
 	if len(hack.Citations) == 0 {
 		t.Error("expected non-empty Citations")
 	}
@@ -359,7 +405,7 @@ func TestSplitDescriptionContainsCity(t *testing.T) {
 		{Hotel: makeHotel("A", 50), CheckIn: "2026-04-12", CheckOut: "2026-04-15", Nights: 3, TotalCost: 150},
 		{Hotel: makeHotel("B", 40), CheckIn: "2026-04-15", CheckOut: "2026-04-19", Nights: 4, TotalCost: 160},
 	}
-	hack := buildAccommodationHack("Tokyo", segments, 1, 90, 400, "EUR")
+	hack := buildAccommodationHack("Tokyo", segments, 1, 90, 400, 15, "EUR")
 	if !containsSubstring(hack.Description, "Tokyo") {
 		t.Errorf("Description should contain city name, got: %q", hack.Description)
 	}

--- a/internal/hacks/accommodation_split_test.go
+++ b/internal/hacks/accommodation_split_test.go
@@ -147,9 +147,24 @@ func TestDetectAccommodationSplit_tooShortStay(t *testing.T) {
 // is the ISO 4217 "no currency" placeholder — it will never appear in a
 // real exchange-rate table) suppresses the whole detector before any hotel
 // search runs, rather than mixing the EUR-denominated moving-cost constant
-// into a mislabeled total. Deterministic — no live network required (the
-// currency check runs before baseline hotel search).
+// into a mislabeled total. Deterministic — no live network required: the
+// fake seam below always reports "can't convert" without ever dialing out
+// (the prior version of this test relied on the live default seam despite
+// its doc comment's claim otherwise — convertCurrency(ctx, movingCostEUR,
+// "EUR", "XXX") does not short-circuit on from==to, so it reached the live
+// destinations.ConvertCurrency). Mirrors the seam-injection pattern in
+// night_transport_test.go / rail_competition_test.go — no t.Parallel, the
+// seam var is shared package state, set/restored sequentially.
 func TestDetectAccommodationSplit_nonEURTarget_suppressedWhenInconvertible(t *testing.T) {
+	orig := convertCurrency
+	convertCurrency = func(_ context.Context, amount float64, from, to string) (float64, string) {
+		if from == to {
+			return amount, to
+		}
+		return amount, from // can't convert — same contract as the real function
+	}
+	t.Cleanup(func() { convertCurrency = orig })
+
 	in := AccommodationSplitInput{
 		City:     "Prague",
 		CheckIn:  "2026-04-12",

--- a/internal/hacks/back_to_back.go
+++ b/internal/hacks/back_to_back.go
@@ -11,10 +11,6 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
-// backToBackSearchFunc is the function used to search flights. Package-level
-// variable allows test injection without modifying the detectFn signature.
-var backToBackSearchFunc = flights.SearchFlightsWithClient
-
 // backToBackOverlapDays is the offset for the dummy return leg of each
 // overlapping round-trip. 14 days is long enough to trigger the cheaper
 // long-stay round-trip pricing that makes back-to-back work.
@@ -111,34 +107,38 @@ func backToBackLivePrices(ctx context.Context, in DetectorInput) ([]Hack, bool) 
 	// 1. One-way: origin -> dest on depart_date
 	go func() {
 		defer wg.Done()
-		owOutResult, owOutErr = backToBackSearchFunc(ctx, client, origin, dest, departDate, flights.SearchOptions{
-			SortBy: models.SortCheapest,
+		owOutResult, owOutErr = flights.SearchFlightsWithClient(ctx, client, origin, dest, departDate, flights.SearchOptions{
+			SortBy:         models.SortCheapest,
+			SearchOverride: in.SearchOverride,
 		})
 	}()
 
 	// 2. One-way: dest -> origin on return_date
 	go func() {
 		defer wg.Done()
-		owRetResult, owRetErr = backToBackSearchFunc(ctx, client, dest, origin, returnDate, flights.SearchOptions{
-			SortBy: models.SortCheapest,
+		owRetResult, owRetErr = flights.SearchFlightsWithClient(ctx, client, dest, origin, returnDate, flights.SearchOptions{
+			SortBy:         models.SortCheapest,
+			SearchOverride: in.SearchOverride,
 		})
 	}()
 
 	// 3. Overlapping RT from origin: origin->dest depart + dest->origin (depart+14d)
 	go func() {
 		defer wg.Done()
-		rtOriginResult, rtOriginErr = backToBackSearchFunc(ctx, client, origin, dest, departDate, flights.SearchOptions{
-			ReturnDate: rtFromOriginDummyReturn,
-			SortBy:     models.SortCheapest,
+		rtOriginResult, rtOriginErr = flights.SearchFlightsWithClient(ctx, client, origin, dest, departDate, flights.SearchOptions{
+			ReturnDate:     rtFromOriginDummyReturn,
+			SortBy:         models.SortCheapest,
+			SearchOverride: in.SearchOverride,
 		})
 	}()
 
 	// 4. Overlapping RT from dest: dest->origin return + origin->dest (return+14d)
 	go func() {
 		defer wg.Done()
-		rtDestResult, rtDestErr = backToBackSearchFunc(ctx, client, dest, origin, returnDate, flights.SearchOptions{
-			ReturnDate: rtFromDestDummyReturn,
-			SortBy:     models.SortCheapest,
+		rtDestResult, rtDestErr = flights.SearchFlightsWithClient(ctx, client, dest, origin, returnDate, flights.SearchOptions{
+			ReturnDate:     rtFromDestDummyReturn,
+			SortBy:         models.SortCheapest,
+			SearchOverride: in.SearchOverride,
 		})
 	}()
 

--- a/internal/hacks/back_to_back.go
+++ b/internal/hacks/back_to_back.go
@@ -3,6 +3,7 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
@@ -83,7 +84,10 @@ func backToBackLivePrices(ctx context.Context, in DetectorInput) ([]Hack, bool) 
 	dest := in.Destination
 	departDate := in.Date
 	returnDate := in.ReturnDate
-	currency := in.currency()
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
 
 	// Dummy return dates for the overlapping round-trips.
 	rtFromOriginDummyReturn := addDays(departDate, backToBackOverlapDays)
@@ -140,22 +144,19 @@ func backToBackLivePrices(ctx context.Context, in DetectorInput) ([]Hack, bool) 
 
 	wg.Wait()
 
-	// All 4 must succeed for a valid comparison.
-	owOutPrice, owOutCur, _, _ := cheapestFlightInfo(owOutResult, owOutErr)
-	owRetPrice, _, _, _ := cheapestFlightInfo(owRetResult, owRetErr)
-	rtOriginPrice, rtCur, _, _ := cheapestFlightInfo(rtOriginResult, rtOriginErr)
-	rtDestPrice, _, _, _ := cheapestFlightInfo(rtDestResult, rtDestErr)
+	// All 4 must succeed for a valid comparison, and every price must be
+	// convertible into the requested display currency — suppress rather than
+	// show an unconverted or mislabelled figure.
+	owOutPrice, okOwOut := cheapestFlightPriceInCurrency(ctx, owOutResult, owOutErr, target)
+	owRetPrice, okOwRet := cheapestFlightPriceInCurrency(ctx, owRetResult, owRetErr, target)
+	rtOriginPrice, okRtOrigin := cheapestFlightPriceInCurrency(ctx, rtOriginResult, rtOriginErr, target)
+	rtDestPrice, okRtDest := cheapestFlightPriceInCurrency(ctx, rtDestResult, rtDestErr, target)
 
-	if owOutPrice <= 0 || owRetPrice <= 0 || rtOriginPrice <= 0 || rtDestPrice <= 0 {
+	if !okOwOut || !okOwRet || !okRtOrigin || !okRtDest {
 		return nil, false
 	}
 
-	// Pick currency from whichever result provided one.
-	if rtCur != "" {
-		currency = rtCur
-	} else if owOutCur != "" {
-		currency = owOutCur
-	}
+	currency := target
 
 	oneWayTotal := owOutPrice + owRetPrice
 	rtTotal := rtOriginPrice + rtDestPrice
@@ -199,7 +200,13 @@ func backToBackLivePrices(ctx context.Context, in DetectorInput) ([]Hack, bool) 
 }
 
 // backToBackAdvisory returns the original advisory-only hack with no prices.
+// Currency is normalized to the requested target even though no amount is
+// converted (there is nothing to convert — Savings is 0).
 func backToBackAdvisory(in DetectorInput) []Hack {
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
 	return []Hack{{
 		Type:  "back_to_back",
 		Title: "Frequent route? Back-to-back round-trips beat one-ways",
@@ -209,7 +216,7 @@ func backToBackAdvisory(in DetectorInput) []Hack {
 				"20-40%% cheaper than individual one-ways because airlines discount returns.",
 			in.Origin, in.Destination),
 		Savings:  0, // advisory — no concrete savings estimate
-		Currency: in.currency(),
+		Currency: target,
 		Steps: []string{
 			fmt.Sprintf("For your next 2 trips %s→%s:", in.Origin, in.Destination),
 			"Ticket A: round-trip starting from " + in.Origin + " (use outbound only)",

--- a/internal/hacks/back_to_back_test.go
+++ b/internal/hacks/back_to_back_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MikkoParkkola/trvl/internal/batchexec"
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -121,27 +120,19 @@ func TestDetectBackToBack_zeroNights(t *testing.T) {
 // --- advisory fallback (when live search fails) ---
 
 // mockSearchFail always returns an error, forcing the advisory path.
-func mockSearchFail(_ context.Context, _ *batchexec.Client, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+func mockSearchFail(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
 	return nil, fmt.Errorf("mock search failure")
 }
 
-func withMockSearch(t *testing.T, fn func(context.Context, *batchexec.Client, string, string, string, flights.SearchOptions) (*models.FlightSearchResult, error)) {
-	t.Helper()
-	original := backToBackSearchFunc
-	backToBackSearchFunc = fn
-	t.Cleanup(func() { backToBackSearchFunc = original })
-}
-
 func TestDetectBackToBack_advisoryFallback(t *testing.T) {
-	withMockSearch(t, mockSearchFail)
-
 	depart := time.Now().AddDate(0, 0, 30)
 	ret := depart.AddDate(0, 0, 3)
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        depart.Format("2006-01-02"),
-		ReturnDate:  ret.Format("2006-01-02"),
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           depart.Format("2006-01-02"),
+		ReturnDate:     ret.Format("2006-01-02"),
+		SearchOverride: mockSearchFail,
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 advisory hack on search failure, got %d", len(hacks))
@@ -165,15 +156,14 @@ func TestDetectBackToBack_advisoryFallback(t *testing.T) {
 }
 
 func TestDetectBackToBack_advisoryCurrencyDefault(t *testing.T) {
-	withMockSearch(t, mockSearchFail)
-
 	depart := time.Now().AddDate(0, 0, 30)
 	ret := depart.AddDate(0, 0, 3)
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        depart.Format("2006-01-02"),
-		ReturnDate:  ret.Format("2006-01-02"),
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           depart.Format("2006-01-02"),
+		ReturnDate:     ret.Format("2006-01-02"),
+		SearchOverride: mockSearchFail,
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 hack, got %d", len(hacks))
@@ -184,16 +174,15 @@ func TestDetectBackToBack_advisoryCurrencyDefault(t *testing.T) {
 }
 
 func TestDetectBackToBack_advisoryCustomCurrency(t *testing.T) {
-	withMockSearch(t, mockSearchFail)
-
 	depart := time.Now().AddDate(0, 0, 30)
 	ret := depart.AddDate(0, 0, 3)
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        depart.Format("2006-01-02"),
-		ReturnDate:  ret.Format("2006-01-02"),
-		Currency:    "GBP",
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           depart.Format("2006-01-02"),
+		ReturnDate:     ret.Format("2006-01-02"),
+		Currency:       "GBP",
+		SearchOverride: mockSearchFail,
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 hack, got %d", len(hacks))
@@ -224,16 +213,16 @@ func makeFlightResult(price float64, currency, airline string) *models.FlightSea
 
 // mockSearchWithPrices returns a mock search function that returns different
 // prices based on whether ReturnDate is set (round-trip vs one-way).
-func mockSearchWithPrices(owOutPrice, owRetPrice, rtOriginPrice, rtDestPrice float64) func(context.Context, *batchexec.Client, string, string, string, flights.SearchOptions) (*models.FlightSearchResult, error) {
-	return func(_ context.Context, _ *batchexec.Client, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+func mockSearchWithPrices(owOutPrice, owRetPrice, rtOriginPrice, rtDestPrice float64) flights.SearchFunc {
+	return func(_ context.Context, origin, dest, date string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
 		if opts.ReturnDate != "" {
 			// Round-trip search. Distinguish by direction.
 			// RT from origin: origin is the user's origin
 			// RT from dest: origin is the user's destination
 			// We detect by checking which direction this is.
 			// In the implementation:
-			//   RT from origin: backToBackSearchFunc(ctx, client, origin, dest, departDate, ...)
-			//   RT from dest:   backToBackSearchFunc(ctx, client, dest, origin, returnDate, ...)
+			//   RT from origin: SearchFlightsWithClient(ctx, client, origin, dest, departDate, ...)
+			//   RT from dest:   SearchFlightsWithClient(ctx, client, dest, origin, returnDate, ...)
 			// So if origin param matches user origin -> rtOriginPrice, else rtDestPrice.
 			// To keep tests simple, we use date to distinguish:
 			// departDate -> rtOriginPrice, returnDate -> rtDestPrice
@@ -259,13 +248,12 @@ func TestDetectBackToBack_livePrices_savings(t *testing.T) {
 	// OW out: 200, OW ret: 180, total = 380
 	// RT origin: 130, RT dest: 120, total = 250
 	// Savings: 380 - 250 = 130
-	withMockSearch(t, mockSearchWithPrices(200, 180, 130, 120))
-
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        "2026-06-01",
-		ReturnDate:  "2026-06-04",
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		ReturnDate:     "2026-06-04",
+		SearchOverride: mockSearchWithPrices(200, 180, 130, 120),
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 hack with savings, got %d", len(hacks))
@@ -299,13 +287,12 @@ func TestDetectBackToBack_livePrices_noSavings(t *testing.T) {
 	// OW total = 200 + 180 = 380
 	// RT total = 200 + 200 = 400
 	// No savings — RT is more expensive.
-	withMockSearch(t, mockSearchWithPrices(200, 180, 200, 200))
-
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        "2026-06-01",
-		ReturnDate:  "2026-06-04",
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		ReturnDate:     "2026-06-04",
+		SearchOverride: mockSearchWithPrices(200, 180, 200, 200),
 	})
 	if len(hacks) != 0 {
 		t.Errorf("expected no hacks when RT is more expensive, got %d", len(hacks))
@@ -316,13 +303,12 @@ func TestDetectBackToBack_livePrices_minimalSavings(t *testing.T) {
 	// OW total = 200 + 200 = 400
 	// RT total = 195 + 195 = 390
 	// Savings = 10, ratio = 10/400 = 2.5% — below 5% threshold
-	withMockSearch(t, mockSearchWithPrices(200, 200, 195, 195))
-
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        "2026-06-01",
-		ReturnDate:  "2026-06-04",
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		ReturnDate:     "2026-06-04",
+		SearchOverride: mockSearchWithPrices(200, 200, 195, 195),
 	})
 	if len(hacks) != 0 {
 		t.Errorf("expected no hacks when savings below threshold, got %d", len(hacks))
@@ -332,19 +318,20 @@ func TestDetectBackToBack_livePrices_minimalSavings(t *testing.T) {
 func TestDetectBackToBack_livePrices_partialSearchFailure(t *testing.T) {
 	// One search fails -> falls back to advisory
 	var callCount atomic.Int32
-	withMockSearch(t, func(_ context.Context, _ *batchexec.Client, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+	override := func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
 		n := callCount.Add(1)
 		if n == 3 {
 			return nil, fmt.Errorf("network error")
 		}
 		return makeFlightResult(200, "EUR", "Finnair"), nil
-	})
+	}
 
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        "2026-06-01",
-		ReturnDate:  "2026-06-04",
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		ReturnDate:     "2026-06-04",
+		SearchOverride: override,
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 advisory hack on partial failure, got %d", len(hacks))
@@ -356,18 +343,19 @@ func TestDetectBackToBack_livePrices_partialSearchFailure(t *testing.T) {
 
 func TestDetectBackToBack_livePrices_zeroPriceResult(t *testing.T) {
 	// One search returns 0 price -> falls back to advisory
-	withMockSearch(t, func(_ context.Context, _ *batchexec.Client, origin, _, _ string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+	override := func(_ context.Context, origin, _, _ string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
 		if origin == "HEL" && opts.ReturnDate != "" {
 			return makeFlightResult(0, "EUR", "Finnair"), nil
 		}
 		return makeFlightResult(200, "EUR", "Finnair"), nil
-	})
+	}
 
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        "2026-06-01",
-		ReturnDate:  "2026-06-04",
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		ReturnDate:     "2026-06-04",
+		SearchOverride: override,
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 advisory hack on zero price, got %d", len(hacks))
@@ -378,13 +366,12 @@ func TestDetectBackToBack_livePrices_zeroPriceResult(t *testing.T) {
 }
 
 func TestDetectBackToBack_livePrices_stepsContainDates(t *testing.T) {
-	withMockSearch(t, mockSearchWithPrices(300, 280, 150, 140))
-
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        "2026-06-01",
-		ReturnDate:  "2026-06-04",
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		ReturnDate:     "2026-06-04",
+		SearchOverride: mockSearchWithPrices(300, 280, 150, 140),
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 hack, got %d", len(hacks))
@@ -408,18 +395,19 @@ func TestDetectBackToBack_livePrices_stepsContainDates(t *testing.T) {
 
 func TestDetectBackToBack_livePrices_contextCancelled(t *testing.T) {
 	// Cancelled context -> search fails -> advisory
-	withMockSearch(t, func(ctx context.Context, _ *batchexec.Client, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+	override := func(ctx context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
 		return nil, ctx.Err()
-	})
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
 	hacks := detectBackToBack(ctx, DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        "2026-06-01",
-		ReturnDate:  "2026-06-04",
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		ReturnDate:     "2026-06-04",
+		SearchOverride: override,
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 advisory hack on cancelled context, got %d", len(hacks))
@@ -432,16 +420,17 @@ func TestDetectBackToBack_livePrices_contextCancelled(t *testing.T) {
 func TestDetectBackToBack_livePrices_searchCount(t *testing.T) {
 	// Verify exactly 4 searches are made.
 	var count atomic.Int32
-	withMockSearch(t, func(_ context.Context, _ *batchexec.Client, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+	override := func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
 		count.Add(1)
 		return makeFlightResult(200, "EUR", "Finnair"), nil
-	})
+	}
 
 	detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        "2026-06-01",
-		ReturnDate:  "2026-06-04",
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		ReturnDate:     "2026-06-04",
+		SearchOverride: override,
 	})
 	if got := count.Load(); got != 4 {
 		t.Errorf("expected exactly 4 search calls, got %d", got)
@@ -452,13 +441,12 @@ func TestDetectBackToBack_livePrices_savingsRounding(t *testing.T) {
 	// OW: 199.5 + 180.3 = 379.8
 	// RT: 129.7 + 119.4 = 249.1
 	// Savings: 130.7 -> rounds to 131
-	withMockSearch(t, mockSearchWithPrices(199.5, 180.3, 129.7, 119.4))
-
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        "2026-06-01",
-		ReturnDate:  "2026-06-04",
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		ReturnDate:     "2026-06-04",
+		SearchOverride: mockSearchWithPrices(199.5, 180.3, 129.7, 119.4),
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 hack, got %d", len(hacks))
@@ -471,15 +459,14 @@ func TestDetectBackToBack_livePrices_savingsRounding(t *testing.T) {
 // --- boundary tests ---
 
 func TestDetectBackToBack_oneNight(t *testing.T) {
-	withMockSearch(t, mockSearchFail)
-
 	depart := time.Now().AddDate(0, 0, 30)
 	ret := depart.AddDate(0, 0, 1)
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        depart.Format("2006-01-02"),
-		ReturnDate:  ret.Format("2006-01-02"),
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           depart.Format("2006-01-02"),
+		ReturnDate:     ret.Format("2006-01-02"),
+		SearchOverride: mockSearchFail,
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 hack for 1-night trip, got %d", len(hacks))
@@ -487,15 +474,14 @@ func TestDetectBackToBack_oneNight(t *testing.T) {
 }
 
 func TestDetectBackToBack_twoWeekTrip(t *testing.T) {
-	withMockSearch(t, mockSearchFail)
-
 	depart := time.Now().AddDate(0, 0, 30)
 	ret := depart.AddDate(0, 0, 14)
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        depart.Format("2006-01-02"),
-		ReturnDate:  ret.Format("2006-01-02"),
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           depart.Format("2006-01-02"),
+		ReturnDate:     ret.Format("2006-01-02"),
+		SearchOverride: mockSearchFail,
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 hack for 14-night trip, got %d", len(hacks))
@@ -516,14 +502,13 @@ func TestBackToBackOverlapDays(t *testing.T) {
 // honesty case (a): an EUR target with EUR-denominated flights passes
 // through labelled EUR.
 func TestDetectBackToBack_livePrices_eurTargetPassthrough(t *testing.T) {
-	withMockSearch(t, mockSearchWithPrices(200, 180, 130, 120))
-
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        "2026-06-01",
-		ReturnDate:  "2026-06-04",
-		Currency:    "EUR",
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		ReturnDate:     "2026-06-04",
+		Currency:       "EUR",
+		SearchOverride: mockSearchWithPrices(200, 180, 130, 120),
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 hack with savings, got %d", len(hacks))
@@ -542,19 +527,20 @@ func TestDetectBackToBack_livePrices_eurTargetPassthrough(t *testing.T) {
 // real exchange-rate table, and the context is cancelled so no live FX fetch
 // can populate the cache either.
 func TestDetectBackToBack_livePrices_nonEURTargetFallsBackToAdvisory(t *testing.T) {
-	withMockSearch(t, func(_ context.Context, _ *batchexec.Client, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+	override := func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
 		return makeFlightResult(200, "ZZZ", "Finnair"), nil
-	})
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	hacks := detectBackToBack(ctx, DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        "2026-06-01",
-		ReturnDate:  "2026-06-04",
-		Currency:    "ZZY",
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		ReturnDate:     "2026-06-04",
+		Currency:       "ZZY",
+		SearchOverride: override,
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 advisory hack (suppressed price), got %d", len(hacks))
@@ -571,14 +557,13 @@ func TestDetectBackToBack_livePrices_nonEURTargetFallsBackToAdvisory(t *testing.
 // whenever a live-priced hack surfaces, its Currency field equals the
 // normalized target currency.
 func TestDetectBackToBack_livePrices_hackCurrencyMatchesTarget(t *testing.T) {
-	withMockSearch(t, mockSearchWithPrices(200, 180, 130, 120))
-
 	hacks := detectBackToBack(context.Background(), DetectorInput{
-		Origin:      "HEL",
-		Destination: "BCN",
-		Date:        "2026-06-01",
-		ReturnDate:  "2026-06-04",
-		Currency:    "eur", // lower-case input must normalize to EUR
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		ReturnDate:     "2026-06-04",
+		Currency:       "eur", // lower-case input must normalize to EUR
+		SearchOverride: mockSearchWithPrices(200, 180, 130, 120),
 	})
 	if len(hacks) != 1 {
 		t.Fatalf("expected 1 hack, got %d", len(hacks))

--- a/internal/hacks/back_to_back_test.go
+++ b/internal/hacks/back_to_back_test.go
@@ -509,3 +509,81 @@ func TestBackToBackOverlapDays(t *testing.T) {
 		t.Errorf("expected backToBackOverlapDays=14, got %d", backToBackOverlapDays)
 	}
 }
+
+// --- currency honesty (display-currency conversion) ---
+
+// TestDetectBackToBack_livePrices_eurTargetPassthrough covers currency
+// honesty case (a): an EUR target with EUR-denominated flights passes
+// through labelled EUR.
+func TestDetectBackToBack_livePrices_eurTargetPassthrough(t *testing.T) {
+	withMockSearch(t, mockSearchWithPrices(200, 180, 130, 120))
+
+	hacks := detectBackToBack(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		ReturnDate:  "2026-06-04",
+		Currency:    "EUR",
+	})
+	if len(hacks) != 1 {
+		t.Fatalf("expected 1 hack with savings, got %d", len(hacks))
+	}
+	if hacks[0].Currency != "EUR" {
+		t.Errorf("expected Currency=EUR, got %q", hacks[0].Currency)
+	}
+}
+
+// TestDetectBackToBack_livePrices_nonEURTargetFallsBackToAdvisory covers case
+// (b): a non-EUR target with no usable rate table must suppress the priced
+// figure rather than show an unconverted or mislabelled one. The detector's
+// existing search-failure fallback (advisory, Savings=0, no concrete price)
+// is the honest suppression path here. Placeholder currency codes (ZZZ/ZZY)
+// are used by convention (see currency_sweep_test.go) since they appear in no
+// real exchange-rate table, and the context is cancelled so no live FX fetch
+// can populate the cache either.
+func TestDetectBackToBack_livePrices_nonEURTargetFallsBackToAdvisory(t *testing.T) {
+	withMockSearch(t, func(_ context.Context, _ *batchexec.Client, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+		return makeFlightResult(200, "ZZZ", "Finnair"), nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	hacks := detectBackToBack(ctx, DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		ReturnDate:  "2026-06-04",
+		Currency:    "ZZY",
+	})
+	if len(hacks) != 1 {
+		t.Fatalf("expected 1 advisory hack (suppressed price), got %d", len(hacks))
+	}
+	if hacks[0].Savings != 0 {
+		t.Errorf("expected advisory fallback with 0 savings when inconvertible, got %.0f", hacks[0].Savings)
+	}
+	if hacks[0].Currency != "ZZY" {
+		t.Errorf("expected Currency=ZZY (normalized target), got %q", hacks[0].Currency)
+	}
+}
+
+// TestDetectBackToBack_livePrices_hackCurrencyMatchesTarget covers case (c):
+// whenever a live-priced hack surfaces, its Currency field equals the
+// normalized target currency.
+func TestDetectBackToBack_livePrices_hackCurrencyMatchesTarget(t *testing.T) {
+	withMockSearch(t, mockSearchWithPrices(200, 180, 130, 120))
+
+	hacks := detectBackToBack(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		ReturnDate:  "2026-06-04",
+		Currency:    "eur", // lower-case input must normalize to EUR
+	})
+	if len(hacks) != 1 {
+		t.Fatalf("expected 1 hack, got %d", len(hacks))
+	}
+	if hacks[0].Currency != "EUR" {
+		t.Errorf("expected Hack.Currency == target EUR, got %q", hacks[0].Currency)
+	}
+}

--- a/internal/hacks/coverage_max_split2_test.go
+++ b/internal/hacks/coverage_max_split2_test.go
@@ -176,7 +176,7 @@ func TestDetectTuesdayBooking_saturdayNotExpensive(t *testing.T) {
 // --- detectMultiTripCombo: 0% coverage, test input guard ---
 
 func TestDetectMultiTripCombo_empty(t *testing.T) {
-	h := detectMultiTripCombo(context.Background(), "", "", nil, "EUR")
+	h := detectMultiTripCombo(context.Background(), "", "", nil, "EUR", nil)
 	if h != nil {
 		t.Error("expected nil for empty inputs")
 	}

--- a/internal/hacks/coverage_target_split2_test.go
+++ b/internal/hacks/coverage_target_split2_test.go
@@ -374,7 +374,7 @@ func TestDetectMultiTripCombo_validTwoTrips(t *testing.T) {
 		{DepartDate: "2026-06-01", ReturnDate: "2026-06-08"},
 		{DepartDate: "2026-07-01", ReturnDate: "2026-07-08"},
 	}
-	h := detectMultiTripCombo(context.Background(), "HEL", "BCN", trips, "EUR")
+	h := detectMultiTripCombo(context.Background(), "HEL", "BCN", trips, "EUR", nil)
 	_ = h
 }
 
@@ -388,7 +388,7 @@ func TestDetectMultiTripCombo_moreThanMax(t *testing.T) {
 			ReturnDate: "2026-06-08",
 		}
 	}
-	h := detectMultiTripCombo(context.Background(), "HEL", "BCN", trips, "EUR")
+	h := detectMultiTripCombo(context.Background(), "HEL", "BCN", trips, "EUR", nil)
 	_ = h
 }
 

--- a/internal/hacks/currency.go
+++ b/internal/hacks/currency.go
@@ -1,0 +1,98 @@
+package hacks
+
+import (
+	"context"
+
+	"github.com/MikkoParkkola/trvl/internal/destinations"
+	"github.com/MikkoParkkola/trvl/internal/ground"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// convertCurrencyFn is the package-level currency-conversion seam every
+// detector must go through instead of calling destinations.ConvertCurrency
+// directly. Production wires it to destinations.ConvertCurrency; tests
+// replace it with a deterministic fake. This is shared mutable package
+// state — tests that reassign it must save/restore the original sequentially
+// and must not run under t.Parallel.
+var convertCurrencyFn = destinations.ConvertCurrency
+
+// convertCurrency converts amount from `from` into `target` through the
+// package's currency seam and reports whether the conversion actually landed
+// in target. This is the single gate every hack detector must pass a price
+// through before combining it with, or displaying it alongside, a price
+// already expressed in a different currency: a non-ok result means the
+// caller must drop the candidate rather than mix denominations or mislabel a
+// total. amount<=0 is always non-convertible (nothing to display).
+func convertCurrency(ctx context.Context, amount float64, from, target string) (float64, bool) {
+	if amount <= 0 {
+		return 0, false
+	}
+	conv, gotCur := convertCurrencyFn(ctx, amount, from, target)
+	if gotCur != target {
+		return 0, false
+	}
+	return conv, true
+}
+
+// cheapestFlightPriceInTarget returns the cheapest positive flight price
+// after converting every flight's price into target via convertCurrency,
+// together with an ok flag. Flights that are non-positive or inconvertible
+// into target are skipped rather than shown unconverted or mislabelled.
+// Returns (0, false) when nothing is convertible.
+//
+// This is the currency.go counterpart of positioning.go's cheapestFlightPriceIn
+// and flight_combo.go's cheapestFlightPriceInCurrency (both of which call
+// destinations.ConvertCurrency directly and predate this seam); new detectors
+// route through here instead so their currency-conversion behaviour is
+// injectable in tests via convertCurrencyFn.
+func cheapestFlightPriceInTarget(ctx context.Context, r *models.FlightSearchResult, target string) (float64, bool) {
+	if r == nil || !r.Success {
+		return 0, false
+	}
+	best := 0.0
+	found := false
+	for _, f := range r.Flights {
+		conv, ok := convertCurrency(ctx, f.Price, f.Currency, target)
+		if !ok {
+			continue
+		}
+		if !found || conv < best {
+			best, found = conv, true
+		}
+	}
+	return best, found
+}
+
+// groundLegPriceInTarget returns the cheapest ground-transport price for a
+// from/to/date/groundType search, converted into target: a live quote when
+// ground.SearchByName returns one in a convertible currency, otherwise the
+// staticEUR fallback estimate converted into target. Returns (0, false) when
+// neither source can be expressed in target.
+//
+// Shared by ferry_positioning.go, multimodal_positioning.go, and
+// multimodal_open_jaw_ground.go — each prices a ground leg by preferring a
+// live provider quote over a conservative static EUR estimate, and each must
+// suppress the candidate rather than mix currencies when neither converts.
+func groundLegPriceInTarget(ctx context.Context, from, to, date, groundType string, staticEUR float64, target string, override ground.SearchFunc) (float64, bool) {
+	best, found := 0.0, false
+	result, err := ground.SearchByName(ctx, from, to, date, ground.SearchOptions{
+		Currency:       target,
+		Type:           groundType,
+		SearchOverride: override,
+	})
+	if err == nil && result.Success {
+		for _, r := range result.Routes {
+			conv, ok := convertCurrency(ctx, r.Price, r.Currency, target)
+			if !ok {
+				continue
+			}
+			if !found || conv < best {
+				best, found = conv, true
+			}
+		}
+	}
+	if found {
+		return best, true
+	}
+	return convertCurrency(ctx, staticEUR, "EUR", target)
+}

--- a/internal/hacks/currency.go
+++ b/internal/hacks/currency.go
@@ -66,14 +66,18 @@ func cheapestFlightPriceInTarget(ctx context.Context, r *models.FlightSearchResu
 // groundLegPriceInTarget returns the cheapest ground-transport price for a
 // from/to/date/groundType search, converted into target: a live quote when
 // ground.SearchByName returns one in a convertible currency, otherwise the
-// staticEUR fallback estimate converted into target. Returns (0, false) when
-// neither source can be expressed in target.
+// staticEUR fallback estimate converted into target. Returns (0, false, false)
+// when neither source can be expressed in target.
+//
+// The third return value, estimated, is true when the price came from the
+// static EUR fallback rather than a live provider quote — callers surface this
+// as an "(estimated fare)" marker so the number is honest about its provenance.
 //
 // Shared by ferry_positioning.go, multimodal_positioning.go, and
 // multimodal_open_jaw_ground.go — each prices a ground leg by preferring a
 // live provider quote over a conservative static EUR estimate, and each must
 // suppress the candidate rather than mix currencies when neither converts.
-func groundLegPriceInTarget(ctx context.Context, from, to, date, groundType string, staticEUR float64, target string, override ground.SearchFunc) (float64, bool) {
+func groundLegPriceInTarget(ctx context.Context, from, to, date, groundType string, staticEUR float64, target string, override ground.SearchFunc) (price float64, ok bool, estimated bool) {
 	best, found := 0.0, false
 	result, err := ground.SearchByName(ctx, from, to, date, ground.SearchOptions{
 		Currency:       target,
@@ -92,7 +96,8 @@ func groundLegPriceInTarget(ctx context.Context, from, to, date, groundType stri
 		}
 	}
 	if found {
-		return best, true
+		return best, true, false
 	}
-	return convertCurrency(ctx, staticEUR, "EUR", target)
+	est, converted := convertCurrency(ctx, staticEUR, "EUR", target)
+	return est, converted, converted
 }

--- a/internal/hacks/currency.go
+++ b/internal/hacks/currency.go
@@ -1,0 +1,12 @@
+package hacks
+
+import "github.com/MikkoParkkola/trvl/internal/destinations"
+
+// convertCurrency is the seam hack detectors use to re-denominate fixed EUR
+// classification constants into the caller's requested currency. Defaults to
+// the live destinations.ConvertCurrency; overridable in tests so the default
+// suite stays offline/deterministic (destinations.ConvertCurrency has no
+// offline fallback). Mirrors the existing railGroundSearcher seam pattern.
+// ponytail: package-level var; currency-injecting tests set/restore it
+// sequentially and must NOT call t.Parallel(), same contract as railGroundSearcher.
+var convertCurrency = destinations.ConvertCurrency

--- a/internal/hacks/currency_estimated_marker_test.go
+++ b/internal/hacks/currency_estimated_marker_test.go
@@ -61,6 +61,9 @@ func TestGroundLegEstimatedFareMarker_presentOnStaticFallback(t *testing.T) {
 	if !strings.Contains(hacks[0].Description, estimatedFareMarker) {
 		t.Errorf("static-estimate fare should be flagged %q; description = %q", estimatedFareMarker, hacks[0].Description)
 	}
+	if !containsMarker(hacks[0].Steps, estimatedFareMarker) {
+		t.Errorf("static-estimate fare should be flagged %q in steps too; steps = %q", estimatedFareMarker, hacks[0].Steps)
+	}
 }
 
 // TestGroundLegEstimatedFareMarker_absentOnLiveQuote: a live provider quote
@@ -85,4 +88,17 @@ func TestGroundLegEstimatedFareMarker_absentOnLiveQuote(t *testing.T) {
 	if strings.Contains(hacks[0].Description, estimatedFareMarker) {
 		t.Errorf("live-quote fare must not be flagged as estimated; description = %q", hacks[0].Description)
 	}
+	if containsMarker(hacks[0].Steps, estimatedFareMarker) {
+		t.Errorf("live-quote fare must not be flagged as estimated in steps; steps = %q", hacks[0].Steps)
+	}
+}
+
+// containsMarker reports whether any step contains the given substring.
+func containsMarker(steps []string, marker string) bool {
+	for _, s := range steps {
+		if strings.Contains(s, marker) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/hacks/currency_estimated_marker_test.go
+++ b/internal/hacks/currency_estimated_marker_test.go
@@ -1,0 +1,88 @@
+package hacks
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/ground"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// ---------------------------------------------------------------------------
+// Estimated-fare provenance marker (see groundLegPriceInTarget in currency.go).
+// A ground/ferry leg priced from the static EUR fallback must render an
+// "(estimated fare)" marker; a live provider quote must not. No t.Parallel:
+// convertCurrencyFn is a shared package-level var restored via t.Cleanup.
+// ---------------------------------------------------------------------------
+
+const estimatedFareMarker = "estimated fare"
+
+// chLiveGroundResult returns a successful single-route ground search priced in
+// the given currency — exercising the live-quote branch of
+// groundLegPriceInTarget (estimated=false).
+func chLiveGroundResult(price float64, currency string) *models.GroundSearchResult {
+	return &models.GroundSearchResult{
+		Success: true,
+		Routes:  []models.GroundRoute{{Provider: "flixbus", Type: "bus", Price: price, Currency: currency}},
+	}
+}
+
+func chMultiModalFlights(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+	switch origin {
+	case "HEL":
+		return chSearchResult(400, "EUR"), nil // direct: 440 USD
+	case "TLL":
+		return chSearchResult(100, "EUR"), nil // hub->dest: 110 USD
+	default:
+		return &models.FlightSearchResult{Success: false}, nil // RIX, ARN dropped
+	}
+}
+
+// TestGroundLegEstimatedFareMarker_presentOnStaticFallback: with no live ground
+// quote the detector falls back to the static EUR estimate, and the rendered
+// description flags the fare as estimated so the number is honest.
+func TestGroundLegEstimatedFareMarker_presentOnStaticFallback(t *testing.T) {
+	withConvertCurrencyFn(t, eurToUSDConvert)
+
+	hacks := detectMultiModalPositioning(context.Background(), DetectorInput{
+		Origin:               "HEL",
+		Destination:          "BCN",
+		Date:                 "2026-06-01",
+		Currency:             "USD",
+		SearchOverride:       chMultiModalFlights,
+		GroundSearchOverride: chFailedGroundSearch, // no live quote -> static estimate
+	})
+
+	if len(hacks) != 1 {
+		t.Fatalf("expected exactly 1 hack, got %d: %+v", len(hacks), hacks)
+	}
+	if !strings.Contains(hacks[0].Description, estimatedFareMarker) {
+		t.Errorf("static-estimate fare should be flagged %q; description = %q", estimatedFareMarker, hacks[0].Description)
+	}
+}
+
+// TestGroundLegEstimatedFareMarker_absentOnLiveQuote: a live provider quote
+// priced the ground leg, so it must not be mislabelled as an estimate.
+func TestGroundLegEstimatedFareMarker_absentOnLiveQuote(t *testing.T) {
+	withConvertCurrencyFn(t, eurToUSDConvert)
+
+	hacks := detectMultiModalPositioning(context.Background(), DetectorInput{
+		Origin:         "HEL",
+		Destination:    "BCN",
+		Date:           "2026-06-01",
+		Currency:       "USD",
+		SearchOverride: chMultiModalFlights,
+		GroundSearchOverride: func(_ context.Context, _, _, _ string, _ ground.SearchOptions) (*models.GroundSearchResult, error) {
+			return chLiveGroundResult(10, "EUR"), nil // live quote -> 11 USD, not an estimate
+		},
+	})
+
+	if len(hacks) != 1 {
+		t.Fatalf("expected exactly 1 hack, got %d: %+v", len(hacks), hacks)
+	}
+	if strings.Contains(hacks[0].Description, estimatedFareMarker) {
+		t.Errorf("live-quote fare must not be flagged as estimated; description = %q", hacks[0].Description)
+	}
+}

--- a/internal/hacks/currency_honesty_test.go
+++ b/internal/hacks/currency_honesty_test.go
@@ -1,0 +1,358 @@
+package hacks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/ground"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// ---------------------------------------------------------------------------
+// Shared currency-honesty test seams for ferry_positioning, multimodal_positioning,
+// multimodal_open_jaw_ground, and multimodal_skip_flight — the four detectors
+// that route every leg through convertCurrency/cheapestFlightPriceInTarget/
+// groundLegPriceInTarget (see currency.go). No t.Parallel: convertCurrencyFn is
+// a shared package-level var, restored sequentially via t.Cleanup.
+// ---------------------------------------------------------------------------
+
+// withConvertCurrencyFn swaps the package-level currency conversion seam for
+// the duration of a test and restores the original on cleanup.
+func withConvertCurrencyFn(t *testing.T, fn func(ctx context.Context, amount float64, from, to string) (float64, string)) {
+	t.Helper()
+	original := convertCurrencyFn
+	convertCurrencyFn = fn
+	t.Cleanup(func() { convertCurrencyFn = original })
+}
+
+// eurToUSDConvert converts EUR->USD at a fixed 1.1 rate and refuses everything
+// else, deterministically (no live rate-table lookup, no network).
+func eurToUSDConvert(_ context.Context, amount float64, from, to string) (float64, string) {
+	if from == "EUR" && to == "USD" {
+		return amount * 1.1, "USD"
+	}
+	return 0, ""
+}
+
+// eurToUSDConvertExceptSmall behaves like eurToUSDConvert but refuses to
+// convert any EUR amount below 50 — used to force exactly one leg (a static
+// ground/ferry estimate) to fail conversion while flight-sized amounts still
+// succeed, isolating the "inconvertible leg drops the candidate" path.
+func eurToUSDConvertExceptSmall(_ context.Context, amount float64, from, to string) (float64, string) {
+	if from == "EUR" && to == "USD" && amount >= 50 {
+		return amount * 1.1, "USD"
+	}
+	return 0, ""
+}
+
+func chSearchResult(price float64, currency string) *models.FlightSearchResult {
+	return &models.FlightSearchResult{Success: true, Flights: []models.FlightResult{{Price: price, Currency: currency}}}
+}
+
+func chFailedGroundSearch(_ context.Context, _, _, _ string, _ ground.SearchOptions) (*models.GroundSearchResult, error) {
+	return &models.GroundSearchResult{Success: false}, nil
+}
+
+// ---------------------------------------------------------------------------
+// ferry_positioning
+// ---------------------------------------------------------------------------
+
+// TestDetectFerryPositioning_nonEURTarget_allLegsConvert_correctTotal covers
+// case (a): a USD target where every leg (direct flight, TLL ferry static
+// estimate, TLL->destination flight) converts cleanly. Only the HEL->TLL route
+// is made to produce a flight leg; ARN/RIX flight legs are forced to fail so
+// they drop out, isolating one deterministic candidate to check arithmetic on.
+func TestDetectFerryPositioning_nonEURTarget_allLegsConvert_correctTotal(t *testing.T) {
+	withConvertCurrencyFn(t, eurToUSDConvert)
+
+	hacks := detectFerryPositioning(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		Currency:    "USD",
+		SearchOverride: func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			switch origin {
+			case "HEL":
+				return chSearchResult(300, "EUR"), nil // direct: 300*1.1=330 USD
+			case "TLL":
+				return chSearchResult(100, "EUR"), nil // positioning leg: 100*1.1=110 USD
+			default:
+				return &models.FlightSearchResult{Success: false}, nil // ARN, RIX dropped
+			}
+		},
+		GroundSearchOverride: chFailedGroundSearch, // forces static-EUR-estimate fallback
+	})
+
+	if len(hacks) != 1 {
+		t.Fatalf("expected exactly 1 hack (TLL route only), got %d: %+v", len(hacks), hacks)
+	}
+	h := hacks[0]
+	if h.Currency != "USD" {
+		t.Errorf("Currency = %q, want USD", h.Currency)
+	}
+	// TLL ferry static estimate is 19 EUR -> 20.9 USD; flight leg 110 USD;
+	// total 130.9; direct 330 USD; savings 199.1 -> rounds to 199.
+	wantSavings := 199.0
+	if h.Savings != wantSavings {
+		t.Errorf("Savings = %v, want %v", h.Savings, wantSavings)
+	}
+}
+
+// TestDetectFerryPositioning_inconvertibleFerryLeg_dropsCandidate covers case
+// (b): the ferry static-EUR estimate (19 EUR, below the 50 floor) cannot
+// convert to target while the flight legs (>=100 EUR) can — the candidate
+// must be dropped rather than mixing currencies, leaving 0 hacks.
+func TestDetectFerryPositioning_inconvertibleFerryLeg_dropsCandidate(t *testing.T) {
+	withConvertCurrencyFn(t, eurToUSDConvertExceptSmall)
+
+	hacks := detectFerryPositioning(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		Currency:    "USD",
+		SearchOverride: func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			switch origin {
+			case "HEL":
+				return chSearchResult(300, "EUR"), nil
+			case "TLL":
+				return chSearchResult(100, "EUR"), nil
+			default:
+				return &models.FlightSearchResult{Success: false}, nil
+			}
+		},
+		GroundSearchOverride: chFailedGroundSearch,
+	})
+
+	if len(hacks) != 0 {
+		t.Errorf("expected 0 hacks when ferry leg cannot convert to target, got %d: %+v", len(hacks), hacks)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// multimodal_positioning
+// ---------------------------------------------------------------------------
+
+// TestDetectMultiModalPositioning_nonEURTarget_allLegsConvert_correctTotal
+// covers case (a) for the ground-then-fly detector.
+func TestDetectMultiModalPositioning_nonEURTarget_allLegsConvert_correctTotal(t *testing.T) {
+	withConvertCurrencyFn(t, eurToUSDConvert)
+
+	hacks := detectMultiModalPositioning(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		Currency:    "USD",
+		SearchOverride: func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			switch origin {
+			case "HEL":
+				return chSearchResult(400, "EUR"), nil // direct: 440 USD
+			case "TLL":
+				return chSearchResult(100, "EUR"), nil // hub->dest: 110 USD
+			default:
+				return &models.FlightSearchResult{Success: false}, nil // RIX, ARN dropped
+			}
+		},
+		GroundSearchOverride: chFailedGroundSearch, // forces static-EUR-estimate fallback
+	})
+
+	if len(hacks) != 1 {
+		t.Fatalf("expected exactly 1 hack (TLL hub only), got %d: %+v", len(hacks), hacks)
+	}
+	h := hacks[0]
+	if h.Currency != "USD" {
+		t.Errorf("Currency = %q, want USD", h.Currency)
+	}
+	// TLL ground static estimate is 19 EUR -> 20.9 USD; flight leg 110 USD;
+	// total 130.9; direct 440 USD; savings 309.1 -> rounds to 309.
+	wantSavings := 309.0
+	if h.Savings != wantSavings {
+		t.Errorf("Savings = %v, want %v", h.Savings, wantSavings)
+	}
+}
+
+// TestDetectMultiModalPositioning_inconvertibleGroundLeg_dropsCandidate
+// covers case (b): the ground static-EUR estimate (19 EUR) cannot convert
+// while flight legs can, so the candidate is dropped -> 0 hacks.
+func TestDetectMultiModalPositioning_inconvertibleGroundLeg_dropsCandidate(t *testing.T) {
+	withConvertCurrencyFn(t, eurToUSDConvertExceptSmall)
+
+	hacks := detectMultiModalPositioning(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		Currency:    "USD",
+		SearchOverride: func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			switch origin {
+			case "HEL":
+				return chSearchResult(400, "EUR"), nil
+			case "TLL":
+				return chSearchResult(100, "EUR"), nil
+			default:
+				return &models.FlightSearchResult{Success: false}, nil
+			}
+		},
+		GroundSearchOverride: chFailedGroundSearch,
+	})
+
+	if len(hacks) != 0 {
+		t.Errorf("expected 0 hacks when ground leg cannot convert to target, got %d: %+v", len(hacks), hacks)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// multimodal_open_jaw_ground
+// ---------------------------------------------------------------------------
+
+// TestDetectMultiModalOpenJawGround_nonEURTarget_allLegsConvert_correctTotal
+// covers case (a), isolating the overnight ZAG hub (which also exercises the
+// hotel-bonus conversion) while SPU is dropped via a failed flight leg.
+func TestDetectMultiModalOpenJawGround_nonEURTarget_allLegsConvert_correctTotal(t *testing.T) {
+	withConvertCurrencyFn(t, eurToUSDConvert)
+
+	hacks := detectMultiModalOpenJawGround(context.Background(), DetectorInput{
+		Origin:      "AMS",
+		Destination: "DBV",
+		Date:        "2026-06-01",
+		Currency:    "USD",
+		SearchOverride: func(_ context.Context, _, destination, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			switch destination {
+			case "DBV":
+				return chSearchResult(500, "EUR"), nil // direct: 550 USD
+			case "ZAG":
+				return chSearchResult(150, "EUR"), nil // origin->hub: 165 USD
+			default:
+				return &models.FlightSearchResult{Success: false}, nil // SPU dropped
+			}
+		},
+		GroundSearchOverride: chFailedGroundSearch, // forces static-EUR-estimate fallback
+	})
+
+	if len(hacks) != 1 {
+		t.Fatalf("expected exactly 1 hack (ZAG hub only), got %d: %+v", len(hacks), hacks)
+	}
+	h := hacks[0]
+	if h.Currency != "USD" {
+		t.Errorf("Currency = %q, want USD", h.Currency)
+	}
+	// ZAG ground static estimate 15 EUR -> 16.5 USD; flight leg 165 USD;
+	// total 181.5; direct 550 USD; hotel bonus 60 EUR -> 66 USD;
+	// savings = 550 - 181.5 + 66 = 434.5 -> rounds to 434 (banker's-safe: 434.5
+	// rounds away from zero to 435 per math.Round; verified below).
+	wantSavings := 435.0
+	if h.Savings != wantSavings {
+		t.Errorf("Savings = %v, want %v", h.Savings, wantSavings)
+	}
+}
+
+// TestDetectMultiModalOpenJawGround_inconvertibleGroundLeg_dropsCandidate
+// covers case (b): the ground static-EUR estimate (15 EUR) cannot convert
+// while flight and hotel-bonus amounts (>=50 EUR) can, so the candidate is
+// dropped -> 0 hacks.
+func TestDetectMultiModalOpenJawGround_inconvertibleGroundLeg_dropsCandidate(t *testing.T) {
+	withConvertCurrencyFn(t, eurToUSDConvertExceptSmall)
+
+	hacks := detectMultiModalOpenJawGround(context.Background(), DetectorInput{
+		Origin:      "AMS",
+		Destination: "DBV",
+		Date:        "2026-06-01",
+		Currency:    "USD",
+		SearchOverride: func(_ context.Context, _, destination, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			switch destination {
+			case "DBV":
+				return chSearchResult(500, "EUR"), nil
+			case "ZAG":
+				return chSearchResult(150, "EUR"), nil
+			default:
+				return &models.FlightSearchResult{Success: false}, nil
+			}
+		},
+		GroundSearchOverride: chFailedGroundSearch,
+	})
+
+	if len(hacks) != 0 {
+		t.Errorf("expected 0 hacks when ground leg cannot convert to target, got %d: %+v", len(hacks), hacks)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// multimodal_skip_flight
+// ---------------------------------------------------------------------------
+
+func chOvernightGroundResult(price float64, currency string) *models.GroundSearchResult {
+	return &models.GroundSearchResult{
+		Success: true,
+		Routes: []models.GroundRoute{{
+			Provider:   "flixbus",
+			Type:       "bus",
+			Price:      price,
+			Currency:   currency,
+			Departure:  models.GroundStop{City: "Helsinki", Time: "2026-06-01T22:00"},
+			Arrival:    models.GroundStop{City: "Barcelona", Time: "2026-06-02T06:00"},
+			BookingURL: "https://example.test/bus",
+		}},
+	}
+}
+
+// TestDetectMultiModalSkipFlight_nonEURTarget_allLegsConvert_correctTotal
+// covers case (a): flight, overnight ground route, and hotel bonus all
+// convert to a non-EUR target with correct arithmetic.
+func TestDetectMultiModalSkipFlight_nonEURTarget_allLegsConvert_correctTotal(t *testing.T) {
+	withConvertCurrencyFn(t, eurToUSDConvert)
+
+	hacks := detectMultiModalSkipFlight(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		Currency:    "USD",
+		SearchOverride: func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			return chSearchResult(300, "EUR"), nil // 330 USD
+		},
+		GroundSearchOverride: func(_ context.Context, _, _, _ string, _ ground.SearchOptions) (*models.GroundSearchResult, error) {
+			return chOvernightGroundResult(100, "EUR"), nil // 110 USD
+		},
+	})
+
+	if len(hacks) != 1 {
+		t.Fatalf("expected exactly 1 hack, got %d: %+v", len(hacks), hacks)
+	}
+	h := hacks[0]
+	if h.Currency != "USD" {
+		t.Errorf("Currency = %q, want USD", h.Currency)
+	}
+	// flight 330 USD - ground 110 USD + hotel bonus (60 EUR -> 66 USD) = 286.
+	wantSavings := 286.0
+	if h.Savings != wantSavings {
+		t.Errorf("Savings = %v, want %v", h.Savings, wantSavings)
+	}
+}
+
+// TestDetectMultiModalSkipFlight_inconvertibleGroundLeg_dropsCandidate covers
+// case (b): the only overnight ground route is priced in a currency the
+// conversion seam refuses, so it must be skipped rather than mixed into the
+// saving figure -- no route survives -> 0 hacks.
+func TestDetectMultiModalSkipFlight_inconvertibleGroundLeg_dropsCandidate(t *testing.T) {
+	withConvertCurrencyFn(t, func(_ context.Context, amount float64, from, to string) (float64, string) {
+		if from == "EUR" && to == "USD" {
+			return amount * 1.1, "USD" // flight + hotel bonus convert fine
+		}
+		return 0, "" // ground route currency ("XXX") never converts
+	})
+
+	hacks := detectMultiModalSkipFlight(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		Currency:    "USD",
+		SearchOverride: func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			return chSearchResult(300, "EUR"), nil
+		},
+		GroundSearchOverride: func(_ context.Context, _, _, _ string, _ ground.SearchOptions) (*models.GroundSearchResult, error) {
+			return chOvernightGroundResult(100, "XXX"), nil // inconvertible leg
+		},
+	})
+
+	if len(hacks) != 0 {
+		t.Errorf("expected 0 hacks when the only overnight ground route cannot convert to target, got %d: %+v", len(hacks), hacks)
+	}
+}

--- a/internal/hacks/currency_sweep_test.go
+++ b/internal/hacks/currency_sweep_test.go
@@ -1,0 +1,190 @@
+package hacks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// gr builds a minimal GroundRoute for the currency-conversion tests.
+func gr(price float64, currency, depTime, arrTime string) models.GroundRoute {
+	return models.GroundRoute{
+		Provider: "flixbus",
+		Type:     "bus",
+		Price:    price,
+		Currency: currency,
+		Departure: models.GroundStop{City: "A", Time: depTime},
+		Arrival:   models.GroundStop{City: "B", Time: arrTime},
+	}
+}
+
+// offlineCtx returns a context guaranteed to make any outbound currency-rate
+// fetch fail immediately, so no new network traffic originates from this test.
+// Determinism does NOT rely on offline-ness alone: the "inconvertible" cases use
+// placeholder currency codes (ZZZ/ZZY) that appear in no real exchange-rate
+// table, so ConvertCurrency returns the original currency (!= target) and the
+// route is skipped whether the shared rate cache is warm or cold. Same-currency
+// (EUR→EUR) conversions short-circuit before any HTTP call.
+func offlineCtx() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
+
+const (
+	dayDep, dayArr     = "2026-04-13T09:00", "2026-04-13T14:00"
+	nightDep, nightArr = "2026-04-13T22:00", "2026-04-14T06:00"
+)
+
+// TestSelectCheapestGroundConverted is the regression guard for the currency
+// honesty of the multimodal detectors (skip_flight, open_jaw_ground,
+// positioning, ferry_positioning). Every price is FX-converted into the
+// requested target currency; a route that cannot be converted is skipped rather
+// than mislabelled. The "inconvertible" cases use placeholder currency codes
+// (ZZZ/ZZY) so they are deterministically unconvertible regardless of the shared
+// rate cache's state.
+func TestSelectCheapestGroundConverted(t *testing.T) {
+	tests := []struct {
+		name          string
+		routes        []models.GroundRoute
+		target        string
+		overnightOnly bool
+		offline       bool
+		wantOK        bool
+		wantPrice     float64
+	}{
+		{
+			// A foreign route that cannot be converted is skipped; the
+			// same-currency EUR route is selected and labelled honestly.
+			name:      "foreign inconvertible skipped, EUR selected",
+			routes:    []models.GroundRoute{gr(20, "ZZZ", dayDep, dayArr), gr(30, "EUR", dayDep, dayArr)},
+			target:    "EUR",
+			offline:   true,
+			wantOK:    true,
+			wantPrice: 30,
+		},
+		{
+			name:      "single EUR route selected",
+			routes:    []models.GroundRoute{gr(45, "EUR", dayDep, dayArr)},
+			target:    "EUR",
+			wantOK:    true,
+			wantPrice: 45,
+		},
+		{
+			// No convertible route => suppress rather than mislabel.
+			name:    "all-foreign inconvertible suppresses",
+			routes:  []models.GroundRoute{gr(20, "ZZZ", dayDep, dayArr), gr(25, "ZZY", dayDep, dayArr)},
+			target:  "EUR",
+			offline: true,
+			wantOK:  false,
+		},
+		{
+			name:          "overnightOnly filters out daytime route",
+			routes:        []models.GroundRoute{gr(40, "EUR", dayDep, dayArr)},
+			target:        "EUR",
+			overnightOnly: true,
+			wantOK:        false,
+		},
+		{
+			name:          "overnightOnly keeps overnight route",
+			routes:        []models.GroundRoute{gr(40, "EUR", nightDep, nightArr)},
+			target:        "EUR",
+			overnightOnly: true,
+			wantOK:        true,
+			wantPrice:     40,
+		},
+		{
+			name:      "non-positive prices ignored, positive EUR picked",
+			routes:    []models.GroundRoute{gr(0, "EUR", dayDep, dayArr), gr(-5, "EUR", dayDep, dayArr), gr(55, "EUR", dayDep, dayArr)},
+			target:    "EUR",
+			wantOK:    true,
+			wantPrice: 55,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.offline {
+				ctx = offlineCtx()
+			}
+			route, price, ok := selectCheapestGroundConverted(ctx, tc.routes, tc.target, tc.overnightOnly)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (route=%+v price=%.0f)", ok, tc.wantOK, route, price)
+			}
+			if !tc.wantOK {
+				if route != nil {
+					t.Fatalf("expected nil route on suppression, got %+v", route)
+				}
+				return
+			}
+			if route == nil {
+				t.Fatalf("expected a route at %.0f, got nil", tc.wantPrice)
+			}
+			if price != tc.wantPrice {
+				t.Errorf("price = %.0f, want %.0f", price, tc.wantPrice)
+			}
+			if route.price != tc.wantPrice {
+				t.Errorf("route.price = %.0f, want %.0f", route.price, tc.wantPrice)
+			}
+			if route.currency != tc.target {
+				t.Errorf("route.currency = %q, want %q", route.currency, tc.target)
+			}
+		})
+	}
+}
+
+// flightResult builds a FlightSearchResult from (price) pairs, all in currency.
+func flightResult(success bool, currency string, prices ...float64) *models.FlightSearchResult {
+	flights := make([]models.FlightResult, 0, len(prices))
+	for _, p := range prices {
+		flights = append(flights, models.FlightResult{Price: p, Currency: currency})
+	}
+	return &models.FlightSearchResult{Success: success, Flights: flights}
+}
+
+// TestMinFlightPriceConverted pins the flight-side helper: same-currency flights
+// convert trivially and the minimum positive price wins; nil/failed/empty
+// results yield ok=false.
+func TestMinFlightPriceConverted(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("same-currency min selected", func(t *testing.T) {
+		r := flightResult(true, "EUR", 120, 90, 150)
+		got, ok := minFlightPriceConverted(ctx, r, "EUR")
+		if !ok {
+			t.Fatalf("ok = false, want true")
+		}
+		if got != 90 {
+			t.Errorf("got = %.0f, want 90", got)
+		}
+	})
+
+	t.Run("nil result", func(t *testing.T) {
+		if _, ok := minFlightPriceConverted(ctx, nil, "EUR"); ok {
+			t.Errorf("ok = true, want false for nil result")
+		}
+	})
+
+	t.Run("unsuccessful result", func(t *testing.T) {
+		r := flightResult(false, "EUR", 100)
+		if _, ok := minFlightPriceConverted(ctx, r, "EUR"); ok {
+			t.Errorf("ok = true, want false for unsuccessful result")
+		}
+	})
+
+	t.Run("no positive-priced flights", func(t *testing.T) {
+		r := flightResult(true, "EUR", 0, -10)
+		if _, ok := minFlightPriceConverted(ctx, r, "EUR"); ok {
+			t.Errorf("ok = true, want false when no positive prices")
+		}
+	})
+
+	t.Run("foreign inconvertible", func(t *testing.T) {
+		r := flightResult(true, "ZZZ", 100)
+		if _, ok := minFlightPriceConverted(offlineCtx(), r, "EUR"); ok {
+			t.Errorf("ok = true, want false when foreign fare is inconvertible")
+		}
+	})
+}

--- a/internal/hacks/departure_tax.go
+++ b/internal/hacks/departure_tax.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 )
 
 // departureTaxEUR maps country ISO codes to approximate aviation departure tax
@@ -49,7 +51,7 @@ func countryName(cc string) string {
 // detectDepartureTax fires when the origin airport is in a country with
 // significant aviation departure tax and a nearby alternative airport sits
 // in a zero-tax country. Purely advisory — zero API calls.
-func detectDepartureTax(_ context.Context, in DetectorInput) []Hack {
+func detectDepartureTax(ctx context.Context, in DetectorInput) []Hack {
 	if !in.valid() {
 		return nil
 	}
@@ -105,25 +107,39 @@ func detectDepartureTax(_ context.Context, in DetectorInput) []Hack {
 
 	savings := originTax // per person per departure
 
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+	convTax, taxCur := destinations.ConvertCurrency(ctx, originTax, "EUR", target)
+	if taxCur != target {
+		return nil
+	}
+	convGround, groundCur := destinations.ConvertCurrency(ctx, best.groundCost, "EUR", target)
+	if groundCur != target {
+		return nil
+	}
+	savings = convTax
+
 	return []Hack{{
 		Type: "departure_tax",
-		Title: fmt.Sprintf("Save ~EUR %.0f tax — fly from %s (%s) instead",
-			savings, best.city, best.iata),
+		Title: fmt.Sprintf("Save ~%s %.0f tax — fly from %s (%s) instead",
+			target, savings, best.city, best.iata),
 		Description: fmt.Sprintf(
-			"%s charges EUR %.0f aviation tax per departure. %s (%s, %s) has zero aviation tax. "+
-				"Ground transport to %s costs ~EUR %.0f.",
-			countryName(originCountry), originTax,
+			"%s charges %s %.0f aviation tax per departure. %s (%s, %s) has zero aviation tax. "+
+				"Ground transport to %s costs ~%s %.0f.",
+			countryName(originCountry), target, convTax,
 			best.city, best.iata, countryName(best.country),
-			best.city, best.groundCost),
+			best.city, target, convGround),
 		Savings:  savings,
-		Currency: in.currency(),
+		Currency: target,
 		Steps: []string{
 			fmt.Sprintf("Compare flight prices from %s vs %s to %s",
 				strings.ToUpper(in.Origin), best.iata, strings.ToUpper(in.Destination)),
-			fmt.Sprintf("Add ~EUR %.0f ground transport cost from %s to %s",
-				best.groundCost, strings.ToUpper(in.Origin), best.iata),
-			fmt.Sprintf("Savings: EUR %.0f per person in avoided departure tax (minus transport cost)",
-				savings),
+			fmt.Sprintf("Add ~%s %.0f ground transport cost from %s to %s",
+				target, convGround, strings.ToUpper(in.Origin), best.iata),
+			fmt.Sprintf("Savings: %s %.0f per person in avoided departure tax (minus transport cost)",
+				target, savings),
 		},
 		Risks: []string{
 			"Ground transport adds travel time and complexity",

--- a/internal/hacks/departure_tax.go
+++ b/internal/hacks/departure_tax.go
@@ -105,8 +105,6 @@ func detectDepartureTax(ctx context.Context, in DetectorInput) []Hack {
 		}
 	}
 
-	savings := originTax // per person per departure
-
 	target := strings.ToUpper(strings.TrimSpace(in.currency()))
 	if target == "" {
 		target = "EUR"
@@ -119,11 +117,18 @@ func detectDepartureTax(ctx context.Context, in DetectorInput) []Hack {
 	if groundCur != target {
 		return nil
 	}
-	savings = convTax
+	// Savings must be net of the cost of actually reaching the alternative
+	// airport — the Steps text below says "minus transport cost", so the
+	// number has to match, not report the gross tax figure as if transport
+	// were free.
+	savings := roundSavings(convTax - convGround)
+	if savings <= 0 {
+		return nil
+	}
 
 	return []Hack{{
 		Type: "departure_tax",
-		Title: fmt.Sprintf("Save ~%s %.0f tax — fly from %s (%s) instead",
+		Title: fmt.Sprintf("Save ~%s %.0f (net of transport) — fly from %s (%s) instead",
 			target, savings, best.city, best.iata),
 		Description: fmt.Sprintf(
 			"%s charges %s %.0f aviation tax per departure. %s (%s, %s) has zero aviation tax. "+

--- a/internal/hacks/departure_tax.go
+++ b/internal/hacks/departure_tax.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-
-	"github.com/MikkoParkkola/trvl/internal/destinations"
 )
 
 // departureTaxEUR maps country ISO codes to approximate aviation departure tax
@@ -109,11 +107,11 @@ func detectDepartureTax(ctx context.Context, in DetectorInput) []Hack {
 	if target == "" {
 		target = "EUR"
 	}
-	convTax, taxCur := destinations.ConvertCurrency(ctx, originTax, "EUR", target)
+	convTax, taxCur := convertCurrency(ctx, originTax, "EUR", target)
 	if taxCur != target {
 		return nil
 	}
-	convGround, groundCur := destinations.ConvertCurrency(ctx, best.groundCost, "EUR", target)
+	convGround, groundCur := convertCurrency(ctx, best.groundCost, "EUR", target)
 	if groundCur != target {
 		return nil
 	}

--- a/internal/hacks/departure_tax_test.go
+++ b/internal/hacks/departure_tax_test.go
@@ -2,11 +2,8 @@ package hacks
 
 import (
 	"context"
-	"math"
 	"strings"
 	"testing"
-
-	"github.com/MikkoParkkola/trvl/internal/destinations"
 )
 
 func TestDetectDepartureTax_emptyInput(t *testing.T) {
@@ -214,10 +211,35 @@ func TestDetectDepartureTax_eurTarget_labelsEURAndConverts(t *testing.T) {
 // finding #6 (Savings must be net of ground cost, not the gross tax) AND
 // asserts both the converted numeric amount and the currency label for a
 // non-EUR target, per the review's coverage requirement.
+//
+// codex CHANGES-REQUIRED: the prior version of this test called
+// destinations.ConvertCurrency BOTH to exercise the detector (via the
+// package-level default) and to derive its own expected value — a live
+// network call on each side that proved nothing offline and could not fail
+// deterministically. This version injects a fake convertCurrency at a fixed,
+// known rate (EUR->GBP @ 0.85) via the seam in currency.go, and computes the
+// expected savings independently from that same fixed rate rather than by
+// calling the production converter. No t.Parallel — the seam var is shared
+// package state, set/restored sequentially like railGroundSearcher.
 func TestDetectDepartureTax_nonEURTarget_netsGroundCostAndConverts(t *testing.T) {
 	newSyntheticTaxRoute(t)
-	ctx := context.Background()
-	hacks := detectDepartureTax(ctx, DetectorInput{
+
+	const fakeRate = 0.85
+	orig := convertCurrency
+	convertCurrency = func(_ context.Context, amount float64, from, to string) (float64, string) {
+		if from == to {
+			return amount, to
+		}
+		if from == "EUR" && to == "GBP" {
+			return amount * fakeRate, "GBP"
+		}
+		// Mirror destinations.ConvertCurrency's "can't convert" contract:
+		// return the original amount/currency unchanged.
+		return amount, from
+	}
+	t.Cleanup(func() { convertCurrency = orig })
+
+	hacks := detectDepartureTax(context.Background(), DetectorInput{
 		Origin:      syntheticTaxOrigin,
 		Destination: "BCN",
 		Currency:    "GBP",
@@ -229,14 +251,13 @@ func TestDetectDepartureTax_nonEURTarget_netsGroundCostAndConverts(t *testing.T)
 	if h.Currency != "GBP" {
 		t.Errorf("Currency = %q, want GBP", h.Currency)
 	}
-	// Net EUR 14 (20 tax - 6 ground cost) converted to GBP.
-	wantSavings, cur := destinations.ConvertCurrency(ctx, 14, "EUR", "GBP")
-	if cur != "GBP" {
-		t.Fatalf("test setup: EUR->GBP should be convertible offline, got currency %q", cur)
-	}
-	wantSavings = roundSavings(wantSavings)
-	if math.Abs(h.Savings-wantSavings) > 1 {
-		t.Errorf("Savings = %.2f, want ~%.2f (net EUR 14 converted to GBP)", h.Savings, wantSavings)
+	// Independently computed: EUR 20 tax and EUR 6 ground cost (the synthetic
+	// route's fixtures), each converted at the fixed fake rate, then netted —
+	// the same arithmetic detectDepartureTax performs, but derived here from
+	// known constants rather than by calling the seam under test.
+	wantSavings := roundSavings(20*fakeRate - 6*fakeRate)
+	if h.Savings != wantSavings {
+		t.Errorf("Savings = %.2f, want %.2f (net EUR 14 converted to GBP @ %.2f)", h.Savings, wantSavings, fakeRate)
 	}
 	if h.Savings == 20 {
 		t.Error("Savings equals the gross tax — ground cost was not netted out")
@@ -248,8 +269,22 @@ func TestDetectDepartureTax_nonEURTarget_netsGroundCostAndConverts(t *testing.T)
 // is the ISO 4217 "no currency" placeholder — it will never appear in a
 // real exchange-rate table) suppresses the hack rather than labeling
 // EUR-denominated tax/ground-cost figures with the wrong currency.
-// Deterministic — no live network required.
+// Deterministic — no live network required: the fake seam below always
+// reports "can't convert" (mirroring destinations.ConvertCurrency's real
+// contract for an inconvertible target) without ever dialing out. Prior to
+// this fix the doc comment claimed "no live network required" while the
+// test actually fell through to the live default seam — verified via timing
+// (0.57s vs 0.00s for an offline call) during this seam's introduction.
 func TestDetectDepartureTax_nonEURTarget_suppressedWhenInconvertible(t *testing.T) {
+	orig := convertCurrency
+	convertCurrency = func(_ context.Context, amount float64, from, to string) (float64, string) {
+		if from == to {
+			return amount, to
+		}
+		return amount, from // can't convert — same contract as the real function
+	}
+	t.Cleanup(func() { convertCurrency = orig })
+
 	hacks := detectDepartureTax(context.Background(), DetectorInput{
 		Origin:      "CPH",
 		Destination: "BCN",

--- a/internal/hacks/departure_tax_test.go
+++ b/internal/hacks/departure_tax_test.go
@@ -2,7 +2,11 @@ package hacks
 
 import (
 	"context"
+	"math"
+	"strings"
 	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 )
 
 func TestDetectDepartureTax_emptyInput(t *testing.T) {
@@ -73,15 +77,65 @@ func TestDetectDepartureTax_highTaxNoAlternative(t *testing.T) {
 	}
 }
 
+// TestDetectDepartureTax_cphToHel proves the net-of-ground-cost fix: CPH
+// (DK) has only EUR 5 departure tax, and its cheapest zero-tax alternative
+// (MMX/Malmo) costs EUR 10 in ground transport to reach. Once Savings is
+// honestly netted against the transport cost (rather than reporting the
+// gross tax as if transport were free), that is not a real saving, so no
+// hack should surface.
 func TestDetectDepartureTax_cphToHel(t *testing.T) {
-	// CPH (DK) has EUR 5 tax. Nearby: MMX (SE, zero tax after 2025 abolition).
 	hacks := detectDepartureTax(context.Background(), DetectorInput{
 		Origin:      "CPH",
 		Destination: "BCN",
 	})
-	// CPH has nearby airports (MMX is SE = zero tax).
+	if len(hacks) != 0 {
+		t.Errorf("expected no hack once ground cost (EUR 10) is netted against the EUR 5 tax, got %d", len(hacks))
+	}
+}
+
+// syntheticTaxOrigin/syntheticTaxAlt are injected into the package-level
+// fixture tables for the duration of a test so the net-of-ground-cost
+// arithmetic and non-EUR currency conversion can be proven deterministically.
+// No route in the real fixture data has a ground cost cheaper than the tax
+// saved (see TestDetectDepartureTax_cphToHel), so a synthetic route is
+// required to exercise the surfaced-hack path at all.
+const (
+	syntheticTaxOrigin = "ZZ1"
+	syntheticTaxAlt    = "ZZ2"
+)
+
+// newSyntheticTaxRoute registers a high-tax origin (EUR 20) with a single
+// zero-tax alternative reachable for EUR 6 ground transport — a genuine net
+// saving of EUR 14 — and removes the fixture entries when the test ends.
+func newSyntheticTaxRoute(t *testing.T) {
+	t.Helper()
+	iataToCountry[syntheticTaxOrigin] = "Z1"
+	iataToCountry[syntheticTaxAlt] = "Z2"
+	departureTaxEUR["Z1"] = 20
+	departureTaxEUR["Z2"] = 0
+	nearbyAirports[syntheticTaxOrigin] = []nearbyEntry{
+		{Code: syntheticTaxAlt, City: "Zed City", GroundCost: 6, GroundMins: 30, Description: "Bus"},
+	}
+	t.Cleanup(func() {
+		delete(iataToCountry, syntheticTaxOrigin)
+		delete(iataToCountry, syntheticTaxAlt)
+		delete(departureTaxEUR, "Z1")
+		delete(departureTaxEUR, "Z2")
+		delete(nearbyAirports, syntheticTaxOrigin)
+	})
+}
+
+// TestDetectDepartureTax_fieldsPopulated proves the surfaced hack carries a
+// full set of user-facing fields, using the synthetic route so a genuine net
+// saving actually exists to surface.
+func TestDetectDepartureTax_fieldsPopulated(t *testing.T) {
+	newSyntheticTaxRoute(t)
+	hacks := detectDepartureTax(context.Background(), DetectorInput{
+		Origin:      syntheticTaxOrigin,
+		Destination: "BCN",
+	})
 	if len(hacks) == 0 {
-		t.Fatal("expected a hack for CPH (DK tax) with MMX (SE zero tax) alternative")
+		t.Fatal("expected a hack for the synthetic high-tax route")
 	}
 	h := hacks[0]
 	if h.Type != "departure_tax" {
@@ -105,20 +159,21 @@ func TestDetectDepartureTax_cphToHel(t *testing.T) {
 }
 
 func TestDetectDepartureTax_caseInsensitive(t *testing.T) {
+	newSyntheticTaxRoute(t)
 	// Lowercase input should work.
 	hacks := detectDepartureTax(context.Background(), DetectorInput{
-		Origin:      "cph",
+		Origin:      strings.ToLower(syntheticTaxOrigin),
 		Destination: "bcn",
 	})
-	// CPH has nearby zero-tax alternatives.
 	if len(hacks) == 0 {
-		t.Fatal("expected hack for lowercase cph")
+		t.Fatal("expected hack for lowercase origin")
 	}
 }
 
 func TestDetectDepartureTax_currencyDefault(t *testing.T) {
+	newSyntheticTaxRoute(t)
 	hacks := detectDepartureTax(context.Background(), DetectorInput{
-		Origin:      "CPH",
+		Origin:      syntheticTaxOrigin,
 		Destination: "BCN",
 	})
 	if len(hacks) == 0 {
@@ -127,15 +182,20 @@ func TestDetectDepartureTax_currencyDefault(t *testing.T) {
 	if hacks[0].Currency != "EUR" {
 		t.Errorf("currency = %q, want EUR", hacks[0].Currency)
 	}
+	if hacks[0].Savings <= 0 {
+		t.Errorf("savings should be > 0, got %.0f", hacks[0].Savings)
+	}
 }
 
 // TestDetectDepartureTax_eurTarget_labelsEURAndConverts proves cases (a)
 // and (c) explicitly: EUR passes through untouched (no network —
-// ConvertCurrency short-circuits on from==to) and the surfaced hack's
-// Currency matches the target.
+// ConvertCurrency short-circuits on from==to), the surfaced hack's Currency
+// matches the target, and Savings is net of the EUR 6 ground cost (finding
+// #6): 20 - 6 = 14.
 func TestDetectDepartureTax_eurTarget_labelsEURAndConverts(t *testing.T) {
+	newSyntheticTaxRoute(t)
 	hacks := detectDepartureTax(context.Background(), DetectorInput{
-		Origin:      "CPH",
+		Origin:      syntheticTaxOrigin,
 		Destination: "BCN",
 		Currency:    "EUR",
 	})
@@ -145,8 +205,41 @@ func TestDetectDepartureTax_eurTarget_labelsEURAndConverts(t *testing.T) {
 	if hacks[0].Currency != "EUR" {
 		t.Errorf("Currency = %q, want EUR", hacks[0].Currency)
 	}
-	if hacks[0].Savings <= 0 {
-		t.Errorf("savings should be > 0, got %.0f", hacks[0].Savings)
+	if hacks[0].Savings != 14 {
+		t.Errorf("Savings = %.2f, want 14 (net of the EUR 6 ground cost)", hacks[0].Savings)
+	}
+}
+
+// TestDetectDepartureTax_nonEURTarget_netsGroundCostAndConverts proves
+// finding #6 (Savings must be net of ground cost, not the gross tax) AND
+// asserts both the converted numeric amount and the currency label for a
+// non-EUR target, per the review's coverage requirement.
+func TestDetectDepartureTax_nonEURTarget_netsGroundCostAndConverts(t *testing.T) {
+	newSyntheticTaxRoute(t)
+	ctx := context.Background()
+	hacks := detectDepartureTax(ctx, DetectorInput{
+		Origin:      syntheticTaxOrigin,
+		Destination: "BCN",
+		Currency:    "GBP",
+	})
+	if len(hacks) == 0 {
+		t.Fatal("expected at least one hack")
+	}
+	h := hacks[0]
+	if h.Currency != "GBP" {
+		t.Errorf("Currency = %q, want GBP", h.Currency)
+	}
+	// Net EUR 14 (20 tax - 6 ground cost) converted to GBP.
+	wantSavings, cur := destinations.ConvertCurrency(ctx, 14, "EUR", "GBP")
+	if cur != "GBP" {
+		t.Fatalf("test setup: EUR->GBP should be convertible offline, got currency %q", cur)
+	}
+	wantSavings = roundSavings(wantSavings)
+	if math.Abs(h.Savings-wantSavings) > 1 {
+		t.Errorf("Savings = %.2f, want ~%.2f (net EUR 14 converted to GBP)", h.Savings, wantSavings)
+	}
+	if h.Savings == 20 {
+		t.Error("Savings equals the gross tax — ground cost was not netted out")
 	}
 }
 

--- a/internal/hacks/departure_tax_test.go
+++ b/internal/hacks/departure_tax_test.go
@@ -129,17 +129,41 @@ func TestDetectDepartureTax_currencyDefault(t *testing.T) {
 	}
 }
 
-func TestDetectDepartureTax_customCurrency(t *testing.T) {
+// TestDetectDepartureTax_eurTarget_labelsEURAndConverts proves cases (a)
+// and (c) explicitly: EUR passes through untouched (no network —
+// ConvertCurrency short-circuits on from==to) and the surfaced hack's
+// Currency matches the target.
+func TestDetectDepartureTax_eurTarget_labelsEURAndConverts(t *testing.T) {
 	hacks := detectDepartureTax(context.Background(), DetectorInput{
 		Origin:      "CPH",
 		Destination: "BCN",
-		Currency:    "DKK",
+		Currency:    "EUR",
 	})
 	if len(hacks) == 0 {
 		t.Fatal("expected at least one hack")
 	}
-	if hacks[0].Currency != "DKK" {
-		t.Errorf("currency = %q, want DKK", hacks[0].Currency)
+	if hacks[0].Currency != "EUR" {
+		t.Errorf("Currency = %q, want EUR", hacks[0].Currency)
+	}
+	if hacks[0].Savings <= 0 {
+		t.Errorf("savings should be > 0, got %.0f", hacks[0].Savings)
+	}
+}
+
+// TestDetectDepartureTax_nonEURTarget_suppressedWhenInconvertible proves
+// case (b): a non-EUR target currency that can't be honestly converted (XXX
+// is the ISO 4217 "no currency" placeholder — it will never appear in a
+// real exchange-rate table) suppresses the hack rather than labeling
+// EUR-denominated tax/ground-cost figures with the wrong currency.
+// Deterministic — no live network required.
+func TestDetectDepartureTax_nonEURTarget_suppressedWhenInconvertible(t *testing.T) {
+	hacks := detectDepartureTax(context.Background(), DetectorInput{
+		Origin:      "CPH",
+		Destination: "BCN",
+		Currency:    "XXX",
+	})
+	if len(hacks) != 0 {
+		t.Errorf("expected no hacks for inconvertible target currency, got %d", len(hacks))
 	}
 }
 

--- a/internal/hacks/error_fare.go
+++ b/internal/hacks/error_fare.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math"
 	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 )
 
 // expectedPriceRange defines the typical EUR price range for a route class.
@@ -96,7 +98,7 @@ func CheckErrorFare(origin, dest string, price float64, isRoundTrip bool) (hackT
 // expected floor for the route distance. Error fares are mispriced tickets
 // that airlines sometimes honour — they should be booked immediately.
 // Purely advisory — zero API calls.
-func detectErrorFare(_ context.Context, in DetectorInput) []Hack {
+func detectErrorFare(ctx context.Context, in DetectorInput) []Hack {
 	if !in.valid() || in.NaivePrice <= 0 {
 		return nil
 	}
@@ -144,6 +146,22 @@ func detectErrorFare(_ context.Context, in DetectorInput) []Hack {
 		return nil // price is normal
 	}
 
+	// ponytail: NaivePrice/floorEUR/typicalEUR stay EUR-internal for
+	// classification (fixed EUR bands); only the display values below get
+	// converted to the target currency.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+	dispPrice, pcur := destinations.ConvertCurrency(ctx, price, "EUR", target)
+	if pcur != target {
+		return nil
+	}
+	dispTypical, tcur := destinations.ConvertCurrency(ctx, expected.typicalEUR, "EUR", target)
+	if tcur != target {
+		return nil
+	}
+
 	tripType := "one-way"
 	if isRoundTrip {
 		tripType = "round-trip"
@@ -154,13 +172,13 @@ func detectErrorFare(_ context.Context, in DetectorInput) []Hack {
 		discount := math.Round(((expected.typicalEUR - price) / expected.typicalEUR) * 100)
 		return []Hack{{
 			Type:  "error_fare",
-			Title: fmt.Sprintf("Possible error fare: €%.0f for %s %s (%s)", price, expected.label, tripType, fmt.Sprintf("%.0f km", dist)),
+			Title: fmt.Sprintf("Possible error fare: %s %.0f for %s %s (%.0f km)", target, dispPrice, expected.label, tripType, dist),
 			Description: fmt.Sprintf(
-				"€%.0f is %.0f%% below the typical €%.0f for %s %s routes (%.0f km). "+
+				"%s %.0f is %.0f%% below the typical %s %.0f for %s %s routes (%.0f km). "+
 					"This may be an error fare — airlines sometimes honour mispriced tickets. Book immediately if interested.",
-				price, discount, expected.typicalEUR, expected.label, tripType, dist),
-			Savings:  math.Round(expected.typicalEUR - price),
-			Currency: in.currency(),
+				target, dispPrice, discount, target, dispTypical, expected.label, tripType, dist),
+			Savings:  roundSavings(dispTypical - dispPrice),
+			Currency: target,
 			Steps: []string{
 				"Book immediately — error fares get corrected within hours",
 				"Pay with a card that has travel protection (chargeback if cancelled)",
@@ -176,16 +194,20 @@ func detectErrorFare(_ context.Context, in DetectorInput) []Hack {
 	}
 
 	// Flash sale — unusually cheap but not error-level.
+	dispFloor, fcur := destinations.ConvertCurrency(ctx, expected.floorEUR, "EUR", target)
+	if fcur != target {
+		return nil
+	}
 	discount := math.Round(((expected.typicalEUR - price) / expected.typicalEUR) * 100)
 	return []Hack{{
 		Type:  "flash_sale",
-		Title: fmt.Sprintf("Flash sale: €%.0f for %s %s (%.0f%% below average)", price, expected.label, tripType, discount),
+		Title: fmt.Sprintf("Flash sale: %s %.0f for %s %s (%.0f%% below average)", target, dispPrice, expected.label, tripType, discount),
 		Description: fmt.Sprintf(
-			"€%.0f is below the typical floor of €%.0f for %s %s routes (%.0f km). "+
+			"%s %.0f is below the typical floor of %s %.0f for %s %s routes (%.0f km). "+
 				"This is likely a legitimate flash sale or promotional fare — good deal, book soon.",
-			price, expected.floorEUR, expected.label, tripType, dist),
-		Savings:  math.Round(expected.typicalEUR - price),
-		Currency: in.currency(),
+			target, dispPrice, target, dispFloor, expected.label, tripType, dist),
+		Savings:  roundSavings(dispTypical - dispPrice),
+		Currency: target,
 		Steps: []string{
 			"Book soon — flash sale inventory is limited",
 			"Check if the fare includes baggage or is basic economy",

--- a/internal/hacks/error_fare.go
+++ b/internal/hacks/error_fare.go
@@ -134,31 +134,45 @@ func detectErrorFare(ctx context.Context, in DetectorInput) []Hack {
 
 	price := in.NaivePrice
 
+	// price (== in.NaivePrice) is already denominated in the caller's
+	// requested currency (see DetectorInput.NaivePrice / DetectorInput.Currency
+	// contract) — it must NOT be converted again from EUR, or every non-EUR
+	// request would show a double-converted figure. But the classification
+	// thresholds below (errorThreshold/flashThreshold) start out as fixed EUR
+	// constants, so THEY must be converted into the target currency before
+	// being compared against price — otherwise a target-currency price is
+	// compared against a raw EUR threshold, and for e.g. JPY (large nominal
+	// values) the detector silently never fires.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
+	// Convert the fixed EUR classification constants into the target
+	// currency before any comparison against price. If we can't honestly
+	// convert, suppress the whole detector rather than compare a
+	// target-currency price against a mislabeled EUR threshold.
+	convFloor, fcur := convertCurrency(ctx, expected.floorEUR, "EUR", target)
+	if fcur != target {
+		return nil
+	}
+	dispTypical, tcur := convertCurrency(ctx, expected.typicalEUR, "EUR", target)
+	if tcur != target {
+		return nil
+	}
+
 	// Error fare threshold: price is below 50% of the floor for this route class.
 	// This is aggressive — we want to catch genuine anomalies, not just sales.
-	errorThreshold := expected.floorEUR * 0.5
+	errorThreshold := convFloor * 0.5
 	// Flash sale threshold: price is below the floor but above the error threshold.
-	flashThreshold := expected.floorEUR
+	flashThreshold := convFloor
 
 	if price >= flashThreshold {
 		return nil // price is normal
 	}
 
-	// price (== in.NaivePrice) is already denominated in the caller's
-	// requested currency (see DetectorInput.NaivePrice / DetectorInput.Currency
-	// contract) — it must NOT be converted again from EUR, or every non-EUR
-	// request would show a double-converted figure. Only the fixed EUR
-	// classification constants (typicalEUR/floorEUR) need conversion for
-	// display.
-	target := strings.ToUpper(strings.TrimSpace(in.currency()))
-	if target == "" {
-		target = "EUR"
-	}
 	dispPrice := price
-	dispTypical, tcur := convertCurrency(ctx, expected.typicalEUR, "EUR", target)
-	if tcur != target {
-		return nil
-	}
+	dispFloor := convFloor
 
 	tripType := "one-way"
 	if isRoundTrip {
@@ -166,8 +180,11 @@ func detectErrorFare(ctx context.Context, in DetectorInput) []Hack {
 	}
 
 	if price <= errorThreshold {
-		// Likely error fare — book immediately.
-		discount := math.Round(((expected.typicalEUR - price) / expected.typicalEUR) * 100)
+		// Likely error fare — book immediately. dispTypical (already in the
+		// target currency) is used for both the discount percentage and the
+		// display text — never the raw EUR expected.typicalEUR mixed with a
+		// target-currency price.
+		discount := math.Round(((dispTypical - price) / dispTypical) * 100)
 		return []Hack{{
 			Type:  "error_fare",
 			Title: fmt.Sprintf("Possible error fare: %s %.0f for %s %s (%.0f km)", target, dispPrice, expected.label, tripType, dist),
@@ -191,12 +208,10 @@ func detectErrorFare(ctx context.Context, in DetectorInput) []Hack {
 		}}
 	}
 
-	// Flash sale — unusually cheap but not error-level.
-	dispFloor, fcur := convertCurrency(ctx, expected.floorEUR, "EUR", target)
-	if fcur != target {
-		return nil
-	}
-	discount := math.Round(((expected.typicalEUR - price) / expected.typicalEUR) * 100)
+	// Flash sale — unusually cheap but not error-level. dispFloor was already
+	// converted above (shared with the threshold comparison) — no second
+	// conversion call needed.
+	discount := math.Round(((dispTypical - price) / dispTypical) * 100)
 	return []Hack{{
 		Type:  "flash_sale",
 		Title: fmt.Sprintf("Flash sale: %s %.0f for %s %s (%.0f%% below average)", target, dispPrice, expected.label, tripType, discount),

--- a/internal/hacks/error_fare.go
+++ b/internal/hacks/error_fare.go
@@ -146,17 +146,17 @@ func detectErrorFare(ctx context.Context, in DetectorInput) []Hack {
 		return nil // price is normal
 	}
 
-	// ponytail: NaivePrice/floorEUR/typicalEUR stay EUR-internal for
-	// classification (fixed EUR bands); only the display values below get
-	// converted to the target currency.
+	// price (== in.NaivePrice) is already denominated in the caller's
+	// requested currency (see DetectorInput.NaivePrice / DetectorInput.Currency
+	// contract) — it must NOT be converted again from EUR, or every non-EUR
+	// request would show a double-converted figure. Only the fixed EUR
+	// classification constants (typicalEUR/floorEUR) need conversion for
+	// display.
 	target := strings.ToUpper(strings.TrimSpace(in.currency()))
 	if target == "" {
 		target = "EUR"
 	}
-	dispPrice, pcur := destinations.ConvertCurrency(ctx, price, "EUR", target)
-	if pcur != target {
-		return nil
-	}
+	dispPrice := price
 	dispTypical, tcur := destinations.ConvertCurrency(ctx, expected.typicalEUR, "EUR", target)
 	if tcur != target {
 		return nil

--- a/internal/hacks/error_fare.go
+++ b/internal/hacks/error_fare.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-
-	"github.com/MikkoParkkola/trvl/internal/destinations"
 )
 
 // expectedPriceRange defines the typical EUR price range for a route class.
@@ -157,7 +155,7 @@ func detectErrorFare(ctx context.Context, in DetectorInput) []Hack {
 		target = "EUR"
 	}
 	dispPrice := price
-	dispTypical, tcur := destinations.ConvertCurrency(ctx, expected.typicalEUR, "EUR", target)
+	dispTypical, tcur := convertCurrency(ctx, expected.typicalEUR, "EUR", target)
 	if tcur != target {
 		return nil
 	}
@@ -194,7 +192,7 @@ func detectErrorFare(ctx context.Context, in DetectorInput) []Hack {
 	}
 
 	// Flash sale — unusually cheap but not error-level.
-	dispFloor, fcur := destinations.ConvertCurrency(ctx, expected.floorEUR, "EUR", target)
+	dispFloor, fcur := convertCurrency(ctx, expected.floorEUR, "EUR", target)
 	if fcur != target {
 		return nil
 	}

--- a/internal/hacks/error_fare_test.go
+++ b/internal/hacks/error_fare_test.go
@@ -2,6 +2,8 @@ package hacks
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -182,8 +184,20 @@ func TestCheckErrorFare_empty_input(t *testing.T) {
 // (b): a non-EUR target currency that can't be honestly converted (XXX is
 // the ISO 4217 "no currency" placeholder — it will never appear in a real
 // exchange-rate table) suppresses the hack rather than labeling EUR-priced
-// math with the wrong currency. Deterministic — no live network required.
+// math with the wrong currency. Deterministic — no live network required:
+// the fake seam below always reports "can't convert" without ever dialing
+// out (the prior version of this test relied on the live default seam
+// despite its doc comment's claim otherwise).
 func TestDetectErrorFare_nonEURTarget_suppressedWhenInconvertible(t *testing.T) {
+	orig := convertCurrency
+	convertCurrency = func(_ context.Context, amount float64, from, to string) (float64, string) {
+		if from == to {
+			return amount, to
+		}
+		return amount, from // can't convert — same contract as the real function
+	}
+	t.Cleanup(func() { convertCurrency = orig })
+
 	in := DetectorInput{
 		Origin:      "HEL",
 		Destination: "BCN",
@@ -216,6 +230,70 @@ func TestDetectErrorFare_eurTarget_labelsEURAndConverts(t *testing.T) {
 	}
 	if hacks[0].Savings <= 0 {
 		t.Error("expected positive savings")
+	}
+}
+
+// TestDetectErrorFare_nonEURTarget_noDoubleConversion is a deterministic
+// regression test for the double-conversion bug: in.NaivePrice is already
+// denominated in the caller's requested currency (per the
+// DetectorInput.NaivePrice/Currency contract), so it must be displayed
+// as-is — NOT converted again from EUR. Only the fixed EUR classification
+// constant (typicalEUR) needs conversion for display.
+//
+// Uses a fake convertCurrency injected via the seam in currency.go at a
+// fixed, known rate (EUR->GBP @ 0.85) so the assertion is computed
+// independently of the live destinations.ConvertCurrency — no network
+// required, no t.Parallel (seam var is shared package state, set/restored
+// sequentially like railGroundSearcher).
+func TestDetectErrorFare_nonEURTarget_noDoubleConversion(t *testing.T) {
+	const fakeRate = 0.85
+	orig := convertCurrency
+	convertCurrency = func(_ context.Context, amount float64, from, to string) (float64, string) {
+		if from == to {
+			return amount, to
+		}
+		if from == "EUR" && to == "GBP" {
+			return amount * fakeRate, "GBP"
+		}
+		return amount, from
+	}
+	t.Cleanup(func() { convertCurrency = orig })
+
+	// HEL->BCN is ~2900 km (long-haul). One-way floor = EUR 60, typical =
+	// EUR 250, error threshold = EUR 30. NaivePrice 20 (already in GBP, per
+	// contract) is below the error threshold, so error_fare fires.
+	const naivePriceGBP = 20.0
+	in := DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		NaivePrice:  naivePriceGBP,
+		Currency:    "GBP",
+	}
+	hacks := detectErrorFare(context.Background(), in)
+	if len(hacks) == 0 {
+		t.Fatal("expected error_fare hack for GBP 20 HEL->BCN one-way")
+	}
+	h := hacks[0]
+
+	if h.Currency != "GBP" {
+		t.Errorf("Currency = %q, want GBP", h.Currency)
+	}
+
+	displayedPrice := fmt.Sprintf("GBP %.0f", naivePriceGBP)
+	if !strings.Contains(h.Title, displayedPrice) {
+		t.Errorf("Title = %q, want it to contain %q (raw NaivePrice, not re-converted)", h.Title, displayedPrice)
+	}
+	if !strings.Contains(h.Description, displayedPrice) {
+		t.Errorf("Description = %q, want it to contain %q (raw NaivePrice, not re-converted)", h.Description, displayedPrice)
+	}
+
+	// typicalEUR for long-haul one-way is 250 (routePriceRanges in
+	// error_fare.go); converted at the fixed fake rate, independent of the
+	// seam under test.
+	const typicalEUR = 250.0
+	wantSavings := roundSavings(typicalEUR*fakeRate - naivePriceGBP)
+	if h.Savings != wantSavings {
+		t.Errorf("Savings = %.2f, want %.2f (typicalEUR converted to GBP minus raw NaivePrice)", h.Savings, wantSavings)
 	}
 }
 

--- a/internal/hacks/error_fare_test.go
+++ b/internal/hacks/error_fare_test.go
@@ -178,6 +178,47 @@ func TestCheckErrorFare_empty_input(t *testing.T) {
 	}
 }
 
+// TestDetectErrorFare_nonEURTarget_suppressedWhenInconvertible proves case
+// (b): a non-EUR target currency that can't be honestly converted (XXX is
+// the ISO 4217 "no currency" placeholder — it will never appear in a real
+// exchange-rate table) suppresses the hack rather than labeling EUR-priced
+// math with the wrong currency. Deterministic — no live network required.
+func TestDetectErrorFare_nonEURTarget_suppressedWhenInconvertible(t *testing.T) {
+	in := DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		NaivePrice:  20,
+		Currency:    "XXX",
+	}
+	hacks := detectErrorFare(context.Background(), in)
+	if len(hacks) != 0 {
+		t.Errorf("expected no hacks for inconvertible target currency, got %d", len(hacks))
+	}
+}
+
+// TestDetectErrorFare_eurTarget_labelsEURAndConverts proves cases (a) and
+// (c): EUR passes through untouched (no network — ConvertCurrency
+// short-circuits on from==to) and the surfaced hack's Currency matches the
+// target.
+func TestDetectErrorFare_eurTarget_labelsEURAndConverts(t *testing.T) {
+	in := DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		NaivePrice:  20,
+		Currency:    "EUR",
+	}
+	hacks := detectErrorFare(context.Background(), in)
+	if len(hacks) == 0 {
+		t.Fatal("expected error_fare hack for €20 HEL→BCN one-way")
+	}
+	if hacks[0].Currency != "EUR" {
+		t.Errorf("Currency = %q, want EUR", hacks[0].Currency)
+	}
+	if hacks[0].Savings <= 0 {
+		t.Error("expected positive savings")
+	}
+}
+
 func TestDetectErrorFare_intercontinental(t *testing.T) {
 	// LHR→JFK is ~5500 km. Intercontinental OW floor = €150, error = €75.
 	// €50 should trigger error_fare.

--- a/internal/hacks/error_fare_test.go
+++ b/internal/hacks/error_fare_test.go
@@ -3,6 +3,7 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 )
@@ -294,6 +295,90 @@ func TestDetectErrorFare_nonEURTarget_noDoubleConversion(t *testing.T) {
 	wantSavings := roundSavings(typicalEUR*fakeRate - naivePriceGBP)
 	if h.Savings != wantSavings {
 		t.Errorf("Savings = %.2f, want %.2f (typicalEUR converted to GBP minus raw NaivePrice)", h.Savings, wantSavings)
+	}
+}
+
+// TestDetectErrorFare_nonEURTarget_JPY_classifiesCorrectly is a deterministic
+// regression test for the threshold-currency-mismatch bug: in.NaivePrice is
+// denominated in the caller's requested currency (target), but the
+// classification thresholds (errorThreshold/flashThreshold) started life as
+// fixed EUR constants. Before the fix, those EUR thresholds were compared
+// directly against a target-currency price with no conversion — for a
+// large-nominal currency like JPY, a EUR 15 flashThreshold is tiny next to
+// any realistic JPY price, so `price >= flashThreshold` was always true and
+// the detector never fired for JPY (or any non-EUR currency).
+//
+// Uses a fake convertCurrency injected via the seam in currency.go at a
+// fixed, known rate (EUR->JPY @ 130) so the assertion is computed
+// independently of the live destinations.ConvertCurrency — no network
+// required, no t.Parallel (seam var is shared package state, set/restored
+// sequentially like railGroundSearcher).
+func TestDetectErrorFare_nonEURTarget_JPY_classifiesCorrectly(t *testing.T) {
+	const fakeRate = 130.0
+	orig := convertCurrency
+	convertCurrency = func(_ context.Context, amount float64, from, to string) (float64, string) {
+		if from == to {
+			return amount, to
+		}
+		if from == "EUR" && to == "JPY" {
+			return amount * fakeRate, "JPY"
+		}
+		return amount, from
+	}
+	t.Cleanup(func() { convertCurrency = orig })
+
+	// HEL->BCN is ~2900 km (long-haul). One-way floor = EUR 60, typical =
+	// EUR 250. Converted at the fake rate: floor = JPY 7800, typical =
+	// JPY 32500, error threshold = JPY 3900 (50% of floor).
+	//
+	// NaivePrice 2000 (already in JPY, per contract) is below the JPY error
+	// threshold (3900) but was NEVER below the buggy raw-EUR flashThreshold
+	// comparison (JPY 2000 >= EUR 60 is always true in float terms) — so the
+	// pre-fix detector silently returned nil for this input.
+	const naivePriceJPY = 2000.0
+	in := DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		NaivePrice:  naivePriceJPY,
+		Currency:    "JPY",
+	}
+	hacks := detectErrorFare(context.Background(), in)
+	if len(hacks) == 0 {
+		t.Fatal("expected error_fare hack for JPY 2000 HEL->BCN one-way (threshold must be converted to JPY, not compared raw EUR)")
+	}
+	h := hacks[0]
+
+	if h.Type != "error_fare" {
+		t.Errorf("Type = %q, want error_fare", h.Type)
+	}
+	if h.Currency != "JPY" {
+		t.Errorf("Currency = %q, want JPY", h.Currency)
+	}
+
+	const typicalEUR = 250.0
+	const floorEUR = 60.0
+	dispTypical := typicalEUR * fakeRate // JPY 32500
+	convFloor := floorEUR * fakeRate     // JPY 7800
+	errorThreshold := convFloor * 0.5    // JPY 3900
+
+	if naivePriceJPY > errorThreshold {
+		t.Fatalf("test precondition failed: naivePriceJPY (%.0f) must be <= errorThreshold (%.0f)", naivePriceJPY, errorThreshold)
+	}
+
+	wantSavings := roundSavings(dispTypical - naivePriceJPY)
+	if h.Savings != wantSavings {
+		t.Errorf("Savings = %.2f, want %.2f (JPY typical minus JPY price)", h.Savings, wantSavings)
+	}
+
+	wantDiscount := math.Round(((dispTypical - naivePriceJPY) / dispTypical) * 100)
+	wantDiscountStr := fmt.Sprintf("%.0f%%", wantDiscount)
+	if !strings.Contains(h.Description, wantDiscountStr) {
+		t.Errorf("Description = %q, want it to contain discount %q computed in JPY (not mixed with raw EUR typical)", h.Description, wantDiscountStr)
+	}
+
+	wantPriceStr := fmt.Sprintf("JPY %.0f", naivePriceJPY)
+	if !strings.Contains(h.Title, wantPriceStr) {
+		t.Errorf("Title = %q, want it to contain %q (raw NaivePrice, not re-converted)", h.Title, wantPriceStr)
 	}
 }
 

--- a/internal/hacks/ferry_positioning.go
+++ b/internal/hacks/ferry_positioning.go
@@ -3,9 +3,9 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/MikkoParkkola/trvl/internal/flights"
-	"github.com/MikkoParkkola/trvl/internal/ground"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
 )
 
@@ -84,6 +84,16 @@ var ferryPositioningRoutes = map[string][]ferryRoute{
 	},
 }
 
+// ferryCandidate is the result of pricing one ferry-positioning route: the
+// ferry leg and the onward flight leg, both already converted into the
+// detector's requested target currency.
+type ferryCandidate struct {
+	route       ferryRoute
+	flightPrice float64
+	ferryPrice  float64
+}
+
+
 // detectFerryPositioning checks whether taking a ferry to a nearby port and
 // then flying from there is cheaper than flying directly, even after adding
 // the ferry cost.
@@ -103,63 +113,59 @@ func detectFerryPositioning(ctx context.Context, in DetectorInput) []Hack {
 		return nil
 	}
 
+	// All user-visible prices (direct flight, ferry leg, and positioning
+	// flight leg) are converted into the requested currency before being
+	// combined; a leg that cannot be converted drops its candidate rather
+	// than mixing currencies in the total.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
 	// Baseline: cheapest direct flight from origin.
-	directResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
+	directResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{SearchOverride: in.SearchOverride})
 	if err != nil || !directResult.Success || len(directResult.Flights) == 0 {
 		return nil
 	}
-	directPrice := minFlightPrice(directResult)
-	if directPrice <= 0 {
+	directPrice, ok := cheapestFlightPriceInTarget(ctx, directResult, target)
+	if !ok {
 		return nil
 	}
-	currency := flightCurrency(directResult, in.currency())
+	currency := target
 
-	type candidate struct {
-		route     ferryRoute
-		flightEUR float64
-		ferryEUR  float64
-	}
-	ch := make(chan candidate, len(routes))
+	ch := make(chan ferryCandidate, len(routes))
 
 	for _, r := range routes {
 		r := r
 		go func() {
-			// Real ferry price (may override the static estimate).
-			ferryPrice := r.FerryEUR
-			ferryResult, ferryErr := ground.SearchByName(ctx, r.FerryFrom, r.FerryTo, in.Date, ground.SearchOptions{
-				Currency: "EUR",
-				Type:     "ferry",
-			})
-			if ferryErr == nil && ferryResult.Success && len(ferryResult.Routes) > 0 {
-				for _, fr := range ferryResult.Routes {
-					if fr.Price > 0 && fr.Price < ferryPrice {
-						ferryPrice = fr.Price
-					}
-				}
+			ferryPrice, ok := groundLegPriceInTarget(ctx, r.FerryFrom, r.FerryTo, in.Date, "ferry", r.FerryEUR, target, in.GroundSearchOverride)
+			if !ok {
+				ch <- ferryCandidate{}
+				return
 			}
 
 			// Flight from the ferry destination airport.
-			flightResult, flightErr := flights.SearchFlights(ctx, r.AirportTo, in.Destination, in.Date, flights.SearchOptions{})
+			flightResult, flightErr := flights.SearchFlights(ctx, r.AirportTo, in.Destination, in.Date, flights.SearchOptions{SearchOverride: in.SearchOverride})
 			if flightErr != nil || !flightResult.Success || len(flightResult.Flights) == 0 {
-				ch <- candidate{}
+				ch <- ferryCandidate{}
 				return
 			}
-			flightPrice := minFlightPrice(flightResult)
-			if flightPrice <= 0 {
-				ch <- candidate{}
+			flightPrice, ok := cheapestFlightPriceInTarget(ctx, flightResult, target)
+			if !ok {
+				ch <- ferryCandidate{}
 				return
 			}
-			ch <- candidate{route: r, flightEUR: flightPrice, ferryEUR: ferryPrice}
+			ch <- ferryCandidate{route: r, flightPrice: flightPrice, ferryPrice: ferryPrice}
 		}()
 	}
 
 	var hacks []Hack
 	for range routes {
 		c := <-ch
-		if c.flightEUR == 0 {
+		if c.flightPrice <= 0 {
 			continue
 		}
-		total := c.flightEUR + c.ferryEUR
+		total := c.flightPrice + c.ferryPrice
 		savings := directPrice - total
 		if savings < 10 {
 			continue
@@ -176,10 +182,10 @@ func detectFerryPositioning(ctx context.Context, in DetectorInput) []Hack {
 			Currency: currency,
 			Savings:  roundSavings(savings),
 			Description: fmt.Sprintf(
-				"Ferry %s→%s (%.0f%s) + flight %s→%s (%.0f) = %.0f total vs %.0f direct flight. Saves %s %.0f.",
-				c.route.FerryFrom, c.route.FerryTo, c.ferryEUR, overnightNote,
-				c.route.AirportTo, in.Destination, c.flightEUR,
-				total, directPrice, currency, savings,
+				"Ferry %s→%s (%.0f %s%s) + flight %s→%s (%.0f %s) = %.0f %s total vs %.0f %s direct flight. Saves %s %.0f.",
+				c.route.FerryFrom, c.route.FerryTo, c.ferryPrice, currency, overnightNote,
+				c.route.AirportTo, in.Destination, c.flightPrice, currency,
+				total, currency, directPrice, currency, currency, savings,
 			),
 			Risks: []string{
 				"Ferry schedule must align with your flight — check departure times carefully",
@@ -188,9 +194,9 @@ func detectFerryPositioning(ctx context.Context, in DetectorInput) []Hack {
 				"Two separate tickets — no through-check protection",
 			},
 			Steps: []string{
-				fmt.Sprintf("Book ferry %s→%s on %s (%s: %.0f EUR)", c.route.FerryFrom, c.route.FerryTo, in.Date, c.route.Notes, c.ferryEUR),
+				fmt.Sprintf("Book ferry %s→%s on %s (%s: %.0f %s)", c.route.FerryFrom, c.route.FerryTo, in.Date, c.route.Notes, c.ferryPrice, currency),
 				fmt.Sprintf("Transfer from %s port to %s airport (see notes: %s)", c.route.FerryTo, c.route.AirportTo, c.route.Notes),
-				fmt.Sprintf("Book flight %s→%s (%s %.0f)", c.route.AirportTo, in.Destination, currency, c.flightEUR),
+				fmt.Sprintf("Book flight %s→%s (%s %.0f)", c.route.AirportTo, in.Destination, currency, c.flightPrice),
 				"Allow at least 3 hours between ferry arrival and flight departure",
 			},
 			Citations: []string{

--- a/internal/hacks/ferry_positioning.go
+++ b/internal/hacks/ferry_positioning.go
@@ -91,6 +91,7 @@ type ferryCandidate struct {
 	route       ferryRoute
 	flightPrice float64
 	ferryPrice  float64
+	estimated   bool
 }
 
 
@@ -138,7 +139,7 @@ func detectFerryPositioning(ctx context.Context, in DetectorInput) []Hack {
 	for _, r := range routes {
 		r := r
 		go func() {
-			ferryPrice, ok := groundLegPriceInTarget(ctx, r.FerryFrom, r.FerryTo, in.Date, "ferry", r.FerryEUR, target, in.GroundSearchOverride)
+			ferryPrice, ok, estimated := groundLegPriceInTarget(ctx, r.FerryFrom, r.FerryTo, in.Date, "ferry", r.FerryEUR, target, in.GroundSearchOverride)
 			if !ok {
 				ch <- ferryCandidate{}
 				return
@@ -155,7 +156,7 @@ func detectFerryPositioning(ctx context.Context, in DetectorInput) []Hack {
 				ch <- ferryCandidate{}
 				return
 			}
-			ch <- ferryCandidate{route: r, flightPrice: flightPrice, ferryPrice: ferryPrice}
+			ch <- ferryCandidate{route: r, flightPrice: flightPrice, ferryPrice: ferryPrice, estimated: estimated}
 		}()
 	}
 
@@ -176,14 +177,19 @@ func detectFerryPositioning(ctx context.Context, in DetectorInput) []Hack {
 			overnightNote = " (overnight ferry — no hotel needed)"
 		}
 
+		ferryFareNote := ""
+		if c.estimated {
+			ferryFareNote = ", estimated fare"
+		}
+
 		hacks = append(hacks, Hack{
 			Type:     "ferry_positioning",
 			Title:    fmt.Sprintf("Ferry to %s then fly to %s", c.route.FerryTo, in.Destination),
 			Currency: currency,
 			Savings:  roundSavings(savings),
 			Description: fmt.Sprintf(
-				"Ferry %s→%s (%.0f %s%s) + flight %s→%s (%.0f %s) = %.0f %s total vs %.0f %s direct flight. Saves %s %.0f.",
-				c.route.FerryFrom, c.route.FerryTo, c.ferryPrice, currency, overnightNote,
+				"Ferry %s→%s (%.0f %s%s%s) + flight %s→%s (%.0f %s) = %.0f %s total vs %.0f %s direct flight. Saves %s %.0f.",
+				c.route.FerryFrom, c.route.FerryTo, c.ferryPrice, currency, ferryFareNote, overnightNote,
 				c.route.AirportTo, in.Destination, c.flightPrice, currency,
 				total, currency, directPrice, currency, currency, savings,
 			),

--- a/internal/hacks/ferry_positioning.go
+++ b/internal/hacks/ferry_positioning.go
@@ -3,7 +3,9 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/ground"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
@@ -103,16 +105,25 @@ func detectFerryPositioning(ctx context.Context, in DetectorInput) []Hack {
 		return nil
 	}
 
-	// Baseline: cheapest direct flight from origin.
+	// Ferry legs are EUR-denominated static estimates; each is converted via FX
+	// into the traveller's requested currency so the itinerary is labelled
+	// honestly in that one currency. A candidate whose ferry estimate cannot be
+	// converted is skipped rather than mislabelled.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
+	// Baseline: cheapest direct flight from origin, converted into the requested currency.
 	directResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
 	if err != nil || !directResult.Success || len(directResult.Flights) == 0 {
 		return nil
 	}
-	directPrice := minFlightPrice(directResult)
-	if directPrice <= 0 {
+	directPrice, ok := minFlightPriceConverted(ctx, directResult, target)
+	if !ok {
 		return nil
 	}
-	currency := flightCurrency(directResult, in.currency())
+	currency := target
 
 	type candidate struct {
 		route     ferryRoute
@@ -124,28 +135,41 @@ func detectFerryPositioning(ctx context.Context, in DetectorInput) []Hack {
 	for _, r := range routes {
 		r := r
 		go func() {
-			// Real ferry price (may override the static estimate).
-			ferryPrice := r.FerryEUR
+			// Prefer a live ferry price (converted into target); fall back to the
+			// static EUR estimate converted into target. Suppress the candidate
+			// only when NEITHER the live route nor the static estimate can be
+			// shown in the requested currency. Cheapest convertible price wins.
+			ferryPrice := 0.0
+			haveFerry := false
 			ferryResult, ferryErr := ground.SearchByName(ctx, r.FerryFrom, r.FerryTo, in.Date, ground.SearchOptions{
 				Currency: "EUR",
 				Type:     "ferry",
 			})
 			if ferryErr == nil && ferryResult.Success && len(ferryResult.Routes) > 0 {
-				for _, fr := range ferryResult.Routes {
-					if fr.Price > 0 && fr.Price < ferryPrice {
-						ferryPrice = fr.Price
-					}
+				if _, live, lok := selectCheapestGroundConverted(ctx, ferryResult.Routes, target, false); lok && live > 0 {
+					ferryPrice = live
+					haveFerry = true
 				}
 			}
+			if est, fec := destinations.ConvertCurrency(ctx, r.FerryEUR, "EUR", target); fec == target {
+				if !haveFerry || est < ferryPrice {
+					ferryPrice = est
+					haveFerry = true
+				}
+			}
+			if !haveFerry {
+				ch <- candidate{}
+				return
+			}
 
-			// Flight from the ferry destination airport.
+			// Flight from the ferry destination airport, converted into the requested currency.
 			flightResult, flightErr := flights.SearchFlights(ctx, r.AirportTo, in.Destination, in.Date, flights.SearchOptions{})
 			if flightErr != nil || !flightResult.Success || len(flightResult.Flights) == 0 {
 				ch <- candidate{}
 				return
 			}
-			flightPrice := minFlightPrice(flightResult)
-			if flightPrice <= 0 {
+			flightPrice, flok := minFlightPriceConverted(ctx, flightResult, target)
+			if !flok {
 				ch <- candidate{}
 				return
 			}
@@ -176,10 +200,10 @@ func detectFerryPositioning(ctx context.Context, in DetectorInput) []Hack {
 			Currency: currency,
 			Savings:  roundSavings(savings),
 			Description: fmt.Sprintf(
-				"Ferry %s→%s (%.0f%s) + flight %s→%s (%.0f) = %.0f total vs %.0f direct flight. Saves %s %.0f.",
-				c.route.FerryFrom, c.route.FerryTo, c.ferryEUR, overnightNote,
-				c.route.AirportTo, in.Destination, c.flightEUR,
-				total, directPrice, currency, savings,
+				"Ferry %s→%s (%.0f %s%s) + flight %s→%s (%.0f %s) = %.0f %s total vs %.0f %s direct flight. Saves %s %.0f.",
+				c.route.FerryFrom, c.route.FerryTo, c.ferryEUR, currency, overnightNote,
+				c.route.AirportTo, in.Destination, c.flightEUR, currency,
+				total, currency, directPrice, currency, currency, savings,
 			),
 			Risks: []string{
 				"Ferry schedule must align with your flight — check departure times carefully",
@@ -188,7 +212,7 @@ func detectFerryPositioning(ctx context.Context, in DetectorInput) []Hack {
 				"Two separate tickets — no through-check protection",
 			},
 			Steps: []string{
-				fmt.Sprintf("Book ferry %s→%s on %s (%s: %.0f EUR)", c.route.FerryFrom, c.route.FerryTo, in.Date, c.route.Notes, c.ferryEUR),
+				fmt.Sprintf("Book ferry %s→%s on %s (%s: %.0f %s)", c.route.FerryFrom, c.route.FerryTo, in.Date, c.route.Notes, c.ferryEUR, currency),
 				fmt.Sprintf("Transfer from %s port to %s airport (see notes: %s)", c.route.FerryTo, c.route.AirportTo, c.route.Notes),
 				fmt.Sprintf("Book flight %s→%s (%s %.0f)", c.route.AirportTo, in.Destination, currency, c.flightEUR),
 				"Allow at least 3 hours between ferry arrival and flight departure",

--- a/internal/hacks/ferry_positioning.go
+++ b/internal/hacks/ferry_positioning.go
@@ -200,7 +200,7 @@ func detectFerryPositioning(ctx context.Context, in DetectorInput) []Hack {
 				"Two separate tickets — no through-check protection",
 			},
 			Steps: []string{
-				fmt.Sprintf("Book ferry %s→%s on %s (%s: %.0f %s)", c.route.FerryFrom, c.route.FerryTo, in.Date, c.route.Notes, c.ferryPrice, currency),
+				fmt.Sprintf("Book ferry %s→%s on %s (%s: %.0f %s%s)", c.route.FerryFrom, c.route.FerryTo, in.Date, c.route.Notes, c.ferryPrice, currency, ferryFareNote),
 				fmt.Sprintf("Transfer from %s port to %s airport (see notes: %s)", c.route.FerryTo, c.route.AirportTo, c.route.Notes),
 				fmt.Sprintf("Book flight %s→%s (%s %.0f)", c.route.AirportTo, in.Destination, currency, c.flightPrice),
 				"Allow at least 3 hours between ferry arrival and flight departure",

--- a/internal/hacks/flight_combo.go
+++ b/internal/hacks/flight_combo.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -72,7 +74,7 @@ func DetectFlightCombo(ctx context.Context, in FlightComboInput) []Hack {
 		return nil
 	}
 
-	currency := in.Currency
+	currency := strings.ToUpper(strings.TrimSpace(in.Currency))
 	if currency == "" {
 		currency = "EUR"
 	}
@@ -111,8 +113,27 @@ func cheapestFlightInfo(result *models.FlightSearchResult, err error) (price flo
 	return best.Price, best.Currency, air, &best
 }
 
+// cheapestFlightPriceInCurrency picks the cheapest flight via cheapestFlightInfo
+// and converts its price into target. Returns (0, false) when there is no
+// priced flight or its price cannot be converted into target — callers must
+// suppress rather than show an unconverted or mislabelled figure. Shared by
+// the currency-honesty fix across flight_combo.go and back_to_back.go.
+func cheapestFlightPriceInCurrency(ctx context.Context, result *models.FlightSearchResult, err error, target string) (float64, bool) {
+	price, cur, _, _ := cheapestFlightInfo(result, err)
+	if price <= 0 {
+		return 0, false
+	}
+	conv, gotCur := destinations.ConvertCurrency(ctx, price, cur, target)
+	if gotCur != target {
+		return 0, false
+	}
+	return conv, true
+}
+
 // detectSingleTripCombo compares a round-trip price against the sum of two
-// one-way tickets (potentially on different airlines).
+// one-way tickets (potentially on different airlines). currency is the
+// requested display (target) currency; every price is converted into it and
+// suppressed rather than shown unconverted when conversion fails.
 func detectSingleTripCombo(ctx context.Context, origin, dest string, trip TripLeg, currency string) []Hack {
 	client := batchexec.NewClient()
 
@@ -145,22 +166,20 @@ func detectSingleTripCombo(ctx context.Context, origin, dest string, trip TripLe
 	}()
 	wg.Wait()
 
-	rtPrice, rtCurrency, _, _ := cheapestFlightInfo(rtResult, rtErr)
-	owOutPrice, _, owOutAirline, _ := cheapestFlightInfo(owOutResult, owOutErr)
-	owRetPrice, _, owRetAirline, _ := cheapestFlightInfo(owRetResult, owRetErr)
+	_, _, owOutAirline, _ := cheapestFlightInfo(owOutResult, owOutErr)
+	_, _, owRetAirline, _ := cheapestFlightInfo(owRetResult, owRetErr)
 
-	if rtCurrency != "" {
-		currency = rtCurrency
-	}
+	rtPrice, validRT := cheapestFlightPriceInCurrency(ctx, rtResult, rtErr, currency)
+	owOutPrice, okOut := cheapestFlightPriceInCurrency(ctx, owOutResult, owOutErr, currency)
+	owRetPrice, okRet := cheapestFlightPriceInCurrency(ctx, owRetResult, owRetErr, currency)
+	validSplit := okOut && okRet
 
 	// Need at least one valid strategy.
-	if rtPrice <= 0 && (owOutPrice <= 0 || owRetPrice <= 0) {
+	if !validRT && !validSplit {
 		return nil
 	}
 
 	splitTotal := owOutPrice + owRetPrice
-	validRT := rtPrice > 0
-	validSplit := owOutPrice > 0 && owRetPrice > 0
 
 	// Determine the better option and compute savings.
 	if validRT && validSplit {
@@ -178,6 +197,9 @@ func detectSingleTripCombo(ctx context.Context, origin, dest string, trip TripLe
 }
 
 // detectMultiTripCombo finds the optimal ticket assignment for multiple trips.
+// currency is the requested display (target) currency; every price is
+// converted into it and a trip whose price cannot be converted suppresses
+// the whole comparison (baseline is required for every trip).
 func detectMultiTripCombo(ctx context.Context, origin, dest string, trips []TripLeg, currency string) []Hack {
 	if len(trips) > maxComboTrips {
 		trips = trips[:maxComboTrips]
@@ -187,11 +209,7 @@ func detectMultiTripCombo(ctx context.Context, origin, dest string, trips []Trip
 	n := len(trips)
 
 	// Step 1: get baseline (N separate round-trips).
-	type rtInfo struct {
-		price    float64
-		currency string
-	}
-	baselinePrices := make([]rtInfo, n)
+	baselinePrices := make([]float64, n)
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 3) // limit concurrency
 
@@ -206,21 +224,21 @@ func detectMultiTripCombo(ctx context.Context, origin, dest string, trips []Trip
 				ReturnDate: t.ReturnDate,
 				SortBy:     models.SortCheapest,
 			})
-			p, c, _, _ := cheapestFlightInfo(result, err)
-			baselinePrices[i] = rtInfo{price: p, currency: c}
+			p, ok := cheapestFlightPriceInCurrency(ctx, result, err, currency)
+			if !ok {
+				p = 0
+			}
+			baselinePrices[i] = p
 		}()
 	}
 	wg.Wait()
 
 	baseline := 0.0
 	for _, p := range baselinePrices {
-		if p.price <= 0 {
+		if p <= 0 {
 			return nil // can't compute baseline
 		}
-		baseline += p.price
-		if p.currency != "" {
-			currency = p.currency
-		}
+		baseline += p
 	}
 
 	// Step 2: try all permutations of pairing outbound[i] with return[perm[i]].
@@ -261,8 +279,8 @@ func detectMultiTripCombo(ctx context.Context, origin, dest string, trips []Trip
 				})
 				<-sem
 
-				p, _, _, _ := cheapestFlightInfo(result, err)
-				if p <= 0 {
+				p, ok := cheapestFlightPriceInCurrency(ctx, result, err, currency)
+				if !ok {
 					return // this permutation is invalid
 				}
 				totalCost += p

--- a/internal/hacks/flight_combo.go
+++ b/internal/hacks/flight_combo.go
@@ -20,6 +20,13 @@ type FlightComboInput struct {
 	ReturnDate  string    // YYYY-MM-DD (first/only trip)
 	Trips       []TripLeg // multiple trips (overrides DepartDate/ReturnDate if non-empty)
 	Currency    string
+
+	// SearchOverride, when non-nil, is threaded into every
+	// flights.SearchOptions built by this detector, replacing the real
+	// flights.SearchFlightsWithClient call for the duration of one
+	// DetectFlightCombo invocation. Nil (the default) runs live search.
+	// Optional test/DI seam; mirrors DetectorInput.SearchOverride.
+	SearchOverride flights.SearchFunc
 }
 
 // TripLeg represents one trip's dates.
@@ -79,9 +86,9 @@ func DetectFlightCombo(ctx context.Context, in FlightComboInput) []Hack {
 	}
 
 	if len(trips) == 1 {
-		return detectSingleTripCombo(ctx, in.Origin, in.Destination, trips[0], currency)
+		return detectSingleTripCombo(ctx, in.Origin, in.Destination, trips[0], currency, in.SearchOverride)
 	}
-	return detectMultiTripCombo(ctx, in.Origin, in.Destination, trips, currency)
+	return detectMultiTripCombo(ctx, in.Origin, in.Destination, trips, currency, in.SearchOverride)
 }
 
 // cheapestFlightInfo extracts the cheapest price, currency, and airline from a
@@ -132,7 +139,7 @@ func cheapestFlightPriceInCurrency(ctx context.Context, result *models.FlightSea
 // one-way tickets (potentially on different airlines). currency is the
 // requested display (target) currency; every price is converted into it and
 // suppressed rather than shown unconverted when conversion fails.
-func detectSingleTripCombo(ctx context.Context, origin, dest string, trip TripLeg, currency string) []Hack {
+func detectSingleTripCombo(ctx context.Context, origin, dest string, trip TripLeg, currency string, searchOverride flights.SearchFunc) []Hack {
 	client := batchexec.NewClient()
 
 	var (
@@ -146,20 +153,23 @@ func detectSingleTripCombo(ctx context.Context, origin, dest string, trip TripLe
 	go func() {
 		defer wg.Done()
 		rtResult, rtErr = flights.SearchFlightsWithClient(ctx, client, origin, dest, trip.DepartDate, flights.SearchOptions{
-			ReturnDate: trip.ReturnDate,
-			SortBy:     models.SortCheapest,
+			ReturnDate:     trip.ReturnDate,
+			SortBy:         models.SortCheapest,
+			SearchOverride: searchOverride,
 		})
 	}()
 	go func() {
 		defer wg.Done()
 		owOutResult, owOutErr = flights.SearchFlightsWithClient(ctx, client, origin, dest, trip.DepartDate, flights.SearchOptions{
-			SortBy: models.SortCheapest,
+			SortBy:         models.SortCheapest,
+			SearchOverride: searchOverride,
 		})
 	}()
 	go func() {
 		defer wg.Done()
 		owRetResult, owRetErr = flights.SearchFlightsWithClient(ctx, client, dest, origin, trip.ReturnDate, flights.SearchOptions{
-			SortBy: models.SortCheapest,
+			SortBy:         models.SortCheapest,
+			SearchOverride: searchOverride,
 		})
 	}()
 	wg.Wait()
@@ -198,7 +208,7 @@ func detectSingleTripCombo(ctx context.Context, origin, dest string, trip TripLe
 // currency is the requested display (target) currency; every price is
 // converted into it and a trip whose price cannot be converted suppresses
 // the whole comparison (baseline is required for every trip).
-func detectMultiTripCombo(ctx context.Context, origin, dest string, trips []TripLeg, currency string) []Hack {
+func detectMultiTripCombo(ctx context.Context, origin, dest string, trips []TripLeg, currency string, searchOverride flights.SearchFunc) []Hack {
 	if len(trips) > maxComboTrips {
 		trips = trips[:maxComboTrips]
 	}
@@ -219,8 +229,9 @@ func detectMultiTripCombo(ctx context.Context, origin, dest string, trips []Trip
 			sem <- struct{}{}
 			defer func() { <-sem }()
 			result, err := flights.SearchFlightsWithClient(ctx, client, origin, dest, t.DepartDate, flights.SearchOptions{
-				ReturnDate: t.ReturnDate,
-				SortBy:     models.SortCheapest,
+				ReturnDate:     t.ReturnDate,
+				SortBy:         models.SortCheapest,
+				SearchOverride: searchOverride,
 			})
 			p, ok := cheapestFlightPriceInCurrency(ctx, result, err, currency)
 			if !ok {
@@ -272,8 +283,9 @@ func detectMultiTripCombo(ctx context.Context, origin, dest string, trips []Trip
 			for i := 0; i < n; i++ {
 				sem <- struct{}{}
 				result, err := flights.SearchFlightsWithClient(ctx, client, origin, dest, trips[i].DepartDate, flights.SearchOptions{
-					ReturnDate: trips[perm[i]].ReturnDate,
-					SortBy:     models.SortCheapest,
+					ReturnDate:     trips[perm[i]].ReturnDate,
+					SortBy:         models.SortCheapest,
+					SearchOverride: searchOverride,
 				})
 				<-sem
 

--- a/internal/hacks/flight_combo.go
+++ b/internal/hacks/flight_combo.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
-	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -119,15 +118,14 @@ func cheapestFlightInfo(result *models.FlightSearchResult, err error) (price flo
 // suppress rather than show an unconverted or mislabelled figure. Shared by
 // the currency-honesty fix across flight_combo.go and back_to_back.go.
 func cheapestFlightPriceInCurrency(ctx context.Context, result *models.FlightSearchResult, err error, target string) (float64, bool) {
-	price, cur, _, _ := cheapestFlightInfo(result, err)
-	if price <= 0 {
+	if err != nil {
 		return 0, false
 	}
-	conv, gotCur := destinations.ConvertCurrency(ctx, price, cur, target)
-	if gotCur != target {
-		return 0, false
-	}
-	return conv, true
+	// Convert every fare into target FIRST, then pick the minimum, so a
+	// numerically-smaller raw fare in a stronger currency can't masquerade as
+	// the cheapest (e.g. 90 GBP beating 100 USD). Routes through the
+	// convertCurrencyFn seam so tests can inject rates deterministically.
+	return cheapestFlightPriceInTarget(ctx, result, target)
 }
 
 // detectSingleTripCombo compares a round-trip price against the sum of two

--- a/internal/hacks/flight_combo_test.go
+++ b/internal/hacks/flight_combo_test.go
@@ -101,6 +101,61 @@ func TestCheapestFlightInfo_error(t *testing.T) {
 	}
 }
 
+// --- cheapestFlightPriceInCurrency: currency honesty (display-currency conversion) ---
+
+// TestCheapestFlightPriceInCurrency_eurTargetPassthrough covers currency
+// honesty case (a): an EUR target with an EUR-denominated flight passes
+// through labelled EUR (identity conversion).
+func TestCheapestFlightPriceInCurrency_eurTargetPassthrough(t *testing.T) {
+	result := &models.FlightSearchResult{
+		Success: true,
+		Flights: []models.FlightResult{{Price: 200, Currency: "EUR"}},
+	}
+	price, ok := cheapestFlightPriceInCurrency(context.Background(), result, nil, "EUR")
+	if !ok {
+		t.Fatalf("expected ok=true for EUR->EUR conversion")
+	}
+	if price != 200 {
+		t.Errorf("expected price=200, got %v", price)
+	}
+}
+
+// TestCheapestFlightPriceInCurrency_nonEURTargetSuppressedWhenInconvertible
+// covers case (b): a non-EUR target with no usable rate table must suppress
+// (ok=false) rather than return an unconverted or mislabelled figure.
+// Placeholder currency codes (ZZZ/ZZY) are used by convention since they
+// appear in no real exchange-rate table, and the context is cancelled so no
+// live FX fetch can populate the cache either.
+func TestCheapestFlightPriceInCurrency_nonEURTargetSuppressedWhenInconvertible(t *testing.T) {
+	result := &models.FlightSearchResult{
+		Success: true,
+		Flights: []models.FlightResult{{Price: 200, Currency: "ZZZ"}},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	price, ok := cheapestFlightPriceInCurrency(ctx, result, nil, "ZZY")
+	if ok {
+		t.Errorf("expected ok=false when inconvertible to target, got price=%v", price)
+	}
+	if price != 0 {
+		t.Errorf("expected price=0 when suppressed, got %v", price)
+	}
+}
+
+// TestCheapestFlightPriceInCurrency_errorOrEmptyIsSuppressed covers the
+// pass-through error/empty-result cases (mirrors cheapestFlightInfo's own
+// zero-value contract): callers must treat these as suppression, not as a
+// false "0-priced" hack.
+func TestCheapestFlightPriceInCurrency_errorOrEmptyIsSuppressed(t *testing.T) {
+	if _, ok := cheapestFlightPriceInCurrency(context.Background(), nil, context.DeadlineExceeded, "EUR"); ok {
+		t.Errorf("expected ok=false on search error")
+	}
+	if _, ok := cheapestFlightPriceInCurrency(context.Background(), &models.FlightSearchResult{Success: false}, nil, "EUR"); ok {
+		t.Errorf("expected ok=false on unsuccessful result")
+	}
+}
+
 func TestCheapestFlightInfo_unsuccessful(t *testing.T) {
 	price, _, _, _ := cheapestFlightInfo(&models.FlightSearchResult{Success: false}, nil)
 	if price != 0 {

--- a/internal/hacks/hacks.go
+++ b/internal/hacks/hacks.go
@@ -180,6 +180,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/preferences"
 )
 
 // Hack represents a detected travel optimization opportunity.
@@ -242,9 +243,15 @@ type DetectorInput struct {
 	Loyalty LoyaltyProfile
 }
 
+// currency returns the display currency for this search: the explicit request
+// currency if set, else the user's saved profile preference
+// (preferences.DisplayCurrency), else EUR as a last-resort fallback.
 func (in *DetectorInput) currency() string {
 	if in.Currency != "" {
 		return in.Currency
+	}
+	if p, err := preferences.Load(); err == nil && p != nil && p.DisplayCurrency != "" {
+		return p.DisplayCurrency
 	}
 	return "EUR"
 }

--- a/internal/hacks/hacks.go
+++ b/internal/hacks/hacks.go
@@ -179,6 +179,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -240,6 +241,16 @@ type DetectorInput struct {
 	// The zero value preserves pre-loyalty behaviour (no regression): detectors
 	// fall back to surfacing every opportunity. See loyalty.go.
 	Loyalty LoyaltyProfile
+
+	// SearchOverride, when non-nil, is threaded into every flights.SearchOptions
+	// this detector builds so tests can inject synthetic search results. Nil
+	// (the default) runs the real flights.SearchFlights. This replaces the old
+	// pattern of mutable package-level function variables (positioningSearchFunc,
+	// openJawSearchFunc), which raced when parallel detector or test calls read
+	// and wrote the same shared global; carrying the override as ordinary
+	// per-call data instead removes the shared mutable state entirely. See
+	// flights.SearchOptions.SearchOverride.
+	SearchOverride flights.SearchFunc
 }
 
 func (in *DetectorInput) currency() string {

--- a/internal/hacks/hacks.go
+++ b/internal/hacks/hacks.go
@@ -180,6 +180,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/ground"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -251,6 +252,13 @@ type DetectorInput struct {
 	// per-call data instead removes the shared mutable state entirely. See
 	// flights.SearchOptions.SearchOverride.
 	SearchOverride flights.SearchFunc
+
+	// GroundSearchOverride, when non-nil, is threaded into every
+	// ground.SearchOptions this detector builds so tests can inject synthetic
+	// ground-transport (ferry/bus/train) results. Nil (the default) runs the
+	// real ground.SearchByName. Mirrors SearchOverride above for the ground
+	// package. See ground.SearchOptions.SearchOverride.
+	GroundSearchOverride ground.SearchFunc
 }
 
 func (in *DetectorInput) currency() string {

--- a/internal/hacks/hacks.go
+++ b/internal/hacks/hacks.go
@@ -334,11 +334,26 @@ func RegisteredDetectorCount() int {
 // DetectAll runs all detectors in parallel and returns every hack found.
 // It respects ctx cancellation; detectors that finish after cancellation
 // are discarded.
+//
+// A cancelled or already-expired ctx short-circuits before any detector is
+// dispatched: several detectors make live provider calls (Google Flights,
+// Kiwi, ground transport providers such as rome2rio/ferryhopper/skiplagged),
+// and there is no point paying for a network round trip whose result nobody
+// can use. This keeps a cancelled MCP request response-fast and keeps the
+// default (offline) test suite free of live provider traffic.
 func DetectAll(ctx context.Context, in DetectorInput) []Hack {
+	// Fast path: ctx is already done (cancelled or deadline already passed).
+	// Don't launch a single detector goroutine.
+	if ctx.Err() != nil {
+		return nil
+	}
+
 	detectors := allDetectors()
 
 	// Each detector gets a child context with a per-detector timeout so a
-	// slow API call cannot block the entire hacks response.
+	// slow API call cannot block the entire hacks response. context.WithTimeout
+	// inherits ctx's deadline if it is earlier than detectorTimeout, so a
+	// tight parent deadline still propagates into every detector's HTTP path.
 	const detectorTimeout = 20 * time.Second
 
 	type result struct {
@@ -349,10 +364,22 @@ func DetectAll(ctx context.Context, in DetectorInput) []Hack {
 	var wg sync.WaitGroup
 
 	for _, fn := range detectors {
+		// ctx can expire mid fan-out (e.g. a parent deadline of a few ms
+		// elapses while we're still iterating the detector roster). Stop
+		// dispatching further detectors the moment that happens rather than
+		// firing off calls that are already doomed to fail.
+		if ctx.Err() != nil {
+			break
+		}
 		fn := fn
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			// Defensive re-check: ctx may expire between the dispatch-loop
+			// check above and this goroutine actually getting scheduled.
+			if ctx.Err() != nil {
+				return
+			}
 			dCtx, cancel := context.WithTimeout(ctx, detectorTimeout)
 			defer cancel()
 			h := fn(dCtx, in)

--- a/internal/hacks/helpers.go
+++ b/internal/hacks/helpers.go
@@ -1,11 +1,13 @@
 package hacks
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -85,6 +87,82 @@ func minFlightPriceInCurrency(r *models.FlightSearchResult, baseCur string) (flo
 		return 0, ""
 	}
 	return min, currency
+}
+
+// selectCheapestGroundConverted returns the cheapest ground route after
+// converting every route's price into the target currency, together with that
+// converted price and an ok flag. Routes are skipped when non-positive, when
+// overnightOnly is set and the route is not overnight, or when their price
+// cannot be converted into target (rates missing/offline/uncovered) — the
+// latter signalled by ConvertCurrency returning a currency string != target.
+//
+// The returned groundRoute carries price=convertedPrice and currency=target so
+// the caller can label the leg honestly in the traveller's requested currency.
+// Returns (nil, 0, false) when nothing is convertible/eligible.
+func selectCheapestGroundConverted(ctx context.Context, routes []models.GroundRoute, target string, overnightOnly bool) (*groundRoute, float64, bool) {
+	min := math.MaxFloat64
+	var best *groundRoute
+	for i := range routes {
+		r := &routes[i]
+		if r.Price <= 0 {
+			continue
+		}
+		if overnightOnly && !isOvernightRoute(r.Departure.Time, r.Arrival.Time) {
+			continue
+		}
+		conv, cur := destinations.ConvertCurrency(ctx, r.Price, r.Currency, target)
+		if cur != target {
+			continue // inconvertible — cannot be shown in target
+		}
+		if conv < min {
+			min = conv
+			best = &groundRoute{
+				provider:   r.Provider,
+				routeType:  r.Type,
+				price:      conv,
+				currency:   target,
+				depCity:    r.Departure.City,
+				arrCity:    r.Arrival.City,
+				depTime:    r.Departure.Time,
+				arrTime:    r.Arrival.Time,
+				bookingURL: r.BookingURL,
+			}
+		}
+	}
+	if best == nil {
+		return nil, 0, false
+	}
+	return best, min, true
+}
+
+// minFlightPriceConverted returns the cheapest flight price after converting
+// every flight's price into target, together with an ok flag. Flights are
+// skipped when non-positive or when their price cannot be converted into target
+// (ConvertCurrency returns a currency string != target). Returns (0, false)
+// when the result is nil/unsuccessful or nothing is convertible.
+func minFlightPriceConverted(ctx context.Context, r *models.FlightSearchResult, target string) (float64, bool) {
+	if r == nil || !r.Success {
+		return 0, false
+	}
+	min := math.MaxFloat64
+	found := false
+	for _, f := range r.Flights {
+		if f.Price <= 0 {
+			continue
+		}
+		conv, cur := destinations.ConvertCurrency(ctx, f.Price, f.Currency, target)
+		if cur != target {
+			continue
+		}
+		if conv < min {
+			min = conv
+			found = true
+		}
+	}
+	if !found {
+		return 0, false
+	}
+	return min, found
 }
 
 // flightCurrency returns the currency of the first flight result, or a fallback.

--- a/internal/hacks/multimodal_open_jaw_ground.go
+++ b/internal/hacks/multimodal_open_jaw_ground.go
@@ -113,6 +113,7 @@ type openJawGroundCandidate struct {
 	groundPrice float64
 	flightPrice float64
 	hotelBonus  float64
+	estimated   bool
 }
 
 // detectMultiModalOpenJawGround checks whether flying to a nearby hub airport
@@ -157,7 +158,7 @@ func detectMultiModalOpenJawGround(ctx context.Context, in DetectorInput) []Hack
 		go func() {
 			defer wg.Done()
 
-			groundPrice, ok := groundLegPriceInTarget(ctx, h.HubCity, h.DestCity, in.Date, "", h.StaticGroundEUR, target, in.GroundSearchOverride)
+			groundPrice, ok, estimated := groundLegPriceInTarget(ctx, h.HubCity, h.DestCity, in.Date, "", h.StaticGroundEUR, target, in.GroundSearchOverride)
 			if !ok {
 				ch <- openJawGroundCandidate{}
 				return
@@ -188,7 +189,7 @@ func detectMultiModalOpenJawGround(ctx context.Context, in DetectorInput) []Hack
 				hotelBonus = bonus
 			}
 
-			ch <- openJawGroundCandidate{hub: h, groundPrice: groundPrice, flightPrice: flightPrice, hotelBonus: hotelBonus}
+			ch <- openJawGroundCandidate{hub: h, groundPrice: groundPrice, flightPrice: flightPrice, hotelBonus: hotelBonus, estimated: estimated}
 		}()
 	}
 
@@ -212,15 +213,20 @@ func detectMultiModalOpenJawGround(ctx context.Context, in DetectorInput) []Hack
 			overnightNote = fmt.Sprintf(" + saves ~%.0f %s hotel night", c.hotelBonus, currency)
 		}
 
+		groundFareNote := ""
+		if c.estimated {
+			groundFareNote = ", estimated fare"
+		}
+
 		hacks = append(hacks, Hack{
 			Type:     "multimodal_open_jaw_ground",
 			Title:    fmt.Sprintf("Fly to %s, complete journey to %s by ground", c.hub.HubCity, cityFromCode(in.Destination)),
 			Currency: currency,
 			Savings:  roundSavings(savings),
 			Description: fmt.Sprintf(
-				"Flight %s→%s (%.0f %s) + ground %s→%s (%.0f %s) = %.0f %s total%s, vs direct %s→%s %.0f %s. Saves %s %.0f.",
+				"Flight %s→%s (%.0f %s) + ground %s→%s (%.0f %s%s) = %.0f %s total%s, vs direct %s→%s %.0f %s. Saves %s %.0f.",
 				in.Origin, c.hub.HubCode, c.flightPrice, currency,
-				c.hub.HubCity, c.hub.DestCity, c.groundPrice, currency,
+				c.hub.HubCity, c.hub.DestCity, c.groundPrice, currency, groundFareNote,
 				total, currency, overnightNote,
 				in.Origin, in.Destination, directPrice, currency,
 				currency, savings,

--- a/internal/hacks/multimodal_open_jaw_ground.go
+++ b/internal/hacks/multimodal_open_jaw_ground.go
@@ -239,7 +239,7 @@ func detectMultiModalOpenJawGround(ctx context.Context, in DetectorInput) []Hack
 			Steps: []string{
 				fmt.Sprintf("Book flight %s→%s on %s (%s %.0f)", in.Origin, c.hub.HubCode, in.Date, currency, c.flightPrice),
 				fmt.Sprintf("Ground transfer: %s", c.hub.Notes),
-				fmt.Sprintf("Arrive at %s (~%s %.0f ground cost)", c.hub.DestCity, currency, c.groundPrice),
+				fmt.Sprintf("Arrive at %s (~%s %.0f ground cost%s)", c.hub.DestCity, currency, c.groundPrice, groundFareNote),
 			},
 			Citations: []string{
 				googleFlightsURL(c.hub.HubCode, in.Origin, in.Date),

--- a/internal/hacks/multimodal_open_jaw_ground.go
+++ b/internal/hacks/multimodal_open_jaw_ground.go
@@ -3,8 +3,10 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/ground"
 )
@@ -117,16 +119,25 @@ func detectMultiModalOpenJawGround(ctx context.Context, in DetectorInput) []Hack
 		return nil
 	}
 
-	// Baseline: direct flight to destination.
+	// Ground legs here are EUR-denominated static estimates; each is converted
+	// via FX into the traveller's requested currency so the whole itinerary is
+	// labelled honestly in that one currency. A candidate whose ground estimate
+	// cannot be converted is skipped rather than mislabelled.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
+	// Baseline: direct flight to destination, converted into the requested currency.
 	directResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
 	if err != nil || !directResult.Success || len(directResult.Flights) == 0 {
 		return nil
 	}
-	directPrice := minFlightPrice(directResult)
-	if directPrice <= 0 {
+	directPrice, ok := minFlightPriceConverted(ctx, directResult, target)
+	if !ok {
 		return nil
 	}
-	currency := flightCurrency(directResult, in.currency())
+	currency := target
 
 	type candidate struct {
 		hub       nearbyHub
@@ -143,31 +154,44 @@ func detectMultiModalOpenJawGround(ctx context.Context, in DetectorInput) []Hack
 		go func() {
 			defer wg.Done()
 
-			// Live ground price (fallback to static estimate).
-			groundEUR := h.StaticGroundEUR
+			// Prefer a live ground price (converted into target); fall back to the
+			// static EUR estimate converted into target. Suppress the candidate
+			// only when NEITHER the live route nor the static estimate can be
+			// shown in the requested currency. Cheapest convertible price wins.
+			groundConv := 0.0
+			haveGround := false
 			gr, gerr := ground.SearchByName(ctx, h.HubCity, h.DestCity, in.Date, ground.SearchOptions{
 				Currency: "EUR",
 			})
 			if gerr == nil && gr.Success {
-				for _, r := range gr.Routes {
-					if r.Price > 0 && r.Price < groundEUR {
-						groundEUR = r.Price
-					}
+				if _, live, lok := selectCheapestGroundConverted(ctx, gr.Routes, target, false); lok && live > 0 {
+					groundConv = live
+					haveGround = true
 				}
 			}
+			if est, gec := destinations.ConvertCurrency(ctx, h.StaticGroundEUR, "EUR", target); gec == target {
+				if !haveGround || est < groundConv {
+					groundConv = est
+					haveGround = true
+				}
+			}
+			if !haveGround {
+				ch <- candidate{}
+				return
+			}
 
-			// Flight from origin to hub.
+			// Flight from origin to hub, converted into the requested currency.
 			fr, ferr := flights.SearchFlights(ctx, in.Origin, h.HubCode, in.Date, flights.SearchOptions{})
 			if ferr != nil || !fr.Success || len(fr.Flights) == 0 {
 				ch <- candidate{}
 				return
 			}
-			flightPrice := minFlightPrice(fr)
-			if flightPrice <= 0 {
+			flightPrice, fok := minFlightPriceConverted(ctx, fr, target)
+			if !fok {
 				ch <- candidate{}
 				return
 			}
-			ch <- candidate{hub: h, groundEUR: groundEUR, flightEUR: flightPrice}
+			ch <- candidate{hub: h, groundEUR: groundConv, flightEUR: flightPrice}
 		}()
 	}
 
@@ -216,7 +240,7 @@ func detectMultiModalOpenJawGround(ctx context.Context, in DetectorInput) []Hack
 			Steps: []string{
 				fmt.Sprintf("Book flight %s→%s on %s (%s %.0f)", in.Origin, c.hub.HubCode, in.Date, currency, c.flightEUR),
 				fmt.Sprintf("Ground transfer: %s", c.hub.Notes),
-				fmt.Sprintf("Arrive at %s (~%.0f EUR ground cost)", c.hub.DestCity, c.groundEUR),
+				fmt.Sprintf("Arrive at %s (~%.0f %s ground cost)", c.hub.DestCity, c.groundEUR, currency),
 			},
 			Citations: []string{
 				googleFlightsURL(c.hub.HubCode, in.Origin, in.Date),

--- a/internal/hacks/multimodal_open_jaw_ground.go
+++ b/internal/hacks/multimodal_open_jaw_ground.go
@@ -3,10 +3,10 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/MikkoParkkola/trvl/internal/flights"
-	"github.com/MikkoParkkola/trvl/internal/ground"
 )
 
 // nearbyHub describes a major airport near a regional destination. Flying into
@@ -104,6 +104,17 @@ var nearbyHubs = map[string][]nearbyHub{
 	},
 }
 
+// openJawGroundCandidate is the result of pricing one hub-then-ground route:
+// the positioning flight and the ground leg, both already converted into the
+// detector's requested target currency, plus the hotel-night bonus (also
+// pre-converted, only set when the ground leg is overnight).
+type openJawGroundCandidate struct {
+	hub         nearbyHub
+	groundPrice float64
+	flightPrice float64
+	hotelBonus  float64
+}
+
 // detectMultiModalOpenJawGround checks whether flying to a nearby hub airport
 // and completing the journey by ground transport is cheaper than flying directly
 // to the destination.
@@ -117,24 +128,27 @@ func detectMultiModalOpenJawGround(ctx context.Context, in DetectorInput) []Hack
 		return nil
 	}
 
+	// All user-visible prices (direct flight, positioning flight, ground leg,
+	// and the hotel-night bonus) are converted into the requested currency
+	// before being combined; a leg that cannot be converted drops its
+	// candidate rather than mixing currencies in the total.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
 	// Baseline: direct flight to destination.
-	directResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
+	directResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{SearchOverride: in.SearchOverride})
 	if err != nil || !directResult.Success || len(directResult.Flights) == 0 {
 		return nil
 	}
-	directPrice := minFlightPrice(directResult)
-	if directPrice <= 0 {
+	directPrice, ok := cheapestFlightPriceInTarget(ctx, directResult, target)
+	if !ok {
 		return nil
 	}
-	currency := flightCurrency(directResult, in.currency())
+	currency := target
 
-	type candidate struct {
-		hub       nearbyHub
-		groundEUR float64
-		flightEUR float64
-	}
-
-	ch := make(chan candidate, len(hubs))
+	ch := make(chan openJawGroundCandidate, len(hubs))
 	var wg sync.WaitGroup
 
 	for _, h := range hubs {
@@ -143,31 +157,38 @@ func detectMultiModalOpenJawGround(ctx context.Context, in DetectorInput) []Hack
 		go func() {
 			defer wg.Done()
 
-			// Live ground price (fallback to static estimate).
-			groundEUR := h.StaticGroundEUR
-			gr, gerr := ground.SearchByName(ctx, h.HubCity, h.DestCity, in.Date, ground.SearchOptions{
-				Currency: "EUR",
-			})
-			if gerr == nil && gr.Success {
-				for _, r := range gr.Routes {
-					if r.Price > 0 && r.Price < groundEUR {
-						groundEUR = r.Price
-					}
-				}
+			groundPrice, ok := groundLegPriceInTarget(ctx, h.HubCity, h.DestCity, in.Date, "", h.StaticGroundEUR, target, in.GroundSearchOverride)
+			if !ok {
+				ch <- openJawGroundCandidate{}
+				return
 			}
 
 			// Flight from origin to hub.
-			fr, ferr := flights.SearchFlights(ctx, in.Origin, h.HubCode, in.Date, flights.SearchOptions{})
+			fr, ferr := flights.SearchFlights(ctx, in.Origin, h.HubCode, in.Date, flights.SearchOptions{SearchOverride: in.SearchOverride})
 			if ferr != nil || !fr.Success || len(fr.Flights) == 0 {
-				ch <- candidate{}
+				ch <- openJawGroundCandidate{}
 				return
 			}
-			flightPrice := minFlightPrice(fr)
-			if flightPrice <= 0 {
-				ch <- candidate{}
+			flightPrice, ok := cheapestFlightPriceInTarget(ctx, fr, target)
+			if !ok {
+				ch <- openJawGroundCandidate{}
 				return
 			}
-			ch <- candidate{hub: h, groundEUR: groundEUR, flightEUR: flightPrice}
+
+			hotelBonus := 0.0
+			if h.Overnight {
+				bonus, ok := convertCurrency(ctx, averageHotelCost, "EUR", target)
+				if !ok {
+					// The hotel-night saving cannot be honestly expressed in
+					// target; drop the candidate rather than silently omit it
+					// or mix currencies in the displayed saving.
+					ch <- openJawGroundCandidate{}
+					return
+				}
+				hotelBonus = bonus
+			}
+
+			ch <- openJawGroundCandidate{hub: h, groundPrice: groundPrice, flightPrice: flightPrice, hotelBonus: hotelBonus}
 		}()
 	}
 
@@ -176,23 +197,19 @@ func detectMultiModalOpenJawGround(ctx context.Context, in DetectorInput) []Hack
 
 	var hacks []Hack
 	for c := range ch {
-		if c.flightEUR == 0 {
+		if c.flightPrice <= 0 {
 			continue
 		}
 
-		total := c.flightEUR + c.groundEUR
-		hotelBonus := 0.0
-		if c.hub.Overnight {
-			hotelBonus = averageHotelCost
-		}
-		savings := directPrice - total + hotelBonus
+		total := c.flightPrice + c.groundPrice
+		savings := directPrice - total + c.hotelBonus
 		if savings < 50 {
 			continue
 		}
 
 		overnightNote := ""
 		if c.hub.Overnight {
-			overnightNote = fmt.Sprintf(" + saves ~%.0f hotel night", averageHotelCost)
+			overnightNote = fmt.Sprintf(" + saves ~%.0f %s hotel night", c.hotelBonus, currency)
 		}
 
 		hacks = append(hacks, Hack{
@@ -201,10 +218,10 @@ func detectMultiModalOpenJawGround(ctx context.Context, in DetectorInput) []Hack
 			Currency: currency,
 			Savings:  roundSavings(savings),
 			Description: fmt.Sprintf(
-				"Flight %s→%s (%.0f %s) + ground %s→%s (%.0f %s) = %.0f total%s, vs direct %s→%s %.0f %s. Saves %s %.0f.",
-				in.Origin, c.hub.HubCode, c.flightEUR, currency,
-				c.hub.HubCity, c.hub.DestCity, c.groundEUR, currency,
-				total, overnightNote,
+				"Flight %s→%s (%.0f %s) + ground %s→%s (%.0f %s) = %.0f %s total%s, vs direct %s→%s %.0f %s. Saves %s %.0f.",
+				in.Origin, c.hub.HubCode, c.flightPrice, currency,
+				c.hub.HubCity, c.hub.DestCity, c.groundPrice, currency,
+				total, currency, overnightNote,
 				in.Origin, in.Destination, directPrice, currency,
 				currency, savings,
 			),
@@ -214,9 +231,9 @@ func detectMultiModalOpenJawGround(ctx context.Context, in DetectorInput) []Hack
 				"Checked luggage complicates ground connections — prefer carry-on",
 			},
 			Steps: []string{
-				fmt.Sprintf("Book flight %s→%s on %s (%s %.0f)", in.Origin, c.hub.HubCode, in.Date, currency, c.flightEUR),
+				fmt.Sprintf("Book flight %s→%s on %s (%s %.0f)", in.Origin, c.hub.HubCode, in.Date, currency, c.flightPrice),
 				fmt.Sprintf("Ground transfer: %s", c.hub.Notes),
-				fmt.Sprintf("Arrive at %s (~%.0f EUR ground cost)", c.hub.DestCity, c.groundEUR),
+				fmt.Sprintf("Arrive at %s (~%s %.0f ground cost)", c.hub.DestCity, currency, c.groundPrice),
 			},
 			Citations: []string{
 				googleFlightsURL(c.hub.HubCode, in.Origin, in.Date),

--- a/internal/hacks/multimodal_positioning.go
+++ b/internal/hacks/multimodal_positioning.go
@@ -3,10 +3,10 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/MikkoParkkola/trvl/internal/flights"
-	"github.com/MikkoParkkola/trvl/internal/ground"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
 )
 
@@ -101,6 +101,15 @@ var multiModalHubs = map[string][]multiModalHub{
 // multi-modal positioning hack is surfaced.
 const minSavingsFraction = 0.20
 
+// multiModalCandidate is the result of pricing one cross-modal positioning
+// route: the ground leg and the onward flight leg, both already converted
+// into the detector's requested target currency.
+type multiModalCandidate struct {
+	hub         multiModalHub
+	groundPrice float64
+	flightPrice float64
+}
+
 // detectMultiModalPositioning checks whether taking ground transport to a
 // nearby hub airport and flying from there is cheaper than flying directly,
 // by more than 20 %.
@@ -119,24 +128,27 @@ func detectMultiModalPositioning(ctx context.Context, in DetectorInput) []Hack {
 		return nil
 	}
 
+	// All user-visible prices (direct flight, ground leg, and positioning
+	// flight leg) are converted into the requested currency before being
+	// combined; a leg that cannot be converted drops its candidate rather
+	// than mixing currencies in the total.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
 	// Baseline: cheapest direct flight from origin.
-	directResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
+	directResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{SearchOverride: in.SearchOverride})
 	if err != nil || !directResult.Success || len(directResult.Flights) == 0 {
 		return nil
 	}
-	directPrice := minFlightPrice(directResult)
-	if directPrice <= 0 {
+	directPrice, ok := cheapestFlightPriceInTarget(ctx, directResult, target)
+	if !ok {
 		return nil
 	}
-	currency := flightCurrency(directResult, in.currency())
+	currency := target
 
-	type candidate struct {
-		hub       multiModalHub
-		groundEUR float64
-		flightEUR float64
-	}
-
-	ch := make(chan candidate, len(hubs))
+	ch := make(chan multiModalCandidate, len(hubs))
 	var wg sync.WaitGroup
 
 	for _, h := range hubs {
@@ -145,32 +157,24 @@ func detectMultiModalPositioning(ctx context.Context, in DetectorInput) []Hack {
 		go func() {
 			defer wg.Done()
 
-			// Live ground price (fallback to static estimate).
-			groundEUR := h.StaticGroundEUR
-			gr, gerr := ground.SearchByName(ctx, h.OriginCity, h.HubCity, in.Date, ground.SearchOptions{
-				Currency: "EUR",
-				Type:     h.GroundType,
-			})
-			if gerr == nil && gr.Success {
-				for _, r := range gr.Routes {
-					if r.Price > 0 && r.Price < groundEUR {
-						groundEUR = r.Price
-					}
-				}
+			groundPrice, ok := groundLegPriceInTarget(ctx, h.OriginCity, h.HubCity, in.Date, h.GroundType, h.StaticGroundEUR, target, in.GroundSearchOverride)
+			if !ok {
+				ch <- multiModalCandidate{}
+				return
 			}
 
 			// Flight from hub to destination.
-			fr, ferr := flights.SearchFlights(ctx, h.HubCode, in.Destination, in.Date, flights.SearchOptions{})
+			fr, ferr := flights.SearchFlights(ctx, h.HubCode, in.Destination, in.Date, flights.SearchOptions{SearchOverride: in.SearchOverride})
 			if ferr != nil || !fr.Success || len(fr.Flights) == 0 {
-				ch <- candidate{}
+				ch <- multiModalCandidate{}
 				return
 			}
-			flightPrice := minFlightPrice(fr)
-			if flightPrice <= 0 {
-				ch <- candidate{}
+			flightPrice, ok := cheapestFlightPriceInTarget(ctx, fr, target)
+			if !ok {
+				ch <- multiModalCandidate{}
 				return
 			}
-			ch <- candidate{hub: h, groundEUR: groundEUR, flightEUR: flightPrice}
+			ch <- multiModalCandidate{hub: h, groundPrice: groundPrice, flightPrice: flightPrice}
 		}()
 	}
 
@@ -179,12 +183,12 @@ func detectMultiModalPositioning(ctx context.Context, in DetectorInput) []Hack {
 
 	var hacks []Hack
 	for c := range ch {
-		if c.flightEUR == 0 {
+		if c.flightPrice <= 0 {
 			continue
 		}
-		total := c.groundEUR + c.flightEUR
+		total := c.groundPrice + c.flightPrice
 		savings := directPrice - total
-		// Require both an absolute saving of EUR 10 and a relative saving of 20 %.
+		// Require both an absolute saving of 10 and a relative saving of 20 %.
 		if savings < 10 || savings/directPrice < minSavingsFraction {
 			continue
 		}
@@ -195,10 +199,10 @@ func detectMultiModalPositioning(ctx context.Context, in DetectorInput) []Hack {
 			Currency: currency,
 			Savings:  roundSavings(savings),
 			Description: fmt.Sprintf(
-				"%s to %s (%.0f EUR) + flight %s→%s (%.0f EUR) = %.0f EUR total, vs direct flight %.0f EUR. Saves %s %.0f (%.0f%%).",
-				c.hub.OriginCity, c.hub.HubCity, c.groundEUR,
-				c.hub.HubCode, in.Destination, c.flightEUR,
-				total, directPrice,
+				"%s to %s (%.0f %s) + flight %s→%s (%.0f %s) = %.0f %s total, vs direct flight %.0f %s. Saves %s %.0f (%.0f%%).",
+				c.hub.OriginCity, c.hub.HubCity, c.groundPrice, currency,
+				c.hub.HubCode, in.Destination, c.flightPrice, currency,
+				total, currency, directPrice, currency,
 				currency, savings, 100*savings/directPrice,
 			),
 			Risks: []string{
@@ -208,9 +212,9 @@ func detectMultiModalPositioning(ctx context.Context, in DetectorInput) []Hack {
 				"Overnight ground legs add travel time; factor in comfort",
 			},
 			Steps: []string{
-				fmt.Sprintf("%s (%s %.0f)", c.hub.Notes, currency, c.groundEUR),
+				fmt.Sprintf("%s (%s %.0f)", c.hub.Notes, currency, c.groundPrice),
 				fmt.Sprintf("Transfer from %s to %s airport", c.hub.HubCity, c.hub.HubCode),
-				fmt.Sprintf("Book flight %s→%s on %s (%s %.0f)", c.hub.HubCode, in.Destination, in.Date, currency, c.flightEUR),
+				fmt.Sprintf("Book flight %s→%s on %s (%s %.0f)", c.hub.HubCode, in.Destination, in.Date, currency, c.flightPrice),
 				"Allow at least 2 hours between ground arrival and flight departure",
 			},
 			Citations: []string{

--- a/internal/hacks/multimodal_positioning.go
+++ b/internal/hacks/multimodal_positioning.go
@@ -218,7 +218,7 @@ func detectMultiModalPositioning(ctx context.Context, in DetectorInput) []Hack {
 				"Overnight ground legs add travel time; factor in comfort",
 			},
 			Steps: []string{
-				fmt.Sprintf("%s (%s %.0f)", c.hub.Notes, currency, c.groundPrice),
+				fmt.Sprintf("%s (%s %.0f%s)", c.hub.Notes, currency, c.groundPrice, groundFareNote),
 				fmt.Sprintf("Transfer from %s to %s airport", c.hub.HubCity, c.hub.HubCode),
 				fmt.Sprintf("Book flight %s→%s on %s (%s %.0f)", c.hub.HubCode, in.Destination, in.Date, currency, c.flightPrice),
 				"Allow at least 2 hours between ground arrival and flight departure",

--- a/internal/hacks/multimodal_positioning.go
+++ b/internal/hacks/multimodal_positioning.go
@@ -108,6 +108,7 @@ type multiModalCandidate struct {
 	hub         multiModalHub
 	groundPrice float64
 	flightPrice float64
+	estimated   bool
 }
 
 // detectMultiModalPositioning checks whether taking ground transport to a
@@ -157,7 +158,7 @@ func detectMultiModalPositioning(ctx context.Context, in DetectorInput) []Hack {
 		go func() {
 			defer wg.Done()
 
-			groundPrice, ok := groundLegPriceInTarget(ctx, h.OriginCity, h.HubCity, in.Date, h.GroundType, h.StaticGroundEUR, target, in.GroundSearchOverride)
+			groundPrice, ok, estimated := groundLegPriceInTarget(ctx, h.OriginCity, h.HubCity, in.Date, h.GroundType, h.StaticGroundEUR, target, in.GroundSearchOverride)
 			if !ok {
 				ch <- multiModalCandidate{}
 				return
@@ -174,7 +175,7 @@ func detectMultiModalPositioning(ctx context.Context, in DetectorInput) []Hack {
 				ch <- multiModalCandidate{}
 				return
 			}
-			ch <- multiModalCandidate{hub: h, groundPrice: groundPrice, flightPrice: flightPrice}
+			ch <- multiModalCandidate{hub: h, groundPrice: groundPrice, flightPrice: flightPrice, estimated: estimated}
 		}()
 	}
 
@@ -193,14 +194,19 @@ func detectMultiModalPositioning(ctx context.Context, in DetectorInput) []Hack {
 			continue
 		}
 
+		groundFareNote := ""
+		if c.estimated {
+			groundFareNote = ", estimated fare"
+		}
+
 		hacks = append(hacks, Hack{
 			Type:     "multimodal_positioning",
 			Title:    fmt.Sprintf("Ground to %s, then fly to %s cheaper", c.hub.HubCity, in.Destination),
 			Currency: currency,
 			Savings:  roundSavings(savings),
 			Description: fmt.Sprintf(
-				"%s to %s (%.0f %s) + flight %s→%s (%.0f %s) = %.0f %s total, vs direct flight %.0f %s. Saves %s %.0f (%.0f%%).",
-				c.hub.OriginCity, c.hub.HubCity, c.groundPrice, currency,
+				"%s to %s (%.0f %s%s) + flight %s→%s (%.0f %s) = %.0f %s total, vs direct flight %.0f %s. Saves %s %.0f (%.0f%%).",
+				c.hub.OriginCity, c.hub.HubCity, c.groundPrice, currency, groundFareNote,
 				c.hub.HubCode, in.Destination, c.flightPrice, currency,
 				total, currency, directPrice, currency,
 				currency, savings, 100*savings/directPrice,

--- a/internal/hacks/multimodal_positioning.go
+++ b/internal/hacks/multimodal_positioning.go
@@ -3,8 +3,10 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/ground"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
@@ -119,16 +121,25 @@ func detectMultiModalPositioning(ctx context.Context, in DetectorInput) []Hack {
 		return nil
 	}
 
-	// Baseline: cheapest direct flight from origin.
+	// Ground legs here are EUR-denominated static estimates; each is converted
+	// via FX into the traveller's requested currency so the itinerary is
+	// labelled honestly in that one currency. A candidate whose ground estimate
+	// cannot be converted is skipped rather than mislabelled.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
+	// Baseline: cheapest direct flight from origin, converted into the requested currency.
 	directResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
 	if err != nil || !directResult.Success || len(directResult.Flights) == 0 {
 		return nil
 	}
-	directPrice := minFlightPrice(directResult)
-	if directPrice <= 0 {
+	directPrice, ok := minFlightPriceConverted(ctx, directResult, target)
+	if !ok {
 		return nil
 	}
-	currency := flightCurrency(directResult, in.currency())
+	currency := target
 
 	type candidate struct {
 		hub       multiModalHub
@@ -145,32 +156,45 @@ func detectMultiModalPositioning(ctx context.Context, in DetectorInput) []Hack {
 		go func() {
 			defer wg.Done()
 
-			// Live ground price (fallback to static estimate).
-			groundEUR := h.StaticGroundEUR
+			// Prefer a live ground price (converted into target); fall back to the
+			// static EUR estimate converted into target. Suppress the candidate
+			// only when NEITHER the live route nor the static estimate can be
+			// shown in the requested currency. Cheapest convertible price wins.
+			groundConv := 0.0
+			haveGround := false
 			gr, gerr := ground.SearchByName(ctx, h.OriginCity, h.HubCity, in.Date, ground.SearchOptions{
 				Currency: "EUR",
 				Type:     h.GroundType,
 			})
 			if gerr == nil && gr.Success {
-				for _, r := range gr.Routes {
-					if r.Price > 0 && r.Price < groundEUR {
-						groundEUR = r.Price
-					}
+				if _, live, lok := selectCheapestGroundConverted(ctx, gr.Routes, target, false); lok && live > 0 {
+					groundConv = live
+					haveGround = true
 				}
 			}
+			if est, gec := destinations.ConvertCurrency(ctx, h.StaticGroundEUR, "EUR", target); gec == target {
+				if !haveGround || est < groundConv {
+					groundConv = est
+					haveGround = true
+				}
+			}
+			if !haveGround {
+				ch <- candidate{}
+				return
+			}
 
-			// Flight from hub to destination.
+			// Flight from hub to destination, converted into the requested currency.
 			fr, ferr := flights.SearchFlights(ctx, h.HubCode, in.Destination, in.Date, flights.SearchOptions{})
 			if ferr != nil || !fr.Success || len(fr.Flights) == 0 {
 				ch <- candidate{}
 				return
 			}
-			flightPrice := minFlightPrice(fr)
-			if flightPrice <= 0 {
+			flightPrice, fok := minFlightPriceConverted(ctx, fr, target)
+			if !fok {
 				ch <- candidate{}
 				return
 			}
-			ch <- candidate{hub: h, groundEUR: groundEUR, flightEUR: flightPrice}
+			ch <- candidate{hub: h, groundEUR: groundConv, flightEUR: flightPrice}
 		}()
 	}
 
@@ -195,10 +219,10 @@ func detectMultiModalPositioning(ctx context.Context, in DetectorInput) []Hack {
 			Currency: currency,
 			Savings:  roundSavings(savings),
 			Description: fmt.Sprintf(
-				"%s to %s (%.0f EUR) + flight %s→%s (%.0f EUR) = %.0f EUR total, vs direct flight %.0f EUR. Saves %s %.0f (%.0f%%).",
-				c.hub.OriginCity, c.hub.HubCity, c.groundEUR,
-				c.hub.HubCode, in.Destination, c.flightEUR,
-				total, directPrice,
+				"%s to %s (%.0f %s) + flight %s→%s (%.0f %s) = %.0f %s total, vs direct flight %.0f %s. Saves %s %.0f (%.0f%%).",
+				c.hub.OriginCity, c.hub.HubCity, c.groundEUR, currency,
+				c.hub.HubCode, in.Destination, c.flightEUR, currency,
+				total, currency, directPrice, currency,
 				currency, savings, 100*savings/directPrice,
 			),
 			Risks: []string{

--- a/internal/hacks/multimodal_skip_flight.go
+++ b/internal/hacks/multimodal_skip_flight.go
@@ -3,7 +3,9 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/ground"
 )
@@ -18,18 +20,24 @@ func detectMultiModalSkipFlight(ctx context.Context, in DetectorInput) []Hack {
 		return nil
 	}
 
-	// Baseline: cheapest direct flight.
+	// Baseline: cheapest direct flight, converted into the traveller's
+	// requested currency so every leg and total below is labelled honestly in
+	// that one currency via FX conversion (not currency-suppression).
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
 	flightResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
 	if err != nil || !flightResult.Success || len(flightResult.Flights) == 0 {
 		return nil
 	}
-	flightPrice := minFlightPrice(flightResult)
-	if flightPrice <= 0 {
-		return nil
+	flightPrice, ok := minFlightPriceConverted(ctx, flightResult, target)
+	if !ok {
+		return nil // no flight convertible into the requested currency
 	}
-	currency := flightCurrency(flightResult, in.currency())
 
-	// Ground search — any mode.
+	// Ground search — any mode. The request stays EUR; each route's own price
+	// is converted into target below.
 	originCity := cityFromCode(in.Origin)
 	destCity := cityFromCode(in.Destination)
 	groundResult, err := ground.SearchByName(ctx, originCity, destCity, in.Date, ground.SearchOptions{
@@ -39,63 +47,45 @@ func detectMultiModalSkipFlight(ctx context.Context, in DetectorInput) []Hack {
 		return nil
 	}
 
-	// Find the cheapest overnight route.
-	var bestPrice float64
-	var bestRoute *groundRoute
-	for i := range groundResult.Routes {
-		r := &groundResult.Routes[i]
-		if r.Price <= 0 {
-			continue
-		}
-		if !isOvernightRoute(r.Departure.Time, r.Arrival.Time) {
-			continue
-		}
-		if bestRoute == nil || r.Price < bestPrice {
-			bestPrice = r.Price
-			bestRoute = &groundRoute{
-				provider:   r.Provider,
-				routeType:  r.Type,
-				price:      r.Price,
-				currency:   r.Currency,
-				depCity:    r.Departure.City,
-				arrCity:    r.Arrival.City,
-				depTime:    r.Departure.Time,
-				arrTime:    r.Arrival.Time,
-				bookingURL: r.BookingURL,
-			}
-		}
-	}
-
-	if bestRoute == nil {
+	// Cheapest overnight route, converted into the requested currency.
+	bestRoute, bestPrice, gok := selectCheapestGroundConverted(ctx, groundResult.Routes, target, true)
+	if !gok {
 		return nil
 	}
 
-	// Total saving: flight price − ground price + saved hotel night.
-	savings := (flightPrice - bestPrice) + averageHotelCost
+	// Total saving: flight − ground + saved hotel night. The hotel saving is a
+	// EUR estimate, converted into target; folded in only if convertible.
+	hotelBonus := 0.0
+	if hb, hbcur := destinations.ConvertCurrency(ctx, averageHotelCost, "EUR", target); hbcur == target {
+		hotelBonus = hb
+	}
+	savings := (flightPrice - bestPrice) + hotelBonus
 	if savings < 50 {
 		return nil
 	}
 
-	displayCurrency := currency
-	if bestRoute.currency != "" {
-		displayCurrency = bestRoute.currency
-	}
+	currency := target
 	depTime := trimToHHMM(bestRoute.depTime)
 	arrTime := trimToHHMM(bestRoute.arrTime)
 
+	hotelNote := ""
+	if hotelBonus > 0 {
+		hotelNote = fmt.Sprintf(" + ~%.0f saved hotel night", hotelBonus)
+	}
+
 	return []Hack{{
 		Type:     "multimodal_skip_flight",
-		Title:    fmt.Sprintf("Skip the flight — overnight %s saves EUR %.0f", bestRoute.routeType, savings),
-		Currency: displayCurrency,
+		Title:    fmt.Sprintf("Skip the flight — overnight %s saves %s %.0f", bestRoute.routeType, currency, savings),
+		Currency: currency,
 		Savings:  roundSavings(savings),
 		Description: fmt.Sprintf(
 			"Overnight %s %s→%s departs %s arrives %s (%.0f %s) vs flight %.0f %s. "+
-				"Ground saves %.0f on transport + ~%.0f saved hotel night = %.0f total saving.",
+				"Ground saves %.0f on transport%s = %.0f total saving.",
 			bestRoute.routeType, bestRoute.depCity, bestRoute.arrCity,
 			depTime, arrTime,
-			bestRoute.price, displayCurrency,
+			bestRoute.price, currency,
 			flightPrice, currency,
-			flightPrice-bestRoute.price, averageHotelCost, savings,
+			flightPrice-bestRoute.price, hotelNote, savings,
 		),
 		Risks: []string{
 			"Overnight ground transport is slower; factor in comfort and rest quality",
@@ -106,7 +96,7 @@ func detectMultiModalSkipFlight(ctx context.Context, in DetectorInput) []Hack {
 		Steps: []string{
 			fmt.Sprintf("Book overnight %s %s→%s departing %s on %s (%.0f %s)",
 				bestRoute.routeType, bestRoute.depCity, bestRoute.arrCity,
-				depTime, in.Date, bestRoute.price, displayCurrency),
+				depTime, in.Date, bestRoute.price, currency),
 			"Skip booking a hotel for that night — arrive early morning rested",
 			fmt.Sprintf("Check booking at: %s", bestRoute.bookingURL),
 		},

--- a/internal/hacks/multimodal_skip_flight.go
+++ b/internal/hacks/multimodal_skip_flight.go
@@ -3,6 +3,7 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/ground"
@@ -12,34 +13,45 @@ import (
 // taking an overnight ground option (bus or train) is cheaper, factoring in the
 // saved hotel night.
 //
-// Threshold: net saving must exceed EUR 50 before this hack is surfaced.
+// Threshold: net saving must exceed 50 (in the requested currency) before this
+// hack is surfaced.
 func detectMultiModalSkipFlight(ctx context.Context, in DetectorInput) []Hack {
 	if !in.valid() || in.Date == "" {
 		return nil
 	}
 
+	// The flight price, every ground route's price, and the flat EUR hotel
+	// estimate are each converted into the requested target currency before
+	// being combined; anything that cannot be converted drops the whole
+	// candidate rather than mixing currencies in one saving figure.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
 	// Baseline: cheapest direct flight.
-	flightResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
+	flightResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{SearchOverride: in.SearchOverride})
 	if err != nil || !flightResult.Success || len(flightResult.Flights) == 0 {
 		return nil
 	}
-	flightPrice := minFlightPrice(flightResult)
-	if flightPrice <= 0 {
+	flightPrice, ok := cheapestFlightPriceInTarget(ctx, flightResult, target)
+	if !ok {
 		return nil
 	}
-	currency := flightCurrency(flightResult, in.currency())
+	currency := target
 
 	// Ground search — any mode.
 	originCity := cityFromCode(in.Origin)
 	destCity := cityFromCode(in.Destination)
 	groundResult, err := ground.SearchByName(ctx, originCity, destCity, in.Date, ground.SearchOptions{
-		Currency: "EUR",
+		Currency:       target,
+		SearchOverride: in.GroundSearchOverride,
 	})
 	if err != nil || !groundResult.Success || len(groundResult.Routes) == 0 {
 		return nil
 	}
 
-	// Find the cheapest overnight route.
+	// Find the cheapest overnight route whose price converts into target.
 	var bestPrice float64
 	var bestRoute *groundRoute
 	for i := range groundResult.Routes {
@@ -50,13 +62,17 @@ func detectMultiModalSkipFlight(ctx context.Context, in DetectorInput) []Hack {
 		if !isOvernightRoute(r.Departure.Time, r.Arrival.Time) {
 			continue
 		}
-		if bestRoute == nil || r.Price < bestPrice {
-			bestPrice = r.Price
+		conv, ok := convertCurrency(ctx, r.Price, r.Currency, target)
+		if !ok {
+			continue
+		}
+		if bestRoute == nil || conv < bestPrice {
+			bestPrice = conv
 			bestRoute = &groundRoute{
 				provider:   r.Provider,
 				routeType:  r.Type,
-				price:      r.Price,
-				currency:   r.Currency,
+				price:      conv,
+				currency:   target,
 				depCity:    r.Departure.City,
 				arrCity:    r.Arrival.City,
 				depTime:    r.Departure.Time,
@@ -70,32 +86,35 @@ func detectMultiModalSkipFlight(ctx context.Context, in DetectorInput) []Hack {
 		return nil
 	}
 
-	// Total saving: flight price − ground price + saved hotel night.
-	savings := (flightPrice - bestPrice) + averageHotelCost
+	// The saved hotel night is a flat EUR estimate; convert it into target
+	// before adding it to a saving figure already expressed in target.
+	hotelBonus, ok := convertCurrency(ctx, averageHotelCost, "EUR", target)
+	if !ok {
+		return nil
+	}
+
+	// Total saving: flight price − ground price + saved hotel night, all in target.
+	savings := (flightPrice - bestPrice) + hotelBonus
 	if savings < 50 {
 		return nil
 	}
 
-	displayCurrency := currency
-	if bestRoute.currency != "" {
-		displayCurrency = bestRoute.currency
-	}
 	depTime := trimToHHMM(bestRoute.depTime)
 	arrTime := trimToHHMM(bestRoute.arrTime)
 
 	return []Hack{{
 		Type:     "multimodal_skip_flight",
-		Title:    fmt.Sprintf("Skip the flight — overnight %s saves EUR %.0f", bestRoute.routeType, savings),
-		Currency: displayCurrency,
+		Title:    fmt.Sprintf("Skip the flight — overnight %s saves %s %.0f", bestRoute.routeType, currency, savings),
+		Currency: currency,
 		Savings:  roundSavings(savings),
 		Description: fmt.Sprintf(
 			"Overnight %s %s→%s departs %s arrives %s (%.0f %s) vs flight %.0f %s. "+
 				"Ground saves %.0f on transport + ~%.0f saved hotel night = %.0f total saving.",
 			bestRoute.routeType, bestRoute.depCity, bestRoute.arrCity,
 			depTime, arrTime,
-			bestRoute.price, displayCurrency,
+			bestRoute.price, currency,
 			flightPrice, currency,
-			flightPrice-bestRoute.price, averageHotelCost, savings,
+			flightPrice-bestRoute.price, hotelBonus, savings,
 		),
 		Risks: []string{
 			"Overnight ground transport is slower; factor in comfort and rest quality",
@@ -106,7 +125,7 @@ func detectMultiModalSkipFlight(ctx context.Context, in DetectorInput) []Hack {
 		Steps: []string{
 			fmt.Sprintf("Book overnight %s %s→%s departing %s on %s (%.0f %s)",
 				bestRoute.routeType, bestRoute.depCity, bestRoute.arrCity,
-				depTime, in.Date, bestRoute.price, displayCurrency),
+				depTime, in.Date, bestRoute.price, currency),
 			"Skip booking a hotel for that night — arrive early morning rested",
 			fmt.Sprintf("Check booking at: %s", bestRoute.bookingURL),
 		},

--- a/internal/hacks/night_transport.go
+++ b/internal/hacks/night_transport.go
@@ -3,7 +3,9 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/ground"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"golang.org/x/text/cases"
@@ -21,6 +23,22 @@ func detectNightTransport(ctx context.Context, in DetectorInput) []Hack {
 		return nil
 	}
 
+	// ponytail: in.currency() doesn't normalize/default; do it here so the
+	// conversion guard below compares like-for-like against the target.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
+	// Convert the notional hotel-night saving (a fixed EUR estimate) into the
+	// target currency before we spend an API call. If we can't honestly
+	// convert it, suppress the whole hack rather than label a EUR number
+	// with the wrong currency.
+	hotelSaving, cur := destinations.ConvertCurrency(ctx, averageHotelCost, "EUR", target)
+	if cur != target {
+		return nil
+	}
+
 	result, err := ground.SearchByName(ctx, cityFromCode(in.Origin), cityFromCode(in.Destination), in.Date, ground.SearchOptions{
 		Currency: in.currency(),
 	})
@@ -34,8 +52,8 @@ func detectNightTransport(ctx context.Context, in DetectorInput) []Hack {
 			continue
 		}
 
-		totalBenefit := averageHotelCost
-		h := buildNightHack(in, r, totalBenefit)
+		r.Currency = target // buildNightHack trusts r.Currency when set
+		h := buildNightHack(in, r, hotelSaving)
 		hacks = append(hacks, h)
 
 		// Report only the best (cheapest) night option.

--- a/internal/hacks/night_transport.go
+++ b/internal/hacks/night_transport.go
@@ -52,7 +52,15 @@ func detectNightTransport(ctx context.Context, in DetectorInput) []Hack {
 			continue
 		}
 
-		r.Currency = target // buildNightHack trusts r.Currency when set
+		// The route was requested in target, but a provider that ignores the
+		// requested currency and returns its own can't be honestly relabeled
+		// as target without converting the route's own price — and this hack
+		// doesn't carry a converted route price to fall back on, so skip
+		// rather than mislabel.
+		if r.Currency != "" && !strings.EqualFold(r.Currency, target) {
+			continue
+		}
+		r.Currency = target // provider echoed target (or left it unset)
 		h := buildNightHack(in, r, hotelSaving)
 		hacks = append(hacks, h)
 

--- a/internal/hacks/night_transport.go
+++ b/internal/hacks/night_transport.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/ground"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"golang.org/x/text/cases"
@@ -34,7 +33,7 @@ func detectNightTransport(ctx context.Context, in DetectorInput) []Hack {
 	// target currency before we spend an API call. If we can't honestly
 	// convert it, suppress the whole hack rather than label a EUR number
 	// with the wrong currency.
-	hotelSaving, cur := destinations.ConvertCurrency(ctx, averageHotelCost, "EUR", target)
+	hotelSaving, cur := convertCurrency(ctx, averageHotelCost, "EUR", target)
 	if cur != target {
 		return nil
 	}

--- a/internal/hacks/night_transport_test.go
+++ b/internal/hacks/night_transport_test.go
@@ -1,0 +1,47 @@
+package hacks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/testutil"
+)
+
+// TestDetectNightTransport_nonEURTarget_suppressedWhenInconvertible proves
+// case (b): a non-EUR target currency that can't be honestly converted
+// (XXX is the ISO 4217 "no currency" placeholder — it will never appear in
+// a real exchange-rate table) suppresses the hack entirely instead of
+// labeling a EUR-denominated hotel-saving estimate with the wrong currency.
+// The guard runs before the ground-transport search, so this is
+// deterministic and network-independent.
+func TestDetectNightTransport_nonEURTarget_suppressedWhenInconvertible(t *testing.T) {
+	hacks := detectNightTransport(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "PRG",
+		Date:        "2026-07-01",
+		Currency:    "XXX",
+	})
+	if len(hacks) != 0 {
+		t.Errorf("expected no hacks for inconvertible target currency, got %d", len(hacks))
+	}
+}
+
+// TestDetectNightTransport_eurTarget_labelsEURAndConverts proves cases (a)
+// and (c): EUR passes through untouched and, when a hack surfaces, its
+// Currency matches the target. Ground-transport search needs the live
+// network, so this is gated the same way as the existing
+// TestDetectNightTransport_validRoute in coverage_target_test.go.
+func TestDetectNightTransport_eurTarget_labelsEURAndConverts(t *testing.T) {
+	testutil.RequireLiveIntegration(t)
+	hacks := detectNightTransport(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "PRG",
+		Date:        "2026-07-01",
+		Currency:    "EUR",
+	})
+	for _, h := range hacks {
+		if h.Currency != "EUR" {
+			t.Errorf("Currency = %q, want EUR", h.Currency)
+		}
+	}
+}

--- a/internal/hacks/night_transport_test.go
+++ b/internal/hacks/night_transport_test.go
@@ -13,8 +13,22 @@ import (
 // a real exchange-rate table) suppresses the hack entirely instead of
 // labeling a EUR-denominated hotel-saving estimate with the wrong currency.
 // The guard runs before the ground-transport search, so this is
-// deterministic and network-independent.
+// deterministic and network-independent. Uses a fake convertCurrency
+// injected via the seam in currency.go so the "can't convert" contract is
+// exercised offline instead of dialing the live rates table (which would
+// otherwise be reached first to resolve EUR, before XXX is even considered).
+// No t.Parallel — the seam var is shared package state, set/restored
+// sequentially like railGroundSearcher.
 func TestDetectNightTransport_nonEURTarget_suppressedWhenInconvertible(t *testing.T) {
+	orig := convertCurrency
+	convertCurrency = func(_ context.Context, amount float64, from, to string) (float64, string) {
+		if from == to {
+			return amount, to
+		}
+		return amount, from // can't convert — same contract as the real function
+	}
+	t.Cleanup(func() { convertCurrency = orig })
+
 	hacks := detectNightTransport(context.Background(), DetectorInput{
 		Origin:      "HEL",
 		Destination: "PRG",

--- a/internal/hacks/open_jaw.go
+++ b/internal/hacks/open_jaw.go
@@ -10,10 +10,6 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/preferences"
 )
 
-// openJawSearchFunc is the function used to search flights. Package-level
-// variable allows test injection without modifying the detector signature.
-var openJawSearchFunc = flights.SearchFlights
-
 // openJawAlternates lists nearby airports that are reasonable alternate return
 // points for an open-jaw itinerary. Keyed by the destination airport: if
 // you fly OUT→DEST, you could return from one of these instead.
@@ -63,8 +59,9 @@ func detectOpenJaw(ctx context.Context, in DetectorInput) []Hack {
 	}
 
 	// Baseline: round-trip from origin to destination.
-	rtResult, err := openJawSearchFunc(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{
-		ReturnDate: in.ReturnDate,
+	rtResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{
+		ReturnDate:     in.ReturnDate,
+		SearchOverride: in.SearchOverride,
 	})
 	if err != nil || !rtResult.Success || len(rtResult.Flights) == 0 {
 		return nil
@@ -76,7 +73,7 @@ func detectOpenJaw(ctx context.Context, in DetectorInput) []Hack {
 	currency := target
 
 	// One-way outbound (origin → destination).
-	owOutResult, err := openJawSearchFunc(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
+	owOutResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{SearchOverride: in.SearchOverride})
 	if err != nil || !owOutResult.Success || len(owOutResult.Flights) == 0 {
 		return nil
 	}
@@ -104,7 +101,7 @@ func detectOpenJaw(ctx context.Context, in DetectorInput) []Hack {
 		}
 		alt := alt
 		go func() {
-			r, err := openJawSearchFunc(ctx, alt, in.Origin, in.ReturnDate, flights.SearchOptions{})
+			r, err := flights.SearchFlights(ctx, alt, in.Origin, in.ReturnDate, flights.SearchOptions{SearchOverride: in.SearchOverride})
 			if err != nil || !r.Success || len(r.Flights) == 0 {
 				results <- ch{alt: alt}
 				return

--- a/internal/hacks/open_jaw.go
+++ b/internal/hacks/open_jaw.go
@@ -3,10 +3,16 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/preferences"
 )
+
+// openJawSearchFunc is the function used to search flights. Package-level
+// variable allows test injection without modifying the detector signature.
+var openJawSearchFunc = flights.SearchFlights
 
 // openJawAlternates lists nearby airports that are reasonable alternate return
 // points for an open-jaw itinerary. Keyed by the destination airport: if
@@ -47,26 +53,35 @@ func detectOpenJaw(ctx context.Context, in DetectorInput) []Hack {
 	// Check if origin is a home airport — the strongest open-jaw signal.
 	isHome := isHomeAirport(in.Origin, prefs)
 
+	// All user-visible prices (round-trip baseline, one-way legs, and the
+	// EUR-denominated ground-cost estimate) are converted into the requested
+	// currency; anything that cannot be converted is suppressed rather than
+	// shown unconverted or mislabelled.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
 	// Baseline: round-trip from origin to destination.
-	rtResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{
+	rtResult, err := openJawSearchFunc(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{
 		ReturnDate: in.ReturnDate,
 	})
 	if err != nil || !rtResult.Success || len(rtResult.Flights) == 0 {
 		return nil
 	}
-	rtPrice := minFlightPrice(rtResult)
-	if rtPrice <= 0 {
+	rtPrice, ok := cheapestFlightPriceIn(ctx, rtResult, target)
+	if !ok {
 		return nil
 	}
-	currency := flightCurrency(rtResult, in.currency())
+	currency := target
 
 	// One-way outbound (origin → destination).
-	owOutResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
+	owOutResult, err := openJawSearchFunc(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
 	if err != nil || !owOutResult.Success || len(owOutResult.Flights) == 0 {
 		return nil
 	}
-	owOutPrice := minFlightPrice(owOutResult)
-	if owOutPrice <= 0 {
+	owOutPrice, ok := cheapestFlightPriceIn(ctx, owOutResult, target)
+	if !ok {
 		return nil
 	}
 
@@ -79,6 +94,7 @@ func detectOpenJaw(ctx context.Context, in DetectorInput) []Hack {
 	type ch struct {
 		alt   string
 		price float64
+		ok    bool
 	}
 	results := make(chan ch, len(alts))
 
@@ -88,24 +104,31 @@ func detectOpenJaw(ctx context.Context, in DetectorInput) []Hack {
 		}
 		alt := alt
 		go func() {
-			r, err := flights.SearchFlights(ctx, alt, in.Origin, in.ReturnDate, flights.SearchOptions{})
+			r, err := openJawSearchFunc(ctx, alt, in.Origin, in.ReturnDate, flights.SearchOptions{})
 			if err != nil || !r.Success || len(r.Flights) == 0 {
-				results <- ch{alt: alt, price: 0}
+				results <- ch{alt: alt}
 				return
 			}
-			results <- ch{alt: alt, price: minFlightPrice(r)}
+			price, ok := cheapestFlightPriceIn(ctx, r, target)
+			results <- ch{alt: alt, price: price, ok: ok}
 		}()
 	}
 
 	var hacks []Hack
 	for range alts {
 		res := <-results
-		if res.price <= 0 {
+		if !res.ok || res.price <= 0 {
 			continue
 		}
 
-		// Estimated ground cost to reach alternate return city (conservative).
-		groundCost := groundCostBetween(in.Destination, res.alt)
+		// Estimated ground cost (EUR) to reach alternate return city, converted
+		// into the requested currency; suppress this candidate rather than mix
+		// currencies when it cannot be converted.
+		groundCostEUR := groundCostBetween(in.Destination, res.alt)
+		groundCost, gcur := destinations.ConvertCurrency(ctx, groundCostEUR, "EUR", target)
+		if gcur != target {
+			continue
+		}
 		totalOpenJaw := owOutPrice + res.price + groundCost
 		savings := rtPrice - totalOpenJaw
 

--- a/internal/hacks/open_jaw_test.go
+++ b/internal/hacks/open_jaw_test.go
@@ -1,0 +1,107 @@
+package hacks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// withOpenJawSearch stubs openJawSearchFunc for the duration of a test.
+func withOpenJawSearch(t *testing.T, fn func(context.Context, string, string, string, flights.SearchOptions) (*models.FlightSearchResult, error)) {
+	t.Helper()
+	original := openJawSearchFunc
+	openJawSearchFunc = fn
+	t.Cleanup(func() { openJawSearchFunc = original })
+}
+
+func openJawFlightResult(price float64, currency string) *models.FlightSearchResult {
+	return &models.FlightSearchResult{
+		Success: true,
+		Flights: []models.FlightResult{{Price: price, Currency: currency}},
+	}
+}
+
+// TestDetectOpenJaw_eurTargetPassthrough covers currency honesty case (a): an
+// EUR target with EUR-denominated flights and ground costs passes through
+// labelled EUR.
+func TestDetectOpenJaw_eurTargetPassthrough(t *testing.T) {
+	withOpenJawSearch(t, func(_ context.Context, _, _, _ string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+		if opts.ReturnDate != "" {
+			// Round-trip baseline.
+			return openJawFlightResult(400, "EUR"), nil
+		}
+		// One-way outbound and one-way alt-return legs.
+		return openJawFlightResult(150, "EUR"), nil
+	})
+
+	hacks := detectOpenJaw(context.Background(), DetectorInput{
+		Origin:      "LHR",
+		Destination: "PRG",
+		Date:        "2026-06-01",
+		ReturnDate:  "2026-06-08",
+		Currency:    "EUR",
+	})
+	if len(hacks) == 0 {
+		t.Fatalf("expected at least one hack, got 0")
+	}
+	for _, h := range hacks {
+		if h.Currency != "EUR" {
+			t.Errorf("expected Currency=EUR, got %q", h.Currency)
+		}
+	}
+}
+
+// TestDetectOpenJaw_nonEURTargetSuppressedWhenInconvertible covers case (b): a
+// non-EUR target with no usable rate table must suppress rather than show an
+// unconverted or mislabelled figure. Placeholder currency codes (ZZZ/ZZY) are
+// used by convention (see currency_sweep_test.go) since they appear in no
+// real exchange-rate table, and the context is cancelled so no live FX fetch
+// can populate the cache either.
+func TestDetectOpenJaw_nonEURTargetSuppressedWhenInconvertible(t *testing.T) {
+	withOpenJawSearch(t, func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+		return openJawFlightResult(400, "ZZZ"), nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	hacks := detectOpenJaw(ctx, DetectorInput{
+		Origin:      "LHR",
+		Destination: "PRG",
+		Date:        "2026-06-01",
+		ReturnDate:  "2026-06-08",
+		Currency:    "ZZY",
+	})
+	if len(hacks) != 0 {
+		t.Errorf("expected suppression when round-trip baseline is inconvertible to target, got %d hacks", len(hacks))
+	}
+}
+
+// TestDetectOpenJaw_hackCurrencyMatchesTarget covers case (c): whenever a
+// hack surfaces, its Currency field equals the normalized target currency.
+func TestDetectOpenJaw_hackCurrencyMatchesTarget(t *testing.T) {
+	withOpenJawSearch(t, func(_ context.Context, _, _, _ string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+		if opts.ReturnDate != "" {
+			return openJawFlightResult(400, "EUR"), nil
+		}
+		return openJawFlightResult(150, "EUR"), nil
+	})
+
+	hacks := detectOpenJaw(context.Background(), DetectorInput{
+		Origin:      "LHR",
+		Destination: "PRG",
+		Date:        "2026-06-01",
+		ReturnDate:  "2026-06-08",
+		Currency:    "eur", // lower-case input must normalize to EUR
+	})
+	if len(hacks) == 0 {
+		t.Fatalf("expected at least one hack, got 0")
+	}
+	for _, h := range hacks {
+		if h.Currency != "EUR" {
+			t.Errorf("expected Hack.Currency == target EUR, got %q", h.Currency)
+		}
+	}
+}

--- a/internal/hacks/open_jaw_test.go
+++ b/internal/hacks/open_jaw_test.go
@@ -8,14 +8,6 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
-// withOpenJawSearch stubs openJawSearchFunc for the duration of a test.
-func withOpenJawSearch(t *testing.T, fn func(context.Context, string, string, string, flights.SearchOptions) (*models.FlightSearchResult, error)) {
-	t.Helper()
-	original := openJawSearchFunc
-	openJawSearchFunc = fn
-	t.Cleanup(func() { openJawSearchFunc = original })
-}
-
 func openJawFlightResult(price float64, currency string) *models.FlightSearchResult {
 	return &models.FlightSearchResult{
 		Success: true,
@@ -27,21 +19,20 @@ func openJawFlightResult(price float64, currency string) *models.FlightSearchRes
 // EUR target with EUR-denominated flights and ground costs passes through
 // labelled EUR.
 func TestDetectOpenJaw_eurTargetPassthrough(t *testing.T) {
-	withOpenJawSearch(t, func(_ context.Context, _, _, _ string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
-		if opts.ReturnDate != "" {
-			// Round-trip baseline.
-			return openJawFlightResult(400, "EUR"), nil
-		}
-		// One-way outbound and one-way alt-return legs.
-		return openJawFlightResult(150, "EUR"), nil
-	})
-
 	hacks := detectOpenJaw(context.Background(), DetectorInput{
 		Origin:      "LHR",
 		Destination: "PRG",
 		Date:        "2026-06-01",
 		ReturnDate:  "2026-06-08",
 		Currency:    "EUR",
+		SearchOverride: func(_ context.Context, _, _, _ string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+			if opts.ReturnDate != "" {
+				// Round-trip baseline.
+				return openJawFlightResult(400, "EUR"), nil
+			}
+			// One-way outbound and one-way alt-return legs.
+			return openJawFlightResult(150, "EUR"), nil
+		},
 	})
 	if len(hacks) == 0 {
 		t.Fatalf("expected at least one hack, got 0")
@@ -60,10 +51,6 @@ func TestDetectOpenJaw_eurTargetPassthrough(t *testing.T) {
 // real exchange-rate table, and the context is cancelled so no live FX fetch
 // can populate the cache either.
 func TestDetectOpenJaw_nonEURTargetSuppressedWhenInconvertible(t *testing.T) {
-	withOpenJawSearch(t, func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
-		return openJawFlightResult(400, "ZZZ"), nil
-	})
-
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -73,6 +60,9 @@ func TestDetectOpenJaw_nonEURTargetSuppressedWhenInconvertible(t *testing.T) {
 		Date:        "2026-06-01",
 		ReturnDate:  "2026-06-08",
 		Currency:    "ZZY",
+		SearchOverride: func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			return openJawFlightResult(400, "ZZZ"), nil
+		},
 	})
 	if len(hacks) != 0 {
 		t.Errorf("expected suppression when round-trip baseline is inconvertible to target, got %d hacks", len(hacks))
@@ -82,19 +72,18 @@ func TestDetectOpenJaw_nonEURTargetSuppressedWhenInconvertible(t *testing.T) {
 // TestDetectOpenJaw_hackCurrencyMatchesTarget covers case (c): whenever a
 // hack surfaces, its Currency field equals the normalized target currency.
 func TestDetectOpenJaw_hackCurrencyMatchesTarget(t *testing.T) {
-	withOpenJawSearch(t, func(_ context.Context, _, _, _ string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
-		if opts.ReturnDate != "" {
-			return openJawFlightResult(400, "EUR"), nil
-		}
-		return openJawFlightResult(150, "EUR"), nil
-	})
-
 	hacks := detectOpenJaw(context.Background(), DetectorInput{
 		Origin:      "LHR",
 		Destination: "PRG",
 		Date:        "2026-06-01",
 		ReturnDate:  "2026-06-08",
 		Currency:    "eur", // lower-case input must normalize to EUR
+		SearchOverride: func(_ context.Context, _, _, _ string, opts flights.SearchOptions) (*models.FlightSearchResult, error) {
+			if opts.ReturnDate != "" {
+				return openJawFlightResult(400, "EUR"), nil
+			}
+			return openJawFlightResult(150, "EUR"), nil
+		},
 	})
 	if len(hacks) == 0 {
 		t.Fatalf("expected at least one hack, got 0")

--- a/internal/hacks/positioning.go
+++ b/internal/hacks/positioning.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -73,6 +75,42 @@ type nearbyEntry struct {
 	Description string
 }
 
+// positioningSearchFunc is the function used to search flights. Package-level
+// variable allows test injection without modifying the detector signature.
+var positioningSearchFunc = flights.SearchFlights
+
+// cheapestFlightPriceIn returns the cheapest positive flight price after
+// converting every flight's price into target, together with an ok flag.
+// Flights are skipped when non-positive or when their price cannot be
+// converted into target (destinations.ConvertCurrency returns a currency
+// string != target). Returns (0, false) when nothing is convertible. Shared
+// by the currency-honesty fix across positioning.go, open_jaw.go,
+// back_to_back.go, and flight_combo.go.
+func cheapestFlightPriceIn(ctx context.Context, r *models.FlightSearchResult, target string) (float64, bool) {
+	if r == nil || !r.Success {
+		return 0, false
+	}
+	min := math.MaxFloat64
+	found := false
+	for _, f := range r.Flights {
+		if f.Price <= 0 {
+			continue
+		}
+		conv, cur := destinations.ConvertCurrency(ctx, f.Price, f.Currency, target)
+		if cur != target {
+			continue
+		}
+		if conv < min {
+			min = conv
+			found = true
+		}
+	}
+	if !found {
+		return 0, false
+	}
+	return min, found
+}
+
 // detectPositioning checks whether flying from a nearby airport is cheaper
 // even after adding ground-transit costs.
 func detectPositioning(ctx context.Context, in DetectorInput) []Hack {
@@ -85,31 +123,47 @@ func detectPositioning(ctx context.Context, in DetectorInput) []Hack {
 		return nil
 	}
 
-	// Baseline: direct flight from origin.
-	directResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
+	// All user-visible prices here (direct flight, alt flight, and the static
+	// EUR ground-cost estimate) are converted into the requested currency; a
+	// candidate whose price cannot be converted is skipped rather than shown
+	// unconverted or mislabelled.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
+	// Baseline: direct flight from origin, converted into the requested currency.
+	directResult, err := positioningSearchFunc(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
 	if err != nil || !directResult.Success || len(directResult.Flights) == 0 {
 		return nil
 	}
-	directPrice := minFlightPrice(directResult)
-	if directPrice <= 0 {
+	directPrice, ok := cheapestFlightPriceIn(ctx, directResult, target)
+	if !ok {
 		return nil
 	}
-	currency := flightCurrency(directResult, in.currency())
+	currency := target
 
 	var hacks []Hack
 	for _, entry := range candidates {
-		altResult, err := flights.SearchFlights(ctx, entry.Code, in.Destination, in.Date, flights.SearchOptions{})
+		altResult, err := positioningSearchFunc(ctx, entry.Code, in.Destination, in.Date, flights.SearchOptions{})
 		if err != nil || !altResult.Success || len(altResult.Flights) == 0 {
 			continue
 		}
-		altPrice := minFlightPrice(altResult)
-		if altPrice <= 0 {
+		altPrice, ok := cheapestFlightPriceIn(ctx, altResult, target)
+		if !ok {
 			continue
 		}
 
-		totalCost := altPrice + entry.GroundCost
+		// entry.GroundCost is an EUR-denominated static estimate; suppress this
+		// candidate rather than mixing currencies when it cannot be converted.
+		groundCost, gcur := destinations.ConvertCurrency(ctx, entry.GroundCost, "EUR", target)
+		if gcur != target {
+			continue
+		}
+
+		totalCost := altPrice + groundCost
 		savings := directPrice - totalCost
-		if savings < 10 { // require at least EUR 10 net saving
+		if savings < 10 { // require at least 10 units net saving
 			continue
 		}
 
@@ -121,7 +175,7 @@ func detectPositioning(ctx context.Context, in DetectorInput) []Hack {
 			Description: fmt.Sprintf(
 				"Fly from %s (%s) instead of %s: flight %.0f + transit %.0f = %.0f total vs %.0f direct. Saves %s %.0f.",
 				entry.Code, entry.City, in.Origin,
-				altPrice, entry.GroundCost, totalCost,
+				altPrice, groundCost, totalCost,
 				directPrice, currency, math.Round(savings),
 			),
 			Risks: []string{

--- a/internal/hacks/positioning.go
+++ b/internal/hacks/positioning.go
@@ -75,10 +75,6 @@ type nearbyEntry struct {
 	Description string
 }
 
-// positioningSearchFunc is the function used to search flights. Package-level
-// variable allows test injection without modifying the detector signature.
-var positioningSearchFunc = flights.SearchFlights
-
 // cheapestFlightPriceIn returns the cheapest positive flight price after
 // converting every flight's price into target, together with an ok flag.
 // Flights are skipped when non-positive or when their price cannot be
@@ -133,7 +129,7 @@ func detectPositioning(ctx context.Context, in DetectorInput) []Hack {
 	}
 
 	// Baseline: direct flight from origin, converted into the requested currency.
-	directResult, err := positioningSearchFunc(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{})
+	directResult, err := flights.SearchFlights(ctx, in.Origin, in.Destination, in.Date, flights.SearchOptions{SearchOverride: in.SearchOverride})
 	if err != nil || !directResult.Success || len(directResult.Flights) == 0 {
 		return nil
 	}
@@ -145,7 +141,7 @@ func detectPositioning(ctx context.Context, in DetectorInput) []Hack {
 
 	var hacks []Hack
 	for _, entry := range candidates {
-		altResult, err := positioningSearchFunc(ctx, entry.Code, in.Destination, in.Date, flights.SearchOptions{})
+		altResult, err := flights.SearchFlights(ctx, entry.Code, in.Destination, in.Date, flights.SearchOptions{SearchOverride: in.SearchOverride})
 		if err != nil || !altResult.Success || len(altResult.Flights) == 0 {
 			continue
 		}

--- a/internal/hacks/positioning_test.go
+++ b/internal/hacks/positioning_test.go
@@ -8,14 +8,6 @@ import (
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
-// withPositioningSearch stubs positioningSearchFunc for the duration of a test.
-func withPositioningSearch(t *testing.T, fn func(context.Context, string, string, string, flights.SearchOptions) (*models.FlightSearchResult, error)) {
-	t.Helper()
-	original := positioningSearchFunc
-	positioningSearchFunc = fn
-	t.Cleanup(func() { positioningSearchFunc = original })
-}
-
 func positioningFlightResult(price float64, currency string) *models.FlightSearchResult {
 	return &models.FlightSearchResult{
 		Success: true,
@@ -27,19 +19,18 @@ func positioningFlightResult(price float64, currency string) *models.FlightSearc
 // an EUR target with EUR-denominated flights and ground costs passes through
 // labelled EUR.
 func TestDetectPositioning_eurTargetPassthrough(t *testing.T) {
-	withPositioningSearch(t, func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
-		if origin == "HEL" {
-			return positioningFlightResult(200, "EUR"), nil
-		}
-		// TLL alt leg (100) + ground cost (30 EUR) = 130 vs 200 direct -> 70 saved.
-		return positioningFlightResult(100, "EUR"), nil
-	})
-
 	hacks := detectPositioning(context.Background(), DetectorInput{
 		Origin:      "HEL",
 		Destination: "BCN",
 		Date:        "2026-06-01",
 		Currency:    "EUR",
+		SearchOverride: func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			if origin == "HEL" {
+				return positioningFlightResult(200, "EUR"), nil
+			}
+			// TLL alt leg (100) + ground cost (30 EUR) = 130 vs 200 direct -> 70 saved.
+			return positioningFlightResult(100, "EUR"), nil
+		},
 	})
 	if len(hacks) == 0 {
 		t.Fatalf("expected at least one hack, got 0")
@@ -58,10 +49,6 @@ func TestDetectPositioning_eurTargetPassthrough(t *testing.T) {
 // appear in no real exchange-rate table, and the context is cancelled so no
 // live FX fetch can populate the cache either.
 func TestDetectPositioning_nonEURTargetSuppressedWhenInconvertible(t *testing.T) {
-	withPositioningSearch(t, func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
-		return positioningFlightResult(200, "ZZZ"), nil
-	})
-
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -70,6 +57,9 @@ func TestDetectPositioning_nonEURTargetSuppressedWhenInconvertible(t *testing.T)
 		Destination: "BCN",
 		Date:        "2026-06-01",
 		Currency:    "ZZY",
+		SearchOverride: func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			return positioningFlightResult(200, "ZZZ"), nil
+		},
 	})
 	if len(hacks) != 0 {
 		t.Errorf("expected suppression when direct flight is inconvertible to target, got %d hacks", len(hacks))
@@ -79,18 +69,17 @@ func TestDetectPositioning_nonEURTargetSuppressedWhenInconvertible(t *testing.T)
 // TestDetectPositioning_hackCurrencyMatchesTarget covers case (c): whenever a
 // hack surfaces, its Currency field equals the normalized target currency.
 func TestDetectPositioning_hackCurrencyMatchesTarget(t *testing.T) {
-	withPositioningSearch(t, func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
-		if origin == "HEL" {
-			return positioningFlightResult(200, "EUR"), nil
-		}
-		return positioningFlightResult(100, "EUR"), nil
-	})
-
 	hacks := detectPositioning(context.Background(), DetectorInput{
 		Origin:      "HEL",
 		Destination: "BCN",
 		Date:        "2026-06-01",
 		Currency:    "eur", // lower-case input must normalize to EUR
+		SearchOverride: func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			if origin == "HEL" {
+				return positioningFlightResult(200, "EUR"), nil
+			}
+			return positioningFlightResult(100, "EUR"), nil
+		},
 	})
 	if len(hacks) == 0 {
 		t.Fatalf("expected at least one hack, got 0")
@@ -105,29 +94,39 @@ func TestDetectPositioning_hackCurrencyMatchesTarget(t *testing.T) {
 // TestDetectPositioning_groundCostInconvertibleSkipsCandidate verifies that a
 // candidate whose EUR ground-cost estimate cannot be converted into the
 // target is skipped even though the flight legs themselves are convertible.
+//
+// The flight legs are priced directly in the target currency ("XXX", ISO
+// 4217's reserved "no currency" code — guaranteed absent from any real or
+// live rate table) so their own conversion succeeds via ConvertCurrency's
+// identity short-circuit (from == to, no network call). Only the
+// EUR-denominated static ground-cost estimate then needs an actual
+// EUR-><target> lookup; the cancelled context makes that live fetch fail
+// deterministically offline, so it has no rate and is dropped. This proves
+// the candidate is skipped specifically because its ground cost could not be
+// converted — not because a flight leg was inconvertible (that path is
+// already covered by TestDetectPositioning_nonEURTargetSuppressedWhenInconvertible).
+// Previously this test left target=EUR, where ConvertCurrency's identity
+// short-circuit made GroundCost trivially "convert" too, so the drop path was
+// never actually exercised.
 func TestDetectPositioning_groundCostInconvertibleSkipsCandidate(t *testing.T) {
-	// destinations.ConvertCurrency never fails to convert EUR->EUR (identity
-	// short-circuit), so exercise this by leaving target=EUR and instead
-	// confirming that a directly-EUR-priced scenario yields a hack; this
-	// pins the reuse of destinations.ConvertCurrency for GroundCost rather
-	// than the raw entry.GroundCost constant leaking through unconverted.
-	withPositioningSearch(t, func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
-		if origin == "HEL" {
-			return positioningFlightResult(200, "EUR"), nil
-		}
-		return positioningFlightResult(100, "EUR"), nil
-	})
+	const target = "XXX"
 
-	hacks := detectPositioning(context.Background(), DetectorInput{
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	hacks := detectPositioning(ctx, DetectorInput{
 		Origin:      "HEL",
 		Destination: "BCN",
 		Date:        "2026-06-01",
-		Currency:    "EUR",
+		Currency:    target,
+		SearchOverride: func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+			if origin == "HEL" {
+				return positioningFlightResult(200, target), nil
+			}
+			return positioningFlightResult(100, target), nil
+		},
 	})
-	if len(hacks) == 0 {
-		t.Fatalf("expected at least one hack, got 0")
-	}
-	if hacks[0].Savings <= 0 {
-		t.Errorf("expected positive savings once ground cost is converted, got %v", hacks[0].Savings)
+	if len(hacks) != 0 {
+		t.Errorf("expected the candidate to be dropped when its ground cost cannot be converted, got %d hacks", len(hacks))
 	}
 }

--- a/internal/hacks/positioning_test.go
+++ b/internal/hacks/positioning_test.go
@@ -1,0 +1,133 @@
+package hacks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/flights"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// withPositioningSearch stubs positioningSearchFunc for the duration of a test.
+func withPositioningSearch(t *testing.T, fn func(context.Context, string, string, string, flights.SearchOptions) (*models.FlightSearchResult, error)) {
+	t.Helper()
+	original := positioningSearchFunc
+	positioningSearchFunc = fn
+	t.Cleanup(func() { positioningSearchFunc = original })
+}
+
+func positioningFlightResult(price float64, currency string) *models.FlightSearchResult {
+	return &models.FlightSearchResult{
+		Success: true,
+		Flights: []models.FlightResult{{Price: price, Currency: currency}},
+	}
+}
+
+// TestDetectPositioning_eurTargetPassthrough covers currency honesty case (a):
+// an EUR target with EUR-denominated flights and ground costs passes through
+// labelled EUR.
+func TestDetectPositioning_eurTargetPassthrough(t *testing.T) {
+	withPositioningSearch(t, func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+		if origin == "HEL" {
+			return positioningFlightResult(200, "EUR"), nil
+		}
+		// TLL alt leg (100) + ground cost (30 EUR) = 130 vs 200 direct -> 70 saved.
+		return positioningFlightResult(100, "EUR"), nil
+	})
+
+	hacks := detectPositioning(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		Currency:    "EUR",
+	})
+	if len(hacks) == 0 {
+		t.Fatalf("expected at least one hack, got 0")
+	}
+	for _, h := range hacks {
+		if h.Currency != "EUR" {
+			t.Errorf("expected Currency=EUR, got %q", h.Currency)
+		}
+	}
+}
+
+// TestDetectPositioning_nonEURTargetSuppressedWhenInconvertible covers case
+// (b): a non-EUR target with no usable rate table must suppress rather than
+// show an unconverted or mislabelled figure. Placeholder currency codes
+// (ZZZ/ZZY) are used by convention (see currency_sweep_test.go) since they
+// appear in no real exchange-rate table, and the context is cancelled so no
+// live FX fetch can populate the cache either.
+func TestDetectPositioning_nonEURTargetSuppressedWhenInconvertible(t *testing.T) {
+	withPositioningSearch(t, func(_ context.Context, _, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+		return positioningFlightResult(200, "ZZZ"), nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	hacks := detectPositioning(ctx, DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		Currency:    "ZZY",
+	})
+	if len(hacks) != 0 {
+		t.Errorf("expected suppression when direct flight is inconvertible to target, got %d hacks", len(hacks))
+	}
+}
+
+// TestDetectPositioning_hackCurrencyMatchesTarget covers case (c): whenever a
+// hack surfaces, its Currency field equals the normalized target currency.
+func TestDetectPositioning_hackCurrencyMatchesTarget(t *testing.T) {
+	withPositioningSearch(t, func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+		if origin == "HEL" {
+			return positioningFlightResult(200, "EUR"), nil
+		}
+		return positioningFlightResult(100, "EUR"), nil
+	})
+
+	hacks := detectPositioning(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		Currency:    "eur", // lower-case input must normalize to EUR
+	})
+	if len(hacks) == 0 {
+		t.Fatalf("expected at least one hack, got 0")
+	}
+	for _, h := range hacks {
+		if h.Currency != "EUR" {
+			t.Errorf("expected Hack.Currency == target EUR, got %q", h.Currency)
+		}
+	}
+}
+
+// TestDetectPositioning_groundCostInconvertibleSkipsCandidate verifies that a
+// candidate whose EUR ground-cost estimate cannot be converted into the
+// target is skipped even though the flight legs themselves are convertible.
+func TestDetectPositioning_groundCostInconvertibleSkipsCandidate(t *testing.T) {
+	// destinations.ConvertCurrency never fails to convert EUR->EUR (identity
+	// short-circuit), so exercise this by leaving target=EUR and instead
+	// confirming that a directly-EUR-priced scenario yields a hack; this
+	// pins the reuse of destinations.ConvertCurrency for GroundCost rather
+	// than the raw entry.GroundCost constant leaking through unconverted.
+	withPositioningSearch(t, func(_ context.Context, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+		if origin == "HEL" {
+			return positioningFlightResult(200, "EUR"), nil
+		}
+		return positioningFlightResult(100, "EUR"), nil
+	})
+
+	hacks := detectPositioning(context.Background(), DetectorInput{
+		Origin:      "HEL",
+		Destination: "BCN",
+		Date:        "2026-06-01",
+		Currency:    "EUR",
+	})
+	if len(hacks) == 0 {
+		t.Fatalf("expected at least one hack, got 0")
+	}
+	if hacks[0].Savings <= 0 {
+		t.Errorf("expected positive savings once ground cost is converted, got %v", hacks[0].Savings)
+	}
+}

--- a/internal/hacks/rail_competition.go
+++ b/internal/hacks/rail_competition.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 )
 
 // railCorridor describes a route with multiple competing rail operators,
@@ -59,7 +61,7 @@ var railCityMap = map[string]string{
 // detectRailCompetition fires when origin and destination match a known
 // competitive rail corridor where multiple operators drive down prices.
 // Purely advisory — zero API calls.
-func detectRailCompetition(_ context.Context, in DetectorInput) []Hack {
+func detectRailCompetition(ctx context.Context, in DetectorInput) []Hack {
 	if !in.valid() {
 		return nil
 	}
@@ -67,30 +69,42 @@ func detectRailCompetition(_ context.Context, in DetectorInput) []Hack {
 	origin := strings.ToUpper(in.Origin)
 	dest := strings.ToUpper(in.Destination)
 
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
 	var hacks []Hack
 
 	for _, c := range competitiveCorridors {
 		// Match in either direction.
 		if (c.From == origin && c.To == dest) || (c.From == dest && c.To == origin) {
+			minFare, mcur := destinations.ConvertCurrency(ctx, c.MinFareEUR, "EUR", target)
+			if mcur != target {
+				// Can't honestly convert the fare — suppress rather than
+				// mislabel it.
+				break
+			}
+
 			fromCity := railCityName(c.From)
 			toCity := railCityName(c.To)
 			operators := strings.Join(c.Operators, ", ")
 
 			notes := c.Notes
 			if notes == "" {
-				notes = fmt.Sprintf("Book advance tickets for fares from EUR %.0f", c.MinFareEUR)
+				notes = fmt.Sprintf("Book advance tickets for fares from %s %.0f", target, minFare)
 			}
 
 			hack := Hack{
 				Type: "rail_competition",
-				Title: fmt.Sprintf("%s to %s — %d competing rail operators (from EUR %.0f)",
-					fromCity, toCity, len(c.Operators), c.MinFareEUR),
+				Title: fmt.Sprintf("%s to %s — %d competing rail operators (from %s %.0f)",
+					fromCity, toCity, len(c.Operators), target, minFare),
 				Description: fmt.Sprintf(
 					"%s to %s has %d competing operators: %s. "+
-						"Competition keeps advance fares as low as EUR %.0f. %s.",
-					fromCity, toCity, len(c.Operators), operators, c.MinFareEUR, notes),
+						"Competition keeps advance fares as low as %s %.0f. %s.",
+					fromCity, toCity, len(c.Operators), operators, target, minFare, notes),
 				Savings:  0, // advisory — no concrete savings without flight price comparison
-				Currency: in.currency(),
+				Currency: target,
 				Steps: []string{
 					fmt.Sprintf("Compare prices across all operators: %s", operators),
 					"Book 30+ days in advance for the lowest fares",
@@ -103,15 +117,18 @@ func detectRailCompetition(_ context.Context, in DetectorInput) []Hack {
 			}
 
 			// If we have a flight price to compare against, note the potential saving.
-			if in.NaivePrice > 0 && in.NaivePrice > c.MinFareEUR {
-				saving := in.NaivePrice - c.MinFareEUR
-				hack.Savings = roundSavings(saving)
-				hack.Description += fmt.Sprintf(
-					" Your flight costs EUR %.0f — rail from EUR %.0f saves up to EUR %.0f.",
-					in.NaivePrice, c.MinFareEUR, saving)
-				hack.Steps = append(hack.Steps,
-					fmt.Sprintf("Flight costs EUR %.0f; cheapest rail is EUR %.0f — consider the trade-off (rail is slower but cheaper and city-centre to city-centre)",
-						in.NaivePrice, c.MinFareEUR))
+			if in.NaivePrice > 0 {
+				naivePrice, ncur := destinations.ConvertCurrency(ctx, in.NaivePrice, "EUR", target)
+				if ncur == target && naivePrice > minFare {
+					saving := naivePrice - minFare
+					hack.Savings = roundSavings(saving)
+					hack.Description += fmt.Sprintf(
+						" Your flight costs %s %.0f — rail from %s %.0f saves up to %s %.0f.",
+						target, naivePrice, target, minFare, target, saving)
+					hack.Steps = append(hack.Steps,
+						fmt.Sprintf("Flight costs %s %.0f; cheapest rail is %s %.0f — consider the trade-off (rail is slower but cheaper and city-centre to city-centre)",
+							target, naivePrice, target, minFare))
+				}
 			}
 
 			hacks = append(hacks, hack)

--- a/internal/hacks/rail_competition.go
+++ b/internal/hacks/rail_competition.go
@@ -116,10 +116,14 @@ func detectRailCompetition(ctx context.Context, in DetectorInput) []Hack {
 				},
 			}
 
-			// If we have a flight price to compare against, note the potential saving.
+			// If we have a flight price to compare against, note the potential
+			// saving. in.NaivePrice is already denominated in target (see
+			// DetectorInput.NaivePrice contract) — converting it again from EUR
+			// would double-convert and corrupt the comparison for every
+			// non-EUR request.
 			if in.NaivePrice > 0 {
-				naivePrice, ncur := destinations.ConvertCurrency(ctx, in.NaivePrice, "EUR", target)
-				if ncur == target && naivePrice > minFare {
+				naivePrice := in.NaivePrice
+				if naivePrice > minFare {
 					saving := naivePrice - minFare
 					hack.Savings = roundSavings(saving)
 					hack.Description += fmt.Sprintf(

--- a/internal/hacks/rail_competition.go
+++ b/internal/hacks/rail_competition.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-
-	"github.com/MikkoParkkola/trvl/internal/destinations"
 )
 
 // railCorridor describes a route with multiple competing rail operators,
@@ -79,7 +77,7 @@ func detectRailCompetition(ctx context.Context, in DetectorInput) []Hack {
 	for _, c := range competitiveCorridors {
 		// Match in either direction.
 		if (c.From == origin && c.To == dest) || (c.From == dest && c.To == origin) {
-			minFare, mcur := destinations.ConvertCurrency(ctx, c.MinFareEUR, "EUR", target)
+			minFare, mcur := convertCurrency(ctx, c.MinFareEUR, "EUR", target)
 			if mcur != target {
 				// Can't honestly convert the fare — suppress rather than
 				// mislabel it.

--- a/internal/hacks/rail_competition_test.go
+++ b/internal/hacks/rail_competition_test.go
@@ -173,6 +173,45 @@ func TestDetectRailCompetition_currencyDefault(t *testing.T) {
 	}
 }
 
+// TestDetectRailCompetition_nonEURTarget_suppressedWhenInconvertible proves
+// case (b): a non-EUR target currency that can't be honestly converted (XXX
+// is the ISO 4217 "no currency" placeholder — it will never appear in a
+// real exchange-rate table) suppresses the hack rather than labeling the
+// EUR-denominated MinFareEUR with the wrong currency. Deterministic — no
+// live network required.
+func TestDetectRailCompetition_nonEURTarget_suppressedWhenInconvertible(t *testing.T) {
+	hacks := detectRailCompetition(context.Background(), DetectorInput{
+		Origin:      "MAD",
+		Destination: "BCN",
+		Currency:    "XXX",
+	})
+	if len(hacks) != 0 {
+		t.Errorf("expected no hacks for inconvertible target currency, got %d", len(hacks))
+	}
+}
+
+// TestDetectRailCompetition_eurTarget_labelsEURAndConverts proves cases (a)
+// and (c) explicitly, including the NaivePrice comparison path: EUR passes
+// through untouched (no network — ConvertCurrency short-circuits on
+// from==to) and the surfaced hack's Currency matches the target.
+func TestDetectRailCompetition_eurTarget_labelsEURAndConverts(t *testing.T) {
+	hacks := detectRailCompetition(context.Background(), DetectorInput{
+		Origin:      "MAD",
+		Destination: "BCN",
+		Currency:    "EUR",
+		NaivePrice:  80,
+	})
+	if len(hacks) != 1 {
+		t.Fatalf("expected 1 hack, got %d", len(hacks))
+	}
+	if hacks[0].Currency != "EUR" {
+		t.Errorf("Currency = %q, want EUR", hacks[0].Currency)
+	}
+	if hacks[0].Savings != 73 {
+		t.Errorf("Savings = %.0f, want 73", hacks[0].Savings)
+	}
+}
+
 // --- Static data tests ---
 
 func TestCompetitiveCorridors_populated(t *testing.T) {

--- a/internal/hacks/rail_competition_test.go
+++ b/internal/hacks/rail_competition_test.go
@@ -178,8 +178,20 @@ func TestDetectRailCompetition_currencyDefault(t *testing.T) {
 // is the ISO 4217 "no currency" placeholder — it will never appear in a
 // real exchange-rate table) suppresses the hack rather than labeling the
 // EUR-denominated MinFareEUR with the wrong currency. Deterministic — no
-// live network required.
+// live network required: a fake convertCurrency is injected via the seam in
+// currency.go so the "can't convert" contract is exercised offline instead
+// of dialing the live rates table. No t.Parallel — the seam var is shared
+// package state, set/restored sequentially like railGroundSearcher.
 func TestDetectRailCompetition_nonEURTarget_suppressedWhenInconvertible(t *testing.T) {
+	orig := convertCurrency
+	convertCurrency = func(_ context.Context, amount float64, from, to string) (float64, string) {
+		if from == to {
+			return amount, to
+		}
+		return amount, from // can't convert — same contract as the real function
+	}
+	t.Cleanup(func() { convertCurrency = orig })
+
 	hacks := detectRailCompetition(context.Background(), DetectorInput{
 		Origin:      "MAD",
 		Destination: "BCN",

--- a/internal/hacks/rail_fly.go
+++ b/internal/hacks/rail_fly.go
@@ -174,7 +174,13 @@ func detectRailFlyArb(ctx context.Context, origin, destination, departDate, retu
 	// is a different airport, so the rail leg is a real out-of-pocket cost that
 	// must be subtracted from net savings. A ground-provider error degrades
 	// gracefully to a conservative estimate; it never aborts the search.
-	railLeg := convertRailLeg(ctx, resolveRailLegCost(ctx, origin, *bestStation, departDate), target)
+	railLeg, railOK := convertRailLeg(ctx, resolveRailLegCost(ctx, origin, *bestStation, departDate), target)
+	if !railOK {
+		// The rail leg is priced in a currency that cannot be expressed in the
+		// traveller's display currency, so no honest single-denomination saving can
+		// be reported. Drop the hack rather than mix denominations under a target label.
+		return nil
+	}
 
 	// Net savings subtract any non-bundled rail cost (railLeg.Cost is 0 when the
 	// train is bundled in the airline ticket).

--- a/internal/hacks/rail_fly.go
+++ b/internal/hacks/rail_fly.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -55,6 +56,17 @@ var railFlyFlightSearcher = flights.SearchFlightsWithClient
 // alias origin (e.g. ANR/BRU) the rail leg is a real cost subtracted from the
 // reported net saving.
 func DetectRailFlyArbitrage(ctx context.Context, origin, destination, departDate, returnDate string) []Hack {
+	// Exported entry defaults to EUR — the historical provider denomination — so
+	// existing callers and tests keep their behaviour. The DetectAll adapter
+	// routes through detectRailFlyArb with the traveller's requested currency.
+	return detectRailFlyArb(ctx, origin, destination, departDate, returnDate, "EUR")
+}
+
+// detectRailFlyArb is the currency-aware worker. target is the traveller's
+// requested display currency; every fare and rail-leg cost is FX-converted into
+// it so the surfaced saving is honest in one denomination. The hack is dropped
+// when the baseline fare cannot be converted into target (no honest baseline).
+func detectRailFlyArb(ctx context.Context, origin, destination, departDate, returnDate, target string) []Hack {
 	if origin == "" || destination == "" || departDate == "" {
 		return nil
 	}
@@ -136,6 +148,24 @@ func DetectRailFlyArbitrage(ctx context.Context, origin, destination, departDate
 		return nil
 	}
 
+	// Convert the base and best fares into the traveller's requested currency so
+	// the saving, the hack label, and every downstream leg are honest in one
+	// denomination. If the baseline cannot be expressed in target there is no
+	// honest comparison to make, so the hack is dropped rather than mislabelled.
+	target = strings.ToUpper(strings.TrimSpace(target))
+	if target == "" {
+		target = "EUR"
+	}
+	basePrice, baseCur := destinations.ConvertCurrency(ctx, basePrice, baseCurrency, target)
+	if baseCur != target {
+		return nil
+	}
+	bestPrice, bestCur := destinations.ConvertCurrency(ctx, bestPrice, bestCurrency, target)
+	if bestCur != target {
+		return nil
+	}
+	baseCurrency, bestCurrency = target, target
+
 	grossSavings := basePrice - bestPrice
 
 	// Price the rail leg explicitly BEFORE thresholding so reported savings are
@@ -144,7 +174,7 @@ func DetectRailFlyArbitrage(ctx context.Context, origin, destination, departDate
 	// is a different airport, so the rail leg is a real out-of-pocket cost that
 	// must be subtracted from net savings. A ground-provider error degrades
 	// gracefully to a conservative estimate; it never aborts the search.
-	railLeg := resolveRailLegCost(ctx, origin, *bestStation, departDate)
+	railLeg := convertRailLeg(ctx, resolveRailLegCost(ctx, origin, *bestStation, departDate), target)
 
 	// Net savings subtract any non-bundled rail cost (railLeg.Cost is 0 when the
 	// train is bundled in the airline ticket).
@@ -192,7 +222,7 @@ func DetectRailFlyArbitrage(ctx context.Context, origin, destination, departDate
 // detectRailFlyArbitrage adapts DetectRailFlyArbitrage to the detectFn signature
 // used by DetectAll.
 func detectRailFlyArbitrage(ctx context.Context, in DetectorInput) []Hack {
-	return DetectRailFlyArbitrage(ctx, in.Origin, in.Destination, in.Date, in.ReturnDate)
+	return detectRailFlyArb(ctx, in.Origin, in.Destination, in.Date, in.ReturnDate, in.currency())
 }
 
 // railFlyOriginAlias maps a real departure airport (the IATA the traveller

--- a/internal/hacks/rail_fly_bundle.go
+++ b/internal/hacks/rail_fly_bundle.go
@@ -72,7 +72,7 @@ func composeRailFlyBundle(ctx context.Context, origin, destination, departDate, 
 		flightCurrency = "EUR"
 	}
 
-	railLeg := resolveRailLegCost(ctx, origin, st, departDate)
+	railLeg := convertRailLeg(ctx, resolveRailLegCost(ctx, origin, st, departDate), flightCurrency)
 	roundTrip := returnDate != ""
 	// bundled is true when the search origin IS the airline hub, so the Air&Rail
 	// train is included in (and protected by) the ticket.
@@ -183,7 +183,7 @@ func composeOpenJawRailReturn(ctx context.Context, origin, flyInto, trainOutOf s
 		currency = "EUR"
 	}
 
-	railReturn := openJawRailReturnQuote(ctx, trainOutOf, origin, returnDate)
+	railReturn := convertRailLeg(ctx, openJawRailReturnQuote(ctx, trainOutOf, origin, returnDate), currency)
 
 	legs := []BundleLeg{
 		{

--- a/internal/hacks/rail_fly_bundle.go
+++ b/internal/hacks/rail_fly_bundle.go
@@ -72,7 +72,12 @@ func composeRailFlyBundle(ctx context.Context, origin, destination, departDate, 
 		flightCurrency = "EUR"
 	}
 
-	railLeg := convertRailLeg(ctx, resolveRailLegCost(ctx, origin, st, departDate), flightCurrency)
+	railLeg, railOK := convertRailLeg(ctx, resolveRailLegCost(ctx, origin, st, departDate), flightCurrency)
+	if !railOK {
+		// Rail leg inconvertible to the bundle currency: a single honest total is
+		// impossible, so emit no bundle rather than a mixed-denomination one.
+		return Hack{}
+	}
 	roundTrip := returnDate != ""
 	// bundled is true when the search origin IS the airline hub, so the Air&Rail
 	// train is included in (and protected by) the ticket.
@@ -183,7 +188,13 @@ func composeOpenJawRailReturn(ctx context.Context, origin, flyInto, trainOutOf s
 		currency = "EUR"
 	}
 
-	railReturn := convertRailLeg(ctx, openJawRailReturnQuote(ctx, trainOutOf, origin, returnDate), currency)
+	railReturn, railOK := convertRailLeg(ctx, openJawRailReturnQuote(ctx, trainOutOf, origin, returnDate), currency)
+	if !railOK {
+		// Return rail leg inconvertible to the display currency: drop the open-jaw
+		// variant rather than report a mixed-denomination total. Zero Savings keeps
+		// the caller's `oj.Savings > 0` guard from surfacing it.
+		return Hack{}
+	}
 
 	legs := []BundleLeg{
 		{

--- a/internal/hacks/rail_fly_cost.go
+++ b/internal/hacks/rail_fly_cost.go
@@ -3,10 +3,34 @@ package hacks
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/ground"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
+
+// convertRailLeg re-denominates a priced rail leg into target so its cost can be
+// honestly summed with, or subtracted from, target-denominated flight fares. A
+// bundled 0-cost leg carries no FX risk and is simply relabelled. An
+// inconvertible currency keeps its original denomination (rare — the FX table is
+// EUR-based and every caller has already proven EUR↔target convertibility) so a
+// number is never silently relabelled into a currency it was not priced in.
+func convertRailLeg(ctx context.Context, leg railLegCost, target string) railLegCost {
+	target = strings.ToUpper(strings.TrimSpace(target))
+	if target == "" || leg.Cost == 0 || leg.Currency == "" || strings.EqualFold(leg.Currency, target) {
+		if target != "" {
+			leg.Currency = target
+		}
+		return leg
+	}
+	c, cur := destinations.ConvertCurrency(ctx, leg.Cost, leg.Currency, target)
+	if cur != target {
+		return leg // inconvertible: keep the honest original denomination
+	}
+	leg.Cost, leg.Currency = c, target
+	return leg
+}
 
 // railLegCost is the resolved cost of the rail segment of a rail-fly hack.
 type railLegCost struct {

--- a/internal/hacks/rail_fly_cost.go
+++ b/internal/hacks/rail_fly_cost.go
@@ -11,25 +11,27 @@ import (
 )
 
 // convertRailLeg re-denominates a priced rail leg into target so its cost can be
-// honestly summed with, or subtracted from, target-denominated flight fares. A
-// bundled 0-cost leg carries no FX risk and is simply relabelled. An
-// inconvertible currency keeps its original denomination (rare — the FX table is
-// EUR-based and every caller has already proven EUR↔target convertibility) so a
-// number is never silently relabelled into a currency it was not priced in.
-func convertRailLeg(ctx context.Context, leg railLegCost, target string) railLegCost {
+// honestly summed with, or subtracted from, target-denominated flight fares. It
+// returns ok=false when a non-zero cost cannot be expressed in target: the caller
+// MUST then drop the whole hack, because subtracting or summing a foreign-priced
+// leg against target fares — and labelling the result target — is exactly the
+// mixed-denomination lie this sweep exists to kill. A bundled 0-cost leg carries
+// no FX risk and is simply relabelled (ok=true).
+func convertRailLeg(ctx context.Context, leg railLegCost, target string) (railLegCost, bool) {
 	target = strings.ToUpper(strings.TrimSpace(target))
-	if target == "" || leg.Cost == 0 || leg.Currency == "" || strings.EqualFold(leg.Currency, target) {
+	cur := strings.ToUpper(strings.TrimSpace(leg.Currency))
+	if target == "" || leg.Cost == 0 || cur == "" || cur == target {
 		if target != "" {
 			leg.Currency = target
 		}
-		return leg
+		return leg, true
 	}
-	c, cur := destinations.ConvertCurrency(ctx, leg.Cost, leg.Currency, target)
-	if cur != target {
-		return leg // inconvertible: keep the honest original denomination
+	c, got := destinations.ConvertCurrency(ctx, leg.Cost, cur, target)
+	if got != target {
+		return leg, false // inconvertible: caller must drop; mixing denominations would lie
 	}
 	leg.Cost, leg.Currency = c, target
-	return leg
+	return leg, true
 }
 
 // railLegCost is the resolved cost of the rail segment of a rail-fly hack.

--- a/internal/hacks/rail_fly_cost_test.go
+++ b/internal/hacks/rail_fly_cost_test.go
@@ -265,3 +265,33 @@ func TestBuildRailFlyHack_hubOriginUnchangedBundledText(t *testing.T) {
 		t.Errorf("hub-origin description should keep bundled wording, got %q", h.Description)
 	}
 }
+
+// TestConvertRailLeg_honestyContract locks the cross-currency honesty boundary:
+// a non-zero cost that cannot be expressed in target must return ok=false so the
+// caller drops the whole hack rather than subtracting/summing a foreign-priced
+// leg against target fares under a target label. Offline (no FX table) any
+// cross-currency conversion is "unavailable", which is the exact failed-rail
+// -conversion path the codex review flagged as a BLOCKER.
+func TestConvertRailLeg_honestyContract(t *testing.T) {
+	ctx := context.Background()
+	// Non-zero foreign cost, inconvertible offline -> ok=false, leg unchanged.
+	got, ok := convertRailLeg(ctx, railLegCost{Cost: 39, Currency: "XXX"}, "EUR")
+	if ok {
+		t.Fatalf("inconvertible XXX->EUR: ok=true, want false (would mislabel)")
+	}
+	if got.Currency != "XXX" || got.Cost != 39 {
+		t.Fatalf("inconvertible leg mutated: %+v, want unchanged 39 XXX", got)
+	}
+	// Bundled 0-cost leg carries no FX risk: relabel to target, ok=true.
+	if g, ok := convertRailLeg(ctx, railLegCost{Cost: 0, Currency: "PLN"}, "EUR"); !ok || g.Currency != "EUR" {
+		t.Fatalf("bundled 0-cost leg: got %+v ok=%v, want EUR-relabelled ok=true", g, ok)
+	}
+	// Same-currency (case/space-insensitive) is a trivial relabel, ok=true.
+	if g, ok := convertRailLeg(ctx, railLegCost{Cost: 39, Currency: " eur "}, "EUR"); !ok || g.Currency != "EUR" || g.Cost != 39 {
+		t.Fatalf("same-currency leg: got %+v ok=%v, want 39 EUR ok=true", g, ok)
+	}
+	// Empty target never mutates currency and is a no-op success.
+	if g, ok := convertRailLeg(ctx, railLegCost{Cost: 39, Currency: "EUR"}, ""); !ok || g.Currency != "EUR" {
+		t.Fatalf("empty target: got %+v ok=%v, want unchanged EUR ok=true", g, ok)
+	}
+}

--- a/internal/hacks/rail_fly_test.go
+++ b/internal/hacks/rail_fly_test.go
@@ -556,3 +556,40 @@ func TestRailFlyDetectSavingsBelowThreshold(t *testing.T) {
 		t.Fatalf("expected no hacks below savings threshold, got %d", len(hacks))
 	}
 }
+
+// TestRailFlyDetect_nonEURTarget_neverMislabelsEUR is the cross-currency honesty
+// gate: EUR provider fares under a GBP display target must never surface a hack
+// labelled EUR. Offline FX cannot convert EUR->GBP, so the honest outcome is
+// suppression; if FX is reachable the hack (and its bundle) must be relabelled
+// GBP. Either way a GBP request never receives an EUR-labelled number.
+func TestRailFlyDetect_nonEURTarget_neverMislabelsEUR(t *testing.T) {
+	withRailFlyFlightSearcher(t, func(_ context.Context, _ *batchexec.Client, origin, _, _ string, _ flights.SearchOptions) (*models.FlightSearchResult, error) {
+		switch origin {
+		case "AMS":
+			return railFlyFlight(420, "EUR"), nil
+		case "ZWE", "ZYR":
+			return railFlyFlight(260, "EUR"), nil
+		default:
+			return railFlyFlight(0, "EUR"), nil
+		}
+	})
+	withRailGroundSearcher(t, func(_ context.Context, _, _, _ string, _ ground.SearchOptions) (*models.GroundSearchResult, error) {
+		return &models.GroundSearchResult{Success: true, Count: 1, Routes: []models.GroundRoute{
+			{Provider: "eurostar", Type: "train", Price: 39, Currency: "EUR"},
+		}}, nil
+	})
+
+	for _, h := range detectRailFlyArb(context.Background(), "ams", "bcn", "2026-05-01", "", "GBP") {
+		if h.Currency != "GBP" {
+			t.Fatalf("GBP request produced a %q-labelled hack (want GBP or suppressed): %+v", h.Currency, h)
+		}
+		if h.Bundle != nil && h.Bundle.Currency != "GBP" {
+			t.Fatalf("bundle currency = %q, want GBP", h.Bundle.Currency)
+		}
+	}
+
+	// EUR target preserves the historical passthrough behaviour.
+	if eur := detectRailFlyArb(context.Background(), "ams", "bcn", "2026-05-01", "", "EUR"); len(eur) != 1 || eur[0].Currency != "EUR" {
+		t.Fatalf("EUR target: expected one EUR-labelled hack, got %+v", eur)
+	}
+}

--- a/internal/hacks/savings.go
+++ b/internal/hacks/savings.go
@@ -3,6 +3,7 @@ package hacks
 import (
 	"context"
 	"math"
+	"strings"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -12,6 +13,14 @@ import (
 // deterministic detector so the savings-surfacing behaviour can be proven
 // offline without any network fan-out.
 type DetectFunc func(ctx context.Context, in DetectorInput) []Hack
+
+// isMoney reports whether v is a usable, finite, strictly-positive monetary
+// amount. NaN and +Inf are rejected here so a poisoned detector value can never
+// reach the JSON headline (encoding/json cannot marshal non-finite floats). The
+// v > 0 test already excludes NaN and negatives; the IsInf test rules out +Inf.
+func isMoney(v float64) bool {
+	return v > 0 && !math.IsInf(v, 0) && !math.IsNaN(v)
+}
 
 // BestSaving runs the hack detectors against the same route/date/naive-price as
 // a just-completed naive search and returns the single best money-saving option,
@@ -33,19 +42,55 @@ func BestSaving(ctx context.Context, in DetectorInput, detect DetectFunc) *model
 	if detect == nil {
 		detect = DetectAll
 	}
-	if in.NaivePrice <= 0 || !in.valid() {
+	if !isMoney(in.NaivePrice) || !in.valid() {
 		return nil
 	}
 
 	found := detect(ctx, in)
 
+	// The naive baseline (in.NaivePrice) is denominated in the requested
+	// currency. A hack's Savings is denominated in that hack's own Currency.
+	// Comparing or subtracting the two only tells the truth when both are the
+	// same currency, so we normalise to the requested currency and drop any
+	// candidate that reports a different one. Detectors are expected to emit
+	// their card in in.currency(); a candidate in a foreign currency signals a
+	// detector that has not been migrated to convert honestly, and surfacing it
+	// would mix currencies in the headline saving. Dropping it is the honest
+	// failure mode. ponytail: guard, not converter — conversion belongs in each
+	// detector, so the aggregator stays simple.
+	target := strings.ToUpper(strings.TrimSpace(in.currency()))
+	if target == "" {
+		target = "EUR"
+	}
+
 	var best *Hack
 	for i := range found {
 		h := &found[i]
-		// Only a hack with a real, strictly-positive saving represents a lower
-		// price. A saving at or above the whole naive fare cannot be real, so we
-		// drop it rather than surface a fabricated "free or negative" price.
-		if h.Savings <= 0 || h.Savings >= in.NaivePrice {
+		hc := strings.ToUpper(strings.TrimSpace(h.Currency))
+		if hc == "" {
+			// A blank currency is only trustworthy while EUR is the migration
+			// default. If the caller asked for anything else, an unlabelled EUR
+			// constant would be silently relabelled (e.g. shown as GBP), so we
+			// drop it rather than lie about the denomination.
+			if target != "EUR" {
+				continue
+			}
+			hc = target
+		}
+		if hc != target {
+			continue // foreign-currency saving cannot be honestly compared to the baseline
+		}
+		// Only a hack with a real, strictly-positive, finite saving represents a
+		// lower price. A saving at or above the whole naive fare cannot be real,
+		// and a non-finite value would poison the JSON headline, so both are
+		// dropped rather than surfaced as a fabricated "free or negative" price.
+		if !isMoney(h.Savings) || h.Savings >= in.NaivePrice {
+			continue
+		}
+		// Guard the rounding boundary: a saving that rounds the resulting price to
+		// zero-or-below (e.g. 100 - 99.6) is not an honest lower price. Skip it so
+		// a genuinely cheaper hack can still win.
+		if roundSavings(in.NaivePrice-h.Savings) <= 0 {
 			continue
 		}
 		if best == nil || h.Savings > best.Savings {
@@ -56,10 +101,7 @@ func BestSaving(ctx context.Context, in DetectorInput, detect DetectFunc) *model
 		return nil
 	}
 
-	currency := best.Currency
-	if currency == "" {
-		currency = in.currency()
-	}
+	currency := target
 	price := roundSavings(in.NaivePrice - best.Savings)
 	pct := math.Round(best.Savings/in.NaivePrice*1000) / 10
 

--- a/internal/hacks/savings_test.go
+++ b/internal/hacks/savings_test.go
@@ -2,6 +2,7 @@ package hacks
 
 import (
 	"context"
+	"math"
 	"testing"
 )
 
@@ -78,11 +79,130 @@ func TestBestSaving_RequiresPositiveNaivePrice(t *testing.T) {
 	}
 }
 
-func TestBestSaving_DefaultsCurrencyToInput(t *testing.T) {
-	in := DetectorInput{Origin: "HEL", Destination: "AMS", Date: "2026-09-01", NaivePrice: 200, Currency: "GBP"}
+func TestBestSaving_BlankCurrencyTrustedOnlyForEUR(t *testing.T) {
+	// A detector that leaves Currency blank is assumed to be mid-migration and
+	// still emitting EUR. That assumption is honest only when the request is also
+	// EUR: the saving surfaces, labelled EUR.
+	in := DetectorInput{Origin: "HEL", Destination: "AMS", Date: "2026-09-01", NaivePrice: 200, Currency: "EUR"}
 	detect := stubDetect([]Hack{{Type: "split", Savings: 50}}) // no currency on hack
 	got := BestSaving(context.Background(), in, detect)
-	if got == nil || got.Currency != "GBP" {
-		t.Fatalf("Currency = %v, want GBP from input", got)
+	if got == nil || got.Currency != "EUR" {
+		t.Fatalf("Currency = %v, want EUR (blank hack trusted as EUR under migration)", got)
+	}
+}
+
+func TestBestSaving_DropsBlankCurrencyForNonEURRequest(t *testing.T) {
+	// Same blank-currency hack, but the caller asked for GBP. Trusting the blank
+	// value would relabel an assumed-EUR constant as GBP — a silent lie. The
+	// honest outcome is to drop it and surface nothing.
+	in := DetectorInput{Origin: "LHR", Destination: "AMS", Date: "2026-09-01", NaivePrice: 200, Currency: "GBP"}
+	detect := stubDetect([]Hack{{Type: "split", Savings: 50}}) // no currency on hack
+	if got := BestSaving(context.Background(), in, detect); got != nil {
+		t.Fatalf("expected nil (blank currency untrustworthy for non-EUR request), got %+v", got)
+	}
+}
+
+func TestBestSaving_MatchesCurrencyCaseAndWhitespace(t *testing.T) {
+	// Currency comparison must normalise case and surrounding whitespace so a
+	// detector emitting " eur " is not spuriously treated as foreign.
+	in := DetectorInput{Origin: "HEL", Destination: "AMS", Date: "2026-09-01", NaivePrice: 300, Currency: "eur"}
+	detect := stubDetect([]Hack{{Type: "split", Title: "Messy", Savings: 60, Currency: " eur "}})
+	got := BestSaving(context.Background(), in, detect)
+	if got == nil {
+		t.Fatal("expected the normalised-currency hack to win, got nil")
+	}
+	if got.Currency != "EUR" || got.Savings != 60 || got.Price != 240 {
+		t.Errorf("got Currency/Savings/Price = %v/%v/%v, want EUR/60/240", got.Currency, got.Savings, got.Price)
+	}
+}
+
+func TestBestSaving_RejectsNonFiniteValues(t *testing.T) {
+	// NaN/Inf must never reach the JSON headline (encoding/json cannot marshal
+	// them). A non-finite baseline yields nil; a non-finite saving is skipped so a
+	// finite candidate can still win.
+	nan, inf := math.NaN(), math.Inf(1)
+
+	if got := BestSaving(context.Background(),
+		DetectorInput{Origin: "HEL", Destination: "AMS", Date: "2026-09-01", NaivePrice: nan, Currency: "EUR"},
+		stubDetect([]Hack{{Type: "x", Savings: 50, Currency: "EUR"}})); got != nil {
+		t.Fatalf("NaN baseline: expected nil, got %+v", got)
+	}
+	if got := BestSaving(context.Background(),
+		DetectorInput{Origin: "HEL", Destination: "AMS", Date: "2026-09-01", NaivePrice: inf, Currency: "EUR"},
+		stubDetect([]Hack{{Type: "x", Savings: 50, Currency: "EUR"}})); got != nil {
+		t.Fatalf("Inf baseline: expected nil, got %+v", got)
+	}
+
+	in := DetectorInput{Origin: "HEL", Destination: "AMS", Date: "2026-09-01", NaivePrice: 300, Currency: "EUR"}
+	detect := stubDetect([]Hack{
+		{Type: "poison", Title: "NaN saving", Savings: nan, Currency: "EUR"},
+		{Type: "poison2", Title: "Inf saving", Savings: inf, Currency: "EUR"},
+		{Type: "split", Title: "Real", Savings: 40, Currency: "EUR"},
+	})
+	got := BestSaving(context.Background(), in, detect)
+	if got == nil || got.Type != "split" || got.Savings != 40 {
+		t.Fatalf("expected the finite split hack (40) to win over NaN/Inf, got %+v", got)
+	}
+}
+
+func TestBestSaving_DropsSavingThatRoundsPriceToZero(t *testing.T) {
+	// A saving that leaves a rounded resulting price of zero-or-below is not an
+	// honest lower price (100 - 99.6 -> ~0). It must be skipped so a genuinely
+	// cheaper hack can win instead of surfacing a free/zero fare.
+	in := DetectorInput{Origin: "HEL", Destination: "AMS", Date: "2026-09-01", NaivePrice: 100, Currency: "EUR"}
+	detect := stubDetect([]Hack{
+		{Type: "rounds_to_zero", Title: "99.6 off 100", Savings: 99.6, Currency: "EUR"},
+		{Type: "split", Title: "Honest", Savings: 30, Currency: "EUR"},
+	})
+	got := BestSaving(context.Background(), in, detect)
+	if got == nil {
+		t.Fatal("expected the honest 30-saving hack, got nil")
+	}
+	if got.Type != "split" || got.Savings != 30 {
+		t.Errorf("Type/Savings = %q/%v, want split/30 (rounds-to-zero hack must be dropped)", got.Type, got.Savings)
+	}
+	if got.Price <= 0 {
+		t.Errorf("Price = %v, want a positive fare", got.Price)
+	}
+}
+
+func TestBestSaving_DropsForeignOnlyToNil(t *testing.T) {
+	// When every candidate is in a foreign currency, there is nothing that can be
+	// honestly compared to the baseline, so the result is nil (not a mislabelled
+	// pick).
+	in := DetectorInput{Origin: "ARN", Destination: "AMS", Date: "2026-09-01", NaivePrice: 300, Currency: "EUR"}
+	detect := stubDetect([]Hack{
+		{Type: "positioning", Title: "SEK only", Savings: 250, Currency: "SEK"},
+		{Type: "split", Title: "USD only", Savings: 80, Currency: "USD"},
+	})
+	if got := BestSaving(context.Background(), in, detect); got != nil {
+		t.Fatalf("expected nil (all foreign-currency), got %+v", got)
+	}
+}
+
+func TestBestSaving_DropsForeignCurrencyHack(t *testing.T) {
+	// The naive baseline is EUR. A detector reporting its saving in a different
+	// currency (SEK) must not be compared against the EUR baseline nor mixed into
+	// the headline. Even though its raw Savings (250) is numerically larger than
+	// the EUR candidate's (40), currencies are not interchangeable numbers: the
+	// SEK hack is dropped and only the EUR candidate can win. Under the old code
+	// the SEK hack won on its raw number and yielded a nonsense Price (300-250).
+	in := DetectorInput{Origin: "ARN", Destination: "AMS", Date: "2026-09-01", NaivePrice: 300, Currency: "EUR"}
+	detect := stubDetect([]Hack{
+		{Type: "positioning", Title: "SEK hack", Savings: 250, Currency: "SEK"},
+		{Type: "split", Title: "EUR hack", Savings: 40, Currency: "EUR"},
+	})
+	got := BestSaving(context.Background(), in, detect)
+	if got == nil {
+		t.Fatal("expected the EUR candidate, got nil")
+	}
+	if got.Type != "split" {
+		t.Errorf("Type = %q, want split (foreign-currency SEK hack must be dropped, not chosen for its larger raw number)", got.Type)
+	}
+	if got.Currency != "EUR" {
+		t.Errorf("Currency = %q, want EUR (requested)", got.Currency)
+	}
+	if got.Savings != 40 || got.Price != 260 {
+		t.Errorf("Savings/Price = %v/%v, want 40/260", got.Savings, got.Price)
 	}
 }

--- a/internal/hacks/split.go
+++ b/internal/hacks/split.go
@@ -9,7 +9,7 @@ import (
 )
 
 // splitSearchFunc is the flight search seam (overridable in tests). Mirrors the
-// backToBackSearchFunc / railFlyFlightSearcher house pattern.
+// railFlyFlightSearcher house pattern.
 var splitSearchFunc = flights.SearchFlights
 
 // detectSplit compares a round-trip ticket against the sum of two separate

--- a/internal/preferences/preferences.go
+++ b/internal/preferences/preferences.go
@@ -82,9 +82,18 @@ type Preferences struct {
 	DealTolerance     string  `json:"deal_tolerance"`       // "price", "comfort", "balanced"
 
 	// Flight preferences
-	FlightTimeEarliest string `json:"flight_time_earliest"` // "06:00" — won't take flights before this
-	FlightTimeLatest   string `json:"flight_time_latest"`   // "23:00" — won't take flights after this
-	RedEyeOK           bool   `json:"red_eye_ok"`           // overnight flights acceptable?
+	FlightTimeEarliest string `json:"flight_time_earliest"` // "06:00" — SOFT window start
+	FlightTimeLatest   string `json:"flight_time_latest"`   // "23:00" — SOFT window end
+
+	// FlightTimeHardFloor is the tolerance, in MINUTES, by which a flight's
+	// departure may fall outside the [FlightTimeEarliest, FlightTimeLatest] SOFT
+	// window and still be KEPT — ranked lower (soft-penalised) rather than
+	// dropped. Only flights that fall MORE than this many minutes outside the
+	// soft window are hard-dropped. 0 (the default) preserves the legacy
+	// behaviour: any flight outside the soft window is dropped.
+	FlightTimeHardFloor int `json:"flight_time_hard_floor,omitempty"`
+
+	RedEyeOK bool `json:"red_eye_ok"` // overnight flights acceptable?
 
 	// Identity
 	Nationality string   `json:"nationality"`         // ISO 3166-1 alpha-2 (e.g. "FI") — for visa warnings

--- a/internal/preferences/preferences_hardfloor_test.go
+++ b/internal/preferences/preferences_hardfloor_test.go
@@ -1,0 +1,44 @@
+package preferences
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// #473: FlightTimeHardFloor round-trips through JSON and is omitted when zero.
+func TestFlightTimeHardFloor_JSONRoundTrip(t *testing.T) {
+	p := Default()
+	p.FlightTimeEarliest = "06:00"
+	p.FlightTimeLatest = "22:00"
+	p.FlightTimeHardFloor = 45
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"flight_time_hard_floor":45`) {
+		t.Errorf("marshalled JSON missing flight_time_hard_floor:45\n%s", b)
+	}
+
+	var got Preferences
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.FlightTimeHardFloor != 45 {
+		t.Errorf("round-trip FlightTimeHardFloor = %d, want 45", got.FlightTimeHardFloor)
+	}
+}
+
+// #473: a zero hard floor is omitted from the serialised JSON (omitempty).
+func TestFlightTimeHardFloor_OmitEmpty(t *testing.T) {
+	p := Default()
+	p.FlightTimeHardFloor = 0
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "flight_time_hard_floor") {
+		t.Errorf("zero FlightTimeHardFloor should be omitted, got:\n%s", b)
+	}
+}

--- a/internal/scoring/profile_match.go
+++ b/internal/scoring/profile_match.go
@@ -22,6 +22,7 @@ const (
 	FactorBudgetFit                 = "budget_fit"
 	FactorLoyaltyEarn               = "loyalty_earn"
 	FactorTimeWindowFit             = "time_window_fit"
+	FactorTimeHardFloorCompliance   = "time_hard_floor_compliance"
 	FactorArrivalWindowFit          = "arrival_window_fit"
 	FactorDirectness                = "directness"
 	FactorDistrictMatch             = "district_match"
@@ -42,6 +43,7 @@ func DefaultWeights() map[string]float64 {
 		FactorBudgetFit:                 25.0,
 		FactorLoyaltyEarn:               12.0,
 		FactorTimeWindowFit:             8.0,
+		FactorTimeHardFloorCompliance:   6.0,
 		FactorArrivalWindowFit:          6.0,
 		FactorDirectness:                10.0,
 		FactorDistrictMatch:             8.0,
@@ -114,6 +116,7 @@ func ComputeProfileMatch(prefs *preferences.Preferences, input DiscoverInput) (s
 	breakdown[FactorBudgetFit] = scoreBudgetFit(input)
 	breakdown[FactorLoyaltyEarn] = scoreLoyaltyEarn(prefs, input)
 	breakdown[FactorTimeWindowFit] = scoreTimeWindowFit(prefs, input)
+	breakdown[FactorTimeHardFloorCompliance] = scoreTimeHardFloorCompliance(prefs, input)
 	breakdown[FactorArrivalWindowFit] = scoreArrivalWindowFit(prefs, input)
 	breakdown[FactorDirectness] = scoreDirectness(prefs, input)
 	breakdown[FactorDistrictMatch] = scoreDistrictMatch(prefs, input)
@@ -218,6 +221,53 @@ func scoreTimeWindowFit(prefs *preferences.Preferences, input DiscoverInput) flo
 		}
 	}
 	return 1.0
+}
+
+// scoreTimeHardFloorCompliance scores a departure against the SOFT time window
+// PLUS the FlightTimeHardFloor tolerance (in minutes). It distinguishes three
+// tiers so the ranking rewards flights that respect the tolerance and punishes
+// those that blow past it:
+//
+//   - 1.0 — departure is inside the [earliest, latest] soft window.
+//   - 0.3 — departure is outside the window but within the hard-floor tolerance
+//     (a soft near-miss: kept by the policy filter, but ranked lower here).
+//   - 0.0 — departure is more than the tolerance outside the window.
+//
+// Returns 0.5 (neutral) when the departure time is unknown, no window is set, or
+// no hard floor is configured (FlightTimeHardFloor <= 0) — in which case the soft
+// band does not exist and this factor carries no signal.
+func scoreTimeHardFloorCompliance(prefs *preferences.Preferences, input DiscoverInput) float64 {
+	if input.DepartTime == "" || prefs.FlightTimeHardFloor <= 0 {
+		return 0.5
+	}
+	earliest := prefs.FlightTimeEarliest
+	latest := prefs.FlightTimeLatest
+	if earliest == "" && latest == "" {
+		return 0.5
+	}
+	dep := parseHHMM(input.DepartTime)
+	if dep < 0 {
+		return 0.5
+	}
+	dev := 0
+	if earliest != "" {
+		if e := parseHHMM(earliest); e >= 0 && dep < e {
+			dev = e - dep
+		}
+	}
+	if latest != "" {
+		if l := parseHHMM(latest); l >= 0 && dep > l {
+			dev = dep - l
+		}
+	}
+	switch {
+	case dev == 0:
+		return 1.0 // inside the soft window
+	case dev <= prefs.FlightTimeHardFloor:
+		return 0.3 // soft near-miss within tolerance
+	default:
+		return 0.0 // beyond the hard floor
+	}
 }
 
 // scoreArrivalWindowFit scores the flight's arrival time at destination against

--- a/internal/scoring/profile_match_hardfloor_test.go
+++ b/internal/scoring/profile_match_hardfloor_test.go
@@ -1,0 +1,53 @@
+package scoring_test
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/preferences"
+	"github.com/MikkoParkkola/trvl/internal/scoring"
+)
+
+// #473: the time-hard-floor factor tiers a departure into inside / soft
+// near-miss / beyond-floor, and stays neutral when it carries no signal.
+func TestScoreTimeHardFloorCompliance_Tiers(t *testing.T) {
+	mk := func(hardFloor int, depart string) float64 {
+		p := preferences.Default()
+		p.FlightTimeEarliest = "06:00"
+		p.FlightTimeLatest = "22:00"
+		p.FlightTimeHardFloor = hardFloor
+		in := scoring.DiscoverInput{AirportCode: "BCN", CityName: "Barcelona", DepartTime: depart}
+		_, breakdown := scoring.ComputeProfileMatch(p, in)
+		v, ok := breakdown[scoring.FactorTimeHardFloorCompliance]
+		if !ok {
+			t.Fatalf("breakdown missing %s", scoring.FactorTimeHardFloorCompliance)
+		}
+		return v
+	}
+
+	if got := mk(30, "08:00"); got != 1.0 {
+		t.Errorf("inside window: got %.2f, want 1.0", got)
+	}
+	if got := mk(30, "05:45"); got != 0.3 { // 15 min before earliest, within 30
+		t.Errorf("soft near-miss: got %.2f, want 0.3", got)
+	}
+	if got := mk(30, "22:20"); got != 0.3 { // 20 min after latest, within 30
+		t.Errorf("soft near-miss (late): got %.2f, want 0.3", got)
+	}
+	if got := mk(30, "04:00"); got != 0.0 { // 120 min before, beyond 30
+		t.Errorf("beyond floor: got %.2f, want 0.0", got)
+	}
+	if got := mk(0, "04:00"); got != 0.5 { // no floor configured -> neutral
+		t.Errorf("no hard floor: got %.2f, want 0.5", got)
+	}
+	if got := mk(30, ""); got != 0.5 { // unknown departure -> neutral
+		t.Errorf("unknown departure: got %.2f, want 0.5", got)
+	}
+}
+
+// #473: the factor is wired into DefaultWeights so it contributes to the score.
+func TestDefaultWeights_IncludesHardFloor(t *testing.T) {
+	w := scoring.DefaultWeights()
+	if _, ok := w[scoring.FactorTimeHardFloorCompliance]; !ok {
+		t.Errorf("DefaultWeights missing %s", scoring.FactorTimeHardFloorCompliance)
+	}
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl-mcp",
   "mcpName": "io.github.MikkoParkkola/trvl",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as legacy-compatible capabilities.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
   "description": "Door-to-door travel MCP + CLI: flights, hotels, trains, cars, ferries. No API keys, Go binary.",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",
     "source": "github"
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mikkoparkkola/trvl:1.19.1",
+      "identifier": "ghcr.io/mikkoparkkola/trvl:1.20.0",
       "transport": {
         "type": "stdio"
       }
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "identifier": "trvl-mcp",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "version": "1.19.1",
+      "version": "1.20.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Problem

The four multimodal travel-hack detectors (skip-flight, open-jaw ground, positioning, ferry positioning) each built a card that could mix currencies. The flight leg came back in whatever the flight source quoted, the ground and ferry legs carried EUR static estimates, and the "total" line summed them as if they shared a currency. A card reading "GBP flight + EUR ferry = 210 total" is not a number a traveller can act on.

The old workaround was a guard that suppressed the card whenever a leg was not already EUR. That kept the arithmetic honest but threw away every genuinely cheaper non-EUR itinerary.

## Change

Convert instead of suppress. Every price leg (flight, ground, ferry, static estimate, saved-hotel bonus) is run through `destinations.ConvertCurrency` into one target currency, and the whole card is labelled in that currency. A card is dropped only when a required leg is genuinely inconvertible (missing rate, offline, or a currency the rate table does not cover), not merely because it started in a different currency.

The target currency is a user preference. `in.currency()` now resolves in this order:

1. the explicit request currency, if set
2. the saved profile preference (`preferences.DisplayCurrency`, from `~/.trvl/preferences.json`)
3. EUR as the last-resort fallback

So a traveller who saves a non-EUR display currency gets itineraries in that currency without repeating it on every call, and EUR stays the zero-config default.

## Estimated-fare provenance marker

When a ground or ferry leg has no live quote, the detector prices it from the static EUR fallback. Those legs now render an "(estimated fare)" marker in both the card Description and the Steps list, so a converted static estimate is never mistaken for a live provider quote. A live quote renders no marker. `groundLegPriceInTarget` returns a third `estimated bool` to carry this, and `currency_estimated_marker_test.go` asserts the marker is present on the static-fallback path and absent on the live path, in both surfaces.

## Notes on the tricky parts

- **Positioning and ferry query live routes first.** A live ground/ferry price may already be in the target currency, so the detector tries the live route, falls back to the converted static EUR estimate, and suppresses only when neither converts. The cheapest convertible option wins. (An earlier revision suppressed on the static estimate before consulting live prices; that was caught in review and fixed.)
- **`ConvertCurrency` contract**: it returns `(amount, from)` unchanged on failure and `(converted, to)` on success, so the helpers treat "returned currency != target" as inconvertible and skip that leg.
- **Tests are hermetic and offline.** `currency_sweep_test.go` uses reserved placeholder ISO codes that appear in no real rate table, so they are deterministically inconvertible regardless of the shared rate cache, and a cancelled context guarantees no network traffic. Same-currency passthrough is verified too.

## Verification

- `go build ./...`, `go vet ./internal/hacks`, `staticcheck ./internal/hacks`: clean
- `go test ./internal/hacks -race -count=1`: pass
- `go test ./...`: pass (exit 0)
- Reviewed independently by a second model (gpt-5.6-sol via codex): clean, once the live-first ordering was fixed, and clean on the profile-preference resolution.

Closes #501
