### PR TITLE
fix(data): SAS SkyTeam/Flying Blue mapping + verify Antwerp ZWE rail baseline

### DIFF
--- a/internal/points/programs.go
+++ b/internal/points/programs.go
@@ -27,11 +27,10 @@ var Programs = []Program{
 		Slug: "finnair-plus", Name: "Finnair Plus",
 		FloorCPP: 1.0, CeilingCPP: 2.2, Category: "airline",
 	},
-	// NOTE: SK (SAS) now SkyTeam; earning maps to Flying Blue. EuroBonus slug kept for compatibility.
-	{
-		Slug: "sas-eurobonus", Name: "SAS EuroBonus",
-		FloorCPP: 1.0, CeilingCPP: 2.1, Category: "airline",
-	},
+	// SK (SAS) joined SkyTeam in 2024; SAS SkyTeam segments earn into Flying Blue
+	// (see the "flying-blue" entry below). The retired "SAS EuroBonus" catalog
+	// row was removed — SAS is no longer modelled as a Star Alliance/EuroBonus
+	// program (issue #466).
 	{
 		Slug: "british-airways-avios", Name: "British Airways Avios",
 		FloorCPP: 1.2, CeilingCPP: 2.0, Category: "airline",

--- a/internal/points/programs_sas_test.go
+++ b/internal/points/programs_sas_test.go
@@ -1,0 +1,27 @@
+package points
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNoStaleEuroBonusProgram guards issue #466: SAS (SK) joined SkyTeam in 2024
+// and its SkyTeam earning currency is Flying Blue, not the retired EuroBonus
+// mapping. The loyalty catalog must not model SAS as a "SAS EuroBonus" program.
+func TestNoStaleEuroBonusProgram(t *testing.T) {
+	if p := LookupProgram("sas-eurobonus"); p != nil {
+		t.Errorf("stale program %q still present: %+v", "sas-eurobonus", p)
+	}
+	for _, prog := range Programs {
+		if strings.Contains(strings.ToLower(prog.Name), "eurobonus") {
+			t.Errorf("stale EuroBonus program in catalog: %q (%s)", prog.Name, prog.Slug)
+		}
+		if strings.Contains(strings.ToLower(prog.Slug), "eurobonus") {
+			t.Errorf("stale EuroBonus slug in catalog: %q", prog.Slug)
+		}
+	}
+	// Flying Blue must exist as the SkyTeam currency SAS members earn into.
+	if p := LookupProgram("flying-blue"); p == nil {
+		t.Fatal("expected flying-blue program to exist as SAS/SkyTeam earning currency")
+	}
+}


### PR DESCRIPTION
## Summary

Two data-quality issues in the loyalty/rail mappings. Both were largely fixed by an earlier feature commit (#464/#475); this PR closes the one remaining stale artifact and verifies the rest green.

### #466 — SAS (SK) alliance/program
SAS left Star Alliance and joined **SkyTeam** in 2024; its SkyTeam earning currency is **Flying Blue**.

Already correct on `main` (prior commit):
- `internal/baggage/alliance.go` — `SK` in `skyteam` (not `star_alliance`)
- `internal/flights/loyalty.go`, `internal/profile/builder.go` — `SK` → SkyTeam
- `internal/points/earning.go` — `SK` earns into `Flying Blue` (revenue-based)
- `mcp/tools_lounges.go` — `SK` lounge cards under Flying Blue

Fixed here (the last stale row):
- `internal/points/programs.go` — removed the `sas-eurobonus` / "SAS EuroBonus" catalog row. Nothing keyed `SK` to that slug; SAS SkyTeam segments earn into the existing `flying-blue` entry.
- Added `TestNoStaleEuroBonusProgram` regression guard.

### #467 — Antwerp rail baseline (ANR vs ZWE)
Antwerp airport = `ANR`; Antwerp-Centraal rail = `ZWE`. The `find` direct-price baseline and preferences default must use the rail code `ZWE`, matching the authoritative detector in `internal/hacks/rail_fly.go`.

Verified already correct on `main` (prior commit), with tests present and green:
- `cmd/trvl/find.go:280` — `baselineDirectPrice` uses `{ZWE, ZYR}` (not `{ZYR, ANR, BRU}`); doc string + banner (`find.go:71,277`) updated.
- `internal/preferences/preferences.go:748` — AMS nearby default is `{EIN, BRU, ZWE, ZYR}`.
- Tests: `cmd/trvl/find_ux_test.go` (baseline excludes ZWE/ZYR), `internal/preferences/rail_fly_default_test.go` (AMS default contains ZWE).

No code change was needed for #467; this PR records the verification. Closing it here since the ACs are satisfied and covered by tests.

## Verification
- `go build ./...` — clean
- `go test ./internal/points/ ./internal/baggage/ ./internal/preferences/ ./cmd/trvl/ ./mcp/` — all pass
- New `TestNoStaleEuroBonusProgram` passes; existing `TestEstimateMilesEarned_SK_SkyTeam_FlyingBlue`, `TestFfStatusToCards_SKisFlyingBlue`, `find_ux_test.go` baseline tests pass.

Closes #466
Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZvtgqANnzjuiK35qJ32st