### PR TITLE
chore(deps): bump gRPC to v1.82.1 (GHSA-hrxh-6v49-42gf)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
GHSA-hrxh-6v49-42gf, CVSS 8.8, reached indirectly through `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp` from `internal/telemetry`. Fixed in 1.82.1.

The OSV gate fails on any fixable vulnerability in the dependency tree, by design — `.github/osv-scanner.toml` states that Dependabot proposes the bump and the gate disposes, refusing to ship until the fix is merged. No Dependabot PR had been raised for this one, so the gate was red for every open PR rather than just its own.

Kept separate from the #507 credential work: a dependency bump and a credential-handling change have nothing to do with each other and should be revertable independently.

## Note for reviewers

Two tests fail on this branch and also on clean `main`, so they are pre-existing and unrelated to the bump:

- `TestSearchAFKLM_UnconfiguredReturnsClearError` — passes only where no AF-KLM credential is resolvable. On a developer machine with 1Password configured, `main` silently picks one up, which is the defect #507 addresses; it passes on that fix branch.
- `TestDetectAll_DeadlineExceeded` — a 1ms deadline takes 1.87s, so `DetectAll` is not honouring its context. Worth its own issue.
