### PR TITLE
chore: gofmt five files already unformatted on main

### DIFF
--- a/internal/flights/wizzair_selfheal_test.go
+++ b/internal/flights/wizzair_selfheal_test.go
@@ -21,7 +21,8 @@ func setWizzVersionForTest(v string) string {
 
 // TestWizzNextCandidates checks the rotation-walk order: next minors first
 // (the common rotation), then patches, then the next majors.
-func TestWizzNextCandidates(t *testing.T) {	got := wizzNextCandidates("29.3.0")
+func TestWizzNextCandidates(t *testing.T) {
+	got := wizzNextCandidates("29.3.0")
 	if len(got) == 0 {
 		t.Fatal("no candidates generated")
 	}

--- a/internal/hacks/currency_sweep_test.go
+++ b/internal/hacks/currency_sweep_test.go
@@ -10,10 +10,10 @@ import (
 // gr builds a minimal GroundRoute for the currency-conversion tests.
 func gr(price float64, currency, depTime, arrTime string) models.GroundRoute {
 	return models.GroundRoute{
-		Provider: "flixbus",
-		Type:     "bus",
-		Price:    price,
-		Currency: currency,
+		Provider:  "flixbus",
+		Type:      "bus",
+		Price:     price,
+		Currency:  currency,
 		Departure: models.GroundStop{City: "A", Time: depTime},
 		Arrival:   models.GroundStop{City: "B", Time: arrTime},
 	}

--- a/internal/hacks/ferry_positioning.go
+++ b/internal/hacks/ferry_positioning.go
@@ -94,7 +94,6 @@ type ferryCandidate struct {
 	estimated   bool
 }
 
-
 // detectFerryPositioning checks whether taking a ferry to a nearby port and
 // then flying from there is cheaper than flying directly, even after adding
 // the ferry cost.

--- a/internal/models/ground.go
+++ b/internal/models/ground.go
@@ -40,23 +40,23 @@ type GroundRoute struct {
 	// (destination->origin on the return date). Empty for one-way searches.
 	// Mirrors models.FlightLeg.Direction so round-trip ground results are
 	// honestly labelled rather than silently flattening the return leg away.
-	Direction  string      `json:"direction,omitempty"`
-	Price      float64     `json:"price"`
-	PriceMax   float64     `json:"price_max,omitempty"` // RegioJet gives price ranges
-	Currency   string      `json:"currency"`
+	Direction string  `json:"direction,omitempty"`
+	Price     float64 `json:"price"`
+	PriceMax  float64 `json:"price_max,omitempty"` // RegioJet gives price ranges
+	Currency  string  `json:"currency"`
 	// ComparablePrice is the price converted to a common target currency for
 	// cross-currency ranking and MaxPrice filtering (and for PriceForRanking).
 	// Set by the normalize pass in ground search when conversion succeeds.
 	// 0 means "use raw Price" (incomparable across currencies).
-	ComparablePrice float64 `json:"comparable_price,omitempty"`
-	Duration   int         `json:"duration_minutes"`
-	Departure  GroundStop  `json:"departure"`
-	Arrival    GroundStop  `json:"arrival"`
-	Transfers  int         `json:"transfers"`
-	Legs       []GroundLeg `json:"legs"`
-	Amenities  []string    `json:"amenities,omitempty"`
-	SeatsLeft  *int        `json:"seats_left,omitempty"`
-	BookingURL string      `json:"booking_url"`
+	ComparablePrice float64     `json:"comparable_price,omitempty"`
+	Duration        int         `json:"duration_minutes"`
+	Departure       GroundStop  `json:"departure"`
+	Arrival         GroundStop  `json:"arrival"`
+	Transfers       int         `json:"transfers"`
+	Legs            []GroundLeg `json:"legs"`
+	Amenities       []string    `json:"amenities,omitempty"`
+	SeatsLeft       *int        `json:"seats_left,omitempty"`
+	BookingURL      string      `json:"booking_url"`
 	// Sources lists every provider that returned this same physical connection
 	// (mirrors HotelResult). Populated by ResolveGroundSources. Headline Price
 	// is the cheapest across sources.

--- a/internal/models/hotel.go
+++ b/internal/models/hotel.go
@@ -80,13 +80,13 @@ type Room struct {
 
 // HotelResult represents a single hotel from a search.
 type HotelResult struct {
-	Name            string        `json:"name"`
-	HotelID         string        `json:"hotel_id"`
-	Rating          float64       `json:"rating"`
-	ReviewCount     int           `json:"review_count"`
-	Stars           int           `json:"stars"`
-	Price           float64       `json:"price"` // Lowest price across all sources
-	Currency        string        `json:"currency"`
+	Name        string  `json:"name"`
+	HotelID     string  `json:"hotel_id"`
+	Rating      float64 `json:"rating"`
+	ReviewCount int     `json:"review_count"`
+	Stars       int     `json:"stars"`
+	Price       float64 `json:"price"` // Lowest price across all sources
+	Currency    string  `json:"currency"`
 	// ComparablePrice is the headline price converted to a common target currency
 	// for cross-currency ranking and Min/MaxPrice filtering (and PriceForRanking).
 	// 0 means the price could not be converted (incomparable across currencies).


### PR DESCRIPTION
Formatting-only, no behaviour change.

V: `gofmt -l .` reported five files before this change and reports none after.

Files: `internal/flights/wizzair_selfheal_test.go`, `internal/hacks/currency_sweep_test.go`, `internal/hacks/ferry_positioning.go`, `internal/models/ground.go`, `internal/models/hotel.go`.

## Why isolated

V: three separate PRs tonight (#515, #517, #518) picked these files up by accident, because a blanket `gofmt -w` sweep touches whatever is unformatted rather than only what you changed. Each time it added unrelated files to the diff and tripped the same-package regression-test gate for packages the PR never meant to touch — see the reverts in #515 commit `80baf06` and #518 commit `4116d26`. Fixing them once, alone, stops that recurring.

## Verification

- V: `gofmt -l .` clean
- V: `go build ./...` and `go vet ./...` clean
- V: `internal/hacks` and `internal/models` pass
- I: `internal/flights` carries one pre-existing failure, `TestSearchAFKLM_UnconfiguredReturnsClearError`. It fails only where an AF-KLM credential is resolvable, passes on CI, and is fixed by #515 — unrelated to formatting.
