### PR TITLE
feat(cookies): user decides what trvl reads from the browser (#521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`TRVL_NO_BROWSER_COOKIES` — decline browser cookie reads.** Set it to anything but
+  `0` or `false` and trvl reads no browser cookie store: neither the in-process reader
+  used by hotel and rail search, nor the nab helper used by the rail 403 retry. The
+  check sits on the low-level readers rather than the exported wrapper, because
+  recovery code reaches them directly and a gate on the public name alone would have
+  ignored the user three ways out of four. Default is unchanged. ([#521](https://github.com/MikkoParkkola/trvl/issues/521))
+
+### Changed
+
+- **The headless cookie harvest now runs by default; `TRVL_NO_TIER2_CDP` turns it
+  off.** It was opt-in behind `TRVL_TIER2_CDP`, which meant that for anyone who had
+  not read the README, a site answering with a bot challenge produced an empty result
+  and no explanation. The path drives an already-installed Chrome, Brave or Edge in
+  headless mode — no window, no focus steal, no bundled browser — so the cost of it
+  running is a browser process for a few seconds, not an interruption. An explicit
+  `TRVL_TIER2_CDP=0` is still honoured: someone who set that meant it.
+
 ### Known limitations
 
 - **On Windows, a helper that forks something in its first instants can leave that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and no explanation. The path drives an already-installed Chrome, Brave or Edge in
   headless mode — no window, no focus steal, no bundled browser — so the cost of it
   running is a browser process for a few seconds, not an interruption. An explicit
-  `TRVL_TIER2_CDP=0` is still honoured: someone who set that meant it.
+  `TRVL_TIER2_CDP=0` is still honoured: someone who set that meant it. The decline
+  is checked on the two functions that actually spawn the browser, so a caller that
+  reaches past the entry points cannot route around it. The `WithTier2Force` option
+  every rail and hotel caller used to pass is gone: it was checked as
+  `!cfg.force && !Tier2Enabled()`, which left the opt-out with no effect on any real
+  search. It governs the headless browser only — the visible-window escape hatch is
+  a separate path with its own per-provider opt-in and its own confirmation prompt.
 
 ### Known limitations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   checked at each of the three places in trvl that can start a browser — the two CDP
   drivers in the provider layer and the ground-provider scraper — rather than at the
   entry points above them, so a caller that reaches past those cannot route around it.
+- **`TRVL_NO_BROWSER_COOKIES` now also stops the `nab` helper.** The three rail
+  providers call `nab` as a fallback once the in-process cookie reader has failed, and
+  every one of those calls hands it `--cookies`, so the helper went and read the same
+  browser cookie stores the opt-out had just refused to read — the README's "no nab"
+  was untrue. The decline is now checked inside the nab client, at the point the helper
+  process would be started, so all three call sites are covered at once. The rule for
+  reading the variable is written twice rather than shared, because `internal/cookies`
+  already imports `internal/nab` and reusing it would close an import cycle; a test in
+  `internal/cookies`, the one package that can see both, fails if the two ever disagree.
   The `WithTier2Force` option every rail and hotel caller used to pass is gone: it was
   checked as `!cfg.force && !Tier2Enabled()`, which left the opt-out with no effect on
   any real search. It governs the headless browser only — the visible-window escape

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and no explanation. The path drives an already-installed Chrome, Brave or Edge in
   headless mode — no window, no focus steal, no bundled browser — so the cost of it
   running is a browser process for a few seconds, not an interruption. An explicit
-  `TRVL_TIER2_CDP=0` is still honoured: someone who set that meant it. The decline
-  is checked on the two functions that actually spawn the browser, so a caller that
-  reaches past the entry points cannot route around it. The `WithTier2Force` option
-  every rail and hotel caller used to pass is gone: it was checked as
-  `!cfg.force && !Tier2Enabled()`, which left the opt-out with no effect on any real
-  search. It governs the headless browser only — the visible-window escape hatch is
-  a separate path with its own per-provider opt-in and its own confirmation prompt.
+  `TRVL_TIER2_CDP=0` is still honoured: someone who set that meant it. The decline is
+  checked at each of the three places in trvl that can start a browser — the two CDP
+  drivers in the provider layer and the ground-provider scraper — rather than at the
+  entry points above them, so a caller that reaches past those cannot route around it.
+  The `WithTier2Force` option every rail and hotel caller used to pass is gone: it was
+  checked as `!cfg.force && !Tier2Enabled()`, which left the opt-out with no effect on
+  any real search. It governs the headless browser only — the visible-window escape
+  hatch is a separate path with its own per-provider opt-in and its own confirmation
+  prompt.
 
 ### Known limitations
 

--- a/README.md
+++ b/README.md
@@ -233,11 +233,30 @@ you can make it deliberately. Decided in
 **The headless browser.** When a site answers with a bot challenge, trvl can drive a
 copy of Chrome, Brave or Edge you already have installed, let the challenge resolve
 itself, and keep the resulting cookies. It runs headless: no window opens, focus is
-never taken, and nothing appears on screen. It bundles no browser of its own. This also
+never taken, and nothing appears on screen. It bundles no browser of its own. It also
+starts from an empty profile, so it does not read the cookies you already have — that
+is the separate switch above, and they are separate because they are separate things:
+one reads the session you are already logged into, this one starts a new anonymous
+session and keeps what that session is given. This also
 runs by default, for the same reason — with it off, a challenged search returns nothing
 and looks like an empty result rather than a switched-off feature. Set
 `TRVL_NO_TIER2_CDP=1` to decline. It costs a browser process for a few seconds per
-challenged search, which is the reason someone might want it off.
+challenged search, which is the reason someone might want it off. The check sits on
+the two functions that actually start the browser, so a provider reaching past the
+usual entry points still cannot spawn one. It governs the *headless* browser only —
+the separate visible-window escape hatch, which asks before it opens anything and
+requires its own per-provider opt-in, is described under
+[What trvl reads from your browser](#what-trvl-reads-from-your-browser).
+
+This is also what gets trvl past the rail sites' bot walls. Measured on 2026-07-27:
+reading cookies off disk returns nothing at all for Trainline, SNCF Connect and
+Rome2Rio, because the tokens those sites check are issued to a live browsing session
+and are not sitting in the cookie store. A headless visit clears the wall for two of
+them and returns usable cookies — Trainline's `datadome`, Rome2Rio's Cloudflare
+`__cf_bm` — so declining this is expected to leave those two empty. SNCF Connect is
+the honest exception: the headless visit reaches a challenge that needs a human, and
+trvl only reuses cookies from a challenge that actually cleared, so tier 2 is not
+what is currently fixing SNCF either way.
 
 AF-KLM is the single exception, and it is worth explaining. Ordinary round-trips are already covered in the default merge: Kiwi returns both legs of a paired itinerary, and Google returns the genuine round-trip fare with the matching return chosen at booking. AF-KLM is there for what neither offers — the rail+fly itineraries it sells, where a train leg from Brussels Midi, Antwerp or Brussels is ticketed as part of the flight instead of being a separate rail booking you have to make and risk yourself. It also returns both legs on KL/AF metal in full detail. It is the only provider whose **API key** can come from a credential manager, under tight rules. (Browser cookie access is a separate matter and is covered in [What trvl reads from your browser](#what-trvl-reads-from-your-browser); several providers do that, and it also touches the Keychain.)
 

--- a/README.md
+++ b/README.md
@@ -219,9 +219,17 @@ thing written to disk is that one token cache.
 
 Documenting this took three attempts, and each earlier version claimed a narrower
 scope than the code has: first that trvl never looked at local credentials
-unrequested, then that rail search was the sole exception. Both were wrong. Whether
-any of it should be opt-in is open at
-[#521](https://github.com/MikkoParkkola/trvl/issues/521).
+unrequested, then that rail search was the sole exception. Both were wrong.
+
+**Turning it off.** Set `TRVL_NO_BROWSER_COOKIES=1` and trvl reads no browser cookie
+store at all — no nab, no Keychain, nothing. It stays on by default because it is what
+makes hotel and rail search work against sites that block non-browser traffic, and
+switching it off does not make those searches fall back to something else: an operator
+that answers with a bot challenge simply returns no results, and it looks like trvl
+finding no trains rather than like a setting you chose. That is the trade, stated so
+you can make it deliberately. Decided in
+[#521](https://github.com/MikkoParkkola/trvl/issues/521); the headless Chrome harvest
+is separately opt-in behind `TRVL_TIER2_CDP` and does not run unless you set it.
 
 AF-KLM is the single exception, and it is worth explaining. Ordinary round-trips are already covered in the default merge: Kiwi returns both legs of a paired itinerary, and Google returns the genuine round-trip fare with the matching return chosen at booking. AF-KLM is there for what neither offers — the rail+fly itineraries it sells, where a train leg from Brussels Midi, Antwerp or Brussels is ticketed as part of the flight instead of being a separate rail booking you have to make and risk yourself. It also returns both legs on KL/AF metal in full detail. It is the only provider whose **API key** can come from a credential manager, under tight rules. (Browser cookie access is a separate matter and is covered in [What trvl reads from your browser](#what-trvl-reads-from-your-browser); several providers do that, and it also touches the Keychain.)
 

--- a/README.md
+++ b/README.md
@@ -228,8 +228,16 @@ switching it off does not make those searches fall back to something else: an op
 that answers with a bot challenge simply returns no results, and it looks like trvl
 finding no trains rather than like a setting you chose. That is the trade, stated so
 you can make it deliberately. Decided in
-[#521](https://github.com/MikkoParkkola/trvl/issues/521); the headless Chrome harvest
-is separately opt-in behind `TRVL_TIER2_CDP` and does not run unless you set it.
+[#521](https://github.com/MikkoParkkola/trvl/issues/521).
+
+**The headless browser.** When a site answers with a bot challenge, trvl can drive a
+copy of Chrome, Brave or Edge you already have installed, let the challenge resolve
+itself, and keep the resulting cookies. It runs headless: no window opens, focus is
+never taken, and nothing appears on screen. It bundles no browser of its own. This also
+runs by default, for the same reason — with it off, a challenged search returns nothing
+and looks like an empty result rather than a switched-off feature. Set
+`TRVL_NO_TIER2_CDP=1` to decline. It costs a browser process for a few seconds per
+challenged search, which is the reason someone might want it off.
 
 AF-KLM is the single exception, and it is worth explaining. Ordinary round-trips are already covered in the default merge: Kiwi returns both legs of a paired itinerary, and Google returns the genuine round-trip fare with the matching return chosen at booking. AF-KLM is there for what neither offers — the rail+fly itineraries it sells, where a train leg from Brussels Midi, Antwerp or Brussels is ticketed as part of the flight instead of being a separate rail booking you have to make and risk yourself. It also returns both legs on KL/AF metal in full detail. It is the only provider whose **API key** can come from a credential manager, under tight rules. (Browser cookie access is a separate matter and is covered in [What trvl reads from your browser](#what-trvl-reads-from-your-browser); several providers do that, and it also touches the Keychain.)
 

--- a/README.md
+++ b/README.md
@@ -242,8 +242,9 @@ runs by default, for the same reason — with it off, a challenged search return
 and looks like an empty result rather than a switched-off feature. Set
 `TRVL_NO_TIER2_CDP=1` to decline. It costs a browser process for a few seconds per
 challenged search, which is the reason someone might want it off. The check sits on
-the two functions that actually start the browser, so a provider reaching past the
-usual entry points still cannot spawn one. It governs the *headless* browser only —
+each of the three places in trvl that can start a browser, rather than on the
+entry points above them, so a provider reaching past the usual route still cannot
+spawn one. It governs the *headless* browser only —
 the separate visible-window escape hatch, which asks before it opens anything and
 requires its own per-provider opt-in, is described under
 [What trvl reads from your browser](#what-trvl-reads-from-your-browser).

--- a/README.md
+++ b/README.md
@@ -253,15 +253,18 @@ the separate visible-window escape hatch, which asks before it opens anything an
 requires its own per-provider opt-in, is described under
 [What trvl reads from your browser](#what-trvl-reads-from-your-browser).
 
-This is also what gets trvl past the rail sites' bot walls. Measured on 2026-07-27:
-reading cookies off disk returns nothing at all for Trainline, SNCF Connect and
-Rome2Rio, because the tokens those sites check are issued to a live browsing session
-and are not sitting in the cookie store. A headless visit clears the wall for two of
-them and returns usable cookies — Trainline's `datadome`, Rome2Rio's Cloudflare
-`__cf_bm` — so declining this is expected to leave those two empty. SNCF Connect is
-the honest exception: the headless visit reaches a challenge that needs a human, and
-trvl only reuses cookies from a challenge that actually cleared, so tier 2 is not
-what is currently fixing SNCF either way.
+This is also what gets trvl past the rail sites' bot walls. A one-off measurement on
+2026-07-27 — a snapshot of how those three sites behaved that day, not a promise about
+how they behave now — found that reading cookies off disk returned nothing at all for
+Trainline, SNCF Connect and Rome2Rio, because the tokens those sites check are issued
+to a live browsing session and are not sitting in the cookie store. A headless visit
+cleared the wall for two of them and returned usable cookies — Trainline's `datadome`,
+Rome2Rio's Cloudflare `__cf_bm` — so declining this is likely to leave those two empty.
+SNCF Connect was the exception: the headless visit reached a challenge that needs a
+human, and trvl only reuses cookies from a challenge that actually cleared, so tier 2
+was not what fixed SNCF either way. Bot walls change without notice and nothing in CI
+re-checks this, so treat the specifics as dated. To re-measure, run the probe test with
+`TRVL_COOKIE_PROBE=1`.
 
 AF-KLM is the single exception, and it is worth explaining. Ordinary round-trips are already covered in the default merge: Kiwi returns both legs of a paired itinerary, and Google returns the genuine round-trip fare with the matching return chosen at booking. AF-KLM is there for what neither offers — the rail+fly itineraries it sells, where a train leg from Brussels Midi, Antwerp or Brussels is ticketed as part of the flight instead of being a separate rail booking you have to make and risk yourself. It also returns both legs on KL/AF metal in full detail. It is the only provider whose **API key** can come from a credential manager, under tight rules. (Browser cookie access is a separate matter and is covered in [What trvl reads from your browser](#what-trvl-reads-from-your-browser); several providers do that, and it also touches the Keychain.)
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,11 @@ scope than the code has: first that trvl never looked at local credentials
 unrequested, then that rail search was the sole exception. Both were wrong.
 
 **Turning it off.** Set `TRVL_NO_BROWSER_COOKIES=1` and trvl reads no browser cookie
-store at all — no nab, no Keychain, nothing. It stays on by default because it is what
+store at all — no nab, no Keychain, nothing. The nab part of that sentence is newer than
+the rest of it: the variable used to stop only the reader inside trvl, while the three
+rail providers went on to run nab as a fallback and nab read the same stores from its own
+process. It is now refused at the point that helper would be started, so the claim above
+covers both. It stays on by default because it is what
 makes hotel and rail search work against sites that block non-browser traffic, and
 switching it off does not make those searches fall back to something else: an operator
 that answers with a bot challenge simply returns no results, and it looks like trvl

--- a/internal/consent/consent.go
+++ b/internal/consent/consent.go
@@ -39,10 +39,21 @@ const CookiesEnv = "TRVL_NO_BROWSER_COOKIES"
 const Tier2Env = "TRVL_NO_TIER2_CDP"
 
 // Tier2LegacyEnv is TRVL_TIER2_CDP, which used to be the opt-IN before the
-// headless path became the default. An explicit 0/false here still declines: a
-// user who set it to keep the browser off meant it, and flipping the default
-// must not quietly overrule them.
+// headless path became the default. A value here that did not switch the
+// browser ON under the old rules still declines: a user who set it to keep the
+// browser off meant it, and flipping the default must not quietly overrule
+// them.
 const Tier2LegacyEnv = "TRVL_TIER2_CDP"
+
+// tier2LegacyEnables lists the values that switched the headless path ON under
+// the old opt-in, copied from the predecessor exactly: Tier2Enabled() was
+// `v == "1" || v == "true" || v == "yes"`. Everything else left the browser off,
+// so everything else has to keep leaving it off.
+//
+// Compared case-insensitively and after trimming, which is strictly more
+// permissive than the predecessor and therefore cannot turn a user who had the
+// browser ON into one who has it off.
+var tier2LegacyEnables = map[string]bool{"1": true, "true": true, "yes": true}
 
 // ErrTier2Declined is returned when the headless path is invoked after the user
 // declined it. Nothing suppresses it -- a declined search fails rather than
@@ -64,9 +75,13 @@ func Tier2Declined() bool {
 	if declined(os.Getenv(Tier2Env)) {
 		return true
 	}
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(Tier2LegacyEnv))) {
-	case "0", "false", "no":
-		return true
+	// The legacy variable is read as an ALLOWLIST of enables, not a denylist of
+	// denials. An adversarial review of the default flip found the denylist
+	// version fails open: TRVL_TIER2_CDP=off matched no denial, so a user who
+	// had explicitly switched the browser off got one launched on upgrade.
+	// Unset still falls through -- that is the new default, not an old opinion.
+	if raw := strings.TrimSpace(os.Getenv(Tier2LegacyEnv)); raw != "" {
+		return !tier2LegacyEnables[strings.ToLower(raw)]
 	}
 	return false
 }

--- a/internal/consent/consent.go
+++ b/internal/consent/consent.go
@@ -50,9 +50,11 @@ const Tier2LegacyEnv = "TRVL_TIER2_CDP"
 // `v == "1" || v == "true" || v == "yes"`. Everything else left the browser off,
 // so everything else has to keep leaving it off.
 //
-// Compared case-insensitively and after trimming, which is strictly more
-// permissive than the predecessor and therefore cannot turn a user who had the
-// browser ON into one who has it off.
+// Compared RAW -- no trimming, no case folding. The predecessor compared raw, so
+// TRVL_TIER2_CDP=TRUE left the browser off, and any normalisation here would
+// launch one for that user on upgrade. It is tempting to argue they obviously
+// meant yes; that is a guess about intent, and guessing about intent at a
+// consent boundary is the whole failure this package exists to stop.
 var tier2LegacyEnables = map[string]bool{"1": true, "true": true, "yes": true}
 
 // ErrTier2Declined is returned when the headless path is invoked after the user
@@ -80,8 +82,12 @@ func Tier2Declined() bool {
 	// version fails open: TRVL_TIER2_CDP=off matched no denial, so a user who
 	// had explicitly switched the browser off got one launched on upgrade.
 	// Unset still falls through -- that is the new default, not an old opinion.
-	if raw := strings.TrimSpace(os.Getenv(Tier2LegacyEnv)); raw != "" {
-		return !tier2LegacyEnables[strings.ToLower(raw)]
+	//
+	// The value is compared raw for the reason given on tier2LegacyEnables: the
+	// predecessor compared raw, and a second review round caught that folding
+	// case here launches a browser for anyone who wrote TRUE.
+	if raw := os.Getenv(Tier2LegacyEnv); raw != "" {
+		return !tier2LegacyEnables[raw]
 	}
 	return false
 }

--- a/internal/consent/consent.go
+++ b/internal/consent/consent.go
@@ -1,0 +1,89 @@
+// Package consent owns the questions "did the user decline this?" for the
+// browser-access opt-outs, and nothing else.
+//
+// It exists because the answer has to be readable from packages that already
+// depend on each other. internal/cookies imports internal/nab, so the cookie
+// decline could not live in internal/cookies and be read from internal/nab
+// without closing an import cycle; for a while it was written out twice, in
+// both packages, held together by a cross-package test that failed if the two
+// copies ever disagreed. That test was a compensating control for a problem
+// that did not need to exist.
+//
+// This package imports nothing but the standard library, so anything can read
+// it. Adding a dependency here would recreate the cycle it was made to avoid.
+//
+// The decline rules themselves are the SSOT: the wrappers left behind in
+// internal/cookies, internal/nab and internal/providers keep their old names
+// for their callers, but all of them answer from here.
+package consent
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+// CookiesEnv is TRVL_NO_BROWSER_COOKIES: decline every read of the user's
+// browser cookie stores, in this process and in any helper it would start.
+//
+// Reading those stores is what makes rail search work against operators that
+// challenge non-browser traffic, so it is on by default. It is also a read of a
+// local credential store -- on macOS it reaches the Keychain -- that the user
+// did not ask for, which is the kind of thing someone is entitled to decline.
+const CookiesEnv = "TRVL_NO_BROWSER_COOKIES"
+
+// Tier2Env is TRVL_NO_TIER2_CDP: decline the headless browser that starts from
+// an empty profile and keeps whatever cookies the site hands it. It never
+// touches the user's own profile, which is why it is a separate decline from
+// CookiesEnv rather than the same one.
+const Tier2Env = "TRVL_NO_TIER2_CDP"
+
+// Tier2LegacyEnv is TRVL_TIER2_CDP, which used to be the opt-IN before the
+// headless path became the default. An explicit 0/false here still declines: a
+// user who set it to keep the browser off meant it, and flipping the default
+// must not quietly overrule them.
+const Tier2LegacyEnv = "TRVL_TIER2_CDP"
+
+// ErrTier2Declined is returned when the headless path is invoked after the user
+// declined it. Nothing suppresses it -- a declined search fails rather than
+// quietly returning worse results.
+var ErrTier2Declined = errors.New("tier2 cdp cookie-refresh declined (unset TRVL_NO_TIER2_CDP to enable)")
+
+// CookiesDeclined reports whether the user has declined browser cookie reads.
+func CookiesDeclined() bool { return declined(os.Getenv(CookiesEnv)) }
+
+// Tier2Declined reports whether the user has EXPLICITLY asked for no headless
+// browser, by either of the two variables that can say so.
+//
+// The question is "did the user say no?", not "is the default on?". Its
+// predecessor asked the latter, which a caller-supplied force option was
+// allowed to overrule -- and every production caller passed that option, which
+// left the opt-out with no effect on any real search. A setting that reads as a
+// privacy control and silently is not.
+func Tier2Declined() bool {
+	if declined(os.Getenv(Tier2Env)) {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(Tier2LegacyEnv))) {
+	case "0", "false", "no":
+		return true
+	}
+	return false
+}
+
+// declined is the whole rule: any non-empty value other than an explicit denial
+// counts as a decline.
+//
+// Someone setting one of these is expressing a preference about their own
+// credentials, and the least surprising reading of TRVL_NO_BROWSER_COOKIES=yes
+// is that they meant it. Being liberal here can only ever refuse an access the
+// user gestured at refusing; being strict would silently ignore them, which is
+// the failure this whole opt-out exists to stop.
+func declined(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "0", "false":
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/consent/consent_test.go
+++ b/internal/consent/consent_test.go
@@ -1,0 +1,59 @@
+package consent
+
+import "testing"
+
+// TestCookiesDeclined pins the rule itself, at the one place it now lives.
+//
+// The wrappers in internal/cookies and internal/nab are checked against each
+// other elsewhere; this checks what they both delegate to. The bias is
+// deliberate and worth pinning: anything the user typed that is not an explicit
+// denial counts as a decline, because being liberal here can only refuse an
+// access they gestured at refusing, while being strict would silently ignore
+// them -- the failure the opt-out exists to stop.
+func TestCookiesDeclined(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{"", false}, {"0", false}, {"false", false}, {"FALSE", false},
+		{" false ", false}, {"  ", false},
+		{"1", true}, {"true", true}, {"yes", true}, {"no", true},
+		{"off", true}, {"please", true}, {"2", true},
+	} {
+		t.Setenv(CookiesEnv, tc.value)
+		if got := CookiesDeclined(); got != tc.want {
+			t.Errorf("%s=%q: CookiesDeclined() = %v, want %v", CookiesEnv, tc.value, got, tc.want)
+		}
+	}
+}
+
+// TestTier2Declined covers the second variable, which has one extra rule: the
+// old opt-in still declines when set to an explicit denial, so flipping the
+// default to on does not quietly overrule someone who had turned it off.
+func TestTier2Declined(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		optOut     string
+		legacyOptI string
+		want       bool
+	}{
+		{"neither set", "", "", false},
+		{"opt-out set", "1", "", true},
+		{"opt-out set to an arbitrary truthy value", "yes", "", true},
+		{"opt-out explicitly denied", "0", "", false},
+		{"legacy opt-in explicitly zero", "", "0", true},
+		{"legacy opt-in explicitly false", "", "false", true},
+		{"legacy opt-in explicitly no", "", "no", true},
+		{"legacy opt-in enabled", "", "1", false},
+		{"opt-out wins over an enabled legacy opt-in", "1", "1", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(Tier2Env, tc.optOut)
+			t.Setenv(Tier2LegacyEnv, tc.legacyOptI)
+			if got := Tier2Declined(); got != tc.want {
+				t.Errorf("%s=%q %s=%q: Tier2Declined() = %v, want %v",
+					Tier2Env, tc.optOut, Tier2LegacyEnv, tc.legacyOptI, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/consent/consent_test.go
+++ b/internal/consent/consent_test.go
@@ -28,8 +28,9 @@ func TestCookiesDeclined(t *testing.T) {
 }
 
 // TestTier2Declined covers the second variable, which has one extra rule: the
-// old opt-in still declines when set to an explicit denial, so flipping the
-// default to on does not quietly overrule someone who had turned it off.
+// old opt-in reads as an allowlist of the values that switched the browser ON
+// before the default flipped, so anything else a user set to keep it off still
+// keeps it off.
 func TestTier2Declined(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
@@ -46,6 +47,24 @@ func TestTier2Declined(t *testing.T) {
 		{"legacy opt-in explicitly no", "", "no", true},
 		{"legacy opt-in enabled", "", "1", false},
 		{"opt-out wins over an enabled legacy opt-in", "1", "1", true},
+
+		// The cases below are the fix for a defect an adversarial review of the
+		// default flip found: the legacy variable was read as a DENYLIST of
+		// three denials, so any other way of saying no fell through and the
+		// browser launched. It is now an allowlist of the three values that
+		// switched it on under the old rules -- copied from the predecessor,
+		// which was `v == "1" || v == "true" || v == "yes"` -- so a value that
+		// did not enable it then cannot enable it now.
+		{"legacy opt-in set to off, which the denylist missed", "", "off", true},
+		{"legacy opt-in set to disabled", "", "disabled", true},
+		{"legacy opt-in set to an unrecognised word", "", "banana", true},
+		// Case and surrounding space are normalised, which is strictly more
+		// permissive than the predecessor: it compared raw, so "TRUE" left the
+		// browser off. Anyone that affects was trying to turn it ON, so the
+		// looser reading cannot switch a user's browser off against their wish.
+		{"legacy opt-in enabled in capitals", "", "TRUE", false},
+		{"legacy opt-in enabled with surrounding space", "", "  yes  ", false},
+		{"legacy opt-in denied in capitals", "", "FALSE", true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(Tier2Env, tc.optOut)

--- a/internal/consent/consent_test.go
+++ b/internal/consent/consent_test.go
@@ -58,13 +58,18 @@ func TestTier2Declined(t *testing.T) {
 		{"legacy opt-in set to off, which the denylist missed", "", "off", true},
 		{"legacy opt-in set to disabled", "", "disabled", true},
 		{"legacy opt-in set to an unrecognised word", "", "banana", true},
-		// Case and surrounding space are normalised, which is strictly more
-		// permissive than the predecessor: it compared raw, so "TRUE" left the
-		// browser off. Anyone that affects was trying to turn it ON, so the
-		// looser reading cannot switch a user's browser off against their wish.
-		{"legacy opt-in enabled in capitals", "", "TRUE", false},
-		{"legacy opt-in enabled with surrounding space", "", "  yes  ", false},
+		// The legacy value is compared RAW. A second review round caught the
+		// first version of this fix folding case and trimming space, which
+		// launches a browser for anyone who wrote TRUE -- on the old rules that
+		// left the browser OFF, because the comparison was raw there too. The
+		// argument for folding was that such a user "obviously meant yes". That
+		// is a guess about intent at a consent boundary, which is the failure
+		// this whole package exists to stop, so these cases pin the raw match.
+		{"legacy opt-in enabled in capitals, which did not enable it before", "", "TRUE", true},
+		{"legacy opt-in enabled with surrounding space, likewise", "", "  yes  ", true},
 		{"legacy opt-in denied in capitals", "", "FALSE", true},
+		{"legacy opt-in enabled exactly", "", "yes", false},
+		{"legacy opt-in enabled exactly, the other spelling", "", "true", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(Tier2Env, tc.optOut)

--- a/internal/cookies/attach_decline_test.go
+++ b/internal/cookies/attach_decline_test.go
@@ -57,55 +57,99 @@ func TestAttachBrowserCookiesRefusedAfterADecline(t *testing.T) {
 	})
 }
 
-// TestGroundProvidersDoNotAttachCookiesDirectly keeps the seam a seam.
+// TestProvidersDoNotSendBrowserCookiesDirectly keeps the seam a seam.
 //
-// The defect above was not a wrong check; it was a call site that never asked.
-// Nothing in the type system stops the next one, so this walks internal/ground
-// and fails on a direct req.AddCookie. A provider whose cookies genuinely never
-// touch the browser — a session it established itself — belongs in the
-// allowlist below WITH the reason, which is the review this test exists to
-// force.
-func TestGroundProvidersDoNotAttachCookiesDirectly(t *testing.T) {
-	// tallink: cookies come from Tallink's own booking session (Set-Cookie on a
-	// prior response in the same flow), never from the user's browser.
-	allowed := map[string]string{"tallink.go": "server-established booking session, not browser-derived"}
-
-	dir := filepath.Join("..", "ground")
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Skipf("internal/ground not readable: %v", err)
+// The defects this family is made of were never a wrong check; they were call
+// sites that never asked. Nothing in the type system stops the next one, so this
+// walks the provider packages and fails on a browser cookie reaching the wire
+// without a post-read consent check.
+//
+// Its job changed in round 11. It used to be the primary defence and it covered
+// internal/ground only — which is exactly why review found a Booking.com path in
+// internal/hotels that it could not see. The guarantee now lives one layer down,
+// in providers.permittedAfterRead, which re-checks the decline on the way out of
+// every browser read. This test is the TRIPWIRE for a reader added outside that
+// gated path. So the fix for a failure here is a wrap or a gated reader, never a
+// new allowlist entry — an entry is only for cookies that never came from the
+// user's browser, and it must say why.
+func TestProvidersDoNotSendBrowserCookiesDirectly(t *testing.T) {
+	allowed := map[string]string{
+		// Tallink: cookies come from Tallink's own booking session (Set-Cookie on
+		// a prior response in the same flow), never from the user's browser.
+		"ground/tallink.go": "server-established booking session, not browser-derived",
+		// Google consent bypass: a hardcoded constant (SOCS/CONSENT), not read
+		// from anyone's browser. See googleConsentCookie in that file.
+		"hotels/search_fetch.go": "hardcoded consent constant, not browser-derived",
 	}
-	for _, e := range entries {
-		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		if _, ok := allowed[name]; ok {
-			continue
-		}
-		src, err := os.ReadFile(filepath.Join(dir, name))
+
+	root := ".."
+	// The seam itself, and the transport primitive every provider calls through.
+	skipDirs := map[string]bool{"cookies": true, "batchexec": true}
+
+	var walked int
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			t.Fatalf("read %s: %v", name, err)
+			return err
 		}
-		// Every read of the user's browser must be wrapped where it is read,
-		// not where it is sent: the read is the slow part, and a decline
-		// arriving during it has to win.
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		if info.IsDir() {
+			if skipDirs[rel] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := info.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		if _, ok := allowed[rel]; ok {
+			return nil
+		}
+		src, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		walked++
+		permitted := func(line string) bool {
+			return strings.Contains(line, "HeaderIfPermitted(") ||
+				strings.Contains(line, "AttachBrowserCookies(")
+		}
 		for _, line := range strings.Split(string(src), "\n") {
-			if !strings.Contains(line, "BrowserCookies(ctx") {
-				continue
+			// Every read of the user's browser must be wrapped where it is read,
+			// not where it is sent: the read is the slow part, and a decline
+			// arriving during it has to win.
+			if strings.Contains(line, "BrowserCookies(ctx") && !permitted(line) {
+				t.Errorf("internal/%s reads browser cookies without a post-read consent "+
+					"check: %s\n\twrap it in cookies.HeaderIfPermitted(...) so an opt-out "+
+					"arriving during the read still stops the credential", rel, strings.TrimSpace(line))
 			}
-			if !strings.Contains(line, "HeaderIfPermitted(") && !strings.Contains(line, "AttachBrowserCookies(") {
-				t.Errorf("internal/ground/%s reads browser cookies without a post-read consent "+
-					"check: %s\n\twrap it in cookies.HeaderIfPermitted(...) so an opt-out arriving "+
-					"during the read still stops the credential", name, strings.TrimSpace(line))
+			// The last line before transmission. Round 11 found two of these in
+			// booking_rooms.go handing a raw browser Cookie header to the client.
+			if strings.Contains(line, ".GetWithCookie(") && !permitted(line) {
+				t.Errorf("internal/%s sends a raw Cookie header: %s\n\twrap the value in "+
+					"cookies.HeaderIfPermitted(...), or add the file to the allowlist in "+
+					"this test with the reason its cookies are not browser-derived",
+					rel, strings.TrimSpace(line))
+			}
+			if strings.Contains(line, ".AddCookie(") && !permitted(line) {
+				t.Errorf("internal/%s attaches cookies directly: %s\n\troute browser-derived "+
+					"cookies through cookies.AttachBrowserCookies so an opt-out arriving "+
+					"during the browser read still stops them, or add the file to the "+
+					"allowlist in this test with the reason its cookies are not "+
+					"browser-derived", rel, strings.TrimSpace(line))
 			}
 		}
-		if strings.Contains(string(src), ".AddCookie(") {
-			t.Errorf("internal/ground/%s attaches cookies directly; route browser-derived "+
-				"cookies through cookies.AttachBrowserCookies so an opt-out arriving during "+
-				"the browser read still stops them, or add the file to the allowlist in this "+
-				"test with the reason its cookies are not browser-derived", name)
-		}
+		return nil
+	})
+	if err != nil {
+		t.Skipf("internal/ not walkable: %v", err)
+	}
+	// A walk that silently covered nothing would pass forever.
+	if walked < 50 {
+		t.Fatalf("the walk only read %d files; it is not covering the provider packages", walked)
 	}
 }
 

--- a/internal/cookies/attach_decline_test.go
+++ b/internal/cookies/attach_decline_test.go
@@ -87,6 +87,19 @@ func TestGroundProvidersDoNotAttachCookiesDirectly(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read %s: %v", name, err)
 		}
+		// Every read of the user's browser must be wrapped where it is read,
+		// not where it is sent: the read is the slow part, and a decline
+		// arriving during it has to win.
+		for _, line := range strings.Split(string(src), "\n") {
+			if !strings.Contains(line, "BrowserCookies(ctx") {
+				continue
+			}
+			if !strings.Contains(line, "HeaderIfPermitted(") && !strings.Contains(line, "AttachBrowserCookies(") {
+				t.Errorf("internal/ground/%s reads browser cookies without a post-read consent "+
+					"check: %s\n\twrap it in cookies.HeaderIfPermitted(...) so an opt-out arriving "+
+					"during the read still stops the credential", name, strings.TrimSpace(line))
+			}
+		}
 		if strings.Contains(string(src), ".AddCookie(") {
 			t.Errorf("internal/ground/%s attaches cookies directly; route browser-derived "+
 				"cookies through cookies.AttachBrowserCookies so an opt-out arriving during "+
@@ -94,4 +107,25 @@ func TestGroundProvidersDoNotAttachCookiesDirectly(t *testing.T) {
 				"test with the reason its cookies are not browser-derived", name)
 		}
 	}
+}
+
+// TestHeaderIfPermittedRefusedAfterADecline covers the string half of the seam:
+// the providers that hand a Cookie header value to a request constructor rather
+// than attaching cookies one at a time (Trainline, SNCF, Eurostar). Same shape,
+// same reason — the check has to sit after the browser read, not before it.
+func TestHeaderIfPermittedRefusedAfterADecline(t *testing.T) {
+	const harvested = "datadome=from-the-users-browser"
+
+	t.Run("passed through while nothing is declined", func(t *testing.T) {
+		if got := HeaderIfPermitted(harvested); got != harvested {
+			t.Fatalf("the header was dropped with no opt-out in force: %q", got)
+		}
+	})
+
+	t.Run("dropped once the user declines", func(t *testing.T) {
+		t.Setenv(DisableEnv, "1")
+		if got := HeaderIfPermitted(harvested); got != "" {
+			t.Errorf("a browser cookie header read before the opt-out survived it: %q", got)
+		}
+	})
 }

--- a/internal/cookies/attach_decline_test.go
+++ b/internal/cookies/attach_decline_test.go
@@ -1,0 +1,97 @@
+package cookies
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAttachBrowserCookiesRefusedAfterADecline pins the ninth path of this
+// family, and the first that never involves a cookie jar at all.
+//
+// A jar is not the only way a browser credential reaches the wire. Trainline's
+// Tier-1 retry and Rome2Rio's Cloudflare path read the user's browser once and
+// then set the cookies on the request directly. The consent check sat before
+// the read — which takes seconds — so a decline arriving during it lost: the
+// read returned afterwards and the credentials went out anyway.
+//
+// The check therefore belongs at the last point before transmission. The test
+// is ordered around a CONTROL so the decline assertion is about the decline and
+// not about a helper that never attaches anything.
+func TestAttachBrowserCookiesRefusedAfterADecline(t *testing.T) {
+	fromBrowser := []*http.Cookie{{Name: "datadome", Value: "from-the-users-browser"}}
+
+	newReq := func(t *testing.T) *http.Request {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodGet, "https://example.test/search", nil)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		return req
+	}
+
+	t.Run("attached while nothing is declined", func(t *testing.T) {
+		req := newReq(t)
+		if !AttachBrowserCookies(req, fromBrowser) {
+			t.Fatal("the attach was refused with no opt-out in force")
+		}
+		if got := req.Header.Get("Cookie"); !strings.Contains(got, "datadome=from-the-users-browser") {
+			t.Fatalf("the fixture attached nothing, so the decline case would prove nothing: %q", got)
+		}
+	})
+
+	t.Run("refused once the user declines", func(t *testing.T) {
+		req := newReq(t)
+		t.Setenv(DisableEnv, "1")
+
+		// These cookies came from a browser read that began before the decline.
+		// They still must not go out.
+		if AttachBrowserCookies(req, fromBrowser) {
+			t.Error("browser cookies read before the opt-out were attached after it")
+		}
+		if got := req.Header.Get("Cookie"); got != "" {
+			t.Errorf("the request would still carry browser cookies: %q", got)
+		}
+	})
+}
+
+// TestGroundProvidersDoNotAttachCookiesDirectly keeps the seam a seam.
+//
+// The defect above was not a wrong check; it was a call site that never asked.
+// Nothing in the type system stops the next one, so this walks internal/ground
+// and fails on a direct req.AddCookie. A provider whose cookies genuinely never
+// touch the browser — a session it established itself — belongs in the
+// allowlist below WITH the reason, which is the review this test exists to
+// force.
+func TestGroundProvidersDoNotAttachCookiesDirectly(t *testing.T) {
+	// tallink: cookies come from Tallink's own booking session (Set-Cookie on a
+	// prior response in the same flow), never from the user's browser.
+	allowed := map[string]string{"tallink.go": "server-established booking session, not browser-derived"}
+
+	dir := filepath.Join("..", "ground")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Skipf("internal/ground not readable: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		if _, ok := allowed[name]; ok {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if strings.Contains(string(src), ".AddCookie(") {
+			t.Errorf("internal/ground/%s attaches cookies directly; route browser-derived "+
+				"cookies through cookies.AttachBrowserCookies so an opt-out arriving during "+
+				"the browser read still stops them, or add the file to the allowlist in this "+
+				"test with the reason its cookies are not browser-derived", name)
+		}
+	}
+}

--- a/internal/cookies/attach_decline_test.go
+++ b/internal/cookies/attach_decline_test.go
@@ -83,8 +83,12 @@ func TestProvidersDoNotSendBrowserCookiesDirectly(t *testing.T) {
 	}
 
 	root := ".."
-	// The seam itself, and the transport primitive every provider calls through.
-	skipDirs := map[string]bool{"cookies": true, "batchexec": true}
+	// Only the seam package itself, which is where the wrappers are DEFINED.
+	// Nothing else is exempt: an earlier version of this test also skipped
+	// internal/batchexec on the grounds that it is "just the transport", which
+	// bought nothing (it holds the GetWithCookie definition, no call sites) and
+	// would have hidden the day it grew one.
+	skipDirs := map[string]bool{"cookies": true}
 
 	var walked int
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
@@ -145,7 +149,10 @@ func TestProvidersDoNotSendBrowserCookiesDirectly(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		t.Skipf("internal/ not walkable: %v", err)
+		// NOT a skip. A detector that disarms itself when its own I/O fails
+		// reports "no bypasses" for the one reason that proves nothing, which is
+		// the failure mode this whole family is made of.
+		t.Fatalf("the walk could not complete, so it proves nothing: %v", err)
 	}
 	// A walk that silently covered nothing would pass forever.
 	if walked < 50 {

--- a/internal/cookies/browser.go
+++ b/internal/cookies/browser.go
@@ -236,9 +236,42 @@ func parseNetscapeCookies(data string) string {
 func ApplyCookies(req *http.Request, domain string) {
 	// The request carries the caller's context; use it rather than starting a
 	// detached lookup on behalf of a request that may already be cancelled.
-	if c := BrowserCookiesContext(req.Context(), domain); c != "" {
-		req.Header.Set("Cookie", c)
+	c := BrowserCookiesContext(req.Context(), domain)
+	if c == "" {
+		return
 	}
+	// Re-checked after the read, not only inside it: reading the browser stores
+	// takes seconds (Keychain unlock, cold profile), and a decline that lands
+	// during the read must still win. See AttachBrowserCookies.
+	if Disabled() {
+		return
+	}
+	req.Header.Set("Cookie", c)
+}
+
+// AttachBrowserCookies attaches cookies that came from the user's browser to a
+// request, unless browser access has been declined. It reports whether anything
+// was attached.
+//
+// It exists because a cookie jar is not the only way browser credentials reach
+// the wire: several providers read the browser once and then set the cookies on
+// the request directly, past any jar. Round 9 of review found two such paths
+// (Trainline's Tier-1 retry, Rome2Rio's Cloudflare path) still sending browser
+// cookies after an opt-out, for the same reason the jar did before it grew a
+// vault — the consent check sat before the slow read rather than after it.
+//
+// So the check belongs here, at the last point before transmission, where a
+// decline that arrives while the browser is being read still wins.
+func AttachBrowserCookies(req *http.Request, list []*http.Cookie) bool {
+	if req == nil || len(list) == 0 || Disabled() {
+		return false
+	}
+	for _, ck := range list {
+		if ck != nil {
+			req.AddCookie(ck)
+		}
+	}
+	return true
 }
 
 // IsCaptchaResponse reports whether an HTTP response is a Datadome CAPTCHA block

--- a/internal/cookies/browser.go
+++ b/internal/cookies/browser.go
@@ -346,3 +346,14 @@ func OpenBrowserForAuth(url string) error {
 	browserAuthOpened.domains[domain] = browserAuthNow()
 	return nil
 }
+
+// HeaderIfPermitted is the string half of AttachBrowserCookies: providers that
+// hand a whole Cookie header value to a request constructor rather than
+// attaching cookies one at a time. Wrap it AT THE READ, not at the send — the
+// browser read is the slow part, so a decline arriving during it has to win.
+func HeaderIfPermitted(header string) string {
+	if Disabled() {
+		return ""
+	}
+	return header
+}

--- a/internal/cookies/browser.go
+++ b/internal/cookies/browser.go
@@ -195,7 +195,17 @@ var errCookieSuppressed = errors.New("cookie extraction suppressed after a recen
 // own permission prompt; unbounded and terminal-attached, that is the exact
 // shape that produced #507: a credential prompt appearing mid-search and a
 // helper that never returns.
+//
+// The decline is re-checked here even though the only caller already checked it.
+// This function is the seam where the helper process is actually started, and
+// three rounds of review on #521 each found the same failure shape: a gate placed
+// on the caller rather than the seam, and then a caller that did not have it. The
+// duplicate check costs one env read on a path that is about to fork a process.
 func extractViaNab(ctx context.Context, browser, domain string) string {
+	if Disabled() {
+		return ""
+	}
+
 	nabPath, err := trvlnab.LookupPath()
 	if err != nil {
 		return ""

--- a/internal/cookies/browser.go
+++ b/internal/cookies/browser.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/consent"
 	trvlnab "github.com/MikkoParkkola/trvl/internal/nab"
 	"github.com/MikkoParkkola/trvl/internal/safeexec"
 	"golang.org/x/sync/singleflight"
@@ -52,27 +52,14 @@ func BrowserCookies(domain string) string {
 
 // DisableEnv turns off every read of the user's browser cookie stores.
 //
-// Reading those stores is what makes rail search work against operators that
-// challenge non-browser traffic, so it is on by default. It is also a read of a
-// local credential store — on macOS it reaches the Keychain — that the user did
-// not ask for, which is the kind of thing someone is entitled to decline. This
-// is the way to decline it. Rail searches against a challenging operator then
-// fail rather than degrade quietly, which is the honest cost of the choice.
-const DisableEnv = "TRVL_NO_BROWSER_COOKIES"
+// The name is kept here for this package's callers; the variable and the rule
+// for reading it live in internal/consent, which both this package and
+// internal/nab can see. They used to hold a copy each, because internal/cookies
+// imports internal/nab and sharing the other way would close an import cycle.
+const DisableEnv = consent.CookiesEnv
 
 // Disabled reports whether the user has declined browser cookie reads.
-//
-// Any non-empty value other than "0" or "false" counts, because someone setting
-// this is expressing a preference about their credentials and the least
-// surprising reading of TRVL_NO_BROWSER_COOKIES=yes is that they meant it.
-func Disabled() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(DisableEnv))) {
-	case "", "0", "false":
-		return false
-	default:
-		return true
-	}
-}
+func Disabled() bool { return consent.CookiesDeclined() }
 
 // BrowserCookiesContext is BrowserCookies with caller cancellation honoured.
 // A request that has gone away must not keep a helper running on its behalf.

--- a/internal/cookies/browser.go
+++ b/internal/cookies/browser.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -49,9 +50,40 @@ func BrowserCookies(domain string) string {
 	return BrowserCookiesContext(context.Background(), domain)
 }
 
+// DisableEnv turns off every read of the user's browser cookie stores.
+//
+// Reading those stores is what makes rail search work against operators that
+// challenge non-browser traffic, so it is on by default. It is also a read of a
+// local credential store — on macOS it reaches the Keychain — that the user did
+// not ask for, which is the kind of thing someone is entitled to decline. This
+// is the way to decline it. Rail searches against a challenging operator then
+// fail rather than degrade quietly, which is the honest cost of the choice.
+const DisableEnv = "TRVL_NO_BROWSER_COOKIES"
+
+// Disabled reports whether the user has declined browser cookie reads.
+//
+// Any non-empty value other than "0" or "false" counts, because someone setting
+// this is expressing a preference about their credentials and the least
+// surprising reading of TRVL_NO_BROWSER_COOKIES=yes is that they meant it.
+func Disabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(DisableEnv))) {
+	case "", "0", "false":
+		return false
+	default:
+		return true
+	}
+}
+
 // BrowserCookiesContext is BrowserCookies with caller cancellation honoured.
 // A request that has gone away must not keep a helper running on its behalf.
 func BrowserCookiesContext(ctx context.Context, domain string) string {
+	// Before the suppression cache and before the singleflight, because a user
+	// who has declined must not have a helper started for them by a concurrent
+	// caller that arrived first.
+	if Disabled() {
+		return ""
+	}
+
 	if _, ok := cookieSuppressed(domain); ok {
 		return ""
 	}

--- a/internal/cookies/browser_read.go
+++ b/internal/cookies/browser_read.go
@@ -38,7 +38,37 @@ var ErrBrowserReadDeclined = errors.New("browser page read declined (unset " + c
 // prompting the user to complete a CAPTCHA challenge.
 var SkipBrowserRead bool
 
-func BrowserReadPage(ctx context.Context, url string, waitSeconds int) (string, error) {
+// pageIfPermitted is the post-read consent gate for the real-browser page read,
+// the text-shaped sibling of HeaderIfPermitted and of providers.permittedAfterRead.
+//
+// Round 12 of review found why the entry checks below are not enough on their
+// own. Driving the user's Chrome or Safari through osascript takes SECONDS — a
+// window opens, a page loads, a challenge may be solved by hand — and the entry
+// check decides the question before any of that. A decline arriving during the
+// read lost: the read completed afterwards and the logged-in page text was
+// returned, and the caching wrapper then persisted it for the whole TTL. Same
+// race the cookie readers had, in a different currency.
+//
+// So the check is re-asked on the way out, on the value, immediately before it
+// can escape. It returns the declined sentinel rather than an empty string so a
+// caller cannot mistake a refusal for a page that simply would not load.
+func pageIfPermitted(text string) (string, error) {
+	if Disabled() {
+		return "", ErrBrowserReadDeclined
+	}
+	return text, nil
+}
+
+func BrowserReadPage(ctx context.Context, url string, waitSeconds int) (text string, err error) {
+	// Every successful return leaves through the post-read gate, including the
+	// per-browser loop below: the read is the slow part and a decline arriving
+	// during it has to win.
+	defer func() {
+		if err == nil {
+			text, err = pageIfPermitted(text)
+		}
+	}()
+
 	// The sixth path of this family, and the most visible of them: this one
 	// activates the user's real Chrome or Safari via osascript and reads the
 	// rendered page out of it. That uses their logged-in session, which is the
@@ -60,13 +90,13 @@ func BrowserReadPage(ctx context.Context, url string, waitSeconds int) (string, 
 
 	// Try Chrome first, then Safari.
 	for _, browser := range []string{"Google Chrome", "Safari"} {
-		text, err := browserReadPageWith(ctx, browser, url, waitSeconds)
-		if err != nil {
-			slog.Debug("browser read failed", "browser", browser, "err", err)
+		page, readErr := browserReadPageWith(ctx, browser, url, waitSeconds)
+		if readErr != nil {
+			slog.Debug("browser read failed", "browser", browser, "err", readErr)
 			continue
 		}
-		if len(text) > 100 {
-			return text, nil
+		if len(page) > 100 {
+			return page, nil
 		}
 	}
 	return "", fmt.Errorf("could not read page from any browser")
@@ -180,8 +210,29 @@ func BrowserReadPageCached(ctx context.Context, url string, waitSeconds int, ttl
 		return "", err
 	}
 
-	browserPageCache.Lock()
-	browserPageCache.entries[url] = browserCacheEntry{text: text, expires: time.Now().Add(ttl)}
-	browserPageCache.Unlock()
+	if err := cachePageIfPermitted(url, text, ttl); err != nil {
+		return "", err
+	}
 	return text, nil
+}
+
+// cachePageIfPermitted stores page text read out of the user's logged-in browser
+// session, re-checking the decline UNDER the write lock.
+//
+// Same reason the cookie vault re-checks under its own: the read that produced
+// this text took seconds, so the decline may have arrived during it. The gate on
+// BrowserReadPage stops the return value; this stops the COPY, which is the more
+// durable half — a page persisted here outlives the request and would be served
+// for the whole TTL, a refusal the user set and then cached away.
+//
+// It is a named function rather than an inline block so the refusal can be
+// tested without a real browser on the machine.
+func cachePageIfPermitted(url, text string, ttl time.Duration) error {
+	browserPageCache.Lock()
+	defer browserPageCache.Unlock()
+	if Disabled() {
+		return ErrBrowserReadDeclined
+	}
+	browserPageCache.entries[url] = browserCacheEntry{text: text, expires: time.Now().Add(ttl)}
+	return nil
 }

--- a/internal/cookies/browser_read.go
+++ b/internal/cookies/browser_read.go
@@ -158,6 +158,15 @@ type browserCacheEntry struct {
 }
 
 func BrowserReadPageCached(ctx context.Context, url string, waitSeconds int, ttl time.Duration) (string, error) {
+	// The cache is checked BEFORE it is served, not only before it is filled.
+	// Entries here are page text taken out of the user's logged-in session, and
+	// serving one after the user declined is the same shape as the cookie-cache
+	// bypass of the previous commit: harvested material replayed from a path the
+	// user believed they had closed. Cheaper to refuse than to reason about
+	// whether the window is reachable.
+	if consent.CookiesDeclined() {
+		return "", ErrBrowserReadDeclined
+	}
 	browserPageCache.RLock()
 	entry, ok := browserPageCache.entries[url]
 	browserPageCache.RUnlock()

--- a/internal/cookies/browser_read.go
+++ b/internal/cookies/browser_read.go
@@ -2,6 +2,7 @@ package cookies
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -9,7 +10,16 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/consent"
 )
+
+// ErrBrowserReadDeclined is returned when the user has declined browser access
+// and something asked to drive their browser anyway. It is distinct from the
+// "browser reading disabled" error above on purpose: that one means an
+// automated context switched the feature off, this one means the user did, and
+// a test that cannot tell them apart proves nothing about the decline.
+var ErrBrowserReadDeclined = errors.New("browser page read declined (unset " + consent.CookiesEnv + " to enable)")
 
 // BrowserReadPage opens a URL in the user's default browser, waits for the page
 // to load, then reads the rendered page text via macOS osascript (AppleScript).
@@ -29,6 +39,15 @@ import (
 var SkipBrowserRead bool
 
 func BrowserReadPage(ctx context.Context, url string, waitSeconds int) (string, error) {
+	// The sixth path of this family, and the most visible of them: this one
+	// activates the user's real Chrome or Safari via osascript and reads the
+	// rendered page out of it. That uses their logged-in session, which is the
+	// same interest TRVL_NO_BROWSER_COOKIES protects, so the same decline
+	// governs it. The check is here at the seam rather than in the callers,
+	// because a caller-side check is what the five earlier bypasses all were.
+	if consent.CookiesDeclined() {
+		return "", ErrBrowserReadDeclined
+	}
 	if SkipBrowserRead {
 		return "", fmt.Errorf("browser reading disabled")
 	}

--- a/internal/cookies/browser_read_decline_test.go
+++ b/internal/cookies/browser_read_decline_test.go
@@ -1,0 +1,50 @@
+package cookies
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/consent"
+)
+
+// TestBrowserReadPageHonoursTheDecline pins the sixth path of this family: the
+// one that drives the user's REAL browser. BrowserReadPage activates Chrome or
+// Safari via osascript and reads the rendered page out of the user's logged-in
+// session. It consulted nothing before doing that.
+//
+// The decline is checked ahead of SkipBrowserRead, and the two return different
+// errors on purpose. SkipBrowserRead is how automated contexts switch the
+// feature off, and it is true in most test runs -- so a test that accepted any
+// error here would pass without the decline being consulted at all. That is the
+// same vacuity trap the hotel test in this branch fell into: two guards, one
+// sentinel, nothing proved. Asserting the specific sentinel is what closes it.
+func TestBrowserReadPageHonoursTheDecline(t *testing.T) {
+	t.Setenv(consent.CookiesEnv, "1")
+
+	// Deliberately left false, which is the state where the browser WOULD open.
+	// If the decline check were removed, this test reaches osascript rather
+	// than failing tidily -- so it is written to run fast and refuse early.
+	SkipBrowserRead = false
+	t.Cleanup(func() { SkipBrowserRead = false })
+
+	start := time.Now()
+	out, err := BrowserReadPage(context.Background(), "https://www.thetrainline.com/search", 4)
+
+	if err == nil {
+		t.Fatal("the page read was attempted despite the decline")
+	}
+	if !errors.Is(err, ErrBrowserReadDeclined) {
+		t.Fatalf("refused, but not for the declared reason: err = %v, want it to wrap ErrBrowserReadDeclined", err)
+	}
+	if out != "" {
+		t.Errorf("page content came back from a declined read: %q", out)
+	}
+	// The function's own wait is 4 seconds before it reads anything. Returning
+	// well inside that is evidence it refused BEFORE launching a browser,
+	// rather than launching one and failing afterwards.
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("refusal took %v, long enough that the browser may have been launched first", elapsed)
+	}
+}

--- a/internal/cookies/browser_read_decline_test.go
+++ b/internal/cookies/browser_read_decline_test.go
@@ -48,3 +48,47 @@ func TestBrowserReadPageHonoursTheDecline(t *testing.T) {
 		t.Errorf("refusal took %v, long enough that the browser may have been launched first", elapsed)
 	}
 }
+
+// TestBrowserReadPageCachedRefusesAWarmEntry pins the half of the sixth path
+// that a check inside BrowserReadPage alone does NOT cover: a cache entry that
+// was filled while browser access was permitted, then served after the user
+// declined. The cached path returns before it ever calls BrowserReadPage, so
+// the seam check there is invisible to it.
+//
+// The entry is seeded directly rather than by a real read, so the test proves
+// the refusal on a cache that is genuinely warm and genuinely servable -- the
+// control being the expiry, set far in the future, which is what would make
+// this entry a hit if the guard were removed.
+func TestBrowserReadPageCachedRefusesAWarmEntry(t *testing.T) {
+	const url = "https://www.thetrainline.com/search"
+
+	browserPageCache.Lock()
+	browserPageCache.entries[url] = browserCacheEntry{
+		text:    "page text taken from the user's logged-in session",
+		expires: time.Now().Add(time.Hour),
+	}
+	browserPageCache.Unlock()
+	t.Cleanup(func() {
+		browserPageCache.Lock()
+		delete(browserPageCache.entries, url)
+		browserPageCache.Unlock()
+	})
+
+	// Control: warm, unexpired, and served when nothing has been declined.
+	if got, err := BrowserReadPageCached(context.Background(), url, 4, time.Hour); err != nil || got == "" {
+		t.Fatalf("the fixture did not produce a servable cache entry, so the assertion below would prove nothing: got %q, err = %v", got, err)
+	}
+
+	t.Setenv(consent.CookiesEnv, "1")
+
+	out, err := BrowserReadPageCached(context.Background(), url, 4, time.Hour)
+	if err == nil {
+		t.Fatal("cached page content was served despite the decline")
+	}
+	if !errors.Is(err, ErrBrowserReadDeclined) {
+		t.Fatalf("refused, but not for the declared reason: err = %v, want it to wrap ErrBrowserReadDeclined", err)
+	}
+	if out != "" {
+		t.Errorf("page content came back from a declined read: %q", out)
+	}
+}

--- a/internal/cookies/disable_test.go
+++ b/internal/cookies/disable_test.go
@@ -1,0 +1,75 @@
+package cookies
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestDisabled_Parsing pins which values count as declining.
+//
+// The reading is deliberately generous: someone who sets a variable named
+// TRVL_NO_BROWSER_COOKIES to "yes" has expressed a preference about their own
+// credential store, and honouring only "1" would read their intent backwards on
+// a technicality. The two spellings that mean the opposite are the exceptions.
+func TestDisabled_Parsing(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"FALSE", false},
+		{"  false  ", false},
+		{"1", true},
+		{"true", true},
+		{"yes", true},
+		{"no", true}, // a preference expressed clumsily is still a preference
+		{"  1  ", true},
+	} {
+		t.Setenv(DisableEnv, tc.value)
+		if got := Disabled(); got != tc.want {
+			t.Errorf("Disabled() with %s=%q = %v, want %v", DisableEnv, tc.value, got, tc.want)
+		}
+	}
+}
+
+// TestBrowserCookiesContext_DeclinedReadsNothing pins that the gate returns
+// before anything can reach a cookie store.
+//
+// Asserting the empty string alone would pass even if a helper had been spawned
+// and its output discarded, which is the part that matters here: the objection
+// this control answers is to the read happening at all, not to the value being
+// used. So the call is also timed. A real extraction shells out to nab, which
+// cannot complete in the time asserted below, so a fast empty answer is evidence
+// that no process was started rather than evidence that one returned nothing.
+func TestBrowserCookiesContext_DeclinedReadsNothing(t *testing.T) {
+	t.Setenv(DisableEnv, "1")
+
+	start := time.Now()
+	got := BrowserCookiesContext(context.Background(), "thetrainline.com")
+	elapsed := time.Since(start)
+
+	if got != "" {
+		t.Errorf("cookies returned while %s is set (%d bytes; value withheld, it is a live session)",
+			DisableEnv, len(got))
+	}
+	// Generous by three orders of magnitude against a process launch, so this
+	// does not become a timing-sensitive test on a loaded CI machine.
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("declined read took %v, which is long enough that a helper may have run; "+
+			"the gate must return before any extraction is attempted", elapsed)
+	}
+}
+
+// TestBrowserCookies_DeclinedThroughTheContextlessWrapper covers the other
+// exported entry point, which delegates but is what older call sites use.
+func TestBrowserCookies_DeclinedThroughTheContextlessWrapper(t *testing.T) {
+	t.Setenv(DisableEnv, "1")
+
+	if got := BrowserCookies("eurostar.com"); got != "" {
+		t.Errorf("cookies returned through BrowserCookies while %s is set (%d bytes; value withheld)",
+			DisableEnv, len(got))
+	}
+}

--- a/internal/cookies/nab_decline_agreement_test.go
+++ b/internal/cookies/nab_decline_agreement_test.go
@@ -3,19 +3,23 @@ package cookies
 import (
 	"testing"
 
+	"github.com/MikkoParkkola/trvl/internal/consent"
 	trvlnab "github.com/MikkoParkkola/trvl/internal/nab"
 )
 
-// TestNabAgreesWithCookiesOnTheDecline pins the one duplicated definition in the
-// opt-out.
+// TestNabAgreesWithCookiesOnTheDecline pins that every reader of the browser
+// cookie opt-out gives the same answer.
 //
-// internal/nab has to answer "did the user decline browser cookie reads?" before
-// it shells out to a helper that reads cookie stores, but it cannot call
-// cookies.Disabled: this package already imports internal/nab, so the reuse
-// would close an import cycle. The parsing rule is therefore written twice.
+// It was written when the parsing rule genuinely existed twice: internal/nab has
+// to answer "did the user decline?" before shelling out to a helper that reads
+// cookie stores, and it could not call cookies.Disabled, because this package
+// imports internal/nab and the reuse would have closed an import cycle. Both
+// copies now delegate to internal/consent, so there is one rule and nothing left
+// to drift.
 //
-// This test is the reason that is safe. It lives here because this package can
-// see both, and it fails the moment the two drift -- which matters, since a
+// The test stays anyway, and asserts across all three names rather than two. It
+// is cheap, and it is what fails if someone reintroduces a local copy in either
+// package -- which is exactly how the duplication arrived the first time. A
 // silent drift would mean a value the user believes is a decline being honoured
 // by one reader and ignored by the other.
 func TestNabAgreesWithCookiesOnTheDecline(t *testing.T) {
@@ -25,10 +29,14 @@ func TestNabAgreesWithCookiesOnTheDecline(t *testing.T) {
 	} {
 		t.Setenv(DisableEnv, value)
 
-		mine, theirs := Disabled(), trvlnab.BrowserCookiesDeclined()
-		if mine != theirs {
-			t.Errorf("with %s=%q: cookies.Disabled() = %v but nab.BrowserCookiesDeclined() = %v",
-				DisableEnv, value, mine, theirs)
+		mine, theirs, shared := Disabled(), trvlnab.BrowserCookiesDeclined(), consent.CookiesDeclined()
+		if mine != shared {
+			t.Errorf("with %s=%q: cookies.Disabled() = %v but consent.CookiesDeclined() = %v",
+				DisableEnv, value, mine, shared)
+		}
+		if theirs != shared {
+			t.Errorf("with %s=%q: nab.BrowserCookiesDeclined() = %v but consent.CookiesDeclined() = %v",
+				DisableEnv, value, theirs, shared)
 		}
 	}
 }

--- a/internal/cookies/nab_decline_agreement_test.go
+++ b/internal/cookies/nab_decline_agreement_test.go
@@ -1,0 +1,34 @@
+package cookies
+
+import (
+	"testing"
+
+	trvlnab "github.com/MikkoParkkola/trvl/internal/nab"
+)
+
+// TestNabAgreesWithCookiesOnTheDecline pins the one duplicated definition in the
+// opt-out.
+//
+// internal/nab has to answer "did the user decline browser cookie reads?" before
+// it shells out to a helper that reads cookie stores, but it cannot call
+// cookies.Disabled: this package already imports internal/nab, so the reuse
+// would close an import cycle. The parsing rule is therefore written twice.
+//
+// This test is the reason that is safe. It lives here because this package can
+// see both, and it fails the moment the two drift -- which matters, since a
+// silent drift would mean a value the user believes is a decline being honoured
+// by one reader and ignored by the other.
+func TestNabAgreesWithCookiesOnTheDecline(t *testing.T) {
+	for _, value := range []string{
+		"", "0", "false", "FALSE", " false ", "1", "true", "TRUE", "yes", "no",
+		"please", "off", "  ", "2",
+	} {
+		t.Setenv(DisableEnv, value)
+
+		mine, theirs := Disabled(), trvlnab.BrowserCookiesDeclined()
+		if mine != theirs {
+			t.Errorf("with %s=%q: cookies.Disabled() = %v but nab.BrowserCookiesDeclined() = %v",
+				DisableEnv, value, mine, theirs)
+		}
+	}
+}

--- a/internal/cookies/nab_seam_test.go
+++ b/internal/cookies/nab_seam_test.go
@@ -1,0 +1,60 @@
+package cookies
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestExtractViaNabRefusesWhenDeclined covers the seam a fourth adversarial
+// review found on #521.
+//
+// extractViaNab builds `nab cookies export <domain> --cookies <browser>` itself
+// rather than going through nab.Client.Fetch, so the gate added to that client
+// does not cover it. Its own caller checks Disabled() first, which is why this
+// was not a live bypass -- but a gate that lives on the caller is exactly what
+// the three previous rounds each found missing on a caller nobody had checked.
+//
+// The assertion is at the command seam and not on the return value: a fake nab
+// on PATH writes a marker file when it runs, so the test fails if the process
+// starts, rather than passing because extractViaNab returned "" for one of the
+// several other reasons it can.
+func TestExtractViaNabRefusesWhenDeclined(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the fake nab is a shell script")
+	}
+
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "nab-ran")
+	// `: > file` and not `touch`: the fake nab inherits the PATH set below, which
+	// holds only this directory, so it cannot call any external program.
+	script := "#!/bin/sh\n: > " + marker + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "nab"), []byte(script), 0o755); err != nil {
+		t.Fatalf("writing the fake nab: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	ran := func() bool {
+		_, err := os.Stat(marker)
+		return err == nil
+	}
+
+	t.Setenv(DisableEnv, "1")
+	if got := extractViaNab(context.Background(), "auto", "thetrainline.com"); got != "" {
+		t.Errorf("extractViaNab returned %q despite an explicit decline", got)
+	}
+	if ran() {
+		t.Fatal("nab was started despite an explicit decline")
+	}
+
+	// The other half: the gate must refuse a decline and only a decline, or the
+	// check above would pass on a function that never runs nab at all.
+	t.Setenv(DisableEnv, "")
+	resetCookieCache()
+	_ = extractViaNab(context.Background(), "auto", "thetrainline.com")
+	if !ran() {
+		t.Fatal("nab was not started without a decline; the gate refuses more than it should")
+	}
+}

--- a/internal/cookies/page_read_decline_test.go
+++ b/internal/cookies/page_read_decline_test.go
@@ -1,0 +1,95 @@
+package cookies
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestPageIfPermittedRefusedAfterADecline pins the twelfth path of this family,
+// and the first in a currency other than cookies.
+//
+// BrowserReadPage drives the user's real Chrome or Safari through osascript and
+// reads the rendered page out of their logged-in session. That takes SECONDS — a
+// window opens, a page loads, a challenge may be solved by hand — and the check
+// sat before all of it. A decline arriving during the read lost: the read
+// finished afterwards and the page text went back to the caller anyway. The
+// cookie readers had exactly this race; the page reader kept it two rounds
+// longer because it returns text rather than cookies and no lint was looking.
+//
+// Ordered around a CONTROL so the decline assertion is about the decline.
+func TestPageIfPermittedRefusedAfterADecline(t *testing.T) {
+	const harvested = "the user's logged-in account page"
+
+	t.Run("returned while nothing is declined", func(t *testing.T) {
+		got, err := pageIfPermitted(harvested)
+		if err != nil {
+			t.Fatalf("the page was refused with no opt-out in force: %v", err)
+		}
+		if got != harvested {
+			t.Fatalf("the fixture returned nothing, so the decline case would prove nothing: %q", got)
+		}
+	})
+
+	t.Run("refused once the user declines", func(t *testing.T) {
+		t.Setenv(DisableEnv, "1")
+
+		// This text came out of a browser read that began before the decline.
+		got, err := pageIfPermitted(harvested)
+		if !errors.Is(err, ErrBrowserReadDeclined) {
+			t.Errorf("a read that finished after the opt-out did not report the decline: %v", err)
+		}
+		if got != "" {
+			t.Errorf("the logged-in page text survived the opt-out: %q", got)
+		}
+	})
+}
+
+// TestCachedPageCannotLandAfterADecline covers the more durable half. A page
+// that escapes into the cache is served for the whole TTL, so a decline that
+// arrives during the read has to stop the COPY as well as the return value.
+func TestCachedPageCannotLandAfterADecline(t *testing.T) {
+	const (
+		url  = "https://example.test/account"
+		text = "the user's logged-in account page"
+	)
+
+	clear := func(t *testing.T) {
+		t.Helper()
+		t.Cleanup(func() {
+			browserPageCache.Lock()
+			delete(browserPageCache.entries, url)
+			browserPageCache.Unlock()
+		})
+	}
+	cached := func() (browserCacheEntry, bool) {
+		browserPageCache.Lock()
+		defer browserPageCache.Unlock()
+		e, ok := browserPageCache.entries[url]
+		return e, ok
+	}
+
+	// CONTROL: the store must work, or the refusal below would be the emptiness
+	// of a cache that never accepts anything.
+	t.Run("stored while nothing is declined", func(t *testing.T) {
+		clear(t)
+		if err := cachePageIfPermitted(url, text, time.Minute); err != nil {
+			t.Fatalf("the store was refused with no opt-out in force: %v", err)
+		}
+		if e, ok := cached(); !ok || e.text != text {
+			t.Fatalf("the fixture stored nothing, so the decline case would prove nothing: %+v", e)
+		}
+	})
+
+	t.Run("refused once the user declines", func(t *testing.T) {
+		clear(t)
+		t.Setenv(DisableEnv, "1")
+
+		if err := cachePageIfPermitted(url, text, time.Minute); !errors.Is(err, ErrBrowserReadDeclined) {
+			t.Errorf("the store did not report the decline: %v", err)
+		}
+		if e, ok := cached(); ok {
+			t.Errorf("the logged-in page was cached after the opt-out and would be served for the whole TTL: %+v", e)
+		}
+	})
+}

--- a/internal/ground/browser_cookie_optout_test.go
+++ b/internal/ground/browser_cookie_optout_test.go
@@ -1,0 +1,57 @@
+package ground
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/cookies"
+)
+
+// TestRailProvidersHonourTheBrowserCookieOptOut pins the control on the path each
+// rail provider actually uses, one case per provider.
+//
+// The gate itself lives in the cookies package and is tested there. This exists
+// because the guarantee a user cares about is not "the gate works" but "no rail
+// search reads my cookie store", and those are only the same claim while every
+// provider still goes through the gated function. A provider rewired to its own
+// extractor — a plausible change when one operator's challenge needs different
+// handling — would leave the cookies-package tests green while quietly reading
+// the store again. Calling each provider's own extractor variable is what makes
+// that regression fail here.
+//
+// Timed for the same reason as the gate's own test: an empty return proves the
+// value was not used, and only the speed proves no helper was launched to
+// produce it.
+func TestRailProvidersHonourTheBrowserCookieOptOut(t *testing.T) {
+	t.Setenv(cookies.DisableEnv, "1")
+
+	for _, tc := range []struct {
+		provider string
+		domain   string
+		extract  func(context.Context, string) string
+	}{
+		{"trainline", "thetrainline.com", trainlineBrowserCookies},
+		{"eurostar", "eurostar.com", eurostarBrowserCookies},
+		{"sncf", "sncf-connect.com", sncfBrowserCookies},
+	} {
+		t.Run(tc.provider, func(t *testing.T) {
+			start := time.Now()
+			got := tc.extract(context.Background(), tc.domain)
+			elapsed := time.Since(start)
+
+			if got != "" {
+				// Length, never the value: a failure here means real session
+				// cookies were extracted, and a test that printed them would put
+				// a contributor's live session into a public CI log.
+				t.Errorf("%s returned cookies while %s is set (%d bytes; value withheld)",
+					tc.provider, cookies.DisableEnv, len(got))
+			}
+			if elapsed > 50*time.Millisecond {
+				t.Errorf("%s took %v to decline, long enough that a helper may have run; "+
+					"if this provider now uses its own extractor it must honour %s too",
+					tc.provider, elapsed, cookies.DisableEnv)
+			}
+		})
+	}
+}

--- a/internal/ground/browser_scraper.go
+++ b/internal/ground/browser_scraper.go
@@ -14,6 +14,7 @@ import (
 	"unicode"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/providers"
 	"github.com/chromedp/cdproto/network"
 	cdppage "github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
@@ -42,10 +43,19 @@ Object.defineProperty(navigator, 'languages', {get: () => ['en-GB', 'en']});
 window.chrome = window.chrome || {runtime: {}};
 `
 
-// BrowserScrapeRoutes fetches opt-in browser-assisted ground routes using the
-// repo's existing Go CDP stack. It intentionally does not spawn an external
-// language runtime; callers already treat non-nil errors as provider-unavailable.
+// BrowserScrapeRoutes fetches browser-assisted ground routes using the repo's
+// existing Go CDP stack. It intentionally does not spawn an external language
+// runtime; callers already treat non-nil errors as provider-unavailable.
+//
+// It runs by default and returns providers.ErrTier2Disabled when the user has
+// declined the headless browser. Its doc comment used to say "opt-in", which was
+// stale: nothing gated it, and both callers (trainline.go, sncf.go) invoke it
+// unconditionally after the challenge path fails.
 func BrowserScrapeRoutes(ctx context.Context, provider, from, to, date, currency string) ([]models.GroundRoute, error) {
+	if providers.Tier2Declined() {
+		return nil, providers.ErrTier2Disabled
+	}
+
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	if currency == "" {
 		currency = "EUR"
@@ -236,7 +246,10 @@ func trainlineSlug(s string) string {
 }
 
 func chromedpNavigateText(ctx context.Context, targetURL string, dwell time.Duration) (string, error) {
-	taskCtx, cancel := newBrowserScraperContext(ctx)
+	taskCtx, cancel, err := newBrowserScraperContext(ctx)
+	if err != nil {
+		return "", err
+	}
 	defer cancel()
 
 	var bodyText string
@@ -254,7 +267,10 @@ func chromedpNavigateText(ctx context.Context, targetURL string, dwell time.Dura
 }
 
 func chromedpCaptureHeader(ctx context.Context, targetURLs []string, headerName string, dwell time.Duration) (string, error) {
-	taskCtx, cancel := newBrowserScraperContext(ctx)
+	taskCtx, cancel, err := newBrowserScraperContext(ctx)
+	if err != nil {
+		return "", err
+	}
 	defer cancel()
 
 	var (
@@ -295,7 +311,10 @@ func chromedpCaptureHeader(ctx context.Context, targetURLs []string, headerName 
 }
 
 func chromedpSNCFResponses(ctx context.Context, bookingURL string, fromStation, toStation SNCFStation, date string) ([]map[string]any, string, error) {
-	taskCtx, cancel := newBrowserScraperContext(ctx)
+	taskCtx, cancel, err := newBrowserScraperContext(ctx)
+	if err != nil {
+		return nil, "", err
+	}
 	defer cancel()
 
 	var (
@@ -399,7 +418,17 @@ func decodeBrowserJSONBodies(raws []string) []map[string]any {
 	return responses
 }
 
-func newBrowserScraperContext(ctx context.Context) (context.Context, context.CancelFunc) {
+func newBrowserScraperContext(ctx context.Context) (context.Context, context.CancelFunc, error) {
+	// An explicit decline is absolute and is checked HERE, on the function that
+	// builds the allocator, for the same reason internal/providers checks it on
+	// runCDPCollect rather than on its entrypoints: this is the third place in
+	// the repo that can start a browser, and gating only the two in
+	// internal/providers left this one spawning Chrome after the user said no
+	// (#521). A caller that reaches past BrowserScrapeRoutes still cannot.
+	if providers.Tier2Declined() {
+		return nil, nil, providers.ErrTier2Disabled
+	}
+
 	allocOpts := append([]chromedp.ExecAllocatorOption{}, chromedp.DefaultExecAllocatorOptions[:]...)
 	allocOpts = append(allocOpts,
 		chromedp.UserAgent(trainlineChromeUA),
@@ -417,7 +446,7 @@ func newBrowserScraperContext(ctx context.Context) (context.Context, context.Can
 	return taskCtx, func() {
 		cancelTask()
 		cancelAlloc()
-	}
+	}, nil
 }
 
 func browserBaseActions() []chromedp.Action {

--- a/internal/ground/browser_scraper_decline_test.go
+++ b/internal/ground/browser_scraper_decline_test.go
@@ -1,0 +1,57 @@
+package ground
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/providers"
+)
+
+// TestBrowserScraperRefusesAnExplicitDecline covers the bypass an adversarial
+// review found in the second cut of #521.
+//
+// The decline gate had been placed on both browser-spawning functions in
+// internal/providers -- and that was the whole repo, as far as the change went
+// looking. It was not: internal/ground has a THIRD chromedp.NewExecAllocator,
+// reached by BrowserScrapeRoutes, which trainline.go and sncf.go both call
+// unconditionally after the challenge path fails. So a user who declined got
+// ErrTier2Disabled from the challenge, fell straight through to the scraper,
+// and had Chrome launched anyway.
+//
+// The tests could not have caught it, because they all lived in
+// internal/providers and tested the two allocators that were already gated.
+// This one lives where the third allocator is.
+func TestBrowserScraperRefusesAnExplicitDecline(t *testing.T) {
+	t.Setenv("TRVL_NO_TIER2_CDP", "1")
+
+	// The allocator itself, not just the entrypoint above it: a caller reaching
+	// past BrowserScrapeRoutes must not be able to start a browser either.
+	if _, _, err := newBrowserScraperContext(context.Background()); !errors.Is(err, providers.ErrTier2Disabled) {
+		t.Fatalf("newBrowserScraperContext: err = %v, want ErrTier2Disabled", err)
+	}
+
+	for _, provider := range []string{"trainline", "sncf"} {
+		if _, err := BrowserScrapeRoutes(context.Background(), provider, "Paris", "Lyon", "2026-09-01", "EUR"); !errors.Is(err, providers.ErrTier2Disabled) {
+			t.Fatalf("BrowserScrapeRoutes(%s): err = %v, want ErrTier2Disabled", provider, err)
+		}
+	}
+}
+
+// TestBrowserScraperAllocatorOpensWithoutADecline is the other half: the gate
+// must refuse a decline and only a decline. Building the allocator does not
+// start a browser -- chromedp launches on the first Run -- so this asserts the
+// gate lets the path through without spawning anything.
+func TestBrowserScraperAllocatorOpensWithoutADecline(t *testing.T) {
+	t.Setenv("TRVL_NO_TIER2_CDP", "")
+	t.Setenv("TRVL_TIER2_CDP", "")
+
+	taskCtx, cancel, err := newBrowserScraperContext(context.Background())
+	if err != nil {
+		t.Fatalf("newBrowserScraperContext without a decline: err = %v, want nil", err)
+	}
+	if taskCtx == nil || cancel == nil {
+		t.Fatal("newBrowserScraperContext returned a nil context or cancel func")
+	}
+	cancel()
+}

--- a/internal/ground/eurostar.go
+++ b/internal/ground/eurostar.go
@@ -364,7 +364,7 @@ func SearchEurostar(ctx context.Context, from, to, startDate, endDate, currency 
 		_ = firstBody // consumed for logging; body closed by defer
 
 		// Attempt retry with browser cookies.
-		cookieHeader := eurostarBrowserCookies(ctx, "eurostar.com")
+		cookieHeader := cookies.HeaderIfPermitted(eurostarBrowserCookies(ctx, "eurostar.com"))
 		if cookieHeader != "" {
 			slog.Debug("retrying eurostar with browser cookies")
 			req2, err2 := newEurostarRequest(cookieHeader)

--- a/internal/ground/rome2rio.go
+++ b/internal/ground/rome2rio.go
@@ -14,6 +14,7 @@ import (
 
 	"golang.org/x/net/html"
 
+	"github.com/MikkoParkkola/trvl/internal/cookies"
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/providers"
 )
@@ -188,9 +189,8 @@ func fetchRome2Rio(ctx context.Context, from, to string, allowBrowser bool) (str
 	if allowBrowser {
 		if tier1, terr := providers.NewTier1Client(); terr == nil {
 			req.Header.Set("User-Agent", rome2rioChromeUA)
-			for _, ck := range providers.BrowserCookiesForURL(target) {
-				req.AddCookie(ck)
-			}
+			// Browser-harvested; the seam re-checks the opt-out after the read.
+			cookies.AttachBrowserCookies(req, providers.BrowserCookiesForURL(target))
 			doer = tier1.Do
 		} else {
 			req.Header.Set("User-Agent", rome2rioChromeUA)

--- a/internal/ground/sncf.go
+++ b/internal/ground/sncf.go
@@ -49,7 +49,7 @@ var (
 	// sncfResolveChallenge escalates SNCF's anti-bot wall HEADLESS-first (no
 	// window, no focus steal) via providers.ResolveChallenge. Overridable in tests.
 	sncfResolveChallenge = func(ctx context.Context, targetURL string) (*providers.ChallengeResult, error) {
-		return providers.ResolveChallenge(ctx, targetURL, providers.WithTier2Force())
+		return providers.ResolveChallenge(ctx, targetURL)
 	}
 	// sncfOpenBrowser opens a VISIBLE browser window so a human can solve an
 	// interactive captcha. Only invoked on ChallengeNeedsHuman. Overridable in tests.

--- a/internal/ground/sncf.go
+++ b/internal/ground/sncf.go
@@ -569,7 +569,7 @@ func searchSNCFCalendar(ctx context.Context, fromStation, toStation SNCFStation,
 		_ = resp.Body.Close()
 
 		if allowBrowserCookies {
-			cookieHeader := sncfBrowserCookies(ctx, "sncf-connect.com")
+			cookieHeader := cookies.HeaderIfPermitted(sncfBrowserCookies(ctx, "sncf-connect.com"))
 			if cookieHeader != "" {
 				slog.Debug("retrying sncf calendar api with browser cookies")
 				req2, err2 := newSNCFRequest(cookieHeader)

--- a/internal/ground/trainline.go
+++ b/internal/ground/trainline.go
@@ -79,7 +79,7 @@ var (
 	// do we open a real window. Overridable in tests so the orchestration is
 	// exercised offline without spawning a browser.
 	trainlineResolveChallenge = func(ctx context.Context, targetURL string) (*providers.ChallengeResult, error) {
-		return providers.ResolveChallenge(ctx, targetURL, providers.WithTier2Force())
+		return providers.ResolveChallenge(ctx, targetURL)
 	}
 	// trainlineOpenBrowser opens a VISIBLE browser window so a human can solve an
 	// interactive captcha. Only invoked on ChallengeNeedsHuman. Overridable in tests.

--- a/internal/ground/trainline.go
+++ b/internal/ground/trainline.go
@@ -402,7 +402,7 @@ func SearchTrainline(ctx context.Context, from, to, date, currency string, allow
 
 		// Try 2: use a real browser session cookie extracted from Brave/Chrome.
 		// Requires the user to have visited thetrainline.com in their browser.
-		cookieHeader := trainlineBrowserCookies(ctx, "thetrainline.com")
+		cookieHeader := cookies.HeaderIfPermitted(trainlineBrowserCookies(ctx, "thetrainline.com"))
 		if cookieHeader != "" {
 			slog.Debug("retrying trainline with browser cookies")
 			req3, err3 := newTrainlineRequest(cookieHeader)

--- a/internal/ground/trainline.go
+++ b/internal/ground/trainline.go
@@ -497,9 +497,9 @@ func trainlineViaTier1(ctx context.Context, body []byte, cks []*http.Cookie, fro
 	// presents (the default headers carry a Chrome 133 UA, which would mismatch).
 	req.Header.Set("User-Agent", trainlineChromeUA)
 	req.Header.Set("sec-ch-ua", trainlineChromeSecCHUA)
-	for _, ck := range cks {
-		req.AddCookie(ck)
-	}
+	// Browser-harvested (datadome clearance). Attached through the consent seam
+	// so a decline landing during the browser read still stops them.
+	cookies.AttachBrowserCookies(req, cks)
 
 	resp, err := tier1.Do(req)
 	if err != nil {

--- a/internal/hotels/booking_rooms.go
+++ b/internal/hotels/booking_rooms.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	cookiesconsent "github.com/MikkoParkkola/trvl/internal/cookies"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -153,8 +154,14 @@ func fetchBookingPage(ctx context.Context, pageURL string) (string, error) {
 		return string(body), nil
 	}
 
-	// Booking.com returns 202/403/503 for WAF challenge pages.
-	// Try reading the bkng cookie from the user's browser via kooky.
+	// Booking.com returns 202/403/503 for WAF challenge pages. Try reading the
+	// bkng cookie from the user's browser via kooky.
+	//
+	// The read itself is gated inside providers (permittedAfterRead), which is
+	// where the guarantee lives. The HeaderIfPermitted wraps below are the second
+	// layer: they sit on the last line before transmission, so a decline arriving
+	// even later than the read still stops the credential. Round 11 of review
+	// found this path sending live Booking.com credentials with neither.
 	if status == 202 || status == 403 || status == 503 {
 		cookies := browserCookies("https://www.booking.com")
 		var cookieStr string
@@ -166,7 +173,7 @@ func fetchBookingPage(ctx context.Context, pageURL string) (string, error) {
 		}
 		if cookieStr != "" {
 			slog.Debug("booking.com challenge, retrying with browser cookie", "status", status)
-			status, body, err = client.GetWithCookie(ctx, pageURL, cookieStr)
+			status, body, err = client.GetWithCookie(ctx, pageURL, cookiesconsent.HeaderIfPermitted(cookieStr))
 			if err == nil && status == 200 {
 				return string(body), nil
 			}
@@ -184,7 +191,7 @@ func fetchBookingPage(ctx context.Context, pageURL string) (string, error) {
 		}
 		if cookieStr != "" {
 			slog.Debug("booking.com challenge, retrying with all browser cookies", "status", status)
-			status, body, err = client.GetWithCookie(ctx, pageURL, cookieStr)
+			status, body, err = client.GetWithCookie(ctx, pageURL, cookiesconsent.HeaderIfPermitted(cookieStr))
 			if err == nil && status == 200 {
 				return string(body), nil
 			}

--- a/internal/hotels/booking_search.go
+++ b/internal/hotels/booking_search.go
@@ -186,7 +186,7 @@ func acquireBookingWAFToken(ctx context.Context, searchURL string, forceRefresh 
 		}
 	}
 
-	cookies, err := providers.RefreshCookiesViaCDP(ctx, searchURL, providers.WithTier2Force())
+	cookies, err := providers.RefreshCookiesViaCDP(ctx, searchURL)
 	if err != nil {
 		return "", fmt.Errorf("cdp token harvest: %w", err)
 	}

--- a/internal/hotels/booking_tier2_decline_test.go
+++ b/internal/hotels/booking_tier2_decline_test.go
@@ -1,0 +1,53 @@
+package hotels
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/providers"
+)
+
+// TestBookingTokenHarvestHonoursTheTier2Decline pins the fourth bypass of the
+// same family the earlier rounds of #521 found, this one on the hotel path.
+//
+// The booking.com aws-waf-token harvest used to pass a force flag that skipped
+// the Tier-2 opt-in, so a hotel search reached a browser by a route the user's
+// setting did not govern. The flag is gone; this test is what keeps it gone.
+//
+// TRVL_ALLOW_BROWSER_COOKIES is set deliberately. Without it the harvest refuses
+// for a second, unrelated reason -- a guard that stops `go test` launching a real
+// browser -- and both guards return the same sentinel, so the test would pass
+// while never exercising the decline at all. A first draft of this test did
+// exactly that, and its own control case caught it. With the test-binary guard
+// disarmed, the decline is the only thing left that can refuse.
+//
+// There is no paired "runs without a decline" case here, and the omission is
+// deliberate rather than forgotten: proving that requires stubbing the browser
+// runner, which is private to internal/providers, and that package already owns
+// both halves of it. What this package has to prove is only that its own call
+// site no longer asks to skip the check.
+//
+// Verified by mutation, with a result worth recording: restoring the force flag
+// does not fail this test, it fails to COMPILE. The option it named was deleted
+// from internal/providers, so the bypass cannot come back through one word at one
+// call site -- someone would have to add the option back first. This test guards
+// the weaker property that survives that: the decline reaches this path at all.
+func TestBookingTokenHarvestHonoursTheTier2Decline(t *testing.T) {
+	t.Setenv("TRVL_ALLOW_BROWSER_COOKIES", "1")
+	t.Setenv("TRVL_NO_TIER2_CDP", "1")
+
+	// forceRefresh skips the cache and the in-process cookie reader, leaving the
+	// browser harvest as the only remaining path. Without it, a machine with a
+	// warm cookie cache returns a token and passes having tested nothing.
+	_, err := acquireBookingWAFToken(context.Background(), bookingBaseURL, true)
+
+	if err == nil {
+		t.Fatal("token harvest succeeded despite an explicit tier-2 decline; the browser gate is not on this path")
+	}
+	// errors.Is against the shared sentinel rather than a string match, so
+	// rewording the message cannot silently turn this green.
+	if !errors.Is(err, providers.ErrTier2Disabled) {
+		t.Fatalf("harvest refused, but not for the declared reason: err = %v, want it to wrap ErrTier2Disabled", err)
+	}
+}

--- a/internal/nab/client.go
+++ b/internal/nab/client.go
@@ -6,9 +6,31 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
+
+// declineEnv is TRVL_NO_BROWSER_COOKIES, the opt-out from #521.
+//
+// The parsing rule is duplicated from cookies.Disabled rather than shared,
+// because internal/cookies already imports this package and reusing it would
+// close an import cycle. internal/cookies owns the definition;
+// TestNabAgreesWithCookiesOnTheDecline (in that package, which can see both)
+// fails if these two ever disagree.
+const declineEnv = "TRVL_NO_BROWSER_COOKIES"
+
+// BrowserCookiesDeclined reports whether the user has declined browser cookie
+// reads. Every Fetch passes --cookies to nab, which reads the user's browser
+// cookie stores, so a decline has to stop the call rather than adjust it.
+func BrowserCookiesDeclined() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(declineEnv))) {
+	case "", "0", "false":
+		return false
+	default:
+		return true
+	}
+}
 
 var ErrNotAvailable = errors.New("nab not available")
 
@@ -63,6 +85,20 @@ func (c *Client) Fetch(ctx context.Context, rawURL string, opts FetchOptions) ([
 	if !c.Available() {
 		return nil, ErrNotAvailable
 	}
+
+	// Every Fetch below passes --cookies, so this whole path reads the user's
+	// browser cookie stores. A user who declined that must not have nab started
+	// for them -- the rail providers reach here as a fallback AFTER the gated
+	// in-process extractor already refused, which is how the opt-out was still
+	// leaking cookie reads after #521's first two rounds.
+	//
+	// ErrNotAvailable rather than a new sentinel: every caller already treats it
+	// as "nab is not an option here" and falls through quietly, which is exactly
+	// the desired behaviour.
+	if BrowserCookiesDeclined() {
+		return nil, ErrNotAvailable
+	}
+
 	if opts.Browser == "" {
 		opts.Browser = "auto"
 	}

--- a/internal/nab/client.go
+++ b/internal/nab/client.go
@@ -6,31 +6,23 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
+	"log/slog"
 	"os/exec"
 	"strings"
-)
 
-// declineEnv is TRVL_NO_BROWSER_COOKIES, the opt-out from #521.
-//
-// The parsing rule is duplicated from cookies.Disabled rather than shared,
-// because internal/cookies already imports this package and reusing it would
-// close an import cycle. internal/cookies owns the definition;
-// TestNabAgreesWithCookiesOnTheDecline (in that package, which can see both)
-// fails if these two ever disagree.
-const declineEnv = "TRVL_NO_BROWSER_COOKIES"
+	"github.com/MikkoParkkola/trvl/internal/consent"
+)
 
 // BrowserCookiesDeclined reports whether the user has declined browser cookie
 // reads. Every Fetch passes --cookies to nab, which reads the user's browser
 // cookie stores, so a decline has to stop the call rather than adjust it.
-func BrowserCookiesDeclined() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(declineEnv))) {
-	case "", "0", "false":
-		return false
-	default:
-		return true
-	}
-}
+//
+// The rule lives in internal/consent. It used to be written out again here,
+// because internal/cookies imports this package and reusing its copy would have
+// closed an import cycle; the two copies were held together by a cross-package
+// test that failed if they ever disagreed. There is now one copy and nothing to
+// disagree with.
+func BrowserCookiesDeclined() bool { return consent.CookiesDeclined() }
 
 var ErrNotAvailable = errors.New("nab not available")
 
@@ -94,8 +86,11 @@ func (c *Client) Fetch(ctx context.Context, rawURL string, opts FetchOptions) ([
 	//
 	// ErrNotAvailable rather than a new sentinel: every caller already treats it
 	// as "nab is not an option here" and falls through quietly, which is exactly
-	// the desired behaviour.
+	// the desired behaviour. The cost is that a declined read and a broken nab
+	// install look identical to everything downstream, so the one place that can
+	// still tell them apart says so here.
 	if BrowserCookiesDeclined() {
+		slog.Debug("nab fetch declined by the user", "env", consent.CookiesEnv, "url", rawURL)
 		return nil, ErrNotAvailable
 	}
 

--- a/internal/nab/client.go
+++ b/internal/nab/client.go
@@ -90,7 +90,13 @@ func (c *Client) Fetch(ctx context.Context, rawURL string, opts FetchOptions) ([
 	// install look identical to everything downstream, so the one place that can
 	// still tell them apart says so here.
 	if BrowserCookiesDeclined() {
-		slog.Debug("nab fetch declined by the user", "env", consent.CookiesEnv, "url", rawURL)
+		// No URL, and no host either. The decline is a global env-var opt-out, so
+		// once it is set EVERY fetch is refused -- which URL was refused tells an
+		// operator nothing they can act on, and rounds 5 to 7 of review spent
+		// three attempts failing to reduce a URL to something provably harmless
+		// (query string, then IPv6 zone, then the hostname itself). The variable
+		// name is the whole actionable content of this line.
+		slog.Debug("nab fetch declined by the user", "env", consent.CookiesEnv)
 		return nil, ErrNotAvailable
 	}
 

--- a/internal/nab/decline_test.go
+++ b/internal/nab/decline_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"os/exec"
 	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/consent"
 )
 
 // TestFetchRefusesWhenBrowserCookiesDeclined covers the bypass a third
@@ -21,7 +23,7 @@ import (
 // The gate is asserted at the command seam: if it leaks, commandContext runs and
 // the test sees it, rather than the test passing because no binary was found.
 func TestFetchRefusesWhenBrowserCookiesDeclined(t *testing.T) {
-	t.Setenv(declineEnv, "1")
+	t.Setenv(consent.CookiesEnv, "1")
 
 	invoked := false
 	prev := commandContext
@@ -47,7 +49,7 @@ func TestFetchRefusesWhenBrowserCookiesDeclined(t *testing.T) {
 // TestFetchRunsWithoutADecline is the other half: the gate must refuse a decline
 // and only a decline, so an absent opt-out still reaches the command seam.
 func TestFetchRunsWithoutADecline(t *testing.T) {
-	t.Setenv(declineEnv, "")
+	t.Setenv(consent.CookiesEnv, "")
 
 	invoked := false
 	prev := commandContext
@@ -73,7 +75,7 @@ func TestBrowserCookiesDeclinedParsing(t *testing.T) {
 		{"", false}, {"0", false}, {"false", false}, {"FALSE", false},
 		{"1", true}, {"true", true}, {"yes", true}, {"no", true}, {"anything", true},
 	} {
-		t.Setenv(declineEnv, tc.value)
+		t.Setenv(consent.CookiesEnv, tc.value)
 		if got := BrowserCookiesDeclined(); got != tc.want {
 			t.Errorf("BrowserCookiesDeclined() with %q = %v, want %v", tc.value, got, tc.want)
 		}

--- a/internal/nab/decline_test.go
+++ b/internal/nab/decline_test.go
@@ -1,0 +1,81 @@
+package nab
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+// TestFetchRefusesWhenBrowserCookiesDeclined covers the bypass a third
+// adversarial review found in #521.
+//
+// Every Fetch passes `--cookies <browser>` (defaulting to "auto") to the nab
+// binary, which reads the user's browser cookie stores. The rail providers call
+// this as a fallback AFTER the gated in-process extractor has already refused --
+// internal/ground/trainline.go, eurostar.go and sncf.go all do -- so declining
+// browser cookie reads stopped the reader trvl controls and left running the
+// helper that does the same thing in another process. The README promised "no
+// nab, no Keychain, nothing", and this was the "no nab" part being untrue.
+//
+// The gate is asserted at the command seam: if it leaks, commandContext runs and
+// the test sees it, rather than the test passing because no binary was found.
+func TestFetchRefusesWhenBrowserCookiesDeclined(t *testing.T) {
+	t.Setenv(declineEnv, "1")
+
+	invoked := false
+	prev := commandContext
+	commandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		invoked = true
+		return prev(ctx, name, args...)
+	}
+	defer func() { commandContext = prev }()
+
+	c := &Client{path: "/nonexistent/nab"}
+
+	if _, err := c.Fetch(context.Background(), "https://www.thetrainline.com/", FetchOptions{}); !errors.Is(err, ErrNotAvailable) {
+		t.Fatalf("Fetch: err = %v, want ErrNotAvailable", err)
+	}
+	if _, err := c.FetchHTML(context.Background(), "https://www.thetrainline.com/", "auto"); !errors.Is(err, ErrNotAvailable) {
+		t.Fatalf("FetchHTML: err = %v, want ErrNotAvailable", err)
+	}
+	if invoked {
+		t.Fatal("nab was invoked despite an explicit decline")
+	}
+}
+
+// TestFetchRunsWithoutADecline is the other half: the gate must refuse a decline
+// and only a decline, so an absent opt-out still reaches the command seam.
+func TestFetchRunsWithoutADecline(t *testing.T) {
+	t.Setenv(declineEnv, "")
+
+	invoked := false
+	prev := commandContext
+	commandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		invoked = true
+		return prev(ctx, name, args...)
+	}
+	defer func() { commandContext = prev }()
+
+	c := &Client{path: "/nonexistent/nab"}
+	_, _ = c.Fetch(context.Background(), "https://www.thetrainline.com/", FetchOptions{})
+
+	if !invoked {
+		t.Fatal("nab was not invoked without a decline; the gate refuses more than it should")
+	}
+}
+
+func TestBrowserCookiesDeclinedParsing(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{"", false}, {"0", false}, {"false", false}, {"FALSE", false},
+		{"1", true}, {"true", true}, {"yes", true}, {"no", true}, {"anything", true},
+	} {
+		t.Setenv(declineEnv, tc.value)
+		if got := BrowserCookiesDeclined(); got != tc.want {
+			t.Errorf("BrowserCookiesDeclined() with %q = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+}

--- a/internal/nab/decline_test.go
+++ b/internal/nab/decline_test.go
@@ -1,9 +1,12 @@
 package nab
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/MikkoParkkola/trvl/internal/consent"
@@ -64,6 +67,50 @@ func TestFetchRunsWithoutADecline(t *testing.T) {
 
 	if !invoked {
 		t.Fatal("nab was not invoked without a decline; the gate refuses more than it should")
+	}
+}
+
+// TestDeclineLogDoesNotLeakTheURL pins the fix for a defect adversarial review
+// found in the debug line added by the consent refactor: it logged the whole
+// URL. This codebase's URLs carry the user's journey in their query parameters
+// -- dates, origin, destination -- so the line that exists to explain a privacy
+// decision was itself disclosing what the user was looking up. To a debug log,
+// but that is where a privacy control least belongs.
+//
+// Three rounds then failed to reduce the URL to something provably harmless:
+// the query string, then the IPv6 zone identifier that survives in url.URL.Host,
+// then the hostname itself, which is only non-sensitive because this repo's
+// callers happen to pass hardcoded provider hosts. The line now logs no part of
+// the URL at all, so this test asserts absence of the host as well.
+//
+// It asserts on the emitted record rather than on a helper, because a helper
+// unit test passes whether or not the call site uses it -- the same
+// caller-instead-of-seam mistake the four earlier rounds each found.
+func TestDeclineLogDoesNotLeakTheURL(t *testing.T) {
+	t.Setenv(consent.CookiesEnv, "1")
+
+	var buf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prevLogger)
+
+	const (
+		host      = "www.thetrainline.com"
+		sensitive = "from=PARIS&to=BERLIN&date=2026-08-14&passenger=M+Parkkola"
+	)
+	c := &Client{path: "/nonexistent/nab"}
+	_, _ = c.Fetch(context.Background(), "https://"+host+"/search?"+sensitive, FetchOptions{})
+
+	logged := buf.String()
+	// Without this the rest is vacuous: a line that is never emitted leaks nothing.
+	// Anchored on the variable name, which is the line's whole actionable content.
+	if !strings.Contains(logged, consent.CookiesEnv) {
+		t.Fatalf("expected the decline to name the variable that refused it, got %q", logged)
+	}
+	for _, leak := range []string{sensitive, "PARIS", "BERLIN", "2026-08-14", "Parkkola", "/search", host} {
+		if strings.Contains(logged, leak) {
+			t.Errorf("decline log leaked %q; full record: %s", leak, logged)
+		}
 	}
 }
 

--- a/internal/providers/auth.go
+++ b/internal/providers/auth.go
@@ -8,11 +8,13 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/cookies"
 	"github.com/MikkoParkkola/trvl/internal/waf"
 	"github.com/andybalholm/brotli"
 	"github.com/klauspost/compress/zstd"
@@ -30,6 +32,15 @@ import (
 // search to a different city can swap the values out from under us. See
 // MIK-3070 for the race that motivated this signature.
 func (rt *Runtime) runPreflight(ctx context.Context, pc *providerClient, vars map[string]string) (map[string]string, error) {
+	// Before every cache read below, including the no-preflight early return.
+	// The auth cache lives in memory and the MCP server is long-lived, so a jar
+	// seeded from the user's browser outlives the moment it was permitted: the
+	// cache hit returns without reaching loadCachedCookies, tryBrowserCookieRetry
+	// or any other guarded reader, and the browser-derived cookies keep going out
+	// on the wire. Discarding the seeded state costs a preflight; keeping it
+	// costs the user the control they set.
+	discardBrowserSeededAuth(pc)
+
 	if pc.config.Auth == nil || pc.config.Auth.PreflightURL == "" {
 		// No preflight needed — but the caller may still rely on existing
 		// pc.authValues populated by other paths (header-based auth, env tokens).
@@ -67,7 +78,12 @@ func (rt *Runtime) runPreflight(ctx context.Context, pc *providerClient, vars ma
 
 	// Tier 0: try loading persisted cookies from a previous successful session.
 	// This makes browser escape hatch a one-time setup rather than per-search.
-	loadCachedCookies(pc.client, resolvedURL)
+	// The file carries no provenance, so anything it yields is treated as
+	// browser-derived — the conservative reading, and the one #534 exists to
+	// replace with a recorded one.
+	if loadCachedCookies(pc.client, resolvedURL) {
+		pc.browserSeeded = true
+	}
 
 	resp, body, err := doPreflightRequest(ctx, pc.client, &resolvedAuth)
 	if err != nil {
@@ -92,6 +108,7 @@ func (rt *Runtime) runPreflight(ctx context.Context, pc *providerClient, vars ma
 	if needsBrowserCookieFallback(resp.StatusCode, extracted, resolvedAuth.Extractions) {
 		// Tier 3a: read cookies from user's browser (kooky).
 		if tryBrowserCookieRetry(ctx, pc, &resolvedAuth) {
+			pc.browserSeeded = true
 			saveCachedCookies(pc.client, resolvedURL)
 			pc.lastPreflightURL = resolvedURL
 			pc.authExpiry = time.Now().Add(pc.effectiveCacheTTL())
@@ -107,6 +124,7 @@ func (rt *Runtime) runPreflight(ctx context.Context, pc *providerClient, vars ma
 		// Tier 4: last-resort escape hatch — open in browser.
 		if resolvedAuth.BrowserEscapeHatch && isInteractive(ctx) {
 			if tryBrowserEscapeHatch(ctx, pc, &resolvedAuth) {
+				pc.browserSeeded = true
 				saveCachedCookies(pc.client, resolvedURL)
 				pc.lastPreflightURL = resolvedURL
 				pc.authExpiry = time.Now().Add(pc.effectiveCacheTTL())
@@ -661,4 +679,54 @@ func decompressBody(resp *http.Response, limit int64) ([]byte, error) {
 		// No encoding or "identity" — read raw.
 		return io.ReadAll(reader)
 	}
+}
+
+// discardBrowserSeededAuth throws away cached auth state that came from the
+// user's browser, once the user has declined browser access.
+//
+// The seventh path of this family, and the first that is purely in-memory: the
+// six before it were a browser launch, an env-var reading, or a file on disk.
+// Here the material has already been harvested into a live http.Client, and the
+// auth cache serves it without consulting anything. In a CLI run that window is
+// short. Under `trvl mcp`, which is the shipping default, the process outlives
+// many searches, so the window is the process.
+//
+// The jar is REPLACED rather than emptied: net/http/cookiejar has no clear, and
+// reaching into it to expire entries one by one would be a second
+// implementation of a thing the standard library already gets right. A nil jar
+// is not used either — a client without one silently drops Set-Cookie, which
+// would turn a privacy control into a broken session.
+//
+// Only browser-seeded state is discarded. A session established by an ordinary
+// preflight never touched the user's browser, and refusing it would punish a
+// user for a setting that says nothing about it.
+func discardBrowserSeededAuth(pc *providerClient) {
+	if pc == nil || !cookies.Disabled() {
+		return
+	}
+
+	pc.authMu.Lock()
+	defer pc.authMu.Unlock()
+
+	if !pc.browserSeeded {
+		return
+	}
+
+	pc.authValues = nil
+	pc.authExpiry = time.Time{}
+	pc.lastPreflightURL = ""
+	pc.browserSeeded = false
+
+	if pc.client != nil {
+		if jar, err := cookiejar.New(nil); err == nil {
+			pc.client.Jar = jar
+		} else {
+			// Unreachable with a nil options argument, but a jar that failed to
+			// build must not leave the old one in place: that is precisely the
+			// state this function exists to remove.
+			pc.client.Jar = nil
+		}
+	}
+
+	slog.Debug("discarded browser-seeded auth state after opt-out", "provider", pc.config.ID)
 }

--- a/internal/providers/auth.go
+++ b/internal/providers/auth.go
@@ -82,7 +82,7 @@ func (rt *Runtime) runPreflight(ctx context.Context, pc *providerClient, vars ma
 	// browser-derived — the conservative reading, and the one #534 exists to
 	// replace with a recorded one.
 	if loadCachedCookies(pc.client, resolvedURL) {
-		pc.browserSeeded = true
+		pc.browserSeeded.Store(true)
 	}
 
 	resp, body, err := doPreflightRequest(ctx, pc.client, &resolvedAuth)
@@ -108,7 +108,7 @@ func (rt *Runtime) runPreflight(ctx context.Context, pc *providerClient, vars ma
 	if needsBrowserCookieFallback(resp.StatusCode, extracted, resolvedAuth.Extractions) {
 		// Tier 3a: read cookies from user's browser (kooky).
 		if tryBrowserCookieRetry(ctx, pc, &resolvedAuth) {
-			pc.browserSeeded = true
+			pc.browserSeeded.Store(true)
 			saveCachedCookies(pc.client, resolvedURL)
 			pc.lastPreflightURL = resolvedURL
 			pc.authExpiry = time.Now().Add(pc.effectiveCacheTTL())
@@ -124,7 +124,7 @@ func (rt *Runtime) runPreflight(ctx context.Context, pc *providerClient, vars ma
 		// Tier 4: last-resort escape hatch — open in browser.
 		if resolvedAuth.BrowserEscapeHatch && isInteractive(ctx) {
 			if tryBrowserEscapeHatch(ctx, pc, &resolvedAuth) {
-				pc.browserSeeded = true
+				pc.browserSeeded.Store(true)
 				saveCachedCookies(pc.client, resolvedURL)
 				pc.lastPreflightURL = resolvedURL
 				pc.authExpiry = time.Now().Add(pc.effectiveCacheTTL())
@@ -184,7 +184,7 @@ func replaceAuthValuesLocked(ctx context.Context, pc *providerClient, auth *Auth
 // true on HTTP 2xx + successful extraction. The auth parameter carries the
 // resolved (city-specific) preflight URL.
 func tryBrowserCookieRetry(ctx context.Context, pc *providerClient, auth *AuthConfig) bool {
-	if !applyBrowserCookies(pc.client, auth.PreflightURL, pc.config.Cookies.Browser) {
+	if !applyBrowserCookies(pc, auth.PreflightURL, pc.config.Cookies.Browser) {
 		return false
 	}
 	resp2, body2, err2 := doPreflightRequest(ctx, pc.client, auth)
@@ -349,6 +349,9 @@ func finishEscapeHatch(ctx context.Context, pc *providerClient, auth *AuthConfig
 	}
 	if len(fresh) > 0 {
 		pc.client.Jar.SetCookies(u, fresh)
+		// Recovered from the user's own browser window, so the jar is now
+		// browser-seeded whether or not the retry below succeeds.
+		pc.browserSeeded.Store(true)
 	}
 
 	resp2, body2, err2 := doPreflightRequest(ctx, pc.client, auth)
@@ -599,7 +602,17 @@ func isAkamaiChallenge(statusCode int, body []byte) bool {
 // URL and seeds them into the client's cookie jar. When browserHint is
 // non-empty, reads only from that specific browser to avoid cross-browser
 // cookie contamination. Returns true if any cookies were applied.
-func applyBrowserCookies(client *http.Client, targetURL, browserHint string) bool {
+// It takes the providerClient rather than the bare client because marking the
+// jar as browser-seeded IS the point of this function's second half: round 7 of
+// review found the flag set at three call sites and missing at four others,
+// which is the caller-instead-of-seam mistake every round of this branch has
+// caught. There is one place browser cookies enter a provider jar, and this is
+// it, so the provenance is recorded here where it cannot be forgotten.
+func applyBrowserCookies(pc *providerClient, targetURL, browserHint string) bool {
+	if pc == nil || pc.client == nil {
+		return false
+	}
+	client := pc.client
 	if client == nil || client.Jar == nil {
 		return false
 	}
@@ -613,6 +626,7 @@ func applyBrowserCookies(client *http.Client, targetURL, browserHint string) boo
 		return false
 	}
 	client.Jar.SetCookies(u, cookies)
+	pc.browserSeeded.Store(true)
 	slog.Debug("applied browser cookies to preflight client", "url", targetURL, "count", len(cookies))
 	return true
 }
@@ -708,14 +722,14 @@ func discardBrowserSeededAuth(pc *providerClient) {
 	pc.authMu.Lock()
 	defer pc.authMu.Unlock()
 
-	if !pc.browserSeeded {
+	if !pc.browserSeeded.Load() {
 		return
 	}
 
 	pc.authValues = nil
 	pc.authExpiry = time.Time{}
 	pc.lastPreflightURL = ""
-	pc.browserSeeded = false
+	pc.browserSeeded.Store(false)
 
 	if pc.client != nil {
 		if jar, err := cookiejar.New(nil); err == nil {

--- a/internal/providers/auth.go
+++ b/internal/providers/auth.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"net/http/cookiejar"
 	"net/url"
 	"regexp"
 	"strings"
@@ -80,10 +79,9 @@ func (rt *Runtime) runPreflight(ctx context.Context, pc *providerClient, vars ma
 	// This makes browser escape hatch a one-time setup rather than per-search.
 	// The file carries no provenance, so anything it yields is treated as
 	// browser-derived — the conservative reading, and the one #534 exists to
-	// replace with a recorded one.
-	if loadCachedCookies(pc.client, resolvedURL) {
-		pc.browserSeeded.Store(true)
-	}
+	// replace with a recorded one. loadCachedCookies records that itself, on the
+	// vault, in the same critical section it commits the cookies in.
+	loadCachedCookies(pc.client, resolvedURL)
 
 	resp, body, err := doPreflightRequest(ctx, pc.client, &resolvedAuth)
 	if err != nil {
@@ -108,7 +106,6 @@ func (rt *Runtime) runPreflight(ctx context.Context, pc *providerClient, vars ma
 	if needsBrowserCookieFallback(resp.StatusCode, extracted, resolvedAuth.Extractions) {
 		// Tier 3a: read cookies from user's browser (kooky).
 		if tryBrowserCookieRetry(ctx, pc, &resolvedAuth) {
-			pc.browserSeeded.Store(true)
 			saveCachedCookies(pc.client, resolvedURL)
 			pc.lastPreflightURL = resolvedURL
 			pc.authExpiry = time.Now().Add(pc.effectiveCacheTTL())
@@ -124,7 +121,6 @@ func (rt *Runtime) runPreflight(ctx context.Context, pc *providerClient, vars ma
 		// Tier 4: last-resort escape hatch — open in browser.
 		if resolvedAuth.BrowserEscapeHatch && isInteractive(ctx) {
 			if tryBrowserEscapeHatch(ctx, pc, &resolvedAuth) {
-				pc.browserSeeded.Store(true)
 				saveCachedCookies(pc.client, resolvedURL)
 				pc.lastPreflightURL = resolvedURL
 				pc.authExpiry = time.Now().Add(pc.effectiveCacheTTL())
@@ -348,10 +344,13 @@ func finishEscapeHatch(ctx context.Context, pc *providerClient, auth *AuthConfig
 		return false
 	}
 	if len(fresh) > 0 {
-		pc.client.Jar.SetCookies(u, fresh)
-		// Recovered from the user's own browser window, so the jar is now
-		// browser-seeded whether or not the retry below succeeds.
-		pc.browserSeeded.Store(true)
+		// Recovered from the user's own browser window, so this is a browser
+		// seed and is recorded as one whether or not the retry below succeeds.
+		// A vault is required, and a decline during the window the user spent
+		// clearing the challenge means these cookies are simply not taken.
+		if !vaultOf(pc.client).seedFromBrowser(u, fresh) {
+			return false
+		}
 	}
 
 	resp2, body2, err2 := doPreflightRequest(ctx, pc.client, auth)
@@ -612,8 +611,11 @@ func applyBrowserCookies(pc *providerClient, targetURL, browserHint string) bool
 	if pc == nil || pc.client == nil {
 		return false
 	}
-	client := pc.client
-	if client == nil || client.Jar == nil {
+	// Fail closed: browser cookies only enter a jar that can revoke them. A
+	// plain jar would take them and keep them past a decline, which is the
+	// whole failure this branch exists to remove.
+	vault := vaultOf(pc.client)
+	if vault == nil {
 		return false
 	}
 	cookies := browserCookiesForURLWithHint(targetURL, browserHint)
@@ -625,8 +627,12 @@ func applyBrowserCookies(pc *providerClient, targetURL, browserHint string) bool
 	if err != nil {
 		return false
 	}
-	client.Jar.SetCookies(u, cookies)
-	pc.browserSeeded.Store(true)
+	// The read above takes seconds; the user may have declined during it. The
+	// vault re-checks that under the same lock it commits under, so a read that
+	// began before the opt-out cannot land after it.
+	if !vault.seedFromBrowser(u, cookies) {
+		return false
+	}
 	slog.Debug("applied browser cookies to preflight client", "url", targetURL, "count", len(cookies))
 	return true
 }
@@ -722,25 +728,17 @@ func discardBrowserSeededAuth(pc *providerClient) {
 	pc.authMu.Lock()
 	defer pc.authMu.Unlock()
 
-	if !pc.browserSeeded.Load() {
+	// The jar goes first, and it decides. It holds the provenance under the same
+	// lock it commits cookies under, so this cannot observe "not seeded" while a
+	// browser read that is already in flight is about to make it so: that read
+	// re-checks the decline before committing and will now take nothing.
+	if !vaultOf(pc.client).discardBrowserSeeded() {
 		return
 	}
 
 	pc.authValues = nil
 	pc.authExpiry = time.Time{}
 	pc.lastPreflightURL = ""
-	pc.browserSeeded.Store(false)
-
-	if pc.client != nil {
-		if jar, err := cookiejar.New(nil); err == nil {
-			pc.client.Jar = jar
-		} else {
-			// Unreachable with a nil options argument, but a jar that failed to
-			// build must not leave the old one in place: that is precisely the
-			// state this function exists to remove.
-			pc.client.Jar = nil
-		}
-	}
 
 	slog.Debug("discarded browser-seeded auth state after opt-out", "provider", pc.config.ID)
 }

--- a/internal/providers/auth_cache_decline_test.go
+++ b/internal/providers/auth_cache_decline_test.go
@@ -3,7 +3,6 @@ package providers
 import (
 	"context"
 	"net/http"
-	"net/http/cookiejar"
 	"net/url"
 	"testing"
 	"time"
@@ -28,29 +27,30 @@ func TestAuthCacheDiscardsBrowserSeededStateAfterADecline(t *testing.T) {
 	const preflight = "https://example.test/preflight"
 
 	newPC := func() *providerClient {
-		jar, err := cookiejar.New(nil)
-		if err != nil {
-			t.Fatalf("cookiejar: %v", err)
+		vault := newCookieVault()
+		if vault == nil {
+			t.Fatal("cookie vault")
 		}
 		u, err := url.Parse(preflight)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
 		}
-		// A cookie of the kind the browser tiers seed: this is the material
-		// that must stop being sent.
-		jar.SetCookies(u, []*http.Cookie{{Name: "datadome", Value: "from-the-users-browser"}})
+		// Seeded through the browser path, so the jar records the provenance
+		// itself. This is the material that must stop being sent.
+		if !vault.seedFromBrowser(u, []*http.Cookie{{Name: "datadome", Value: "from-the-users-browser"}}) {
+			t.Fatal("fixture did not seed browser cookies")
+		}
 
 		pc := &providerClient{
 			config: &ProviderConfig{
 				ID:   "test-auth-cache-decline",
 				Auth: &AuthConfig{PreflightURL: preflight},
 			},
-			client:           &http.Client{Jar: jar},
+			client:           &http.Client{Jar: vault},
 			authValues:       map[string]string{"token": "seeded-from-browser"},
 			authExpiry:       time.Now().Add(time.Hour),
 			lastPreflightURL: preflight,
 		}
-		pc.browserSeeded.Store(true)
 		return pc
 	}
 
@@ -83,7 +83,7 @@ func TestAuthCacheDiscardsBrowserSeededStateAfterADecline(t *testing.T) {
 		pc.authMu.RLock()
 		defer pc.authMu.RUnlock()
 
-		if pc.browserSeeded.Load() {
+		if pc.isBrowserSeeded() {
 			t.Error("the client is still marked browser-seeded after the decline")
 		}
 		if len(pc.authValues) != 0 {
@@ -112,16 +112,23 @@ func TestAuthCacheDiscardsBrowserSeededStateAfterADecline(t *testing.T) {
 func TestAuthCacheKeepsNonBrowserStateAfterADecline(t *testing.T) {
 	const preflight = "https://example.test/preflight"
 
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		t.Fatalf("cookiejar: %v", err)
+	// A vault, but one no browser ever touched: cookies arrived the ordinary
+	// way, via Set-Cookie. The vault must tell the two apart.
+	vault := newCookieVault()
+	if vault == nil {
+		t.Fatal("cookie vault")
 	}
+	u, err := url.Parse(preflight)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	vault.SetCookies(u, []*http.Cookie{{Name: "session", Value: "from-an-ordinary-preflight"}})
 	pc := &providerClient{
 		config: &ProviderConfig{
 			ID:   "test-auth-cache-decline-keep",
 			Auth: &AuthConfig{PreflightURL: preflight},
 		},
-		client:           &http.Client{Jar: jar},
+		client:           &http.Client{Jar: vault},
 		authValues:       map[string]string{"token": "from-an-ordinary-preflight"},
 		authExpiry:       time.Now().Add(time.Hour),
 		lastPreflightURL: preflight,

--- a/internal/providers/auth_cache_decline_test.go
+++ b/internal/providers/auth_cache_decline_test.go
@@ -40,7 +40,7 @@ func TestAuthCacheDiscardsBrowserSeededStateAfterADecline(t *testing.T) {
 		// that must stop being sent.
 		jar.SetCookies(u, []*http.Cookie{{Name: "datadome", Value: "from-the-users-browser"}})
 
-		return &providerClient{
+		pc := &providerClient{
 			config: &ProviderConfig{
 				ID:   "test-auth-cache-decline",
 				Auth: &AuthConfig{PreflightURL: preflight},
@@ -49,8 +49,9 @@ func TestAuthCacheDiscardsBrowserSeededStateAfterADecline(t *testing.T) {
 			authValues:       map[string]string{"token": "seeded-from-browser"},
 			authExpiry:       time.Now().Add(time.Hour),
 			lastPreflightURL: preflight,
-			browserSeeded:    true,
 		}
+		pc.browserSeeded.Store(true)
+		return pc
 	}
 
 	rt := NewRuntime(nil)
@@ -82,7 +83,7 @@ func TestAuthCacheDiscardsBrowserSeededStateAfterADecline(t *testing.T) {
 		pc.authMu.RLock()
 		defer pc.authMu.RUnlock()
 
-		if pc.browserSeeded {
+		if pc.browserSeeded.Load() {
 			t.Error("the client is still marked browser-seeded after the decline")
 		}
 		if len(pc.authValues) != 0 {
@@ -124,7 +125,6 @@ func TestAuthCacheKeepsNonBrowserStateAfterADecline(t *testing.T) {
 		authValues:       map[string]string{"token": "from-an-ordinary-preflight"},
 		authExpiry:       time.Now().Add(time.Hour),
 		lastPreflightURL: preflight,
-		browserSeeded:    false,
 	}
 
 	t.Setenv(consent.CookiesEnv, "1")

--- a/internal/providers/auth_cache_decline_test.go
+++ b/internal/providers/auth_cache_decline_test.go
@@ -1,0 +1,139 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/consent"
+)
+
+// TestAuthCacheDiscardsBrowserSeededStateAfterADecline pins the seventh path of
+// this family, and the first that never touches disk or a browser process.
+//
+// The auth cache is in-memory and `trvl mcp` is long-lived, so a jar seeded
+// from the user's browser survives the moment it was permitted. Every later
+// call for the same URL returns from the cache above the guarded readers, and
+// the browser-derived cookies keep going out on the wire — the setting looks
+// applied and nothing about the traffic changes. That is the shape of the disk
+// cache bypass, moved into memory.
+//
+// The test is ordered around a CONTROL: it asserts the cached auth IS served
+// while nothing is declined, so the assertion afterwards is about the decline
+// rather than about a cache that was never warm.
+func TestAuthCacheDiscardsBrowserSeededStateAfterADecline(t *testing.T) {
+	const preflight = "https://example.test/preflight"
+
+	newPC := func() *providerClient {
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("cookiejar: %v", err)
+		}
+		u, err := url.Parse(preflight)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		// A cookie of the kind the browser tiers seed: this is the material
+		// that must stop being sent.
+		jar.SetCookies(u, []*http.Cookie{{Name: "datadome", Value: "from-the-users-browser"}})
+
+		return &providerClient{
+			config: &ProviderConfig{
+				ID:   "test-auth-cache-decline",
+				Auth: &AuthConfig{PreflightURL: preflight},
+			},
+			client:           &http.Client{Jar: jar},
+			authValues:       map[string]string{"token": "seeded-from-browser"},
+			authExpiry:       time.Now().Add(time.Hour),
+			lastPreflightURL: preflight,
+			browserSeeded:    true,
+		}
+	}
+
+	rt := NewRuntime(nil)
+
+	// CONTROL. Warm, unexpired, same URL: the cache must be served. Without
+	// this the assertion below could pass against a cache that never hit — for
+	// instance if the fixture's expiry or URL were wrong.
+	t.Run("served while nothing is declined", func(t *testing.T) {
+		pc := newPC()
+		got, err := rt.runPreflight(context.Background(), pc, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["token"] != "seeded-from-browser" {
+			t.Fatalf("the fixture did not produce a cache hit, so the decline case would prove nothing: got %v", got)
+		}
+	})
+
+	t.Run("discarded once the user declines", func(t *testing.T) {
+		pc := newPC()
+		t.Setenv(consent.CookiesEnv, "1")
+
+		// runPreflight will now try a real preflight against a host that does
+		// not resolve, and fail. The error is not what is being tested: the
+		// state left behind is. Reaching the network at all is itself part of
+		// the evidence, because a served cache would have returned before it.
+		_, _ = rt.runPreflight(context.Background(), pc, nil)
+
+		pc.authMu.RLock()
+		defer pc.authMu.RUnlock()
+
+		if pc.browserSeeded {
+			t.Error("the client is still marked browser-seeded after the decline")
+		}
+		if len(pc.authValues) != 0 {
+			t.Errorf("browser-derived auth values survived the decline: %v", pc.authValues)
+		}
+		if !pc.authExpiry.IsZero() {
+			t.Errorf("the auth cache is still live after the decline: expiry = %v", pc.authExpiry)
+		}
+		u, err := url.Parse(preflight)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if pc.client.Jar == nil {
+			t.Fatal("the jar was removed rather than replaced, which silently drops Set-Cookie")
+		}
+		if cs := pc.client.Jar.Cookies(u); len(cs) != 0 {
+			t.Errorf("browser-derived cookies are still in the jar and would still be sent: %v", cs)
+		}
+	})
+}
+
+// TestAuthCacheKeepsNonBrowserStateAfterADecline is the other half: a session
+// that was never seeded from the browser is none of the setting's business.
+// Discarding it would punish a user for a control that says nothing about it,
+// and would turn the opt-out into a general cache-buster.
+func TestAuthCacheKeepsNonBrowserStateAfterADecline(t *testing.T) {
+	const preflight = "https://example.test/preflight"
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar: %v", err)
+	}
+	pc := &providerClient{
+		config: &ProviderConfig{
+			ID:   "test-auth-cache-decline-keep",
+			Auth: &AuthConfig{PreflightURL: preflight},
+		},
+		client:           &http.Client{Jar: jar},
+		authValues:       map[string]string{"token": "from-an-ordinary-preflight"},
+		authExpiry:       time.Now().Add(time.Hour),
+		lastPreflightURL: preflight,
+		browserSeeded:    false,
+	}
+
+	t.Setenv(consent.CookiesEnv, "1")
+
+	got, err := (NewRuntime(nil)).runPreflight(context.Background(), pc, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["token"] != "from-an-ordinary-preflight" {
+		t.Errorf("a session that never touched the browser was discarded by the browser opt-out: got %v", got)
+	}
+}

--- a/internal/providers/browser_cookie_optout_test.go
+++ b/internal/providers/browser_cookie_optout_test.go
@@ -1,0 +1,55 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/cookies"
+)
+
+// TestInPackageReadersHonourTheOptOut covers the paths provider recovery code
+// actually takes, not just the exported wrapper. Search recovery reaches the
+// kooky reader through currentCookieSource, through the browser-hint variant,
+// and through the background pre-warm helper — none of which go via
+// BrowserCookiesForURL. Gating only the exported name would leave a control
+// that reads correct and behaves wrong.
+//
+// TRVL_ALLOW_BROWSER_COOKIES is set deliberately: without it the test-binary
+// guard returns nil on its own and every assertion below would pass whether the
+// opt-out existed or not. With it set, nil can only come from the opt-out, so
+// deleting the gate makes these subtests read the developer's real cookie
+// stores and fail.
+func TestInPackageReadersHonourTheOptOut(t *testing.T) {
+	t.Setenv("TRVL_ALLOW_BROWSER_COOKIES", "1")
+	t.Setenv(cookies.DisableEnv, "1")
+
+	const target = "https://www.booking.com/"
+
+	// Counts only. A cookie value is a live session and this test runs against
+	// real stores when the gate is broken; printing one would publish it into a
+	// terminal or a CI log.
+	t.Run("currentCookieSource", func(t *testing.T) {
+		if got := currentCookieSource(target); got != nil {
+			t.Fatalf("opt-out set, still got %d cookies through currentCookieSource", len(got))
+		}
+	})
+
+	t.Run("browserHintPath", func(t *testing.T) {
+		for _, hint := range []string{"brave", "chrome"} {
+			if got := browserCookiesForURLWithHint(target, hint); got != nil {
+				t.Errorf("opt-out set, still got %d cookies with hint %q", len(got), hint)
+			}
+		}
+	})
+
+	t.Run("prewarmReader", func(t *testing.T) {
+		if got := readBrowserCookiesDirect(target, ""); got != nil {
+			t.Fatalf("opt-out set, still got %d cookies through the pre-warm reader", len(got))
+		}
+	})
+
+	t.Run("exportedWrapper", func(t *testing.T) {
+		if got := BrowserCookiesForURL(target); got != nil {
+			t.Fatalf("opt-out set, still got %d cookies through BrowserCookiesForURL", len(got))
+		}
+	})
+}

--- a/internal/providers/browser_read_decline_test.go
+++ b/internal/providers/browser_read_decline_test.go
@@ -1,0 +1,88 @@
+package providers
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/consent"
+)
+
+// TestWarmCacheCookiesRefusedAfterADecline pins the eleventh path of this
+// family, and the reason the fix moved from the call sites to the reader.
+//
+// Every browser read in this package used to decide the consent question on the
+// way IN. Reading a browser takes seconds — Keychain unlock, a cold profile, a
+// window the user has to clear by hand — so a decline arriving during the read
+// lost: the entry check had already passed, the read finished afterwards, and
+// the credentials went out. Review found that shape in the vault (round 8) and
+// then again in the Booking.com room fetch (round 11), which took the result of
+// one of these readers and put it straight into a Cookie header.
+//
+// The warm cache is the sharpest version of it: the read completed BEFORE the
+// user declined and the cookies are already sitting in memory, so nothing about
+// the entry check even applies. The gate therefore has to be on the way out.
+func TestWarmCacheCookiesRefusedAfterADecline(t *testing.T) {
+	const target = "https://example.test/search"
+
+	// A read that has already finished, exactly as the background pre-warm
+	// goroutine leaves it.
+	prime := func(t *testing.T) {
+		t.Helper()
+		done := make(chan struct{})
+		close(done)
+		entry := &warmCacheEntry{
+			cookies: []*http.Cookie{{Name: "datadome", Value: "from-the-users-browser"}},
+			done:    done,
+		}
+		key := warmCacheKey(target, "")
+		warmCache.mu.Lock()
+		warmCache.entries[key] = entry
+		warmCache.mu.Unlock()
+		t.Cleanup(func() {
+			warmCache.mu.Lock()
+			delete(warmCache.entries, key)
+			warmCache.mu.Unlock()
+		})
+	}
+
+	// CONTROL. Nothing declined: the warm result must come back, or the decline
+	// case below would be passing against a cache that never returns anything.
+	t.Run("returned while nothing is declined", func(t *testing.T) {
+		prime(t)
+		got := warmBrowserCookiesResult(target, "", time.Second)
+		if len(got) != 1 || got[0].Value != "from-the-users-browser" {
+			t.Fatalf("the fixture returned nothing, so the decline case would prove nothing: %v", got)
+		}
+	})
+
+	t.Run("refused once the user declines", func(t *testing.T) {
+		prime(t)
+		t.Setenv(consent.CookiesEnv, "1")
+
+		// These cookies were read before the decline and are already in memory.
+		// They still must not be handed to a caller that will send them.
+		if got := warmBrowserCookiesResult(target, "", time.Second); len(got) != 0 {
+			t.Errorf("browser cookies read before the opt-out survived it: %v", got)
+		}
+	})
+}
+
+// TestPermittedAfterReadIsTheGate covers the helper itself, because it is now
+// the single place every browser reader in this package leaves through.
+func TestPermittedAfterReadIsTheGate(t *testing.T) {
+	harvested := []*http.Cookie{{Name: "datadome", Value: "from-the-users-browser"}}
+
+	t.Run("passed through while nothing is declined", func(t *testing.T) {
+		if got := permittedAfterRead(harvested); len(got) != 1 {
+			t.Fatalf("the read was dropped with no opt-out in force: %v", got)
+		}
+	})
+
+	t.Run("dropped once the user declines", func(t *testing.T) {
+		t.Setenv(consent.CookiesEnv, "1")
+		if got := permittedAfterRead(harvested); got != nil {
+			t.Errorf("a browser read that finished before the opt-out survived it: %v", got)
+		}
+	})
+}

--- a/internal/providers/challenge.go
+++ b/internal/providers/challenge.go
@@ -119,8 +119,10 @@ var cdpChallengeRunner = runCDPChallenge
 //     harvested cookies to the ~/.trvl/cookies cache for Tier-1 reuse, and
 //     returns ChallengeCleared.
 //
-// Like RefreshCookiesViaCDP it is gated: without the opt-in (TRVL_TIER2_CDP=1 or
-// WithTier2Force) it returns ErrTier2Disabled. It reuses the Tier2Option set so
+// Gating: the path runs by default and returns ErrTier2Disabled when the user
+// declined it (TRVL_NO_TIER2_CDP, or TRVL_TIER2_CDP=0) unless WithTier2Force is
+// used. It also refuses inside a `go test` binary, so the suite stays offline;
+// TRVL_ALLOW_BROWSER_COOKIES lifts that. It reuses the Tier2Option set so
 // callers configure it the same way as the lower-level CDP refresh.
 func ResolveChallenge(ctx context.Context, targetURL string, opts ...Tier2Option) (*ChallengeResult, error) {
 	cfg := tier2Config{challengeWait: defaultChallengeWait}
@@ -171,6 +173,12 @@ func ResolveChallenge(ctx context.Context, targetURL string, opts ...Tier2Option
 // stolen (Headless + DefaultExecAllocatorOptions; no activation/foreground
 // flags).
 func runCDPChallenge(ctx context.Context, execPath, targetURL string, challengeWait time.Duration) ([]*network.Cookie, string, error) {
+	// Same reason as runCDPCollect: with Tier-2 on by default, the driver is
+	// what must refuse inside a test binary, so stubbed tests still run.
+	if os.Getenv("TRVL_ALLOW_BROWSER_COOKIES") == "" && isTestBinary() {
+		return nil, "", ErrTier2Disabled
+	}
+
 	allocOpts := append([]chromedp.ExecAllocatorOption{},
 		chromedp.DefaultExecAllocatorOptions[:]...)
 	allocOpts = append(allocOpts,

--- a/internal/providers/challenge.go
+++ b/internal/providers/challenge.go
@@ -120,8 +120,8 @@ var cdpChallengeRunner = runCDPChallenge
 //     returns ChallengeCleared.
 //
 // Gating: the path runs by default and returns ErrTier2Disabled when the user
-// declined it (TRVL_NO_TIER2_CDP, or TRVL_TIER2_CDP=0) unless WithTier2Force is
-// used. It also refuses inside a `go test` binary, so the suite stays offline;
+// declined it (TRVL_NO_TIER2_CDP, or TRVL_TIER2_CDP=0). It also refuses inside
+// a `go test` binary, so the suite stays offline;
 // TRVL_ALLOW_BROWSER_COOKIES lifts that. It reuses the Tier2Option set so
 // callers configure it the same way as the lower-level CDP refresh.
 func ResolveChallenge(ctx context.Context, targetURL string, opts ...Tier2Option) (*ChallengeResult, error) {
@@ -130,7 +130,8 @@ func ResolveChallenge(ctx context.Context, targetURL string, opts ...Tier2Option
 		o(&cfg)
 	}
 
-	if !cfg.force && !Tier2Enabled() {
+	// An explicit decline is absolute; see RefreshCookiesViaCDP.
+	if Tier2Declined() {
 		return nil, ErrTier2Disabled
 	}
 
@@ -173,6 +174,13 @@ func ResolveChallenge(ctx context.Context, targetURL string, opts ...Tier2Option
 // stolen (Headless + DefaultExecAllocatorOptions; no activation/foreground
 // flags).
 func runCDPChallenge(ctx context.Context, execPath, targetURL string, challengeWait time.Duration) ([]*network.Cookie, string, error) {
+	// Same reason as runCDPCollect: an explicit decline is absolute and is
+	// enforced on the spawning function, so a caller that reaches past
+	// ResolveChallenge still cannot start a browser.
+	if Tier2Declined() {
+		return nil, "", ErrTier2Disabled
+	}
+
 	// Same reason as runCDPCollect: with Tier-2 on by default, the driver is
 	// what must refuse inside a test binary, so stubbed tests still run.
 	if os.Getenv("TRVL_ALLOW_BROWSER_COOKIES") == "" && isTestBinary() {
@@ -234,7 +242,5 @@ func defaultHeadlessFirstResolve(ctx context.Context, targetURL string) (*Challe
 	if os.Getenv("TRVL_ALLOW_BROWSER_COOKIES") == "" && isTestBinary() {
 		return nil, ErrTier2Disabled
 	}
-	// Force past the env opt-in: the Tier-4 caller has already gated this on
-	// per-provider BrowserEscapeHatch + an interactive context.
-	return ResolveChallenge(ctx, targetURL, WithTier2Force())
+	return ResolveChallenge(ctx, targetURL)
 }

--- a/internal/providers/challenge_test.go
+++ b/internal/providers/challenge_test.go
@@ -76,7 +76,7 @@ func TestResolveChallenge_NoBrowserFound(t *testing.T) {
 	fileExists = func(string) bool { return false }
 	defer func() { fileExists = prevExists }()
 
-	_, err := ResolveChallenge(context.Background(), "https://example.com/", WithTier2Force())
+	_, err := ResolveChallenge(context.Background(), "https://example.com/")
 	if !errors.Is(err, ErrNoBrowserFound) {
 		t.Fatalf("err = %v, want ErrNoBrowserFound", err)
 	}
@@ -94,7 +94,7 @@ func TestResolveChallenge_RunnerError(t *testing.T) {
 	}
 	defer func() { cdpChallengeRunner = prevRunner }()
 
-	_, err := ResolveChallenge(context.Background(), "https://example.com/", WithTier2Force())
+	_, err := ResolveChallenge(context.Background(), "https://example.com/")
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("err = %v, want boom", err)
 	}
@@ -121,7 +121,7 @@ func TestResolveChallenge_ClearedPersistsCookies(t *testing.T) {
 	defer func() { cdpChallengeRunner = prevRunner }()
 
 	target := "https://example.com/"
-	res, err := ResolveChallenge(context.Background(), target, WithTier2Force())
+	res, err := ResolveChallenge(context.Background(), target)
 	if err != nil {
 		t.Fatalf("ResolveChallenge: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestResolveChallenge_NeedsHumanDoesNotPersist(t *testing.T) {
 	defer func() { cdpChallengeRunner = prevRunner }()
 
 	target := "https://example.com/"
-	res, err := ResolveChallenge(context.Background(), target, WithTier2Force())
+	res, err := ResolveChallenge(context.Background(), target)
 	if err != nil {
 		t.Fatalf("ResolveChallenge: %v", err)
 	}

--- a/internal/providers/challenge_test.go
+++ b/internal/providers/challenge_test.go
@@ -64,7 +64,7 @@ func TestChallengeStatusString(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestResolveChallenge_DisabledByDefault(t *testing.T) {
-	t.Setenv(tier2EnableEnv, "")
+	t.Setenv(tier2DisableEnv, "1")
 	_, err := ResolveChallenge(context.Background(), "https://example.com/")
 	if !errors.Is(err, ErrTier2Disabled) {
 		t.Fatalf("err = %v, want ErrTier2Disabled", err)

--- a/internal/providers/challenge_test.go
+++ b/internal/providers/challenge_test.go
@@ -211,10 +211,11 @@ func TestTryBrowserEscapeHatch_HeadlessClears_NoVisibleWindow(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	jar, _ := cookiejar.New(nil)
+	// A vault: the escape-hatch tail seeds cookies recovered from the user's
+	// own browser window, and those only enter a jar that can revoke them.
 	pc := &providerClient{
 		config:     &ProviderConfig{ID: "headless-clear", Name: "HeadlessClear"},
-		client:     &http.Client{Jar: jar},
+		client:     &http.Client{Jar: newCookieVault()},
 		authValues: make(map[string]string),
 	}
 	auth := &AuthConfig{PreflightURL: srv.URL, BrowserEscapeHatch: true}

--- a/internal/providers/cookie_cache.go
+++ b/internal/providers/cookie_cache.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/consent"
 )
 
 const cookieCacheTTL = 24 * time.Hour
@@ -56,7 +58,26 @@ func cookieCachePath(domain string) (string, error) {
 // loadCachedCookies reads persisted cookies for a URL and seeds them into
 // the HTTP client's jar. Returns true if cookies were loaded and are fresh
 // (saved within cookieCacheTTL).
+//
+// It refuses everything when the user has declined browser cookie reads, and
+// that refusal is the fifth bypass of this branch's family -- found by review,
+// not by us. Cookies read out of the user's browser are WRITTEN here:
+// auth.go's tier-3 fallback calls saveCachedCookies right after
+// tryBrowserCookieRetry succeeds. So the decline stopped fresh reads while this
+// path kept replaying a previous harvest for the whole cache TTL. Setting the
+// variable would have looked like it worked and changed nothing for a day.
+//
+// It refuses the WHOLE cache, not the browser-derived entries, because this
+// file records no provenance: a cookie saved after an ordinary preflight and
+// one copied out of Chrome are the same three fields on disk. Distinguishing
+// them is the better fix and is filed separately; refusing all of them is the
+// one available now that cannot be wrong in the direction that matters. The
+// cost is a refetch, paid only by users who asked for exactly this.
 func loadCachedCookies(client *http.Client, targetURL string) bool {
+	if consent.CookiesDeclined() {
+		return false
+	}
+
 	u, err := url.Parse(targetURL)
 	if err != nil || u.Host == "" {
 		return false

--- a/internal/providers/cookie_cache.go
+++ b/internal/providers/cookie_cache.go
@@ -124,6 +124,15 @@ func loadCachedCookies(client *http.Client, targetURL string) bool {
 	}
 
 	if client.Jar != nil {
+		// The cache file carries no provenance, so its contents are treated as
+		// browser-derived (#534). On a provider client that means the vault
+		// records them as such, in the same critical section it commits them —
+		// a later opt-out then takes them back. A plain jar (the throwaway one
+		// CachedCookiesForURL builds to read the file) has nothing to record on
+		// and nothing to revoke, so it just takes them.
+		if v := vaultOf(client); v != nil {
+			return v.seedFromBrowser(u, cookies)
+		}
 		client.Jar.SetCookies(u, cookies)
 		slog.Debug("cookie cache: loaded", "domain", u.Host, "count", len(cookies))
 		return true

--- a/internal/providers/cookie_cache_decline_test.go
+++ b/internal/providers/cookie_cache_decline_test.go
@@ -1,0 +1,66 @@
+package providers
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/consent"
+)
+
+// TestCachedCookiesAreRefusedAfterADecline pins the fifth bypass of this
+// family, and the only one that survived a decline being set correctly.
+//
+// Cookies read out of the user's browser get PERSISTED: auth.go's tier-3
+// fallback calls saveCachedCookies as soon as tryBrowserCookieRetry succeeds.
+// Every read of that file went through loadCachedCookies, which asked nobody's
+// permission. So a user who ran trvl once, then set TRVL_NO_BROWSER_COOKIES,
+// kept sending their harvested browser cookies for the whole 24-hour cache TTL.
+// The setting looked like it worked. Nothing about the requests changed.
+//
+// The control case below is load-bearing and is why the test is written in this
+// order: it proves the fixture actually wrote a cache file that CAN be loaded.
+// Without it, a typo in the temporary HOME would make the decline case pass
+// against a cache that was never there -- which is exactly how the first draft
+// of the hotel test in this branch fooled itself.
+func TestCachedCookiesAreRefusedAfterADecline(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const target = "https://www.thetrainline.com/search"
+	u, err := url.Parse(target)
+	if err != nil {
+		t.Fatalf("parsing the test URL: %v", err)
+	}
+
+	seed, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("building the seed jar: %v", err)
+	}
+	seed.SetCookies(u, []*http.Cookie{{Name: "session", Value: "harvested-from-the-browser"}})
+	saveCachedCookies(&http.Client{Jar: seed}, target)
+
+	// Control: the cache is real and loadable when nothing has been declined.
+	if !loadCachedCookies(freshClient(t), target) {
+		t.Fatal("the fixture wrote no loadable cache, so the decline case below would prove nothing")
+	}
+
+	t.Setenv(consent.CookiesEnv, "1")
+
+	client := freshClient(t)
+	if loadCachedCookies(client, target) {
+		t.Error("the persisted cookies were loaded despite the decline; the cache replays a browser harvest the user asked us to stop")
+	}
+	if got := client.Jar.Cookies(u); len(got) != 0 {
+		t.Errorf("the jar was seeded anyway: %d cookie(s) reached the request, want 0", len(got))
+	}
+}
+
+func freshClient(t *testing.T) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("building a jar: %v", err)
+	}
+	return &http.Client{Jar: jar}
+}

--- a/internal/providers/cookie_vault.go
+++ b/internal/providers/cookie_vault.go
@@ -1,0 +1,152 @@
+package providers
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"sync"
+
+	"github.com/MikkoParkkola/trvl/internal/cookies"
+)
+
+// cookieVault is the cookie jar a providerClient uses. It is an http.CookieJar,
+// so net/http drives it exactly like the standard jar, and it adds the two
+// operations the browser opt-out needs: seed-with-provenance and revoke.
+//
+// Round 8 of review found the reason it has to be a jar rather than a flag next
+// to one. The previous shape stored provenance in an atomic on the client and
+// revoked by assigning a fresh jar over pc.client.Jar. That has two defects and
+// they compound:
+//
+//   - Seeding and revocation took no common lock. A search that had already
+//     started reading the user's browser could commit its cookies *after* a
+//     decline had run, and the discard — having seen the flag still false —
+//     had already returned. The setting appeared applied while browser cookies
+//     kept going out.
+//   - Replacing pc.client.Jar is a write to a pointer that in-flight requests
+//     read inside http.Client.send. A data race, not merely a logical one.
+//
+// Both die if the jar is installed once and never reassigned, and if entering
+// and leaving are the same critical section. Revocation swaps the *inner* jar
+// while the vault address the client holds stays fixed; the decline is
+// re-checked under the lock immediately before cookies are committed, so a read
+// that began before the opt-out cannot land after it.
+//
+// Only browser-derived cookies are tracked. An ordinary preflight session never
+// touched the user's browser, and discarding it would make a browser control
+// into a general cache-buster.
+type cookieVault struct {
+	mu            sync.Mutex
+	jar           http.CookieJar
+	browserSeeded bool
+}
+
+// newCookieVault returns a vault wrapping a fresh standard jar. It returns nil
+// only if the standard jar cannot be built, which cookiejar.New does not do for
+// nil options; callers treat nil as "no vault" and refuse to seed.
+func newCookieVault() *cookieVault {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil
+	}
+	return &cookieVault{jar: jar}
+}
+
+// SetCookies implements http.CookieJar. This is the ordinary server-driven
+// path: Set-Cookie headers from responses. It records no provenance, because
+// none of it came from the user's browser.
+func (v *cookieVault) SetCookies(u *url.URL, list []*http.Cookie) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.jar.SetCookies(u, list)
+}
+
+// Cookies implements http.CookieJar.
+func (v *cookieVault) Cookies(u *url.URL) []*http.Cookie {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.jar.Cookies(u)
+}
+
+// seedFromBrowser commits cookies that came from the user's browser — read live
+// via kooky/CDP, recovered from a browser window, or restored from the on-disk
+// cache, which carries no provenance and so is treated as browser-derived
+// (#534) — and records that provenance in the same critical section.
+//
+// The decline is re-checked here, under the lock, rather than only at the call
+// site: the browser read that produced these cookies takes seconds, and the
+// user may have declined during it. Returns false when nothing was committed.
+func (v *cookieVault) seedFromBrowser(u *url.URL, list []*http.Cookie) bool {
+	if v == nil || u == nil || len(list) == 0 {
+		return false
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if cookies.Disabled() {
+		return false
+	}
+	v.jar.SetCookies(u, list)
+	v.browserSeeded = true
+	return true
+}
+
+// discardBrowserSeeded drops every cookie in the vault if any of them came from
+// the browser, and clears the provenance. Returns true when something was
+// discarded.
+//
+// The whole jar goes, not the browser-derived entries alone: net/http/cookiejar
+// exposes no removal, and a WAF session is a single interdependent set anyway —
+// the token that was harvested and the token minted in reply to it are not
+// separable. Replacing the inner jar is safe here in a way replacing the client's
+// jar was not, because the client's pointer never changes.
+func (v *cookieVault) discardBrowserSeeded() bool {
+	if v == nil {
+		return false
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if !v.browserSeeded {
+		return false
+	}
+	var next http.CookieJar
+	if jar, err := cookiejar.New(nil); err == nil {
+		next = jar
+	} else {
+		// Unreachable with nil options. Leaving the old jar in place would keep
+		// exactly the cookies this call exists to remove, so an empty stand-in
+		// that still accepts Set-Cookie is the safe failure.
+		next = emptyJar{}
+	}
+	v.jar = next
+	v.browserSeeded = false
+	return true
+}
+
+// isBrowserSeeded reports whether the vault currently holds browser-derived
+// cookies.
+func (v *cookieVault) isBrowserSeeded() bool {
+	if v == nil {
+		return false
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.browserSeeded
+}
+
+// emptyJar is the last-resort stand-in described in discardBrowserSeeded. It
+// accepts and forgets, which keeps requests working without retaining anything.
+type emptyJar struct{}
+
+func (emptyJar) SetCookies(*url.URL, []*http.Cookie) {}
+func (emptyJar) Cookies(*url.URL) []*http.Cookie     { return nil }
+
+// vaultOf returns the vault backing a client's jar, or nil when the client uses
+// a plain jar. Browser seeding refuses to proceed on a nil vault: cookies from
+// the user's browser only ever enter a jar that can give them back.
+func vaultOf(client *http.Client) *cookieVault {
+	if client == nil {
+		return nil
+	}
+	v, _ := client.Jar.(*cookieVault)
+	return v
+}

--- a/internal/providers/cookie_vault_decline_test.go
+++ b/internal/providers/cookie_vault_decline_test.go
@@ -1,0 +1,117 @@
+package providers
+
+import (
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/consent"
+)
+
+// TestBrowserSeedCannotLandAfterADecline pins the eighth path of this family,
+// and the first that is a race rather than a missing check.
+//
+// Reading the user's browser takes seconds — Keychain unlock, a cold profile, a
+// window the user has to clear by hand. A decline that arrives during that read
+// used to lose: the revocation looked at a client that was not yet marked as
+// browser-seeded, found nothing to do, and returned; the read then finished and
+// committed its cookies into a jar nobody was going to check again. The setting
+// was applied and the browser cookies kept going out.
+//
+// So the check that matters is not the one at the call site before the read. It
+// is the one under the lock, immediately before the cookies are committed.
+func TestBrowserSeedCannotLandAfterADecline(t *testing.T) {
+	u, err := url.Parse("https://example.test/preflight")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	fromBrowser := []*http.Cookie{{Name: "datadome", Value: "from-the-users-browser"}}
+
+	// CONTROL. Nothing declined: the seed must land, or the assertion below
+	// would pass against a vault that simply never accepts anything.
+	t.Run("lands while nothing is declined", func(t *testing.T) {
+		v := newCookieVault()
+		if !v.seedFromBrowser(u, fromBrowser) {
+			t.Fatal("the seed was refused with no opt-out in force")
+		}
+		if len(v.Cookies(u)) == 0 {
+			t.Fatal("the fixture stored nothing, so the decline case would prove nothing")
+		}
+		if !v.isBrowserSeeded() {
+			t.Error("the provenance was not recorded")
+		}
+	})
+
+	t.Run("refused once the user declines", func(t *testing.T) {
+		v := newCookieVault()
+		t.Setenv(consent.CookiesEnv, "1")
+
+		// The read that produced these cookies began before the decline. It
+		// still must not commit them.
+		if v.seedFromBrowser(u, fromBrowser) {
+			t.Error("a browser read that started before the opt-out committed its cookies after it")
+		}
+		if cs := v.Cookies(u); len(cs) != 0 {
+			t.Errorf("browser-derived cookies are in the jar and would be sent: %v", cs)
+		}
+		if v.isBrowserSeeded() {
+			t.Error("the jar is marked browser-seeded despite committing nothing")
+		}
+	})
+}
+
+// TestConcurrentSeedAndDiscardLeaveNothingBehind runs the two halves against
+// each other. Under `trvl mcp` several searches share one provider client, so
+// seeds and a revocation genuinely overlap; the outcome must not depend on who
+// wins. Run under -race this also covers the second half of the round-8 finding:
+// the jar the http.Client holds is written by one goroutine while others read
+// it through Cookies.
+func TestConcurrentSeedAndDiscardLeaveNothingBehind(t *testing.T) {
+	u, err := url.Parse("https://example.test/preflight")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	v := newCookieVault()
+
+	// CONTROL: a permitted seed first, so the discard below has something real
+	// to remove and the final emptiness is not the emptiness of a jar that was
+	// never filled.
+	if !v.seedFromBrowser(u, []*http.Cookie{{Name: "datadome", Value: "from-the-users-browser"}}) {
+		t.Fatal("the fixture did not seed")
+	}
+
+	t.Setenv(consent.CookiesEnv, "1")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// In-flight browser reads finishing after the decline.
+			v.seedFromBrowser(u, []*http.Cookie{{Name: "datadome", Value: "late-arrival"}})
+			// And the ordinary server-driven path, which must keep working.
+			v.SetCookies(u, []*http.Cookie{{Name: "server", Value: "set-cookie"}})
+			_ = v.Cookies(u)
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			v.discardBrowserSeeded()
+		}()
+	}
+	wg.Wait()
+
+	// Whoever won the interleaving, no browser-derived cookie may survive: once
+	// declined, no seed can commit, so every discard is final.
+	if v.isBrowserSeeded() {
+		t.Error("the vault is still marked browser-seeded after the opt-out")
+	}
+	for _, c := range v.Cookies(u) {
+		if c.Name == "datadome" {
+			t.Errorf("a browser-derived cookie survived and would still be sent: %v", c)
+		}
+	}
+}

--- a/internal/providers/cookies.go
+++ b/internal/providers/cookies.go
@@ -284,7 +284,9 @@ func WarmBrowserCookies(targetURL, browserHint string) {
 // warmBrowserCookiesResult blocks until the warm-up for targetURL completes
 // (up to the given timeout) and returns the cached cookies. Returns nil if
 // no warm-up was started or the timeout expires.
-func warmBrowserCookiesResult(targetURL, browserHint string, timeout time.Duration) []*http.Cookie {
+func warmBrowserCookiesResult(targetURL, browserHint string, timeout time.Duration) (out []*http.Cookie) {
+	defer func() { out = permittedAfterRead(out) }()
+
 	key := warmCacheKey(targetURL, browserHint)
 
 	warmCache.mu.Lock()
@@ -306,7 +308,9 @@ func warmBrowserCookiesResult(targetURL, browserHint string, timeout time.Durati
 // readBrowserCookiesDirect performs the actual kooky cookie read. This is
 // the same logic as browserCookiesForURLWithHint but extracted so it can
 // run in a background goroutine without recursive cache lookups.
-func readBrowserCookiesDirect(targetURL, browserHint string) []*http.Cookie {
+func readBrowserCookiesDirect(targetURL, browserHint string) (out []*http.Cookie) {
+	defer func() { out = permittedAfterRead(out) }()
+
 	// Reached from the background pre-warm goroutine and the browser-hint path,
 	// neither of which passes through browserCookiesForURL, so the opt-out is
 	// checked here too rather than trusting a caller to have done it.
@@ -402,6 +406,30 @@ func InvalidateWarmCache(targetURL, browserHint string) {
 	warmCache.mu.Unlock()
 }
 
+// permittedAfterRead is the post-read consent gate for every function in this
+// package that returns cookies taken from the user's browser.
+//
+// Reading a browser takes seconds — Keychain unlock, a cold profile, a window
+// the user has to clear by hand. The checks that guard the ENTRY to those reads
+// therefore decide the question too early: a decline that arrives while the read
+// is in flight loses, the read finishes, and the credentials go out anyway. That
+// race is what rounds 8 and 11 of review found, in the vault and then in the
+// Booking.com room fetch, and chasing it call site by call site is how a family
+// of eleven bypasses gets built.
+//
+// So the readers below re-check on the way OUT, via a deferred call, on every
+// return path including the warm cache. One place, every caller, no seam for a
+// new call site to miss. It is a package-level helper rather than an inline
+// cookies.Disabled() because several of those readers declare a local variable
+// named cookies, and a check whose correctness depends on where the shadow
+// begins is a check the next editor breaks.
+func permittedAfterRead(list []*http.Cookie) []*http.Cookie {
+	if cookies.Disabled() {
+		return nil
+	}
+	return list
+}
+
 // BrowserCookiesForURL reads matching browser cookies for targetURL using the
 // same bounded, test-guarded path as provider search recovery.
 func BrowserCookiesForURL(targetURL string) []*http.Cookie {
@@ -418,7 +446,9 @@ func BrowserCookiesForURL(targetURL string) []*http.Cookie {
 // JavaScript bot-detection challenges (HTTP 202/403). The user's actual
 // browser has already solved any JS challenges and has valid session
 // cookies, which we can read directly from their disk-backed cookie jars.
-func browserCookiesForURL(targetURL string) []*http.Cookie {
+func browserCookiesForURL(targetURL string) (out []*http.Cookie) {
+	defer func() { out = permittedAfterRead(out) }()
+
 	// The opt-out sits on the low-level reader, not on the exported wrapper,
 	// because a user setting TRVL_NO_BROWSER_COOKIES means their cookie stores
 	// rather than one entry point into them. In-package recovery code reaches
@@ -428,6 +458,10 @@ func browserCookiesForURL(targetURL string) []*http.Cookie {
 	//
 	// Whether this reader returns anything on a given machine is a separate
 	// question, and currently a doubtful one: see #529.
+	//
+	// This entry check only saves the work. The GUARANTEE is the deferred
+	// permittedAfterRead above, which re-asks after the seconds-long read has
+	// finished; deleting this one costs time, deleting that one ships the bug.
 	if cookies.Disabled() {
 		return nil
 	}
@@ -506,7 +540,9 @@ func browserCookiesForURL(targetURL string) []*http.Cookie {
 //
 // Falls back to browserCookiesForURL (all-browser auto-discovery) when the
 // hint is empty or the specified browser's cookie store cannot be found.
-func browserCookiesForURLWithHint(targetURL, browserHint string) []*http.Cookie {
+func browserCookiesForURLWithHint(targetURL, browserHint string) (out []*http.Cookie) {
+	defer func() { out = permittedAfterRead(out) }()
+
 	if cookies.Disabled() {
 		return nil
 	}

--- a/internal/providers/cookies.go
+++ b/internal/providers/cookies.go
@@ -307,6 +307,12 @@ func warmBrowserCookiesResult(targetURL, browserHint string, timeout time.Durati
 // the same logic as browserCookiesForURLWithHint but extracted so it can
 // run in a background goroutine without recursive cache lookups.
 func readBrowserCookiesDirect(targetURL, browserHint string) []*http.Cookie {
+	// Reached from the background pre-warm goroutine and the browser-hint path,
+	// neither of which passes through browserCookiesForURL, so the opt-out is
+	// checked here too rather than trusting a caller to have done it.
+	if cookies.Disabled() {
+		return nil
+	}
 	if os.Getenv("TRVL_ALLOW_BROWSER_COOKIES") == "" && isTestBinary() {
 		return nil
 	}
@@ -399,16 +405,6 @@ func InvalidateWarmCache(targetURL, browserHint string) {
 // BrowserCookiesForURL reads matching browser cookies for targetURL using the
 // same bounded, test-guarded path as provider search recovery.
 func BrowserCookiesForURL(targetURL string) []*http.Cookie {
-	// The same opt-out that covers the nab reader, because a user setting
-	// TRVL_NO_BROWSER_COOKIES means their cookie stores, not one of the two code
-	// paths that reads them. Gating only the other reader would ship a control
-	// whose name promises more than it does.
-	//
-	// Whether this reader returns anything on a given machine is a separate
-	// question, and currently a doubtful one: see #529.
-	if cookies.Disabled() {
-		return nil
-	}
 	return browserCookiesForURL(targetURL)
 }
 
@@ -423,6 +419,19 @@ func BrowserCookiesForURL(targetURL string) []*http.Cookie {
 // browser has already solved any JS challenges and has valid session
 // cookies, which we can read directly from their disk-backed cookie jars.
 func browserCookiesForURL(targetURL string) []*http.Cookie {
+	// The opt-out sits on the low-level reader, not on the exported wrapper,
+	// because a user setting TRVL_NO_BROWSER_COOKIES means their cookie stores
+	// rather than one entry point into them. In-package recovery code reaches
+	// this function directly (currentCookieSource, the warm-cache path), so a
+	// gate on the wrapper alone would ship a control whose name promises more
+	// than it delivers — the same defect class as #507.
+	//
+	// Whether this reader returns anything on a given machine is a separate
+	// question, and currently a doubtful one: see #529.
+	if cookies.Disabled() {
+		return nil
+	}
+
 	// Check warm cache first — returns instantly if pre-warmed.
 	if cached := warmBrowserCookiesResult(targetURL, "", browserCookieLookupTimeout); cached != nil {
 		return cached
@@ -498,6 +507,9 @@ func browserCookiesForURL(targetURL string) []*http.Cookie {
 // Falls back to browserCookiesForURL (all-browser auto-discovery) when the
 // hint is empty or the specified browser's cookie store cannot be found.
 func browserCookiesForURLWithHint(targetURL, browserHint string) []*http.Cookie {
+	if cookies.Disabled() {
+		return nil
+	}
 	if browserHint == "" {
 		return browserCookiesForURL(targetURL)
 	}

--- a/internal/providers/cookies.go
+++ b/internal/providers/cookies.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/cookies"
 	"github.com/browserutils/kooky"
 	_ "github.com/browserutils/kooky/browser/all" // register all browser cookie finders
 	"github.com/browserutils/kooky/browser/brave"
@@ -398,6 +399,16 @@ func InvalidateWarmCache(targetURL, browserHint string) {
 // BrowserCookiesForURL reads matching browser cookies for targetURL using the
 // same bounded, test-guarded path as provider search recovery.
 func BrowserCookiesForURL(targetURL string) []*http.Cookie {
+	// The same opt-out that covers the nab reader, because a user setting
+	// TRVL_NO_BROWSER_COOKIES means their cookie stores, not one of the two code
+	// paths that reads them. Gating only the other reader would ship a control
+	// whose name promises more than it does.
+	//
+	// Whether this reader returns anything on a given machine is a separate
+	// question, and currently a doubtful one: see #529.
+	if cookies.Disabled() {
+		return nil
+	}
 	return browserCookiesForURL(targetURL)
 }
 

--- a/internal/providers/cookies_test.go
+++ b/internal/providers/cookies_test.go
@@ -84,7 +84,7 @@ func TestNeedsBrowserCookieFallback(t *testing.T) {
 // cookie jar is configured.
 func TestApplyBrowserCookies_NilJar(t *testing.T) {
 	client := &http.Client{}
-	if applyBrowserCookies(client, "https://example.com", "") {
+	if applyBrowserCookies(&providerClient{config: &ProviderConfig{ID: "t"}, client: client}, "https://example.com", "") {
 		t.Error("expected false when client has no jar")
 	}
 }
@@ -93,7 +93,7 @@ func TestApplyBrowserCookies_NilJar(t *testing.T) {
 func TestApplyBrowserCookies_BadURL(t *testing.T) {
 	jar, _ := cookiejar.New(nil)
 	client := &http.Client{Jar: jar}
-	if applyBrowserCookies(client, "::not a url::", "") {
+	if applyBrowserCookies(&providerClient{config: &ProviderConfig{ID: "t"}, client: client}, "::not a url::", "") {
 		t.Error("expected false for bad URL")
 	}
 }

--- a/internal/providers/coverage_boost_test.go
+++ b/internal/providers/coverage_boost_test.go
@@ -216,7 +216,8 @@ func TestTryBrowserCookieRetry_Success(t *testing.T) {
 		Endpoint: srv.URL,
 		Cookies:  CookieConfig{Source: "browser"},
 	}
-	jar, _ := cookiejar.New(nil)
+	// A vault, not a bare jar: browser cookies only enter a jar that can hand
+	// them back, so a plain-jar client refuses the seed by design.
 	targetURL := srv.URL + "/page"
 	resetWarmCache(t)
 	entry := &warmCacheEntry{done: make(chan struct{})}
@@ -228,7 +229,7 @@ func TestTryBrowserCookieRetry_Success(t *testing.T) {
 	warmCache.mu.Unlock()
 
 	cl := srv.Client()
-	cl.Jar = jar
+	cl.Jar = newCookieVault()
 	pc := &providerClient{
 		config:     cfg,
 		client:     cl,
@@ -316,8 +317,7 @@ func TestApplyBrowserCookies_WithSyntheticCookies(t *testing.T) {
 	warmCache.entries[warmCacheKey(targetURL, hint)] = entry
 	warmCache.mu.Unlock()
 
-	jar, _ := cookiejar.New(nil)
-	client := &http.Client{Jar: jar}
+	client := &http.Client{Jar: newCookieVault()}
 	if !applyBrowserCookies(&providerClient{config: &ProviderConfig{ID: "t"}, client: client}, targetURL, hint) {
 		t.Error("expected true when warm cache has cookies")
 	}

--- a/internal/providers/coverage_boost_test.go
+++ b/internal/providers/coverage_boost_test.go
@@ -318,7 +318,7 @@ func TestApplyBrowserCookies_WithSyntheticCookies(t *testing.T) {
 
 	jar, _ := cookiejar.New(nil)
 	client := &http.Client{Jar: jar}
-	if !applyBrowserCookies(client, targetURL, hint) {
+	if !applyBrowserCookies(&providerClient{config: &ProviderConfig{ID: "t"}, client: client}, targetURL, hint) {
 		t.Error("expected true when warm cache has cookies")
 	}
 }
@@ -344,7 +344,7 @@ func TestApplyBrowserCookies_BadURLPath(t *testing.T) {
 	jar, _ := cookiejar.New(nil)
 	client := &http.Client{Jar: jar}
 	// url.Parse("://no-scheme-here") → error or empty host → returns false
-	got := applyBrowserCookies(client, targetURL, "")
+	got := applyBrowserCookies(&providerClient{config: &ProviderConfig{ID: "t"}, client: client}, targetURL, "")
 	// Result may be false (url.Parse error) — just confirm no panic
 	_ = got
 }

--- a/internal/providers/kooky_probe_test.go
+++ b/internal/providers/kooky_probe_test.go
@@ -1,0 +1,48 @@
+package providers
+
+import (
+	"os"
+	"testing"
+)
+
+// TestKookyReadsWhatNabReads is the deciding evidence for whether trvl still
+// needs the nab helper to read browser cookies.
+//
+// Two readers exist today. This package reads cookie stores in-process with
+// kooky; internal/cookies shells out to nab. The stated reason for nab is in
+// internal/cookies/browser.go:1-4 — keeping "CGO and keychain dependencies" out
+// of the main binary — which no longer holds, because kooky is linked into that
+// same binary and does the same decryption. If kooky can read the domains nab
+// reads, nab is redundant and one external process dependency can go.
+//
+// Skipped by default: it reads the developer's own live cookie stores, so it is
+// a diagnostic to run deliberately, not something CI should do. Run with
+// TRVL_COOKIE_PROBE=1.
+//
+// Reports counts and cookie NAMES only, never values. A cookie value is a live
+// session; printing one into a terminal or a CI log is the leak this test would
+// otherwise create.
+func TestKookyReadsWhatNabReads(t *testing.T) {
+	if os.Getenv("TRVL_COOKIE_PROBE") == "" {
+		t.Skip("diagnostic: reads your own browser cookie stores; set TRVL_COOKIE_PROBE=1")
+	}
+
+	// The domains nab demonstrably returned cookies for while #521 was being
+	// built, so a fair comparison rather than a friendly one.
+	for _, target := range []string{
+		"https://www.thetrainline.com/",
+		"https://www.eurostar.com/",
+		"https://www.sncf-connect.com/",
+		"https://www.booking.com/",
+		"https://www.rome2rio.com/",
+		"https://www.google.com/",
+		"https://github.com/",
+	} {
+		got := BrowserCookiesForURL(target)
+		names := make([]string, 0, len(got))
+		for _, c := range got {
+			names = append(names, c.Name)
+		}
+		t.Logf("%-34s kooky returned %2d cookies %v", target, len(got), names)
+	}
+}

--- a/internal/providers/kooky_probe_test.go
+++ b/internal/providers/kooky_probe_test.go
@@ -27,6 +27,13 @@ func TestKookyReadsWhatNabReads(t *testing.T) {
 		t.Skip("diagnostic: reads your own browser cookie stores; set TRVL_COOKIE_PROBE=1")
 	}
 
+	// Without this the reader short-circuits on its own test-binary guard
+	// (cookies.go, TRVL_ALLOW_BROWSER_COOKIES) and every domain reports zero
+	// cookies regardless of whether kooky works. The first run of this probe
+	// omitted it and the zero result was read as evidence about decryption; it
+	// was evidence about the guard.
+	t.Setenv("TRVL_ALLOW_BROWSER_COOKIES", "1")
+
 	// The domains nab demonstrably returned cookies for while #521 was being
 	// built, so a fair comparison rather than a friendly one.
 	for _, target := range []string{

--- a/internal/providers/runtime_core.go
+++ b/internal/providers/runtime_core.go
@@ -148,6 +148,18 @@ type providerClient struct {
 	// dest_id are rejected for a different one.
 	lastPreflightURL string
 
+	// browserSeeded records that this client's cookie jar and auth values were
+	// populated, wholly or partly, from the user's browser — either read live
+	// via kooky/nab or loaded from the on-disk cache, which carries no
+	// provenance and so is treated as browser-derived (#534).
+	//
+	// It exists because the auth cache is in-memory and the MCP server is
+	// long-lived: without it, a jar seeded while browser access was permitted
+	// keeps being sent on later calls, and those calls return from the cache
+	// above without reaching any of the guarded readers. Written under authMu,
+	// like authValues and authExpiry.
+	browserSeeded bool
+
 	// ttlState is the AIMD adaptive TTL controller for the auth cache.
 	// Accessed under authMu (same lock that protects authExpiry).
 	ttlState preflightttl.State

--- a/internal/providers/runtime_core.go
+++ b/internal/providers/runtime_core.go
@@ -148,21 +148,6 @@ type providerClient struct {
 	// dest_id are rejected for a different one.
 	lastPreflightURL string
 
-	// browserSeeded records that this client's cookie jar and auth values were
-	// populated, wholly or partly, from the user's browser — either read live
-	// via kooky/nab or loaded from the on-disk cache, which carries no
-	// provenance and so is treated as browser-derived (#534).
-	//
-	// It exists because the auth cache is in-memory and the MCP server is
-	// long-lived: without it, a jar seeded while browser access was permitted
-	// keeps being sent on later calls, and those calls return from the cache
-	// above without reaching any of the guarded readers.
-	//
-	// Atomic rather than authMu-protected: it is written from applyBrowserCookies,
-	// which runs both inside runPreflight (holding authMu) and from the search
-	// path (not holding it). One field, two lock regimes, so it carries its own.
-	browserSeeded atomic.Bool
-
 	// ttlState is the AIMD adaptive TTL controller for the auth cache.
 	// Accessed under authMu (same lock that protects authExpiry).
 	ttlState preflightttl.State
@@ -175,6 +160,18 @@ type providerClient struct {
 	// last429 records when the most recent 429 was received.
 	last429 time.Time
 	rl429Mu sync.Mutex
+}
+
+// isBrowserSeeded reports whether this client's jar currently holds cookies
+// that came from the user's browser. The provenance lives in the jar rather
+// than beside it (see cookie_vault.go): a flag next to the jar can be written
+// after a revocation has already read it, which is the race round 8 of review
+// found.
+func (pc *providerClient) isBrowserSeeded() bool {
+	if pc == nil {
+		return false
+	}
+	return vaultOf(pc.client).isBrowserSeeded()
 }
 
 // effectiveCacheTTL returns the adaptive TTL when the AIMD controller has
@@ -263,8 +260,15 @@ func (rt *Runtime) getOrCreateClient(cfg *ProviderConfig) *providerClient {
 		}
 	}
 	if httpClient.Jar == nil {
-		jar, _ := cookiejar.New(nil)
-		httpClient.Jar = jar
+		// A vault rather than a bare jar: browser-derived cookies may only enter
+		// a jar that records where they came from and can hand them back. See
+		// cookie_vault.go.
+		if v := newCookieVault(); v != nil {
+			httpClient.Jar = v
+		} else {
+			jar, _ := cookiejar.New(nil)
+			httpClient.Jar = jar
+		}
 	}
 
 	rps := cfg.RateLimit.RequestsPerSecond

--- a/internal/providers/runtime_core.go
+++ b/internal/providers/runtime_core.go
@@ -156,9 +156,12 @@ type providerClient struct {
 	// It exists because the auth cache is in-memory and the MCP server is
 	// long-lived: without it, a jar seeded while browser access was permitted
 	// keeps being sent on later calls, and those calls return from the cache
-	// above without reaching any of the guarded readers. Written under authMu,
-	// like authValues and authExpiry.
-	browserSeeded bool
+	// above without reaching any of the guarded readers.
+	//
+	// Atomic rather than authMu-protected: it is written from applyBrowserCookies,
+	// which runs both inside runPreflight (holding authMu) and from the search
+	// path (not holding it). One field, two lock regimes, so it carries its own.
+	browserSeeded atomic.Bool
 
 	// ttlState is the AIMD adaptive TTL controller for the auth cache.
 	// Accessed under authMu (same lock that protects authExpiry).

--- a/internal/providers/runtime_provider.go
+++ b/internal/providers/runtime_provider.go
@@ -23,12 +23,17 @@ func (rt *Runtime) searchProvider(ctx context.Context, cfg *ProviderConfig, loca
 	// config; we then drop the cached providerClient so its HTTP client,
 	// rate limiter and auth cache are rebuilt from the new config.
 	var oldJar http.CookieJar
+	oldJarBrowserSeeded := false
 	if fresh := rt.registry.ReloadIfChanged(cfg.ID); fresh != nil && fresh != cfg {
 		// Preserve the cookie jar so WAF tokens and session cookies survive
 		// config reloads. The jar is installed on the new client below.
 		rt.mu.Lock()
 		if old := rt.clients[cfg.ID]; old != nil && old.client != nil {
 			oldJar = old.client.Jar
+			// The jar survives a config reload, so its provenance must too.
+			// Moving browser-derived cookies into a client marked clean is how
+			// the opt-out would lose track of them across a reload.
+			oldJarBrowserSeeded = old.browserSeeded.Load()
 		}
 		delete(rt.clients, cfg.ID)
 		rt.mu.Unlock()
@@ -37,6 +42,9 @@ func (rt *Runtime) searchProvider(ctx context.Context, cfg *ProviderConfig, loca
 	pc := rt.getOrCreateClient(cfg)
 	if oldJar != nil && pc.client != nil {
 		pc.client.Jar = oldJar
+		if oldJarBrowserSeeded {
+			pc.browserSeeded.Store(true)
+		}
 	}
 
 	// Rate limit.
@@ -115,7 +123,7 @@ func (rt *Runtime) searchProvider(ctx context.Context, cfg *ProviderConfig, loca
 		if cfg.Auth != nil && cfg.Auth.PreflightURL != "" {
 			endpointURL = substituteVars(cfg.Auth.PreflightURL, vars)
 		}
-		browserCookiesApplied = applyBrowserCookies(pc.client, endpointURL, cfg.Cookies.Browser)
+		browserCookiesApplied = applyBrowserCookies(pc, endpointURL, cfg.Cookies.Browser)
 
 		// Fail loudly when a browser-cookie provider (e.g. Booking.com) has no
 		// usable browser session. Without cookies the WAF strips data and the
@@ -336,7 +344,7 @@ func (rt *Runtime) searchProvider(ctx context.Context, cfg *ProviderConfig, loca
 		recovered := false
 
 		// Tier 3a: re-read cookies from the user's browser.
-		if applyBrowserCookies(pc.client, endpoint, cfg.Cookies.Browser) {
+		if applyBrowserCookies(pc, endpoint, cfg.Cookies.Browser) {
 			resp2, body2, err2 := doSearchRequest(ctx, pc.client, req)
 			if err2 == nil && !isAkamaiChallenge(resp2.StatusCode, body2) && resp2.StatusCode >= 200 && resp2.StatusCode < 300 {
 				resp, body = resp2, body2

--- a/internal/providers/runtime_provider.go
+++ b/internal/providers/runtime_provider.go
@@ -23,17 +23,15 @@ func (rt *Runtime) searchProvider(ctx context.Context, cfg *ProviderConfig, loca
 	// config; we then drop the cached providerClient so its HTTP client,
 	// rate limiter and auth cache are rebuilt from the new config.
 	var oldJar http.CookieJar
-	oldJarBrowserSeeded := false
 	if fresh := rt.registry.ReloadIfChanged(cfg.ID); fresh != nil && fresh != cfg {
 		// Preserve the cookie jar so WAF tokens and session cookies survive
-		// config reloads. The jar is installed on the new client below.
+		// config reloads. The jar is installed on the new client below, and it
+		// carries its own provenance (cookie_vault.go), so browser-derived
+		// cookies cannot arrive in the new client marked clean — which is how a
+		// reload would otherwise launder them past the opt-out.
 		rt.mu.Lock()
 		if old := rt.clients[cfg.ID]; old != nil && old.client != nil {
 			oldJar = old.client.Jar
-			// The jar survives a config reload, so its provenance must too.
-			// Moving browser-derived cookies into a client marked clean is how
-			// the opt-out would lose track of them across a reload.
-			oldJarBrowserSeeded = old.browserSeeded.Load()
 		}
 		delete(rt.clients, cfg.ID)
 		rt.mu.Unlock()
@@ -42,9 +40,6 @@ func (rt *Runtime) searchProvider(ctx context.Context, cfg *ProviderConfig, loca
 	pc := rt.getOrCreateClient(cfg)
 	if oldJar != nil && pc.client != nil {
 		pc.client.Jar = oldJar
-		if oldJarBrowserSeeded {
-			pc.browserSeeded.Store(true)
-		}
 	}
 
 	// Rate limit.

--- a/internal/providers/runtime_test_provider.go
+++ b/internal/providers/runtime_test_provider.go
@@ -138,7 +138,7 @@ func TestProvider(ctx context.Context, cfg *ProviderConfig, location string, lat
 		if cfg.Auth != nil && cfg.Auth.PreflightURL != "" {
 			targetURL = substituteVars(cfg.Auth.PreflightURL, vars)
 		}
-		browserCookiesApplied = applyBrowserCookies(pc.client, targetURL, cfg.Cookies.Browser)
+		browserCookiesApplied = applyBrowserCookies(pc, targetURL, cfg.Cookies.Browser)
 	}
 
 	// Step 1: Preflight auth.
@@ -467,7 +467,7 @@ func runTestPreflight(ctx context.Context, pc *providerClient, cfg *ProviderConf
 	// (escape hatch — open URL in browser and wait for fresh cookies).
 	if needsBrowserCookieFallback(resp.StatusCode, matched, cfg.Auth.Extractions) {
 		tier = ""
-		if applied := applyBrowserCookies(pc.client, cfg.Auth.PreflightURL, cfg.Cookies.Browser); applied {
+		if applied := applyBrowserCookies(pc, cfg.Auth.PreflightURL, cfg.Cookies.Browser); applied {
 			resp2, body2, err2 := doPreflightRequest(ctx, pc.client, cfg.Auth)
 			if err2 == nil && resp2.StatusCode >= 200 && resp2.StatusCode < 300 && !isAkamaiChallenge(resp2.StatusCode, body2) {
 				resp, body = resp2, body2

--- a/internal/providers/tier2_chromedp.go
+++ b/internal/providers/tier2_chromedp.go
@@ -6,10 +6,10 @@
 // bot challenge can resolve, harvests the resulting cookies (cf_clearance et al)
 // and writes them into the existing ~/.trvl/cookies cache for Tier-1 to reuse.
 //
-// This path is EXPENSIVE and visible (it spawns a browser process), so it is
-// gated behind an explicit opt-in (TRVL_TIER2_CDP=1, or WithTier2Force) and is
-// meant to be invoked only when Tier-1 returns a challenge page
-// (see IsChallengePage in tier1_client.go). Single static binary is preserved:
+// This path is EXPENSIVE and it spawns a browser process, but nothing is shown
+// on screen and focus is never taken. It runs by default when Tier-1 hits a
+// challenge page (see IsChallengePage in tier1_client.go); set
+// TRVL_NO_TIER2_CDP to decline. Single static binary is preserved:
 // chromedp is pure Go and the browser is the user's own install.
 package providers
 
@@ -21,18 +21,24 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/chromedp"
 )
 
-// tier2EnableEnv opts into the Tier-2 CDP cookie-refresh path.
+// tier2EnableEnv was the opt-in for the Tier-2 CDP cookie-refresh path. The
+// path now runs by default; an explicit 0/false here still turns it off.
 const tier2EnableEnv = "TRVL_TIER2_CDP"
 
-// ErrTier2Disabled is returned when RefreshCookiesViaCDP is invoked without the
-// opt-in (TRVL_TIER2_CDP unset/0 and WithTier2Force not used).
-var ErrTier2Disabled = errors.New("tier2 cdp cookie-refresh disabled (set TRVL_TIER2_CDP=1 to enable)")
+// tier2DisableEnv is the opt-out, named to match TRVL_NO_BROWSER_COOKIES.
+const tier2DisableEnv = "TRVL_NO_TIER2_CDP"
+
+// ErrTier2Disabled is returned when RefreshCookiesViaCDP is invoked after the
+// user declined the path (TRVL_NO_TIER2_CDP set, or TRVL_TIER2_CDP=0) and
+// WithTier2Force was not used.
+var ErrTier2Disabled = errors.New("tier2 cdp cookie-refresh declined (unset TRVL_NO_TIER2_CDP to enable)")
 
 // ErrNoBrowserFound is returned when no installed Chromium-family browser can be
 // located to drive headlessly.
@@ -73,10 +79,40 @@ func WithTier2ExecPath(path string) Tier2Option {
 	return func(c *tier2Config) { c.execPath = path }
 }
 
-// Tier2Enabled reports whether the Tier-2 opt-in is set via TRVL_TIER2_CDP.
+// Tier2Enabled reports whether the Tier-2 headless cookie refresh may run.
+//
+// It is on by default. The path drives an already-installed Chrome, Brave or
+// Edge with chromedp.Headless (runCDPCollect), so nothing appears on screen and
+// focus is never taken; a user who is not looking at the process list cannot
+// tell it ran. What they can tell is that a challenged search returned nothing,
+// which is what leaving it off by default produced.
+//
+// Two ways to decline, both honoured:
+//
+//	TRVL_NO_TIER2_CDP  set to anything but 0/false — the opt-out, matching
+//	                   TRVL_NO_BROWSER_COOKIES (#521)
+//	TRVL_TIER2_CDP     explicitly 0/false — this used to be the opt-IN, so a
+//	                   user who set it to 0 to keep the browser off meant it,
+//	                   and flipping the default must not quietly overrule them
 func Tier2Enabled() bool {
-	v := os.Getenv(tier2EnableEnv)
-	return v == "1" || v == "true" || v == "yes"
+	if truthyEnv(os.Getenv(tier2DisableEnv)) {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(tier2EnableEnv))) {
+	case "0", "false", "no":
+		return false
+	}
+	return true
+}
+
+// truthyEnv reads an opt-out variable the same way internal/cookies does:
+// present and not an explicit denial means the user asked for it.
+func truthyEnv(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "0", "false":
+		return false
+	}
+	return true
 }
 
 // fileExists is overridable in tests so browser detection can be exercised
@@ -141,7 +177,9 @@ var cdpRunner = runCDPCollect
 // RefreshCookiesViaCDP launches the user's installed browser headlessly, lets
 // the anti-bot challenge at targetURL resolve, harvests the resulting cookies,
 // persists them to the ~/.trvl/cookies cache, and returns them. It is the
-// Tier-2 entrypoint and is gated: without the opt-in it returns ErrTier2Disabled.
+// Tier-2 entrypoint. It runs by default and returns ErrTier2Disabled when the
+// user declined (TRVL_NO_TIER2_CDP, or TRVL_TIER2_CDP=0) without WithTier2Force,
+// and also inside a `go test` binary unless TRVL_ALLOW_BROWSER_COOKIES is set.
 func RefreshCookiesViaCDP(ctx context.Context, targetURL string, opts ...Tier2Option) ([]*http.Cookie, error) {
 	cfg := tier2Config{challengeWait: defaultChallengeWait}
 	for _, o := range opts {
@@ -179,6 +217,14 @@ func RefreshCookiesViaCDP(ctx context.Context, targetURL string, opts ...Tier2Op
 // the cookies present after the challenge wait. No window is shown and focus is
 // never stolen (Headless + DefaultExecAllocatorOptions).
 func runCDPCollect(ctx context.Context, execPath, targetURL string, challengeWait time.Duration) ([]*network.Cookie, error) {
+	// Now that Tier-2 is on by default, this is what keeps `go test` from
+	// launching a real browser on a build host. It sits on the driver rather
+	// than the entrypoint so tests that stub cdpRunner still exercise the
+	// orchestration. Mirrors the browserCookiesForURL guard.
+	if os.Getenv("TRVL_ALLOW_BROWSER_COOKIES") == "" && isTestBinary() {
+		return nil, ErrTier2Disabled
+	}
+
 	allocOpts := append([]chromedp.ExecAllocatorOption{},
 		chromedp.DefaultExecAllocatorOptions[:]...)
 	allocOpts = append(allocOpts,

--- a/internal/providers/tier2_chromedp.go
+++ b/internal/providers/tier2_chromedp.go
@@ -35,9 +35,9 @@ const tier2EnableEnv = "TRVL_TIER2_CDP"
 // tier2DisableEnv is the opt-out, named to match TRVL_NO_BROWSER_COOKIES.
 const tier2DisableEnv = "TRVL_NO_TIER2_CDP"
 
-// ErrTier2Disabled is returned when RefreshCookiesViaCDP is invoked after the
-// user declined the path (TRVL_NO_TIER2_CDP set, or TRVL_TIER2_CDP=0) and
-// WithTier2Force was not used.
+// ErrTier2Disabled is returned when the Tier-2 path is invoked after the user
+// declined it (TRVL_NO_TIER2_CDP set, or TRVL_TIER2_CDP=0). Nothing suppresses
+// it — see Tier2Declined.
 var ErrTier2Disabled = errors.New("tier2 cdp cookie-refresh declined (unset TRVL_NO_TIER2_CDP to enable)")
 
 // ErrNoBrowserFound is returned when no installed Chromium-family browser can be
@@ -50,19 +50,12 @@ const defaultChallengeWait = 8 * time.Second
 
 // tier2Config holds resolved options for RefreshCookiesViaCDP.
 type tier2Config struct {
-	force         bool
 	challengeWait time.Duration
 	execPath      string
 }
 
 // Tier2Option configures RefreshCookiesViaCDP.
 type Tier2Option func(*tier2Config)
-
-// WithTier2Force bypasses the TRVL_TIER2_CDP env opt-in (e.g. when the caller
-// has already confirmed escalation interactively).
-func WithTier2Force() Tier2Option {
-	return func(c *tier2Config) { c.force = true }
-}
 
 // WithTier2ChallengeWait overrides how long the page is given to resolve its JS
 // challenge before cookies are harvested.
@@ -79,13 +72,14 @@ func WithTier2ExecPath(path string) Tier2Option {
 	return func(c *tier2Config) { c.execPath = path }
 }
 
-// Tier2Enabled reports whether the Tier-2 headless cookie refresh may run.
+// Tier2Declined reports whether the user has EXPLICITLY asked for no headless
+// browser.
 //
-// It is on by default. The path drives an already-installed Chrome, Brave or
-// Edge with chromedp.Headless (runCDPCollect), so nothing appears on screen and
-// focus is never taken; a user who is not looking at the process list cannot
-// tell it ran. What they can tell is that a challenged search returned nothing,
-// which is what leaving it off by default produced.
+// The Tier-2 path is on by default. It drives an already-installed Chrome,
+// Brave or Edge with chromedp.Headless (runCDPCollect), so nothing appears on
+// screen and focus is never taken; a user who is not looking at the process
+// list cannot tell it ran. What they can tell is that a challenged search
+// returned nothing, which is what leaving it off by default produced.
 //
 // Two ways to decline, both honoured:
 //
@@ -94,15 +88,24 @@ func WithTier2ExecPath(path string) Tier2Option {
 //	TRVL_TIER2_CDP     explicitly 0/false — this used to be the opt-IN, so a
 //	                   user who set it to 0 to keep the browser off meant it,
 //	                   and flipping the default must not quietly overrule them
-func Tier2Enabled() bool {
+//
+// Nothing overrules this. The predecessor of this function answered "is the
+// default on?", which a caller-supplied force option was allowed to overrule —
+// and every production caller passed that option (internal/ground/trainline.go,
+// internal/ground/sncf.go, internal/hotels/booking_search.go), which left
+// TRVL_NO_TIER2_CDP with no effect on any real search: a setting that reads as
+// a privacy control and silently was not. That is the #507/#515 defect class,
+// and it is why the question asked here is "did the user say no?" and why the
+// drivers below are where it gets asked.
+func Tier2Declined() bool {
 	if truthyEnv(os.Getenv(tier2DisableEnv)) {
-		return false
+		return true
 	}
 	switch strings.ToLower(strings.TrimSpace(os.Getenv(tier2EnableEnv))) {
 	case "0", "false", "no":
-		return false
+		return true
 	}
-	return true
+	return false
 }
 
 // truthyEnv reads an opt-out variable the same way internal/cookies does:
@@ -178,15 +181,16 @@ var cdpRunner = runCDPCollect
 // the anti-bot challenge at targetURL resolve, harvests the resulting cookies,
 // persists them to the ~/.trvl/cookies cache, and returns them. It is the
 // Tier-2 entrypoint. It runs by default and returns ErrTier2Disabled when the
-// user declined (TRVL_NO_TIER2_CDP, or TRVL_TIER2_CDP=0) without WithTier2Force,
-// and also inside a `go test` binary unless TRVL_ALLOW_BROWSER_COOKIES is set.
+// user declined (TRVL_NO_TIER2_CDP, or TRVL_TIER2_CDP=0), and also inside a
+// `go test` binary unless TRVL_ALLOW_BROWSER_COOKIES is set.
 func RefreshCookiesViaCDP(ctx context.Context, targetURL string, opts ...Tier2Option) ([]*http.Cookie, error) {
 	cfg := tier2Config{challengeWait: defaultChallengeWait}
 	for _, o := range opts {
 		o(&cfg)
 	}
 
-	if !cfg.force && !Tier2Enabled() {
+	// An explicit decline is absolute; no option overrules it.
+	if Tier2Declined() {
 		return nil, ErrTier2Disabled
 	}
 
@@ -217,6 +221,13 @@ func RefreshCookiesViaCDP(ctx context.Context, targetURL string, opts ...Tier2Op
 // the cookies present after the challenge wait. No window is shown and focus is
 // never stolen (Headless + DefaultExecAllocatorOptions).
 func runCDPCollect(ctx context.Context, execPath, targetURL string, challengeWait time.Duration) ([]*network.Cookie, error) {
+	// An explicit decline is absolute and is checked HERE, on the function that
+	// actually spawns the browser, so a caller that reaches past the entrypoint
+	// still cannot start one.
+	if Tier2Declined() {
+		return nil, ErrTier2Disabled
+	}
+
 	// Now that Tier-2 is on by default, this is what keeps `go test` from
 	// launching a real browser on a build host. It sits on the driver rather
 	// than the entrypoint so tests that stub cdpRunner still exercise the

--- a/internal/providers/tier2_chromedp.go
+++ b/internal/providers/tier2_chromedp.go
@@ -21,24 +21,29 @@ import (
 	"net/url"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/chromedp"
+
+	"github.com/MikkoParkkola/trvl/internal/consent"
 )
 
 // tier2EnableEnv was the opt-in for the Tier-2 CDP cookie-refresh path. The
 // path now runs by default; an explicit 0/false here still turns it off.
-const tier2EnableEnv = "TRVL_TIER2_CDP"
+const tier2EnableEnv = consent.Tier2LegacyEnv
 
 // tier2DisableEnv is the opt-out, named to match TRVL_NO_BROWSER_COOKIES.
-const tier2DisableEnv = "TRVL_NO_TIER2_CDP"
+const tier2DisableEnv = consent.Tier2Env
 
 // ErrTier2Disabled is returned when the Tier-2 path is invoked after the user
 // declined it (TRVL_NO_TIER2_CDP set, or TRVL_TIER2_CDP=0). Nothing suppresses
 // it — see Tier2Declined.
-var ErrTier2Disabled = errors.New("tier2 cdp cookie-refresh declined (unset TRVL_NO_TIER2_CDP to enable)")
+//
+// It is the same value as consent.ErrTier2Declined, not a copy: internal/ground
+// compares against it through this name, and two distinct errors that both mean
+// "declined" is the drift this consolidation removed elsewhere.
+var ErrTier2Disabled = consent.ErrTier2Declined
 
 // ErrNoBrowserFound is returned when no installed Chromium-family browser can be
 // located to drive headlessly.
@@ -97,26 +102,10 @@ func WithTier2ExecPath(path string) Tier2Option {
 // a privacy control and silently was not. That is the #507/#515 defect class,
 // and it is why the question asked here is "did the user say no?" and why the
 // drivers below are where it gets asked.
-func Tier2Declined() bool {
-	if truthyEnv(os.Getenv(tier2DisableEnv)) {
-		return true
-	}
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(tier2EnableEnv))) {
-	case "0", "false", "no":
-		return true
-	}
-	return false
-}
-
-// truthyEnv reads an opt-out variable the same way internal/cookies does:
-// present and not an explicit denial means the user asked for it.
-func truthyEnv(raw string) bool {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "", "0", "false":
-		return false
-	}
-	return true
-}
+//
+// The rule itself lives in internal/consent, alongside the cookie decline, so
+// there is one place to look for "did the user decline this?".
+func Tier2Declined() bool { return consent.Tier2Declined() }
 
 // fileExists is overridable in tests so browser detection can be exercised
 // without depending on what is installed on the build/CI host.

--- a/internal/providers/tier2_chromedp_test.go
+++ b/internal/providers/tier2_chromedp_test.go
@@ -12,18 +12,43 @@ import (
 )
 
 func TestTier2Enabled(t *testing.T) {
+	t.Setenv(tier2DisableEnv, "")
 	t.Setenv(tier2EnableEnv, "")
-	if Tier2Enabled() {
-		t.Fatal("expected disabled when env unset")
+	if !Tier2Enabled() {
+		t.Fatal("expected enabled by default: the path is windowless, and leaving it off returned no results on challenged searches")
 	}
 	t.Setenv(tier2EnableEnv, "1")
 	if !Tier2Enabled() {
-		t.Fatal("expected enabled when env=1")
+		t.Fatal("expected enabled when the old opt-in is set")
+	}
+
+	// The old opt-in doubles as an opt-out when set to a denial, because a user
+	// who set it to 0 to keep a browser off meant it and the default flip must
+	// not overrule them.
+	for _, deny := range []string{"0", "false", "no"} {
+		t.Setenv(tier2EnableEnv, deny)
+		if Tier2Enabled() {
+			t.Errorf("expected disabled with %s=%q", tier2EnableEnv, deny)
+		}
+	}
+	t.Setenv(tier2EnableEnv, "")
+
+	for _, off := range []string{"1", "true", "yes", "please"} {
+		t.Setenv(tier2DisableEnv, off)
+		if Tier2Enabled() {
+			t.Errorf("expected disabled with %s=%q", tier2DisableEnv, off)
+		}
+	}
+	for _, on := range []string{"", "0", "false"} {
+		t.Setenv(tier2DisableEnv, on)
+		if !Tier2Enabled() {
+			t.Errorf("expected enabled with %s=%q", tier2DisableEnv, on)
+		}
 	}
 }
 
 func TestRefreshCookiesViaCDP_DisabledByDefault(t *testing.T) {
-	t.Setenv(tier2EnableEnv, "")
+	t.Setenv(tier2DisableEnv, "1")
 	_, err := RefreshCookiesViaCDP(context.Background(), "https://example.com/")
 	if !errors.Is(err, ErrTier2Disabled) {
 		t.Fatalf("err = %v, want ErrTier2Disabled", err)

--- a/internal/providers/tier2_chromedp_test.go
+++ b/internal/providers/tier2_chromedp_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/chromedp/cdproto/network"
 )
 
-func TestTier2Enabled(t *testing.T) {
+func TestTier2Declined(t *testing.T) {
 	t.Setenv(tier2DisableEnv, "")
 	t.Setenv(tier2EnableEnv, "")
-	if !Tier2Enabled() {
+	if Tier2Declined() {
 		t.Fatal("expected enabled by default: the path is windowless, and leaving it off returned no results on challenged searches")
 	}
 	t.Setenv(tier2EnableEnv, "1")
-	if !Tier2Enabled() {
+	if Tier2Declined() {
 		t.Fatal("expected enabled when the old opt-in is set")
 	}
 
@@ -27,7 +27,7 @@ func TestTier2Enabled(t *testing.T) {
 	// not overrule them.
 	for _, deny := range []string{"0", "false", "no"} {
 		t.Setenv(tier2EnableEnv, deny)
-		if Tier2Enabled() {
+		if !Tier2Declined() {
 			t.Errorf("expected disabled with %s=%q", tier2EnableEnv, deny)
 		}
 	}
@@ -35,13 +35,13 @@ func TestTier2Enabled(t *testing.T) {
 
 	for _, off := range []string{"1", "true", "yes", "please"} {
 		t.Setenv(tier2DisableEnv, off)
-		if Tier2Enabled() {
+		if !Tier2Declined() {
 			t.Errorf("expected disabled with %s=%q", tier2DisableEnv, off)
 		}
 	}
 	for _, on := range []string{"", "0", "false"} {
 		t.Setenv(tier2DisableEnv, on)
-		if !Tier2Enabled() {
+		if Tier2Declined() {
 			t.Errorf("expected enabled with %s=%q", tier2DisableEnv, on)
 		}
 	}
@@ -61,7 +61,7 @@ func TestRefreshCookiesViaCDP_NoBrowserFound(t *testing.T) {
 	fileExists = func(string) bool { return false }
 	defer func() { fileExists = prevExists }()
 
-	_, err := RefreshCookiesViaCDP(context.Background(), "https://example.com/", WithTier2Force())
+	_, err := RefreshCookiesViaCDP(context.Background(), "https://example.com/")
 	if !errors.Is(err, ErrNoBrowserFound) {
 		t.Fatalf("err = %v, want ErrNoBrowserFound", err)
 	}
@@ -86,7 +86,7 @@ func TestRefreshCookiesViaCDP_HarvestsAndCaches(t *testing.T) {
 	defer func() { cdpRunner = prevRunner }()
 
 	target := "https://example.com/"
-	cookies, err := RefreshCookiesViaCDP(context.Background(), target, WithTier2Force())
+	cookies, err := RefreshCookiesViaCDP(context.Background(), target)
 	if err != nil {
 		t.Fatalf("RefreshCookiesViaCDP: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestRefreshCookiesViaCDP_RunnerError(t *testing.T) {
 	}
 	defer func() { cdpRunner = prevRunner }()
 
-	_, err := RefreshCookiesViaCDP(context.Background(), "https://example.com/", WithTier2Force())
+	_, err := RefreshCookiesViaCDP(context.Background(), "https://example.com/")
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("err = %v, want boom", err)
 	}

--- a/internal/providers/tier2_decline_test.go
+++ b/internal/providers/tier2_decline_test.go
@@ -1,0 +1,89 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto/network"
+)
+
+// TestExplicitDeclineHoldsAtBothEntrypoints is the regression test for the defect
+// an adversarial review found in the first cut of #521: the opt-out was checked
+// with `!cfg.force && !Tier2Enabled()`, and every production caller
+// (internal/ground/trainline.go, internal/ground/sncf.go,
+// internal/hotels/booking_search.go) passed a WithTier2Force option that set
+// cfg.force. TRVL_NO_TIER2_CDP therefore had no effect on any real search, while
+// the tests — which only ever called the unforced path — stayed green.
+//
+// The force option is gone now, so the shape that produced the bug cannot recur
+// in that exact form. What this test pins is the property that outlived it: a
+// decline holds at every entrypoint, in every spelling, with no runner reached.
+func TestExplicitDeclineHoldsAtBothEntrypoints(t *testing.T) {
+	declines := []struct {
+		name, env, value string
+	}{
+		{"opt-out set", tier2DisableEnv, "1"},
+		{"opt-out set to an arbitrary truthy value", tier2DisableEnv, "yes"},
+		{"legacy opt-in explicitly zero", tier2EnableEnv, "0"},
+		{"legacy opt-in explicitly false", tier2EnableEnv, "false"},
+	}
+
+	for _, d := range declines {
+		t.Run(d.name, func(t *testing.T) {
+			// Lift the test-binary guard so it cannot be what produces the
+			// refusal. Only the decline may.
+			t.Setenv("TRVL_ALLOW_BROWSER_COOKIES", "1")
+			t.Setenv(tier2DisableEnv, "")
+			t.Setenv(tier2EnableEnv, "")
+			t.Setenv(d.env, d.value)
+
+			// Pretend a browser is installed, so detection cannot be the reason
+			// either.
+			prevExists := fileExists
+			fileExists = func(string) bool { return true }
+			defer func() { fileExists = prevExists }()
+
+			// If any gate leaks, these runners record it instead of spawning a
+			// real browser.
+			spawned := false
+			prevRunner, prevChallenge := cdpRunner, cdpChallengeRunner
+			cdpRunner = func(context.Context, string, string, time.Duration) ([]*network.Cookie, error) {
+				spawned = true
+				return nil, nil
+			}
+			cdpChallengeRunner = func(context.Context, string, string, time.Duration) ([]*network.Cookie, string, error) {
+				spawned = true
+				return nil, "", nil
+			}
+			defer func() { cdpRunner, cdpChallengeRunner = prevRunner, prevChallenge }()
+
+			if _, err := RefreshCookiesViaCDP(context.Background(), "https://www.thetrainline.com/"); !errors.Is(err, ErrTier2Disabled) {
+				t.Fatalf("RefreshCookiesViaCDP: err = %v, want ErrTier2Disabled", err)
+			}
+			if _, err := ResolveChallenge(context.Background(), "https://www.thetrainline.com/"); !errors.Is(err, ErrTier2Disabled) {
+				t.Fatalf("ResolveChallenge: err = %v, want ErrTier2Disabled", err)
+			}
+			if spawned {
+				t.Fatal("a runner was reached despite an explicit decline")
+			}
+		})
+	}
+}
+
+// TestDriversRefuseAnExplicitDecline gates the two functions that actually spawn
+// the browser, not just the entrypoints above them. A future caller that reaches
+// past RefreshCookiesViaCDP/ResolveChallenge still cannot start a browser the
+// user declined -- the low-level placement is the point (#507/#515).
+func TestDriversRefuseAnExplicitDecline(t *testing.T) {
+	t.Setenv("TRVL_ALLOW_BROWSER_COOKIES", "1")
+	t.Setenv(tier2DisableEnv, "1")
+
+	if _, err := runCDPCollect(context.Background(), "/nonexistent/browser", "https://www.thetrainline.com/", time.Millisecond); !errors.Is(err, ErrTier2Disabled) {
+		t.Fatalf("runCDPCollect: err = %v, want ErrTier2Disabled", err)
+	}
+	if _, _, err := runCDPChallenge(context.Background(), "/nonexistent/browser", "https://www.thetrainline.com/", time.Millisecond); !errors.Is(err, ErrTier2Disabled) {
+		t.Fatalf("runCDPChallenge: err = %v, want ErrTier2Disabled", err)
+	}
+}


### PR DESCRIPTION
Closes #521.

Two changes to how trvl reaches your browser, in one direction: the user decides, and the default is the one that produces results.

## 1. `TRVL_NO_BROWSER_COOKIES` — decline cookie reads (#521)

Set it to anything except `0` or `false` and trvl reads no browser cookie store. Default unchanged: reading stays on, because turning it off costs results.

**It gates two readers, not one.** trvl has two ways into a cookie store:

- the in-process kooky reader in `internal/providers` (hotels aws-waf-token, rome2rio, trainline tier-1, the generic tier-1 challenge fallback)
- the nab helper in `internal/cookies`, used by the rail 403 retry in trainline, eurostar and sncf

A flag named "no browser cookies" that covered one of two would be the same defect this repo just fixed in #507: a control whose name promises more than it delivers.

**The gate sits on the low-level readers, not the exported wrapper.** The first version checked only `BrowserCookiesForURL`. The pre-push reviewer caught that provider recovery never calls that name — it reaches the reader through `currentCookieSource`, through the browser-hint variant, and through the background pre-warm goroutine. Three of four ways in would have ignored the user. Fixed in a0542a0.

## 2. The headless harvest now runs by default, `TRVL_NO_TIER2_CDP` declines

The Tier-2 path drives a Chrome, Brave or Edge you already have installed, lets a bot challenge resolve, and keeps the cookies. It was opt-in behind `TRVL_TIER2_CDP`, so for anyone who had not read that far, a challenged search returned nothing with no sign that a capability existed and was off.

The reason for opt-in was cost and visibility. Cost is real — a browser process for a few seconds. Visibility is not: both drivers pass `chromedp.Headless`, no window is created, focus is never taken, and no path drops the flag. So the default flips.

`TRVL_TIER2_CDP=0` is still honoured. Someone who set it meant it, and flipping a default must not overrule them.

## Evidence

- **Mutation.** Delete the cookie gate and the new test reports 11 real booking.com cookies arriving through `currentCookieSource` and through the wrapper. Deleting the nab gate leaks live Eurostar and Trainline sessions and blows the timing assertion: 4 of 5 cases fail. The gates are load-bearing, not decorative.
- Tests report cookie **counts**, never values. A value is a live session; on CI that would publish a contributor's session into a public log.
- New tests call each rail provider's own extractor variable rather than the shared helper, so a provider that rewires itself later cannot silently escape the opt-out.
- The `go test` browser guard moved onto the two driver functions. On by default, the entrypoint guard would either launch a real browser on CI or break every test that stubs `cdpRunner`; on the driver it does neither.
- `internal/providers`, `internal/cookies`, `internal/ground`, `internal/hotels`: 3209 tests pass. `gofmt`, `go vet` clean.

## README and CHANGELOG

Both state the honest cost of switching either off: a challenged search returns nothing, and that reads like trvl finding no trains rather than like a setting you chose.

## Side finding

The #529 probe result was wrong and is corrected there. Its zero-cookie reading came from the pre-existing `TRVL_ALLOW_BROWSER_COOKIES` test-binary guard, not from macOS app-bound encryption. With the guard lifted, kooky returns cookies for 4 of 7 domains including the `aws-waf-token` booking.com needs. The narrower gap — trainline, sncf and rome2rio return nothing from kooky while nab returns live trainline sessions — is real and stays open.
