### PR TITLE
fix #549: refuse to emit a saving with no currency — three sites (V: sabotage-verified per fix, make dod exit 0)

### DIFF
--- a/internal/counterfactual/counterfactual.go
+++ b/internal/counterfactual/counterfactual.go
@@ -77,13 +77,24 @@ func ShiftDay(grid []models.DatePriceResult, currentDate string, minDelta float6
 		// reference's labeled currency -- the exact fabricated-saving bug
 		// class round 24 meant to close, just reachable via the
 		// empty-string escape hatch. Round 25 requires exact equality
-		// after normalization instead: both blank is treated as
-		// compatible (matches the pre-existing unknown-unknown display
-		// convention), one blank and one labeled is now correctly
+		// after normalization instead: one blank and one labeled is
 		// rejected, and any known mismatch is still rejected. Found
 		// independently by both GPT and Grok second-opinion review,
 		// 2026-07-31 (round 25).
-		if cur != currency {
+		//
+		// Round 26 (trvl#549) also rejects BOTH blank, which round 25 had
+		// treated as compatible on the pre-existing unknown-unknown display
+		// convention. Two rows can be currencyless for unrelated reasons --
+		// one provider omitting the currency on a EUR quote, another on a JPY
+		// one -- so "both blank" is not evidence they share a unit; it is the
+		// absence of evidence either way.
+		//
+		// Saving.Amount is documented as money saved IN Currency. With no
+		// currency the number has no defined unit and cannot honestly be shown:
+		// the description rendered "save 123 " with a trailing space. Refusing
+		// costs the rare genuinely-comparable pair a signal that could not have
+		// been displayed anyway.
+		if cur == "" || cur != currency {
 			continue
 		}
 		delta := current - d.Price
@@ -134,7 +145,12 @@ func SameDayAlternative(flights []models.FlightResult, minDelta float64, asOf ti
 		// Found independently by both GPT and Grok second-opinion review,
 		// 2026-07-31 (round 25).
 		fCur := strings.ToUpper(strings.TrimSpace(f.Currency))
-		if fCur != headlineCur {
+		// Round 26 (trvl#549): an unknown currency is not a match for another
+		// unknown one. Same reasoning as ShiftDay above, and it bites harder
+		// here -- this input is a flight result list, which can span several
+		// providers, so two blank rows are more likely to be genuinely
+		// different currencies than in a single date grid.
+		if fCur == "" || fCur != headlineCur {
 			continue
 		}
 		cheapest = f

--- a/internal/counterfactual/counterfactual.go
+++ b/internal/counterfactual/counterfactual.go
@@ -130,6 +130,29 @@ func SameDayAlternative(flights []models.FlightResult, minDelta float64, asOf ti
 		return nil
 	}
 	headlineCur := strings.ToUpper(strings.TrimSpace(headline.Currency))
+	// An unlabeled headline cannot anchor a comparison, so refuse here rather
+	// than relying on the arithmetic below to fall out the right way.
+	//
+	// It does not always fall out the right way. Every candidate is skipped when
+	// the headline is blank, so `cheapest` stays `headline` and delta is 0 --
+	// which returns nil only because `0 < minDelta` holds for a positive
+	// threshold. With minDelta 0 or negative the function instead returned
+	// Saving{Amount: 0, Currency: ""}, rendering "The cheapest same-day fare
+	// (200 ) saves 0 ..." -- the exact unlabeled-money defect the guards above
+	// exist to prevent.
+	//
+	// The only production caller passes MinDelta = 10 (pricefeed.go:29), so this
+	// was not reachable in the shipped path. It was still wrong to leave: this
+	// function is exported, and a correctness guarantee that rests on the value
+	// of an unrelated constant in another package is one nothing enforces and no
+	// test covered.
+	//
+	// Found by GPT second-opinion review, 2026-08-04, and confirmed by probe
+	// before fixing. Grok had flagged the same early-exit as optional polish;
+	// treating it as correctness is what the second opinion added.
+	if headlineCur == "" {
+		return nil
+	}
 	cheapest := headline
 	for _, f := range flights[1:] {
 		if f.Price <= 0 || f.Price >= cheapest.Price {

--- a/internal/counterfactual/counterfactual.go
+++ b/internal/counterfactual/counterfactual.go
@@ -71,29 +71,27 @@ func ShiftDay(grid []models.DatePriceResult, currentDate string, minDelta float6
 			continue
 		}
 		cur := strings.ToUpper(strings.TrimSpace(d.Currency))
-		// Round 24's guard here only rejected a KNOWN mismatch (both sides
-		// labeled and different), so an empty-currency row still slipped
-		// through unchecked and got compared by raw magnitude against the
-		// reference's labeled currency -- the exact fabricated-saving bug
-		// class round 24 meant to close, just reachable via the
-		// empty-string escape hatch. Round 25 requires exact equality
-		// after normalization instead: one blank and one labeled is
-		// rejected, and any known mismatch is still rejected. Found
-		// independently by both GPT and Grok second-opinion review,
-		// 2026-07-31 (round 25).
+		// Round 24 rejected only a KNOWN mismatch (both sides labeled and
+		// different), so an empty-currency row slipped through and got compared
+		// by raw magnitude against the reference's labeled currency -- the exact
+		// fabricated-saving bug class round 24 meant to close, reachable via the
+		// empty-string escape hatch. Round 25 required exact equality after
+		// normalization; round 26 (trvl#549) also rejects BOTH blank, which
+		// round 25 had treated as compatible.
 		//
-		// Round 26 (trvl#549) also rejects BOTH blank, which round 25 had
-		// treated as compatible on the pre-existing unknown-unknown display
-		// convention. Two rows can be currencyless for unrelated reasons --
-		// one provider omitting the currency on a EUR quote, another on a JPY
-		// one -- so "both blank" is not evidence they share a unit; it is the
-		// absence of evidence either way.
+		// Two rows can be currencyless for unrelated reasons -- one provider
+		// omitting the currency on a EUR quote, another on a JPY one -- so "both
+		// blank" is not evidence they share a unit; it is the absence of evidence
+		// either way.
 		//
 		// Saving.Amount is documented as money saved IN Currency. With no
 		// currency the number has no defined unit and cannot honestly be shown:
 		// the description rendered "save 123 " with a trailing space. Refusing
 		// costs the rare genuinely-comparable pair a signal that could not have
 		// been displayed anyway.
+		//
+		// The round-24 hatch was found independently by both GPT and Grok
+		// second-opinion review (2026-07-31, round 25).
 		if cur == "" || cur != currency {
 			continue
 		}
@@ -137,19 +135,20 @@ func SameDayAlternative(flights []models.FlightResult, minDelta float64, asOf ti
 		if f.Price <= 0 || f.Price >= cheapest.Price {
 			continue
 		}
-		// Round 25: the round-24 guard below had the same empty-currency
-		// escape hatch as ShiftDay's -- an unlabeled candidate fare could
-		// still win against a labeled headline by raw magnitude. Require
-		// exact equality after normalization (both blank is compatible,
-		// one blank one labeled is rejected, known mismatch is rejected).
-		// Found independently by both GPT and Grok second-opinion review,
-		// 2026-07-31 (round 25).
+		// Round 25 closed an empty-currency escape hatch here: an unlabeled
+		// candidate fare could win against a labeled headline on raw magnitude.
+		// It required exact equality after normalization, but still treated two
+		// blanks as compatible.
+		//
+		// Round 26 (trvl#549) rejects that case too: an unknown currency is not
+		// a match for another unknown one. Same reasoning as ShiftDay above, and
+		// it bites harder here -- this input is a flight result list, which can
+		// span several providers, so two blank rows are more likely to be
+		// genuinely different currencies than in a single date grid.
+		//
+		// The escape hatch was found independently by both GPT and Grok
+		// second-opinion review (2026-07-31, round 25).
 		fCur := strings.ToUpper(strings.TrimSpace(f.Currency))
-		// Round 26 (trvl#549): an unknown currency is not a match for another
-		// unknown one. Same reasoning as ShiftDay above, and it bites harder
-		// here -- this input is a flight result list, which can span several
-		// providers, so two blank rows are more likely to be genuinely
-		// different currencies than in a single date grid.
 		if fCur == "" || fCur != headlineCur {
 			continue
 		}

--- a/internal/counterfactual/counterfactual.go
+++ b/internal/counterfactual/counterfactual.go
@@ -184,15 +184,39 @@ func VsHistory(pos *pricesignal.Position, currency string, asOf time.Time) *Savi
 	if pos == nil || !pos.Confident || pos.Median <= 0 {
 		return nil
 	}
+	// Round 26 (trvl#549), third emission site. ShiftDay and SameDayAlternative
+	// were fixed to refuse a blank currency; this one was missed, and it is
+	// reachable on the live path: pricefeed.Flight passes cheapestFlight's raw
+	// f.Currency (pricefeed.go:55,71), which is empty whenever the cheapest
+	// provider omits the field.
+	//
+	// Two independent reasons to refuse, not one:
+	//
+	//  1. The emitted Amount has no unit. The description rendered "is 120
+	//     below this route's typical" with a double space where the currency
+	//     belongs -- the same fabricated-money defect as the other two sites.
+	//  2. The median it is derived from is itself untrustworthy. The caller
+	//     builds the series with RoutePrices(key, "") which, since trvl#564,
+	//     exact-matches blank -- so the series pools every currencyless
+	//     observation on the route, and those can be different real currencies.
+	//     The percentile is computed across incomparable numbers.
+	//
+	// Normalizing here also closes the round-25 casing inconsistency: this site
+	// emitted the caller's raw string, so "eur" was returned lowercase while the
+	// other two sites always emit uppercase.
+	cur := strings.ToUpper(strings.TrimSpace(currency))
+	if cur == "" {
+		return nil
+	}
 	delta := pos.Median - pos.Current
 	if delta <= 0 {
 		return nil
 	}
 	return &Saving{
 		Kind:        KindVsHistory,
-		Description: fmt.Sprintf("Current price is %.0f %s below this route's typical (median %.0f over %d obs)", delta, currency, pos.Median, pos.Observations),
+		Description: fmt.Sprintf("Current price is %.0f %s below this route's typical (median %.0f over %d obs)", delta, cur, pos.Median, pos.Observations),
 		Amount:      delta,
-		Currency:    currency,
+		Currency:    cur,
 		AsOf:        asOf,
 		CallFree:    true,
 	}

--- a/internal/counterfactual/counterfactual_test.go
+++ b/internal/counterfactual/counterfactual_test.go
@@ -107,14 +107,23 @@ func TestShiftDayCrossCurrencyMismatch(t *testing.T) {
 		t.Fatalf("cross-currency mismatch must yield no saving, got %+v", out)
 	}
 
-	// Both unlabeled -> saving still allowed (documented unknown-unknown
-	// convention: two currencyless rows are treated as compatible).
+	// Both unlabeled -> NO saving (trvl#549).
+	//
+	// This previously asserted the opposite, on a documented
+	// unknown-unknown-is-compatible convention. Two rows can be currencyless
+	// for unrelated reasons -- one provider omitting the currency on a EUR
+	// quote, another on a JPY one -- so "both blank" is not evidence they share
+	// a unit, it is the absence of evidence either way.
+	//
+	// Saving.Amount is money saved IN Currency. With no currency the number has
+	// no defined unit and cannot honestly be shown: the description rendered
+	// "save 120 " with a trailing space.
 	bothBlank := []models.DatePriceResult{
 		{Date: "2026-07-14", Price: 80},
 		{Date: "2026-07-15", Price: 200}, // current
 	}
-	if out := ShiftDay(bothBlank, "2026-07-15", 5, asOf); len(out) != 1 || out[0].Amount != 120 {
-		t.Fatalf("both-blank rows should still allow a saving, got %+v", out)
+	if out := ShiftDay(bothBlank, "2026-07-15", 5, asOf); len(out) != 0 {
+		t.Fatalf("two currencyless rows produced a saving with no unit: %+v", out)
 	}
 }
 
@@ -154,12 +163,16 @@ func TestSameDayAlternativeCrossCurrencyMismatch(t *testing.T) {
 	// SameDayAlternative did not, even though the production logic (line
 	// `fCur != headlineCur`, "" == "" is true) already takes this path --
 	// parity-only, no behavior change. Fixed as trvl#548.
+	// Both unlabeled -> NO saving (trvl#549), same reasoning as ShiftDay. It
+	// bites harder here: this input is a flight result list, which can span
+	// several providers, so two blank rows are more likely to be genuinely
+	// different currencies than in a single date grid.
 	bothBlank := []models.FlightResult{
 		{Price: 220}, // headline, no currency
 		{Price: 150}, // cheaper, no currency
 	}
-	if s := SameDayAlternative(bothBlank, 10, asOf); s == nil || s.Amount != 70 {
-		t.Fatalf("both-blank flights should still allow a saving, got %+v", s)
+	if s := SameDayAlternative(bothBlank, 10, asOf); s != nil {
+		t.Fatalf("two currencyless flights produced a saving with no unit: %+v", s)
 	}
 }
 

--- a/internal/counterfactual/counterfactual_test.go
+++ b/internal/counterfactual/counterfactual_test.go
@@ -70,7 +70,15 @@ func TestSameDayAlternative(t *testing.T) {
 	if SameDayAlternative(flights[:1], 10, asOf) != nil {
 		t.Fatalf("single flight must yield nil")
 	}
-	if SameDayAlternative([]models.FlightResult{{Price: 155}, {Price: 150}}, 10, asOf) != nil {
+	// Currencies are labeled deliberately. Round 26 made a blank currency its own
+	// reason to return nil, so an unlabeled fixture here would pass whether or not
+	// minDelta worked at all -- the assertion would read as evidence while testing
+	// nothing. Labeling them keeps the 5-below-10 delta the only thing that can
+	// produce the nil.
+	if SameDayAlternative([]models.FlightResult{
+		{Price: 155, Currency: "EUR"},
+		{Price: 150, Currency: "EUR"},
+	}, 10, asOf) != nil {
 		t.Fatalf("delta below minDelta must yield nil")
 	}
 }
@@ -158,16 +166,14 @@ func TestSameDayAlternativeCrossCurrencyMismatch(t *testing.T) {
 		t.Fatalf("cross-currency mismatch must yield no saving, got %+v", s)
 	}
 
-	// Both unlabeled -> saving still allowed (same documented unknown-unknown
-	// convention as ShiftDay's bothBlank case above). Grok round-25 optional
-	// finding #4: ShiftDay had an explicit positive both-blank test but
-	// SameDayAlternative did not, even though the production logic (line
-	// `fCur != headlineCur`, "" == "" is true) already takes this path --
-	// parity-only, no behavior change. Fixed as trvl#548.
 	// Both unlabeled -> NO saving (trvl#549), same reasoning as ShiftDay. It
 	// bites harder here: this input is a flight result list, which can span
 	// several providers, so two blank rows are more likely to be genuinely
 	// different currencies than in a single date grid.
+	//
+	// trvl#548 asked for this case as a PARITY test asserting the old
+	// "saving still allowed" behaviour. That expectation is now the bug, so the
+	// case survives with its assertion inverted rather than as written.
 	bothBlank := []models.FlightResult{
 		{Price: 220}, // headline, no currency
 		{Price: 150}, // cheaper, no currency

--- a/internal/counterfactual/counterfactual_test.go
+++ b/internal/counterfactual/counterfactual_test.go
@@ -1,6 +1,7 @@
 package counterfactual
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -192,5 +193,47 @@ func TestVsHistoryHonesty(t *testing.T) {
 	}
 	if VsHistory(nil, "EUR", asOf) != nil {
 		t.Fatalf("nil position must yield nil")
+	}
+}
+
+// TRVL.549.VSHISTORY.1 -- the third emission site must refuse a blank currency
+// like the other two.
+//
+// This is reachable on the live path: pricefeed.Flight passes cheapestFlight's
+// raw f.Currency, which is empty whenever the cheapest provider omits the field.
+// The old code emitted Amount=50 with Currency="", rendering "is 50  below this
+// route's typical" -- a money figure with no unit, and a double space where the
+// currency belongs.
+//
+// It is also the weaker claim of the two: the median comes from
+// RoutePrices(key, ""), which since trvl#564 exact-matches blank, so the series
+// pools every currencyless observation on the route and those can be different
+// real currencies. Refusing costs a claim that could not have been rendered
+// honestly anyway.
+func TestVsHistoryRefusesBlankCurrency(t *testing.T) {
+	pos := &pricesignal.Position{Confident: true, Median: 200, Current: 150, Observations: 12}
+
+	for _, blank := range []string{"", "   "} {
+		if s := VsHistory(pos, blank, asOf); s != nil {
+			t.Errorf("VsHistory(%q) = %+v, want nil -- an unlabeled amount is not money, and the "+
+				"median behind it pools possibly-different currencies", blank, s)
+		}
+	}
+}
+
+// TRVL.549.VSHISTORY.2 -- and it must normalize casing, as the other two sites
+// do. This site emitted the caller's raw string, so a provider reporting "eur"
+// produced a lowercase Currency while an identical fare via ShiftDay produced
+// "EUR" (the round-25 inconsistency, never applied here).
+func TestVsHistoryNormalizesCurrencyCasing(t *testing.T) {
+	s := VsHistory(&pricesignal.Position{Confident: true, Median: 200, Current: 150, Observations: 12}, " eur ", asOf)
+	if s == nil {
+		t.Fatal("a padded, lowercase but perfectly valid currency must still yield a saving")
+	}
+	if s.Currency != "EUR" {
+		t.Errorf("Currency = %q, want EUR -- the other two sites always emit uppercase", s.Currency)
+	}
+	if !strings.Contains(s.Description, "50 EUR") {
+		t.Errorf("description carries the unnormalized currency: %q", s.Description)
 	}
 }

--- a/internal/counterfactual/counterfactual_test.go
+++ b/internal/counterfactual/counterfactual_test.go
@@ -183,6 +183,49 @@ func TestSameDayAlternativeCrossCurrencyMismatch(t *testing.T) {
 	}
 }
 
+// TRVL.549.SAMEDAY.THRESHOLD -- the blank-currency refusal must not depend on
+// the value of minDelta.
+//
+// The guards above skip mismatched candidates, so a blank headline leaves
+// `cheapest` equal to `headline` and a delta of 0. That returned nil only
+// because `0 < minDelta` holds for a positive threshold. At minDelta 0 or below
+// the function fell through and emitted Saving{Amount: 0, Currency: ""} --
+// rendering "The cheapest same-day fare (200 ) saves 0 " -- which is precisely
+// the unlabeled-money defect #549 exists to prevent, reachable through the one
+// parameter nobody thought was load-bearing for currency handling.
+//
+// Not reachable from the shipped path: the only production caller passes
+// MinDelta = 10 (pricefeed.go:29). Pinned anyway, because SameDayAlternative is
+// exported and a guarantee that holds only while a constant in another package
+// keeps its value is not a guarantee.
+//
+// Found by GPT second-opinion review; Grok had rated the same early-exit as
+// optional polish and returned SHIP without it.
+func TestSameDayBlankHeadlineRefusedAtAnyThreshold(t *testing.T) {
+	blankHeadline := []models.FlightResult{
+		{Price: 200}, // headline, no currency
+		{Price: 150}, // cheaper, no currency
+	}
+
+	for _, minDelta := range []float64{10, 1, 0, -1} {
+		if s := SameDayAlternative(blankHeadline, minDelta, asOf); s != nil {
+			t.Errorf("minDelta=%v produced %+v -- an unlabeled headline must be refused on its own "+
+				"terms, not by whether the threshold happens to catch a zero delta", minDelta, s)
+		}
+	}
+
+	// A labeled pair at the same thresholds still works, so the guard above
+	// refuses blankness rather than quietly disabling the whole function.
+	labeled := []models.FlightResult{
+		{Price: 200, Currency: "EUR"},
+		{Price: 150, Currency: "EUR"},
+	}
+	if s := SameDayAlternative(labeled, 0, asOf); s == nil || s.Amount != 50 || s.Currency != "EUR" {
+		t.Errorf("labeled pair at minDelta=0 = %+v, want a 50 EUR saving -- the fix must not "+
+			"suppress comparable fares", s)
+	}
+}
+
 func TestVsHistoryHonesty(t *testing.T) {
 	// Not confident -> no claim.
 	if VsHistory(&pricesignal.Position{Confident: false, Median: 200, Current: 150}, "EUR", asOf) != nil {

--- a/internal/watch/store_route_history.go
+++ b/internal/watch/store_route_history.go
@@ -262,7 +262,10 @@ func (s *Store) RouteHistory(routeKey string) []PricePoint {
 
 // RoutePrices returns the price values for a route key, filtered to a currency
 // so callers never mix currencies into a single price-position computation.
-// An empty currency returns every recorded price for the key.
+// The match is exact after normalization, including for an empty currency: an
+// empty argument selects only the points that themselves carry no currency, and
+// never every price for the key. It used to mean "every currency", which is the
+// mixing bug #564 closed -- see the comment on the comparison below.
 func (s *Store) RoutePrices(routeKey, currency string) []float64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
Counterfactual suggestions could emit a monetary saving with no currency attached: the rendered text read `Depart X instead of Y to save 120 `, with a trailing space where the currency belongs.

The cause was a convention that two blank currencies are compatible. They are not. Two rows can be currencyless for unrelated reasons — one provider omitting the currency on a EUR quote, another on a JPY one — so "both blank" is not evidence they share a unit, it is the absence of evidence either way. Subtracting them produces a number that means nothing and presents it as money.

Same reasoning as #545 (refuse a cross-currency threshold comparison rather than convert) and #564 (an empty currency is not a wildcard).

## Three sites, not two

The issue names `ShiftDay` and `SameDayAlternative`. Verifying an adversarial reviewer's question — *"any path where a Saving is constructed without going through these two guards?"* — against the source turned up a third: **`VsHistory`** built its Saving straight from its `currency` parameter with no check at all.

It is reachable on the live path, not theoretical: `pricefeed.Flight` passes `cheapestFlight`'s raw `f.Currency`, which is empty whenever the provider of the cheapest fare omits the field.

Two independent defects there, one fix:

1. The emitted amount had no unit — `"Current price is 50  below this route's typical"`, double space and all.
2. The median behind it is itself untrustworthy. The caller builds the series with `RoutePrices(key, "")`, which since #564 exact-matches blank, so the series pools every currencyless observation on the route — and those can be different real currencies. The percentile was computed across incomparable numbers.

Normalizing there also closed a casing inconsistency: this site emitted the caller's raw string, so `"eur"` came back lowercase while an identical fare through `ShiftDay` came back `"EUR"`.

## Accepted trade-off

A provider that never labels its currency previously received a vs-history saving and now receives silence. Its history series is all-blank and therefore self-consistent, so its `Position` can legitimately be `Confident`.

Taking the silence deliberately: the figure could not be rendered honestly anyway (no unit to print), and the median it rests on pools observations that may be different currencies. A missing suggestion is recoverable; a confidently-wrong money figure is not.

## A fixture this branch silently disarmed

Adversarial review caught that the currency guard made an existing assertion stop testing its subject. The sub-`minDelta` case had no currency on either row, so once blank became its own reason to return nil, it would have passed whether or not the `minDelta` gate worked — while still reading as evidence that it did. Both rows now carry EUR, so the delta is the only thing that can produce the nil.

Isolating that needed care: an earlier `t.Fatalf` in the same test aborts before reaching the fixture, so a naive sabotage run "fails" without ever exercising the assertion under test.

## On #548

It asked for a parity test asserting the OLD behaviour on the `SameDayAlternative` path. That test would now assert the bug, so this **supersedes** it rather than leaving it open implying work remains. The case survives with its assertion inverted.

## Evidence

- **V:** three guards, one per emission site, in `internal/counterfactual/counterfactual.go` — `cur == "" || cur != currency` (ShiftDay), `fCur == "" || fCur != headlineCur` (SameDayAlternative), and `cur == ""` after normalization (VsHistory).
- **V:** sabotage-verified per fix. Restoring the old comparison fails the inverted tests at their intended assertions; restoring VsHistory's raw assignment reproduces the literal double-space output `"Current price is 50  below this route's typical"`; disabling the `minDelta` gate now fails the repaired fixture, which it could not do before.
- **V:** a reviewer's further claim that `cfprobe.HacksToSavings` can emit a unitless saving does **not** survive checking — every production hack constructor that sets a positive `Savings` also sets a `Currency`, and `DetectorInput.currency()` defaults to EUR regardless. No issue filed; recorded so it is not re-raised.
- **V:** `PATH="$(go env GOPATH)/bin:$PATH" make dod` (lint, gosec, 101 packages) exit 0.
- **I:** the multi-provider exposure on `SameDayAlternative` is inferred from its input type (a flight result list spanning providers), not from an observed field report.

Closes #549.
Closes #548.
