### PR TITLE
fix #542: make the share-destination guard actually guard (V: old code accepts an undeclared destination with full suite green)

### DIFF
--- a/cmd/trvl/cli_cmds_split3_test.go
+++ b/cmd/trvl/cli_cmds_split3_test.go
@@ -617,48 +617,57 @@ func TestOutputShare_FormatSurfaceIsClosed(t *testing.T) {
 	}
 }
 
-// TRVL.SHAREFMT.3 -- the declared set and the dispatch cannot diverge.
+// TRVL.SHAREFMT.3 -- what outputShare ACCEPTS must equal what is declared.
 //
-// This is the assertion the old arrangement could not make. shareFormats used to
-// be a hand-written slice that outputShare never consulted, so the two were free
-// to disagree: appending to the slice changed no behaviour, and adding a switch
-// case added a destination with every test still green.
+// Deliberately behavioural, not structural. The obvious structural version --
+// compare shareFormats against the keys of shareSinks -- is tautological once
+// one is derived from the other: it cannot fail, and it would pass against a
+// revived `switch` sitting beside an intact map. Adversarial review (Grok,
+// 2026-08-04) called that out on the first draft of this test, as "documentation
+// dressed as a force". A test that cannot fail is worse than no test, because it
+// reads as evidence.
 //
-// Both directions are checked here, because "one source of truth" is a claim
-// about both:
+// So this drives the real entry point instead. Every declared format must be
+// accepted, and destination-shaped names that are NOT declared must be refused.
+// A contributor who adds a route without declaring it fails here.
 //
-//	dispatch -> declared: every sink appears in shareFormats, so a new
-//	destination cannot exist without showing up in the set the test above pins.
-//	declared -> dispatch: every declared format actually resolves to a sink, so
-//	the set cannot advertise a format that does not work.
-//
-// Verified by sabotage rather than assumed: adding a throwaway sink to
-// shareSinks fails TestOutputShare_FormatSurfaceIsClosed on its element-for-
-// element comparison, which is exactly the forcing function #527 needed and did
-// not have.
-func TestShareFormatsAndSinksCannotDiverge(t *testing.T) {
-	if len(shareFormats) != len(shareSinks) {
-		t.Fatalf("shareFormats has %d entries, shareSinks has %d — the declared set and the "+
-			"dispatch have diverged, which is the #542 defect returning",
-			len(shareFormats), len(shareSinks))
-	}
+// Verified by sabotage, not assumed: adding a `case "webhook"` branch ahead of
+// the map lookup fails the undeclared-name loop below.
+func TestOutputShareAcceptsExactlyWhatIsDeclared(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	const card = "**AMS -> HEL** | 10Jun-20Jun\n"
 
 	for _, format := range shareFormats {
-		if _, ok := shareSinks[format]; !ok {
-			t.Errorf("shareFormats advertises %q but no sink dispatches it", format)
+		// "clipboard" shells out to pbcopy/xclip, which the emptied PATH
+		// deliberately blocks. It is a local paste buffer, not a publish, and is
+		// exercised elsewhere.
+		if format == "clipboard" {
+			continue
+		}
+		if err := outputShare(card, format); err != nil {
+			t.Errorf("outputShare(%q) = %v, want nil -- %q is declared in shareFormats but does "+
+				"not dispatch, so the declared set advertises a format that does not work",
+				format, err, format)
 		}
 	}
 
-	for format := range shareSinks {
-		if !slices.Contains(shareFormats, format) {
-			t.Errorf("sink %q dispatches but is absent from shareFormats, so adding it would not "+
-				"have failed the surface test — a destination could ship unenumerated", format)
+	// Undeclared names, shaped like destinations someone might plausibly add.
+	// Each must be refused: reaching a sink without appearing in the declared
+	// set is the exact shape of the #527 defect.
+	for _, format := range []string{"webhook", "gist", "upload", "publish", "http", "post", "url", "link", "typo"} {
+		if err := outputShare(card, format); err == nil {
+			t.Errorf("outputShare(%q) = nil -- %q is not in shareFormats yet something delivered "+
+				"it; a destination is reachable without being declared", format, format)
 		}
 	}
+}
 
-	// shareFormats must stay sorted, or the element-for-element assertion above
-	// becomes order-dependent on Go's randomized map iteration and starts
-	// failing intermittently for a reason that has nothing to do with sharing.
+// TRVL.SHAREFMT.3b -- shareFormats must stay sorted, or the element-for-element
+// pin in TestOutputShare_FormatSurfaceIsClosed becomes order-dependent on Go's
+// randomized map iteration and starts failing intermittently for a reason that
+// has nothing to do with sharing.
+func TestShareFormatsIsSorted(t *testing.T) {
 	if !slices.IsSorted(shareFormats) {
 		t.Errorf("shareFormats = %q is not sorted; map iteration order would make the surface "+
 			"test flaky", shareFormats)

--- a/cmd/trvl/cli_cmds_split3_test.go
+++ b/cmd/trvl/cli_cmds_split3_test.go
@@ -561,9 +561,17 @@ func TestUpgradeCmd_DefaultRunV24(t *testing.T) {
 // until someone edits the expectation and states what they added. That is the
 // seam the removed gist upload slipped through — it was reachable through a
 // format string nobody had enumerated (#527).
+//
+// Since #542 that guarantee is real rather than claimed. shareFormats is derived
+// from the keys of shareSinks, which is also what dispatches, so adding a sink
+// necessarily changes this set and necessarily fails this assertion. Before that
+// the slice was hand-written and outputShare never read it: a new destination
+// could be added to the switch with every test still green, which is the defect
+// this comment used to describe as impossible.
 func TestOutputShare_FormatSurfaceIsClosed(t *testing.T) {
-	// Element-for-element. Adding a destination must land here first.
-	want := []string{"", "markdown", "stdout", "clipboard"}
+	// Element-for-element, in the sorted order shareFormats is derived in.
+	// Adding a destination must land here first.
+	want := []string{"", "clipboard", "markdown", "stdout"}
 	if !slices.Equal(shareFormats, want) {
 		t.Fatalf("shareFormats = %q, want %q — a share destination changed; "+
 			"confirm the new one is local and never publishes, then update this expectation",
@@ -606,6 +614,54 @@ func TestOutputShare_FormatSurfaceIsClosed(t *testing.T) {
 	// in a changelog they have no reason to open.
 	if err != nil && !strings.Contains(err.Error(), "gh gist list") {
 		t.Errorf("outputShare(\"link\") = %v, want it to point at gh gist list so an affected user can clean up", err)
+	}
+}
+
+// TRVL.SHAREFMT.3 -- the declared set and the dispatch cannot diverge.
+//
+// This is the assertion the old arrangement could not make. shareFormats used to
+// be a hand-written slice that outputShare never consulted, so the two were free
+// to disagree: appending to the slice changed no behaviour, and adding a switch
+// case added a destination with every test still green.
+//
+// Both directions are checked here, because "one source of truth" is a claim
+// about both:
+//
+//	dispatch -> declared: every sink appears in shareFormats, so a new
+//	destination cannot exist without showing up in the set the test above pins.
+//	declared -> dispatch: every declared format actually resolves to a sink, so
+//	the set cannot advertise a format that does not work.
+//
+// Verified by sabotage rather than assumed: adding a throwaway sink to
+// shareSinks fails TestOutputShare_FormatSurfaceIsClosed on its element-for-
+// element comparison, which is exactly the forcing function #527 needed and did
+// not have.
+func TestShareFormatsAndSinksCannotDiverge(t *testing.T) {
+	if len(shareFormats) != len(shareSinks) {
+		t.Fatalf("shareFormats has %d entries, shareSinks has %d — the declared set and the "+
+			"dispatch have diverged, which is the #542 defect returning",
+			len(shareFormats), len(shareSinks))
+	}
+
+	for _, format := range shareFormats {
+		if _, ok := shareSinks[format]; !ok {
+			t.Errorf("shareFormats advertises %q but no sink dispatches it", format)
+		}
+	}
+
+	for format := range shareSinks {
+		if !slices.Contains(shareFormats, format) {
+			t.Errorf("sink %q dispatches but is absent from shareFormats, so adding it would not "+
+				"have failed the surface test — a destination could ship unenumerated", format)
+		}
+	}
+
+	// shareFormats must stay sorted, or the element-for-element assertion above
+	// becomes order-dependent on Go's randomized map iteration and starts
+	// failing intermittently for a reason that has nothing to do with sharing.
+	if !slices.IsSorted(shareFormats) {
+		t.Errorf("shareFormats = %q is not sorted; map iteration order would make the surface "+
+			"test flaky", shareFormats)
 	}
 }
 

--- a/cmd/trvl/share.go
+++ b/cmd/trvl/share.go
@@ -3,10 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -102,32 +104,51 @@ func shareLastSearch(formatOut string) error {
 	return outputShare(md, formatOut)
 }
 
-// shareFormats is the closed set of accepted --format values, and the single
-// source of truth for where a trip card may go. Every entry is local: stdout or
-// the system clipboard. A card carries destinations and dates, which together
-// say when a home is empty, so trvl hands the text to the user and lets them
-// choose the recipient. It publishes nowhere.
+// shareSinks is the single declaration of where a trip card may go: one entry
+// per accepted --format value, mapping it to the function that delivers it.
+// Every sink is local -- stdout or the system clipboard. A card carries
+// destinations and dates, which together say when a home is empty, so trvl hands
+// the text to the user and lets them choose the recipient. It publishes nowhere.
 //
-// TestOutputShare_FormatSurfaceIsClosed asserts this slice element for element,
-// so a new destination cannot be added without a failing test that forces
-// whoever adds it to say so out loud. That is the seam the removed gist upload
-// slipped through: it was reachable via a format string nobody had enumerated.
-var shareFormats = []string{"", "markdown", "stdout", "clipboard"}
+// Before #542 the accepted set and the dispatch were separate declarations:
+// shareFormats was a hand-written slice that outputShare never read, so its
+// "single source of truth" comment was false. Appending a value to the slice
+// changed no behaviour, and adding a case to the switch changed behaviour
+// without failing any test. Deriving one from the other removes the drift
+// rather than adding a second check that could also fall out of step.
+var shareSinks = map[string]func(string) error{
+	"":          printShare,
+	"markdown":  printShare,
+	"stdout":    printShare,
+	"clipboard": copyToClipboard,
+}
 
-// outputShare routes the markdown to one of shareFormats.
+// shareFormats is the sorted set of accepted --format values, derived from the
+// sinks above so it cannot fall out of step with what actually dispatches.
 //
-// Anything absent from that set is an error rather than a silent fallback to
+// TestOutputShare_FormatSurfaceIsClosed pins this set element for element, so
+// adding a sink fails that test until whoever added it says what it is. That is
+// the seam the removed gist upload slipped through: it was reachable via a
+// format string nobody had enumerated (#527).
+var shareFormats = slices.Sorted(maps.Keys(shareSinks))
+
+// printShare writes the card to stdout.
+func printShare(md string) error {
+	fmt.Print(md)
+	return nil
+}
+
+// outputShare delivers the markdown to the sink named by formatOut.
+//
+// Anything absent from shareSinks is an error rather than a silent fallback to
 // stdout. A caller asking for a format trvl no longer has is scripting against
 // behaviour that changed, and printing an itinerary where they expected
 // something else is the wrong way to tell them.
 func outputShare(md, formatOut string) error {
-	switch formatOut {
-	case "", "markdown", "stdout":
-		fmt.Print(md)
-		return nil
-	case "clipboard":
-		return copyToClipboard(md)
-	case "link":
+	// Handled before the sink lookup because it is deliberately NOT a sink:
+	// keeping it out of shareSinks is what stops it reappearing in the accepted
+	// set, while still letting the retired format explain itself.
+	if formatOut == "link" {
 		// Removed in #527. This published the card as a public GitHub gist.
 		// Wording matches the changelog entry on purpose: this error is the one
 		// place the affected population self-selects, so it is also where the
@@ -136,9 +157,12 @@ func outputShare(md, formatOut string) error {
 		return fmt.Errorf("--format link has been removed: it created a public GitHub gist of the trip card. " +
 			"Use the default output or --format clipboard and send the text yourself. " +
 			"Gists it created are still on your account (gh gist list)")
-	default:
+	}
+	sink, ok := shareSinks[formatOut]
+	if !ok {
 		return fmt.Errorf("unsupported --format %q: use markdown or clipboard", formatOut)
 	}
+	return sink(md)
 }
 
 // formatTripMarkdown renders a saved trip as clean shareable markdown.


### PR DESCRIPTION
A guard in `trvl share` claimed something it did not do.

`shareFormats` described itself as "the closed set of accepted `--format` values, and the single source of truth for where a trip card may go", and its comment promised that a new destination could not be added without failing a test. `outputShare` never read it. The real gate was its own `switch`, so the two declarations were free to disagree.

## Proven, not argued

On `main`, adding a new outbound destination to the dispatch:

```go
case "webhook":
        fmt.Print(md)
        return nil
```

...introduces a reachable destination and **the entire package still passes**. That is the same unenumerated-format-string shape as #527, where a public gist upload was reachable through a format string nobody had listed.

## The fix removes the drift rather than checking for it

`shareSinks` is now the single declaration — one entry per accepted value, mapped to the function that delivers it — and `shareFormats` is derived from its sorted keys. Adding a sink necessarily changes the derived set, which necessarily fails the element-for-element assertion that pins it. The alternative (a second test asserting the two lists match) would have left two things that can drift and merely noticed afterwards.

Same sabotage against this branch fails, naming exactly what changed:

```
shareFormats = ["" "clipboard" "markdown" "stdout" "webhook"],
want ["" "clipboard" "markdown" "stdout"] -- a share destination changed
```

## A test that could not fail, caught in review

The first draft of the divergence test compared `shareFormats` against the keys of `shareSinks`. Since one is derived from the other, that comparison **cannot fail** — and it would have passed against a revived `switch` sitting beside an intact map, which is precisely the arrangement this issue exists to prevent. Adversarial review named it: "documentation dressed as a force."

Replaced with a behavioural test that drives `outputShare` itself. Sabotage-verified against the exact case the structural version was blind to — a delivery branch added ahead of the map lookup, map untouched:

```
outputShare("webhook") = nil -- "webhook" is not in shareFormats yet
something delivered it; a destination is reachable without being declared
```

Worth noting the element-for-element pin does **not** fail on that sabotage either — it only sees the map. The two tests cover different halves; only together do they close the gap.

## Unchanged on purpose

- The accepted set is identical: screen and clipboard. No user-visible behaviour change.
- `--format link` keeps its byte-identical removal error and is deliberately **not** a sink — keeping it out of the map is what stops the retired format reappearing in the accepted set. Its error is the only surface where users affected by #527 self-select, so the wording is untouched.

The derived list is sorted, so the pinned expectation changed order (same set). A test asserts sortedness: Go randomizes map iteration, and an unsorted derivation would make the surface pin flaky for a reason unrelated to sharing.

## Evidence

- **V:** old code accepts an undeclared destination with the full package green — run before the change, not inferred.
- **V:** new code fails on the same addition; behavioural test additionally fails on the revived-branch variant the structural test missed.
- **V:** `make dod` (lint, gosec, 101 packages) exit 0 on both commits.
- **V:** adversarial review (Grok) — SHIP, no material defects; its finding on the tautological test was verified and acted on.
- **I:** GPT second opinion unavailable — its sandbox blocks every shell command it attempts. One reviewer, not two.

Closes #542.
