### PR TITLE
fix #565: redirect USERPROFILE alongside HOME, and guard it in CI (V: 106->117 sites, 3 rules sabotage-verified)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ repo-hygiene:
 	scripts/ci/check-language-hygiene.sh
 	scripts/ci/check-file-size.sh
 	scripts/ci/check-release-metadata.sh
+	scripts/ci/check-home-isolation.sh
 
 lint: repo-hygiene
 	$(GO_RUN) vet ./...

--- a/internal/pricefeed/pricefeed_test.go
+++ b/internal/pricefeed/pricefeed_test.go
@@ -70,9 +70,13 @@ func TestFlightMultiAirportReturnsEmpty(t *testing.T) {
 }
 
 func TestFlightSameDaySaving(t *testing.T) {
-	// HOME isolation so it doesn't touch the real ~/.trvl.
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("USERPROFILE", t.TempDir())
+	// HOME isolation so it doesn't touch the real ~/.trvl. Both names, one
+	// directory: os.UserHomeDir reads USERPROFILE on Windows, and t.TempDir()
+	// returns a NEW directory per call, so calling it twice pointed the two at
+	// unrelated places (trvl#565).
+	feedHome := t.TempDir()
+	t.Setenv("HOME", feedHome)
+	t.Setenv("USERPROFILE", feedHome)
 	res := &models.FlightSearchResult{Success: true, Flights: []models.FlightResult{
 		{Price: 220, Currency: "EUR"}, // headline
 		{Price: 150, Currency: "EUR"}, // cheapest

--- a/internal/providers/auth_cache_decline_test.go
+++ b/internal/providers/auth_cache_decline_test.go
@@ -30,7 +30,9 @@ func TestAuthCacheDiscardsBrowserSeededStateAfterADecline(t *testing.T) {
 	// invisible because a decline refused the whole file; now that the decline
 	// only withholds the browser-derived entries, a stray site-derived entry
 	// would seed the jar and fail the assertion below for the wrong reason.
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	const preflight = "https://example.test/preflight"
 
@@ -118,7 +120,9 @@ func TestAuthCacheDiscardsBrowserSeededStateAfterADecline(t *testing.T) {
 // Discarding it would punish a user for a control that says nothing about it,
 // and would turn the opt-out into a general cache-buster.
 func TestAuthCacheKeepsNonBrowserStateAfterADecline(t *testing.T) {
-	t.Setenv("HOME", t.TempDir()) // same reason as the test above
+	declineHome := t.TempDir() // same reason as the test above
+	t.Setenv("HOME", declineHome)
+	t.Setenv("USERPROFILE", declineHome)
 	const preflight = "https://example.test/preflight"
 
 	// A vault, but one no browser ever touched: cookies arrived the ordinary

--- a/internal/providers/challenge_test.go
+++ b/internal/providers/challenge_test.go
@@ -102,10 +102,16 @@ func TestResolveChallenge_RunnerError(t *testing.T) {
 }
 
 func TestResolveChallenge_ClearedPersistsCookies(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
 	// os.UserHomeDir reads USERPROFILE on Windows, not HOME — isolate both so
 	// the ~/.trvl cookie cache is per-test on every OS.
-	t.Setenv("USERPROFILE", t.TempDir())
+	//
+	// Both must name the SAME directory. t.TempDir() returns a NEW directory on
+	// every call, so calling it twice pointed HOME and USERPROFILE at unrelated
+	// places: on Windows the test then ran against a directory nothing had
+	// populated, while unix used the other one. Capture once (trvl#565).
+	challengeHome := t.TempDir()
+	t.Setenv("HOME", challengeHome)
+	t.Setenv("USERPROFILE", challengeHome)
 
 	prevExists := fileExists
 	fileExists = func(string) bool { return true }
@@ -143,10 +149,16 @@ func TestResolveChallenge_ClearedPersistsCookies(t *testing.T) {
 }
 
 func TestResolveChallenge_NeedsHumanDoesNotPersist(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
 	// os.UserHomeDir reads USERPROFILE on Windows, not HOME — isolate both so a
 	// prior test's persisted cookies cannot leak into this absence assertion.
-	t.Setenv("USERPROFILE", t.TempDir())
+	//
+	// Both must name the SAME directory; see the note in
+	// TestResolveChallenge_ClearedPersistsCookies. This one matters more than
+	// most: it asserts an ABSENCE, and an assertion that nothing was persisted
+	// passes trivially when it is looking at the wrong directory.
+	needsHumanHome := t.TempDir()
+	t.Setenv("HOME", needsHumanHome)
+	t.Setenv("USERPROFILE", needsHumanHome)
 
 	prevExists := fileExists
 	fileExists = func(string) bool { return true }

--- a/internal/providers/cookie_cache_decline_test.go
+++ b/internal/providers/cookie_cache_decline_test.go
@@ -30,7 +30,9 @@ import (
 // from a plain jar would be site-derived, would legitimately survive the
 // decline, and would prove nothing about this bypass.
 func TestCachedCookiesAreRefusedAfterADecline(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	const target = "https://www.thetrainline.com/search"
 	u, err := url.Parse(target)

--- a/internal/providers/cookie_cache_provenance_test.go
+++ b/internal/providers/cookie_cache_provenance_test.go
@@ -40,7 +40,9 @@ func writeCookieCacheFixture(t *testing.T, host, body string) {
 // coincide because Go zeroes the field, and a future encoding change could
 // separate them.
 func TestLegacyCacheEntriesCountAsBrowserDerived(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	t.Setenv(consent.CookiesEnv, "1")
 
 	u, err := url.Parse(provenanceTestTarget)
@@ -70,7 +72,9 @@ func TestLegacyCacheEntriesCountAsBrowserDerived(t *testing.T) {
 // helper, because a helper that classifies correctly while the load path
 // ignores it would pass a helper test.
 func TestDeclineKeepsSiteDerivedCookies(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	t.Setenv(consent.CookiesEnv, "1")
 
 	u, err := url.Parse(provenanceTestTarget)
@@ -126,7 +130,9 @@ func TestSaveRecordsProvenance(t *testing.T) {
 	}
 
 	t.Run("browser seeded vault", func(t *testing.T) {
-		t.Setenv("HOME", t.TempDir())
+		homeDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("USERPROFILE", homeDir)
 		v := newCookieVault()
 		if v == nil {
 			t.Fatal("building the vault")
@@ -144,7 +150,9 @@ func TestSaveRecordsProvenance(t *testing.T) {
 		// The headless tier-2 path saves from a plain jar filled by a fresh
 		// profile: those cookies came from the site, never from the user's own
 		// browser store, and a decline of browser reads must not drop them.
-		t.Setenv("HOME", t.TempDir())
+		homeDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("USERPROFILE", homeDir)
 		jar, err := cookiejar.New(nil)
 		if err != nil {
 			t.Fatalf("building a jar: %v", err)
@@ -161,7 +169,9 @@ func TestSaveRecordsProvenance(t *testing.T) {
 		// cache into a provider client's vault has to leave the vault
 		// unmarked, or the next save would relabel those cookies browser and
 		// the following opt-out would drop them for good.
-		t.Setenv("HOME", t.TempDir())
+		homeDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("USERPROFILE", homeDir)
 		saved := time.Now().Format(time.RFC3339Nano)
 		writeCookieCacheFixture(t, u.Host, fmt.Sprintf(
 			`[{"name":"waf","value":"issued-by-the-site","domain":"","path":"","expires":"0001-01-01T00:00:00Z","secure":false,"http_only":false,"saved_at":%q,"provenance":"site"}]`,

--- a/internal/providers/tier1_client_test.go
+++ b/internal/providers/tier1_client_test.go
@@ -52,7 +52,9 @@ func TestTier1Client_Get_LiveTLS(t *testing.T) {
 }
 
 func TestTier1Client_SeedCookies_FromCache(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Echo-Cookie", r.Header.Get("Cookie"))
@@ -102,7 +104,9 @@ func TestTier1Client_SeedCookies_FromCache(t *testing.T) {
 }
 
 func TestTier1Client_SeedCookies_NoSourceReturnsZero(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	c, err := NewTier1Client()
 	if err != nil {
 		t.Fatalf("NewTier1Client: %v", err)

--- a/internal/providers/tier2_chromedp_test.go
+++ b/internal/providers/tier2_chromedp_test.go
@@ -68,7 +68,9 @@ func TestRefreshCookiesViaCDP_NoBrowserFound(t *testing.T) {
 }
 
 func TestRefreshCookiesViaCDP_HarvestsAndCaches(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	// Pretend a browser exists.
 	prevExists := fileExists
@@ -175,7 +177,9 @@ func TestDetectInstalledBrowser(t *testing.T) {
 }
 
 func TestPersistCookiesToCache_NoopOnEmpty(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	// Should not panic / should be a no-op.
 	persistCookiesToCache("https://example.com/", nil)
 	persistCookiesToCache("://bad", []*http.Cookie{{Name: "a", Value: "b"}})

--- a/mcp/apps_test.go
+++ b/mcp/apps_test.go
@@ -6,7 +6,9 @@ import (
 )
 
 func TestSearchResultToolsAdvertiseMCPAppResource(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	s := NewServer()
 
 	for _, name := range []string{"search_accommodations", "search_hotels_with_details", "search_hotels", "search_flights"} {
@@ -28,7 +30,9 @@ func TestSearchResultToolsAdvertiseMCPAppResource(t *testing.T) {
 }
 
 func TestSearchResultsAppResourceIsReadable(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	s := NewServer()
 
 	result, err := s.readResource(trvlSearchResultsAppURI)

--- a/mcp/coverage_boost4_split2_test.go
+++ b/mcp/coverage_boost4_split2_test.go
@@ -158,10 +158,18 @@ func TestReadTripsUpcoming_Empty(t *testing.T) {
 // ============================================================
 
 func TestReadTripsList_Empty(t *testing.T) {
+	// t.Setenv rather than os.Setenv with a manual defer: it restores on its
+	// own, and it panics if this test is ever made parallel, which is the
+	// failure the manual version hid. Both names, one directory -- see
+	// scripts/ci/check-home-isolation.sh (trvl#565).
+	//
+	// This test asserts behaviour against an EMPTY home. On Windows the old
+	// HOME-only override did nothing, so it ran against the package-wide home
+	// from TestMain, which siblings may have written to -- the assertion held
+	// for a different reason than the one it names, or not at all.
 	tmp := t.TempDir()
-	orig := os.Getenv("HOME")
-	_ = os.Setenv("HOME", tmp)
-	defer func() { _ = os.Setenv("HOME", orig) }()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 
 	s := NewServer()
 	result, err := s.readTripsList()
@@ -177,10 +185,11 @@ func TestReadTripsList_Empty(t *testing.T) {
 }
 
 func TestReadTripsAlerts_Empty(t *testing.T) {
+	// Same reasoning as TestReadTripsList_Empty above: an empty-home assertion
+	// that the Windows override never actually applied to.
 	tmp := t.TempDir()
-	orig := os.Getenv("HOME")
-	_ = os.Setenv("HOME", tmp)
-	defer func() { _ = os.Setenv("HOME", orig) }()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 
 	s := NewServer()
 	result, err := s.readTripsAlerts()

--- a/mcp/handlers_preferences_race_test.go
+++ b/mcp/handlers_preferences_race_test.go
@@ -17,6 +17,7 @@ func TestWrappedSearchFlights_ConcurrentPreferencesFiltering_LiveIntegration(t *
 
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	if err := preferences.Save(&preferences.Preferences{
 		DisplayCurrency:    "EUR",
 		Locale:             "en",
@@ -46,6 +47,7 @@ func TestWrappedSearchHotels_ConcurrentPreferencesFiltering_LiveIntegration(t *t
 
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	if err := preferences.Save(&preferences.Preferences{
 		DisplayCurrency:    "EUR",
 		Locale:             "en",
@@ -75,6 +77,7 @@ func TestWrappedSearchGround_ConcurrentLiveIntegration(t *testing.T) {
 
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	if err := preferences.Save(&preferences.Preferences{
 		DisplayCurrency: "EUR",
 		Locale:          "en",

--- a/mcp/http_auth_remote_test.go
+++ b/mcp/http_auth_remote_test.go
@@ -107,7 +107,9 @@ func clearHTTPAuthEnv(t *testing.T) {
 // --- Audit counters surfaced on /health ---
 
 func TestHealth_AuthAuditCounters(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	hs := NewHTTPServerWithOptions(HTTPServerOptions{
 		Port:       0,
 		ReadToken:  "read-token",
@@ -154,7 +156,9 @@ func TestHealth_AuthAuditCounters(t *testing.T) {
 
 // /health must never leak subjects, tokens, scopes, or denial reasons.
 func TestHealth_DoesNotLeakSensitiveAuthDetail(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	hs := NewHTTPServerWithOptions(HTTPServerOptions{
 		Port:       0,
 		ReadToken:  "super-secret-read-token",
@@ -189,7 +193,9 @@ func getHealth(t *testing.T, hs *HTTPServer) map[string]any {
 // --- OAuth introspection path (deterministic via httptest fake IdP) ---
 
 func TestOAuthIntrospection_ScopeEnforcement(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	// Fake external IdP introspection endpoint. Token "rw" → read+write,
 	// "ro" → read only, anything else → inactive.

--- a/mcp/server_extra_test.go
+++ b/mcp/server_extra_test.go
@@ -68,7 +68,9 @@ func TestHTTPHandler_POST_RequiresBearerTokenWhenConfigured(t *testing.T) {
 }
 
 func TestHTTPHandler_POST_ReadTokenDeniesMutatingTool(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	hs := NewHTTPServerWithOptions(HTTPServerOptions{
 		Port:       0,
 		ReadToken:  "read-token",
@@ -93,7 +95,9 @@ func TestHTTPHandler_POST_ReadTokenDeniesMutatingTool(t *testing.T) {
 }
 
 func TestHTTPHandler_POST_WriteTokenAllowsMutatingTool(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	hs := NewHTTPServerWithOptions(HTTPServerOptions{
 		Port:       0,
 		ReadToken:  "read-token",
@@ -112,7 +116,9 @@ func TestHTTPHandler_POST_WriteTokenAllowsMutatingTool(t *testing.T) {
 }
 
 func TestHTTPHandler_POST_ReadTokenAllowsReadOnlyTravelRoute(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	hs := NewHTTPServerWithOptions(HTTPServerOptions{
 		Port:      0,
 		ReadToken: "read-token",
@@ -130,7 +136,9 @@ func TestHTTPHandler_POST_ReadTokenAllowsReadOnlyTravelRoute(t *testing.T) {
 }
 
 func TestHTTPHandler_POST_OAuthIntrospectionScopes(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	introspection := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if gotUser, gotPass, ok := r.BasicAuth(); !ok || gotUser != "client-id" || gotPass != "client-secret" {
 			t.Fatalf("BasicAuth = %q/%q/%v, want configured client credentials", gotUser, gotPass, ok)

--- a/mcp/tools_accommodations_290_test.go
+++ b/mcp/tools_accommodations_290_test.go
@@ -44,7 +44,9 @@ func TestAccommodationCandidateLimitBounds(t *testing.T) {
 // the capped number of room-level lookups. This is the rate-limit-safety
 // guarantee in #290's title.
 func TestHandleSearchAccommodationsCapsRoomLookupCallCount(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	origSearchHotels := searchHotelsFunc
 	origRooms := getRoomAvailabilityWithOptsFunc

--- a/mcp/tools_accommodations_test.go
+++ b/mcp/tools_accommodations_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestHandleSearchAccommodationsReturnsOnlyCriteriaMatchedOffers(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	origSearchHotels := searchHotelsFunc
 	origRooms := getRoomAvailabilityWithOptsFunc
@@ -182,7 +184,9 @@ func TestHandleSearchAccommodationsReturnsOnlyCriteriaMatchedOffers(t *testing.T
 }
 
 func TestHandleSearchAccommodationsUsesProviderRoomInventoryWithoutHotelID(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	origSearchHotels := searchHotelsFunc
 	origRooms := getRoomAvailabilityWithOptsFunc
@@ -277,7 +281,9 @@ func TestHandleSearchAccommodationsUsesProviderRoomInventoryWithoutHotelID(t *te
 }
 
 func TestHandleSearchAccommodationsPrioritizesVerifiableCandidateOverLeadInOnly(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	origSearchHotels := searchHotelsFunc
 	origRooms := getRoomAvailabilityWithOptsFunc
@@ -387,7 +393,9 @@ func TestHandleSearchAccommodationsPrioritizesVerifiableCandidateOverLeadInOnly(
 }
 
 func TestHandleSearchAccommodationsPrioritizesRequestedAccommodationType(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	origSearchHotels := searchHotelsFunc
 	origRooms := getRoomAvailabilityWithOptsFunc
@@ -458,7 +466,9 @@ func TestHandleSearchAccommodationsPrioritizesRequestedAccommodationType(t *test
 }
 
 func TestHandleSearchAccommodationsBoundsSlowRoomLookup(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	origSearchHotels := searchHotelsFunc
 	origRooms := getRoomAvailabilityWithOptsFunc

--- a/mcp/tools_extra_test.go
+++ b/mcp/tools_extra_test.go
@@ -429,7 +429,9 @@ func TestSearchHotelsTool_RequiredUnchanged(t *testing.T) {
 // --- handleSearchHotels filter args parsing ---
 
 func TestHandleSearchHotels_FilterArgsDefaults(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	origSearchHotels := searchHotelsFunc
 	t.Cleanup(func() { searchHotelsFunc = origSearchHotels })
 	searchHotelsFunc = func(_ context.Context, location string, opts hotels.HotelSearchOptions) (*models.HotelSearchResult, error) {
@@ -453,7 +455,9 @@ func TestHandleSearchHotels_FilterArgsDefaults(t *testing.T) {
 }
 
 func TestHandleSearchHotels_FilterArgsFloat(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	origSearchHotels := searchHotelsFunc
 	t.Cleanup(func() { searchHotelsFunc = origSearchHotels })
 	searchHotelsFunc = func(_ context.Context, location string, opts hotels.HotelSearchOptions) (*models.HotelSearchResult, error) {

--- a/mcp/tools_ground_policy_test.go
+++ b/mcp/tools_ground_policy_test.go
@@ -12,6 +12,7 @@ import (
 func TestHandleSearchGround_ProfileDoesNotSeedType(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 
 	// Persist a minimal profile fixture whose dominant ground mode is train.
 	// OLD pre-fix code in handleSearchGround would load via profile.Load +

--- a/mcp/tools_hotels_adultsonly_test.go
+++ b/mcp/tools_hotels_adultsonly_test.go
@@ -18,7 +18,9 @@ import (
 // Fail-before / pass-after: revert the ApplySharedHotelPolicy call in
 // runHotelSearch and this test fails (the adults-only property survives).
 func TestHandleSearchHotels_ExcludesAdultsOnlyForChildren(t *testing.T) {
-	t.Setenv("HOME", t.TempDir()) // isolate from the operator's real prefs
+	homeDir := t.TempDir() // isolate from the operator's real prefs
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	orig := searchHotelsFunc
 	t.Cleanup(func() { searchHotelsFunc = orig })
 
@@ -62,7 +64,9 @@ func TestHandleSearchHotels_ExcludesAdultsOnlyForChildren(t *testing.T) {
 // counterpart: with no children in the party, adults-only properties are
 // bookable and must NOT be hidden on the MCP surface (matching the CLI).
 func TestHandleSearchHotels_KeepsAdultsOnlyWithoutChildren(t *testing.T) {
-	t.Setenv("HOME", t.TempDir()) // isolate from the operator's real prefs
+	homeDir := t.TempDir() // isolate from the operator's real prefs
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	orig := searchHotelsFunc
 	t.Cleanup(func() { searchHotelsFunc = orig })
 

--- a/mcp/tools_hotels_currency_test.go
+++ b/mcp/tools_hotels_currency_test.go
@@ -25,6 +25,7 @@ func TestSearchHotelsTool_CurrencyProperty(t *testing.T) {
 func TestHandleSearchHotels_DefaultsCurrencyFromPreferences(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	prefs := preferences.Default()
 	prefs.DisplayCurrency = "EUR"
 	if err := preferences.SaveTo(filepath.Join(tmp, ".trvl", "preferences.json"), prefs); err != nil {
@@ -56,6 +57,7 @@ func TestHandleSearchHotels_DefaultsCurrencyFromPreferences(t *testing.T) {
 func TestHandleSearchHotels_ExplicitCurrencyOverridesPreferences(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 	prefs := preferences.Default()
 	prefs.DisplayCurrency = "EUR"
 	if err := preferences.SaveTo(filepath.Join(tmp, ".trvl", "preferences.json"), prefs); err != nil {

--- a/mcp/tools_hotels_details_test.go
+++ b/mcp/tools_hotels_details_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestHandleSearchHotelsWithDetailsEnrichesTopResults(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	origSearchHotels := searchHotelsFunc
 	origAmenities := fetchHotelAmenitiesFunc
@@ -197,7 +199,9 @@ func TestHandleSearchHotelsWithDetailsEnrichesTopResults(t *testing.T) {
 }
 
 func TestHandleSearchHotelsWithDetailsPartialFailuresUseTypedDetailErrors(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	origSearchHotels := searchHotelsFunc
 	origAmenities := fetchHotelAmenitiesFunc

--- a/mcp/tools_preferences_test.go
+++ b/mcp/tools_preferences_test.go
@@ -400,6 +400,7 @@ func TestUpdatePreferences_ConcurrentUpdatesPreserveDisjointFields(t *testing.T)
 func TestUpdatePreferences_DefaultPathConcurrentUpdatesPreserveDisjointFields(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 
 	initial := &preferences.Preferences{
 		DisplayCurrency: "EUR",

--- a/mcp/tools_price_signals_test.go
+++ b/mcp/tools_price_signals_test.go
@@ -221,7 +221,9 @@ func TestBookingReadinessReasons_NilRefundability(t *testing.T) {
 
 func TestHotelPriceSignals_StoreErrorDoesNotBreakReadiness(t *testing.T) {
 	// GIVEN a temp HOME so watch.DefaultStore uses an isolated dir
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	// GIVEN a valid result
 	result := &models.HotelPriceResult{
@@ -258,7 +260,9 @@ func TestHotelPriceSignals_NilResult(t *testing.T) {
 
 func TestFlightPriceSignals_StoreErrorReturnsNil(t *testing.T) {
 	// GIVEN a temp HOME so watch.DefaultStore uses an isolated dir
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	// GIVEN a minimal successful flight result
 	result := &models.FlightSearchResult{
@@ -306,7 +310,9 @@ func TestFlightPriceSignals_NilResult(t *testing.T) {
 // TestPricePositionAttachedToHotelPayload proves that hotelPriceSignals wires
 // a price_position into the JSON payload when history is available.
 func TestPricePositionAttachedToHotelPayload(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	result := &models.HotelPriceResult{
 		Success: true,
@@ -334,7 +340,9 @@ func TestPricePositionAttachedToHotelPayload(t *testing.T) {
 // a same_day_alternative saving in the payload.
 func TestSameDayAlternativeSaving(t *testing.T) {
 	// t.Setenv requires no t.Parallel.
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	// GIVEN a flight list where the headline is pricier than an alternative
 	result := &models.FlightSearchResult{
@@ -415,7 +423,9 @@ func TestVsHistorySaving_ConfidenceFloorViaCompute(t *testing.T) {
 
 func TestSavingsAreAlwaysCallFree(t *testing.T) {
 	// t.Setenv requires no t.Parallel.
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	result := &models.FlightSearchResult{
 		Success: true,
@@ -441,7 +451,9 @@ func TestSavingsAreAlwaysCallFree(t *testing.T) {
 // TestHotelPriceSignals_AccumulatesPosition proves that after the first call
 // logs an observation the position carries the correct Current field.
 func TestHotelPriceSignals_AccumulatesPosition(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	result := &models.HotelPriceResult{
 		Success: true,

--- a/mcp/tools_watch_price_probe_test.go
+++ b/mcp/tools_watch_price_probe_test.go
@@ -20,7 +20,9 @@ func TestHandleCheckWatches_LiveProbe(t *testing.T) {
 	if os.Getenv("TRVL_TEST_LIVE_PROBES") != "1" {
 		t.Skip("hits live flight APIs; set TRVL_TEST_LIVE_PROBES=1 to run")
 	}
-	t.Setenv("HOME", t.TempDir())
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	store, err := watch.DefaultStore()
 	if err != nil {

--- a/mcp/tools_workspace_test.go
+++ b/mcp/tools_workspace_test.go
@@ -14,6 +14,7 @@ import (
 func TestTripWorkspaceImportReservationMergesIntoTrip(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 
 	_, created, err := handleCreateTrip(context.Background(), map[string]any{"name": "Amsterdam"}, nil, nil, nil)
 	if err != nil {
@@ -69,6 +70,7 @@ func TestTripWorkspaceFareIntelligence(t *testing.T) {
 func TestTravelRoutesWorkspaceActionToTripWorkspace(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 
 	_, created, err := handleCreateTrip(context.Background(), map[string]any{"name": "Candidate"}, nil, nil, nil)
 	if err != nil {
@@ -106,6 +108,7 @@ func TestTravelRoutesWorkspaceActionToTripWorkspace(t *testing.T) {
 func TestTripWorkspaceGetExportImportAndReadiness(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 
 	_, created, err := handleCreateTrip(context.Background(), map[string]any{"name": "Workspace"}, nil, nil, nil)
 	if err != nil {
@@ -207,6 +210,7 @@ func TestTripWorkspaceGetExportImportAndReadiness(t *testing.T) {
 func TestTripWorkspaceReadinessReportsBlockersAndMissingCandidate(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 
 	_, created, err := handleCreateTrip(context.Background(), map[string]any{"name": "Blocked candidate"}, nil, nil, nil)
 	if err != nil {
@@ -252,6 +256,7 @@ func TestTripWorkspaceReadinessReportsBlockersAndMissingCandidate(t *testing.T) 
 func TestTripWorkspaceOptimizeItinerary(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
 
 	_, created, err := handleCreateTrip(context.Background(), map[string]any{"name": "Itinerary"}, nil, nil, nil)
 	if err != nil {

--- a/scripts/ci/check-home-isolation.sh
+++ b/scripts/ci/check-home-isolation.sh
@@ -8,13 +8,14 @@
 # TestRunWatchCheckCycleWithRooms_SkipsInactiveWatches failed on windows-latest
 # with count=3 while passing on Linux and macOS throughout (trvl#565).
 #
-# Two rules, because the obvious fix has a silent failure mode of its own:
+# Three rules, because each of the first two has a silent failure mode of its own.
 #
-#   1. Every t.Setenv("HOME", ...) needs a t.Setenv("USERPROFILE", ...) nearby.
+#   1. Every HOME redirection needs a USERPROFILE redirection to the same
+#      variable, nearby and IN THE SAME FUNCTION.
 #   2. HOME must be bound to a VARIABLE, never an inline t.TempDir().
+#   3. Both t.Setenv and os.Setenv count.
 #
-# Rule 2 is the subtle one. t.TempDir() returns a NEW directory on every call,
-# so the natural-looking
+# Rule 2 is the subtle one. t.TempDir() returns a NEW directory on every call, so
 #
 #     t.Setenv("HOME", t.TempDir())
 #     t.Setenv("USERPROFILE", t.TempDir())
@@ -23,6 +24,15 @@
 # a directory nothing populated -- strictly worse than the bug it was meant to
 # fix, and it satisfies rule 1 while doing it. Three such pairs were already in
 # the tree when this check was written.
+#
+# Rule 3 exists because the first draft matched only t.Setenv, which left two
+# real os.Setenv("HOME") overrides in mcp/coverage_boost4_split2_test.go
+# unisolated on Windows while this check reported the class closed. A guard that
+# gives false assurance is worse than no guard (adversarial review, 2026-08-04).
+#
+# The same-function bound on rule 1 matters for the same reason: a plain
+# line-window can be satisfied by the NEXT function's USERPROFILE, passing a
+# broken site because an unrelated one below it is correct.
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -37,7 +47,7 @@ while IFS= read -r file; do
     line="$(sed -n "${lineno}p" "$file")"
 
     # Rule 2: HOME must name a variable, so USERPROFILE can reuse the same one.
-    if printf '%s' "$line" | grep -q 't\.Setenv("HOME", t\.TempDir())'; then
+    if printf '%s' "$line" | grep -qE '(t|os)\.Setenv\("HOME", t\.TempDir\(\)\)'; then
       printf 'error: %s:%s binds HOME to an inline t.TempDir()\n' "$file" "$lineno" >&2
       printf '       t.TempDir() returns a NEW directory per call, so USERPROFILE cannot reuse it.\n' >&2
       printf '       Capture it first:  dir := t.TempDir(); t.Setenv("HOME", dir); t.Setenv("USERPROFILE", dir)\n' >&2
@@ -45,7 +55,7 @@ while IFS= read -r file; do
       continue
     fi
 
-    var="$(printf '%s' "$line" | sed -nE 's/.*t\.Setenv\("HOME", ([A-Za-z_][A-Za-z0-9_]*)\).*/\1/p')"
+    var="$(printf '%s' "$line" | sed -nE 's/.*(t|os)\.Setenv\("HOME", ([A-Za-z_][A-Za-z0-9_]*)\).*/\2/p')"
     if [ -z "$var" ]; then
       printf 'error: %s:%s sets HOME to something this check cannot verify: %s\n' \
         "$file" "$lineno" "$(printf '%s' "$line" | sed -E 's/^[[:space:]]+//')" >&2
@@ -54,17 +64,38 @@ while IFS= read -r file; do
       continue
     fi
 
-    # Rule 1: the same variable must reach USERPROFILE within a short window.
-    # A window rather than the next line, because existing call sites legitimately
-    # separate them with a comment or a `if runtime.GOOS == "windows"` guard.
-    window="$(sed -n "${lineno},$((lineno + 6))p" "$file")"
-    if ! printf '%s' "$window" | grep -q "t\.Setenv(\"USERPROFILE\", ${var})"; then
-      printf 'error: %s:%s sets HOME=%s with no matching t.Setenv("USERPROFILE", %s) nearby\n' \
+    # A restore line -- os.Setenv("HOME", orig) inside a defer -- is the tail of
+    # a manual save/restore, not a redirection. The redirection itself is checked
+    # on its own line; requiring USERPROFILE here too would demand it twice.
+    if printf '%s' "$line" | grep -q 'defer'; then
+      continue
+    fi
+
+    # Rule 1: same variable must reach USERPROFILE within a short window, and
+    # the window stops at the end of the enclosing function so a later
+    # function's correct pairing cannot vouch for a broken site above it.
+    window=""
+    end=$((lineno + 6))
+    cur=$((lineno + 1))
+    while [ "$cur" -le "$end" ]; do
+      wline="$(sed -n "${cur}p" "$file")"
+      # Column-0 '}' closes the function; 'func ' opens the next one.
+      case "$wline" in
+        '}'*) break ;;
+        'func '*) break ;;
+      esac
+      window="${window}
+${wline}"
+      cur=$((cur + 1))
+    done
+
+    if ! printf '%s' "$window" | grep -qE "(t|os)\.Setenv\(\"USERPROFILE\", ${var}\)"; then
+      printf 'error: %s:%s sets HOME=%s with no matching Setenv("USERPROFILE", %s) in the same function\n' \
         "$file" "$lineno" "$var" "$var" >&2
       printf '       os.UserHomeDir reads USERPROFILE on Windows, so this test does not isolate there.\n' >&2
       fail=1
     fi
-  done < <(grep -n 't\.Setenv("HOME"' "$file" 2>/dev/null || true)
+  done < <(grep -nE '(t|os)\.Setenv\("HOME"' "$file" 2>/dev/null || true)
 done < <(git ls-files '*_test.go' ':!:vendor/**' ':!:third_party/**')
 
 if [ "$fail" -eq 0 ]; then

--- a/scripts/ci/check-home-isolation.sh
+++ b/scripts/ci/check-home-isolation.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Keep test home-directory redirection portable.
+#
+# os.UserHomeDir reads HOME on unix and USERPROFILE on Windows. A test that sets
+# only HOME does not isolate on Windows: it keeps whatever home the package-wide
+# TestMain established and shares a store with every sibling test in the package.
+# That is invisible until a test asserts on the store's CONTENTS, which is how
+# TestRunWatchCheckCycleWithRooms_SkipsInactiveWatches failed on windows-latest
+# with count=3 while passing on Linux and macOS throughout (trvl#565).
+#
+# Two rules, because the obvious fix has a silent failure mode of its own:
+#
+#   1. Every t.Setenv("HOME", ...) needs a t.Setenv("USERPROFILE", ...) nearby.
+#   2. HOME must be bound to a VARIABLE, never an inline t.TempDir().
+#
+# Rule 2 is the subtle one. t.TempDir() returns a NEW directory on every call,
+# so the natural-looking
+#
+#     t.Setenv("HOME", t.TempDir())
+#     t.Setenv("USERPROFILE", t.TempDir())
+#
+# points the two at unrelated directories. On Windows the test then runs against
+# a directory nothing populated -- strictly worse than the bug it was meant to
+# fix, and it satisfies rule 1 while doing it. Three such pairs were already in
+# the tree when this check was written.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail=0
+checked=0
+
+while IFS= read -r file; do
+  while IFS=: read -r lineno _; do
+    [ -n "$lineno" ] || continue
+    checked=$((checked + 1))
+    line="$(sed -n "${lineno}p" "$file")"
+
+    # Rule 2: HOME must name a variable, so USERPROFILE can reuse the same one.
+    if printf '%s' "$line" | grep -q 't\.Setenv("HOME", t\.TempDir())'; then
+      printf 'error: %s:%s binds HOME to an inline t.TempDir()\n' "$file" "$lineno" >&2
+      printf '       t.TempDir() returns a NEW directory per call, so USERPROFILE cannot reuse it.\n' >&2
+      printf '       Capture it first:  dir := t.TempDir(); t.Setenv("HOME", dir); t.Setenv("USERPROFILE", dir)\n' >&2
+      fail=1
+      continue
+    fi
+
+    var="$(printf '%s' "$line" | sed -nE 's/.*t\.Setenv\("HOME", ([A-Za-z_][A-Za-z0-9_]*)\).*/\1/p')"
+    if [ -z "$var" ]; then
+      printf 'error: %s:%s sets HOME to something this check cannot verify: %s\n' \
+        "$file" "$lineno" "$(printf '%s' "$line" | sed -E 's/^[[:space:]]+//')" >&2
+      printf '       Bind it to a variable so USERPROFILE can be set to the same directory.\n' >&2
+      fail=1
+      continue
+    fi
+
+    # Rule 1: the same variable must reach USERPROFILE within a short window.
+    # A window rather than the next line, because existing call sites legitimately
+    # separate them with a comment or a `if runtime.GOOS == "windows"` guard.
+    window="$(sed -n "${lineno},$((lineno + 6))p" "$file")"
+    if ! printf '%s' "$window" | grep -q "t\.Setenv(\"USERPROFILE\", ${var})"; then
+      printf 'error: %s:%s sets HOME=%s with no matching t.Setenv("USERPROFILE", %s) nearby\n' \
+        "$file" "$lineno" "$var" "$var" >&2
+      printf '       os.UserHomeDir reads USERPROFILE on Windows, so this test does not isolate there.\n' >&2
+      fail=1
+    fi
+  done < <(grep -n 't\.Setenv("HOME"' "$file" 2>/dev/null || true)
+done < <(git ls-files '*_test.go' ':!:vendor/**' ':!:third_party/**')
+
+if [ "$fail" -eq 0 ]; then
+  printf 'ok: %d HOME redirections also set USERPROFILE to the same directory\n' "$checked"
+fi
+
+exit "$fail"


### PR DESCRIPTION
Tests that redirect `HOME` do not isolate on Windows: `os.UserHomeDir` reads `HOME` on unix but `USERPROFILE` on Windows, so a `HOME`-only redirect leaves the test using whatever home the package-wide `TestMain` established — sharing a store with every sibling test in the package.

That is invisible until a test asserts on the store's **contents**, which is how `TestRunWatchCheckCycleWithRooms_SkipsInactiveWatches` failed on windows-latest with `count = 3, want 1` while passing on Linux and macOS throughout.

49 call sites across 19 files now set both, to the same directory.

## The sweep found the fix already applied incorrectly

Three sites already had a `USERPROFILE` line — pointing somewhere else:

```go
t.Setenv("HOME", t.TempDir())
t.Setenv("USERPROFILE", t.TempDir())   // a DIFFERENT directory
```

`t.TempDir()` returns a new directory on every call. On Windows those tests ran against a directory nothing had populated — strictly worse than the bug it was meant to fix, and it reads as correct at a glance. One of them, `TestResolveChallenge_NeedsHumanDoesNotPersist`, asserts an **absence**, which passes trivially when it is looking at the wrong directory. Fixed at `challenge_test.go:105`, `:146` and `pricefeed_test.go:74`.

Verifying this needed care of the same kind. A file-level check — *does this file mention `USERPROFILE` at all* — reported everything fixed while those three were still wrong, because the files contained correct pairs elsewhere. Only checking each `HOME`/`USERPROFILE` **pair** found them.

## Codified, because vigilance already failed here twice

`scripts/ci/check-home-isolation.sh`, wired into `make repo-hygiene`. Three rules, because each of the first two has its own silent failure mode:

1. Every `HOME` redirection needs a `USERPROFILE` redirection to the same variable, **in the same function**.
2. `HOME` must bind a variable, never an inline `t.TempDir()` — this is what structurally prevents the two-directory bug, which satisfies rule 1 while being broken.
3. Both `t.Setenv` and `os.Setenv` count.

Bash rather than Go or Python: `scripts/ci/` is the established home for these, and `check-language-hygiene.sh` makes Python require an allowlist entry.

## The guard's own blind spot, caught in review

The first version matched only `t.Setenv`. Adversarial review found two real `os.Setenv("HOME")` overrides at `mcp/coverage_boost4_split2_test.go:163,182` that stayed unisolated on Windows **while `make repo-hygiene` reported the class closed**. A guard that gives false assurance is worse than no guard — the same defect this repo just fixed in #542.

Both now use `t.Setenv` with `USERPROFILE`. Both assert against an **empty** home (`TestReadTripsList_Empty`, `TestReadTripsAlerts_Empty`), so on Windows they ran against the package-wide home siblings may have written to — the assertion held for a different reason than the one it names, or not at all.

Review also found a second hole: a plain line-window can be satisfied by the **next function's** `USERPROFILE`, passing a genuinely broken site. The window now stops at the enclosing function's end.

Checked sites went 106 → 117 — eleven redirections the first version could not see.

## Evidence

- **V:** all three rules sabotage-verified, each exiting 1 and reverting to 0 — removing a `USERPROFILE` line, reintroducing the two-`TempDir` pair, moving a `USERPROFILE` into the following function.
- **V:** exit code checked explicitly. A guard that prints errors and exits 0 is decorative; this one fails.
- **V:** `make dod` (lint including the new check, gosec, 101 packages) exit 0 on both commits.
- **V:** adversarial review (Grok) — SHIP-WITH-FIXES; both material findings verified at source and fixed here.
- **I:** GPT second opinion unavailable — its sandbox blocks every shell command it attempts. One reviewer, not two.
- **I:** no production path changed; a Windows-only test that depended on package-home residue would now fail, which is the correct direction.

Closes #565.
