### PR TITLE
fix #506: bump Wizz Air API version 29.8.0 -> 29.10.0 (V: 29.8.0 404s on the live oracle; search is broken on main)

### DIFF
--- a/internal/flights/wizzair.go
+++ b/internal/flights/wizzair.go
@@ -119,7 +119,16 @@ var ErrWizzRejected = errors.New("wizzair declined the request (validationCodes)
 // success to anything. Whether it survives a datacenter IP is unestablished: it
 // is CloudFront-fronted like the timetable endpoint, and only a CI run settles
 // that.
-const wizzDefaultVersion = "29.8.0"
+// Bumped 29.8.0 -> 29.10.0 on 2026-08-04 (trvl#506). 29.8.0 had rotated away
+// and was returning 404 on the oracle, so every Wizz search on main was failing
+// at the time of the bump -- this is a live-breakage fix, not housekeeping.
+//
+// 29.10.0 rather than the 29.9.0 the sentinel reports: the walk stops at the
+// first live candidate, and probing found BOTH 29.9.0 and 29.10.0 live (405 on
+// GET, 200 on POST to /Api/asset/culture). Taking the newer one buys more time
+// before the next rotation. 29.10.1, 29.11.0 and 29.12.0 were absent, so
+// 29.10.0 is the newest that exists rather than merely the first that answers.
+const wizzDefaultVersion = "29.10.0"
 
 // wizzVersion is the active API version. Overridable in tests; the env var
 // WIZZAIR_API_VERSION takes precedence at request time via wizzResolvedVersion.


### PR DESCRIPTION
The shipped Wizz Air API version had rotated away again. `be.wizzair.com/29.8.0/Api/asset/culture` returns **404** on the live oracle, which is the rotation signature — so **every Wizz Air search on `main` is failing right now**. This is a live breakage fix, not housekeeping.

## Probed rather than trusted

The discovery script reports the first live candidate. Probing the oracle directly showed two are live:

| version | oracle |
|---|---|
| `29.8.0` | **404** — rotated away; the shipped default |
| `29.9.0` | 405 — live |
| **`29.10.0`** | **405 — live, newest** |
| `29.10.1` | 404 |
| `29.11.0` | 404 |
| `29.12.0` | 404 |

`405` means the route exists with the wrong verb; `POST` to both live versions returns `200`. Repeated probes agreed, so these are not transient edge responses.

Taking `29.10.0`, not the `29.9.0` the sentinel reports: the walk stops at the first live candidate, and the newer one buys more time before the next rotation. `29.10.1` and above are absent, so `29.10.0` is the newest that *exists* rather than merely the first that answers.

`scripts/wizzair-discover-version.sh` now reports `STATUS=ok CURRENT=29.10.0`.

## Why the issue existed, and what remains

#506 is **auto-filed**. The version-sentinel CI job creates it verbatim when discovery exhausts its search range. That condition no longer holds — from `29.8.0` the walk finds `29.9.0` and reports `STATUS=rotated`, which the job handles by opening its own bump PR. The exhausted path fired back when the default was `29.4.0` and nothing in range was live yet.

The residual gap the issue title names — *"cannot land what it discovers"* — is the `WIZZAIR_SENTINEL_PAT` secret, documented at the top of that job: a PR opened with `GITHUB_TOKEN` does not start CI, so auto-merge cannot arm and the bump waits for a human click. **That is a repository-secret decision, not a code change, and it is why this rotation sat unlanded.** Worth deciding separately — without it, every future rotation costs a manual click while search is broken.

## Evidence

- **V:** oracle probes above, repeated for stability; `POST` returns 200 on both live versions.
- **V:** `scripts/wizzair-discover-version.sh` → `STATUS=ok CURRENT=29.10.0` after the bump (it reported `STATUS=rotated CURRENT=29.8.0 NEW=29.9.0` before).
- **V:** `make dod` (lint, gosec, 101 packages) exit 0; `go test ./internal/flights/ -run Wizz` 33 passed.
- **A:** the oracle proves the version *path* is live; it cannot confirm a priced search end-to-end, because the timetable endpoint edge-blocks datacenter IPs. The opt-in nightly live probe validates real search from its own vantage.

No regression test accompanies this: it is a data-only constant bump, and `TestWizzDefaultVersionWellFormed` already guards the constant's shape. The self-heal tests that reference `29.4.0` exercise candidate-generation from a fixed input and are unaffected.

Closes #506.
