### PR TITLE
fix #570: refuse a buy/wait verdict computed across possibly-different currencies (V: sabotage shows Verdict:buy, -57%, Confident:true from a pooled median)

### DIFF
--- a/internal/pricefeed/position_blank_currency_test.go
+++ b/internal/pricefeed/position_blank_currency_test.go
@@ -1,0 +1,139 @@
+package pricefeed
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+	"github.com/MikkoParkkola/trvl/internal/watch"
+)
+
+// TRVL.POSBLANK.2/.3 -- a blank currency must not produce a price-position.
+//
+// Position carries a buy/wait Verdict, so it is an active recommendation rather
+// than a diagnostic. When the cheapest fare has no currency, RoutePrices is
+// called with an empty argument, and since #564 that exact-matches: it selects
+// every currencyless observation on the route. Those can be different real
+// currencies -- one provider omitting the label on a EUR quote, another on a JPY
+// one -- so the median, band and percentile are computed across incomparable
+// numbers and shipped as advice.
+//
+// Unlike the blank-currency saving in #549, this one has no visible tell. That
+// rendered "save 120 " with a conspicuous gap where the currency belonged; a
+// position renders normally and reads as trustworthy.
+//
+// Seeded with a spread wide enough that a pooled median would be confidently
+// wrong rather than accidentally harmless: prices from 80 to 400 with no
+// currency, then a current fare of 100 that would land near the bottom of that
+// invented distribution and read as a strong BUY.
+func TestFlightRefusesAPositionWhenTheCheapestFareHasNoCurrency(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	store, err := watch.DefaultStore()
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := store.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Enough currencyless history for pricesignal to consider itself confident.
+	key := watch.RouteKey("flight", "HEL", "NRT", "2026-09-01")
+	for i := 0; i < 30; i++ {
+		if err := store.RecordObservation(key, float64(80+(i*11)%320), ""); err != nil {
+			t.Fatalf("seed observation %d: %v", i, err)
+		}
+	}
+
+	res := &models.FlightSearchResult{
+		Success: true,
+		Flights: []models.FlightResult{
+			{Price: 100}, // cheapest, and NO currency
+			{Price: 260},
+		},
+	}
+
+	got := Flight("HEL", "NRT", "2026-09-01", res, time.Now())
+
+	if got.Position != nil {
+		t.Errorf("a currencyless cheapest fare produced a price-position %+v -- its median comes "+
+			"from a series that pools observations which may be different currencies, and Position "+
+			"carries a buy/wait verdict, so this is an active recommendation computed across "+
+			"incomparable numbers", got.Position)
+	}
+}
+
+// The control that makes the assertion above mean something. A LABELLED fare on
+// the same seeded history must still produce a position, so the fix refuses
+// blankness rather than disabling price-position altogether.
+func TestFlightStillProducesAPositionForALabelledFare(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	store, err := watch.DefaultStore()
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := store.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	key := watch.RouteKey("flight", "HEL", "NRT", "2026-09-01")
+	for i := 0; i < 30; i++ {
+		if err := store.RecordObservation(key, float64(80+(i*11)%320), "EUR"); err != nil {
+			t.Fatalf("seed observation %d: %v", i, err)
+		}
+	}
+
+	res := &models.FlightSearchResult{
+		Success: true,
+		Flights: []models.FlightResult{
+			{Price: 100, Currency: "EUR"},
+			{Price: 260, Currency: "EUR"},
+		},
+	}
+
+	got := Flight("HEL", "NRT", "2026-09-01", res, time.Now())
+
+	if got.Position == nil {
+		t.Error("a labelled fare produced no price-position; the guard must refuse an unlabelled " +
+			"currency, not switch the feature off")
+	}
+}
+
+// TRVL.POSBLANK.4 -- the hotel path has the same shape and is fixed with it,
+// rather than recorded as unaffected.
+func TestHotelPositionRefusesABlankProviderCurrency(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	store, err := watch.DefaultStore()
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := store.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	key := watch.RouteKey("hotel", "hotel-xyz", "", "2026-09-01")
+	for i := 0; i < 30; i++ {
+		if err := store.RecordObservation(key, float64(120+(i*7)%200), ""); err != nil {
+			t.Fatalf("seed observation %d: %v", i, err)
+		}
+	}
+
+	res := &models.HotelPriceResult{
+		Providers: []models.ProviderPrice{
+			{Provider: "someota", Price: 130}, // no currency
+		},
+	}
+
+	if pos := HotelPosition("hotel-xyz", "2026-09-01", res); pos != nil {
+		t.Errorf("a currencyless provider price produced a hotel price-position %+v -- same defect "+
+			"as the flight path, and it would ship the same buy/wait verdict", pos)
+	}
+}

--- a/internal/pricefeed/pricefeed.go
+++ b/internal/pricefeed/pricefeed.go
@@ -10,6 +10,7 @@
 package pricefeed
 
 import (
+	"strings"
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/booking"
@@ -57,9 +58,23 @@ func Flight(origin, dest, date string, result *models.FlightSearchResult, now ti
 	// Price-position + observation logging (watch store; independent best-effort).
 	if store, err := watch.DefaultStore(); err == nil && store.Load() == nil {
 		_ = obslog.FlightSearch(store, origin, dest, date, result)
-		if cheapestPrice > 0 {
+		// A blank currency yields no position at all (trvl#570). RoutePrices
+		// exact-matches its argument since #564, so an empty one selects every
+		// currencyless observation on the route -- and those can be different
+		// real currencies, one provider omitting the label on a EUR quote and
+		// another on a JPY one. A median over that pool is computed across
+		// incomparable numbers, and Position carries a buy/wait Verdict, so the
+		// result is an active recommendation derived from prices that may not
+		// share a unit.
+		//
+		// Refusing rather than degrading, for the same reason #549 refuses a
+		// blank-currency saving: a missing signal is recoverable, a confidently
+		// wrong one is not. This one has no visible tell either -- the blank
+		// saving at least rendered a conspicuous double space where the currency
+		// belonged, whereas a position renders normally and reads as trustworthy.
+		if cur := strings.ToUpper(strings.TrimSpace(cheapestCurrency)); cheapestPrice > 0 && cur != "" {
 			key := watch.RouteKey("flight", origin, dest, date)
-			p := pricesignal.Compute(store.RoutePrices(key, cheapestCurrency), cheapestPrice, 0)
+			p := pricesignal.Compute(store.RoutePrices(key, cur), cheapestPrice, 0)
 			out.Position = &p
 		}
 	}
@@ -123,8 +138,17 @@ func HotelPosition(hotelID, checkIn string, result *models.HotelPriceResult) *pr
 	if cheapest.Price <= 0 {
 		return nil
 	}
+	// TRVL.POSBLANK.4: HotelPosition has the same shape as the flight path and
+	// is affected identically, so it is fixed here rather than recorded as
+	// unaffected. A blank provider currency selects the currencyless
+	// observations for this hotel, which can be different real currencies, and
+	// the resulting median would ship as a buy/wait verdict.
+	cur := strings.ToUpper(strings.TrimSpace(cheapest.Currency))
+	if cur == "" {
+		return nil
+	}
 	key := watch.RouteKey("hotel", hotelID, "", checkIn)
-	p := pricesignal.Compute(store.RoutePrices(key, cheapest.Currency), cheapest.Price, 0)
+	p := pricesignal.Compute(store.RoutePrices(key, cur), cheapest.Price, 0)
 	return &p
 }
 


### PR DESCRIPTION
A price-position carries a buy/wait **verdict**, so it is an active recommendation rather than a diagnostic. Both paths computed one from a price series selected by a currency that can be empty.

Since #564, `RoutePrices` exact-matches its argument — so an empty currency selects every currencyless observation on the route. Those can be different real currencies: one provider omitting the label on a EUR quote, another on a JPY one. The median, band and percentile are then computed across incomparable numbers and shipped as advice.

## What the unfixed code says to a user

The regression test, run against `main`:

```
Band:low Verdict:buy Current:100 Low:80 High:399 Median:234
VsMedianPct:-57.26 Observations:31 Confident:true
```

trvl telling someone **"BUY — this is 57% below typical, and I'm confident"**, from a median over prices that may not share a unit.

**Unlike #549, this has no visible tell.** That one rendered `"save 120 "` with a conspicuous gap where the currency belonged. A position renders perfectly and reads as trustworthy, which is why it is worth fixing even though it is rarer.

## The decision

**TRVL.POSBLANK.1 — option 1, refuse.** Consistent with the ruling already made twice on this bug class (#549, #564): a missing signal is recoverable, a confidently wrong one is not. Option 2 (compute but force `Confident: false`) keeps a pooled median on screen, which is the thing that is actually untrue.

**TRVL.POSBLANK.2** — a blank currency yields no `Position` at all, on both paths. Normalised with trim/uppercase first, so a whitespace-only currency is blank rather than a distinct series of its own.

**TRVL.POSBLANK.4** — `HotelPosition` has the identical shape and is **fixed here** rather than recorded as unaffected. Same sabotage output: `Verdict:buy` at 38% below an invented median.

## Evidence

- **V:** sabotage-verified on both paths against the pre-fix behaviour, with the output above. The regression tests seed 30 currencyless observations spread 80–400, so a pooled median is confidently wrong rather than accidentally harmless.
- **V:** a control test ships alongside — a **labelled** fare on the same seeded history must still produce a position. Without it, deleting price-position entirely would pass the refusal tests.
- **V:** `make dod` exit 0, read from the gate's own log.
- **I:** adversarial second opinion unavailable — `gpt-review` hangs on any review that reads code (its sandbox blocks every shell command it attempts; 44 refusals then a kill). Reported separately.

Closes #570.
