### PR TITLE
feat #535: carry the seller's cancellation terms through, lifting the self-imposed booking-readiness ceiling (V: sabotage-verified)

### DIFF
--- a/docs/superpowers/specs/2026-07-29-provider-trust-tiers-decision.md
+++ b/docs/superpowers/specs/2026-07-29-provider-trust-tiers-decision.md
@@ -1,6 +1,24 @@
 # Provider trust tiers: decision document
 
-Status: proposed, awaiting operator sign-off. Tracks issue #535. Nothing here is implemented.
+Status: **APPROVED as written, 2026-08-05.** Design A ships; the mainstream-seller
+tier of Design B is deferred indefinitely. Tracks issue #535.
+
+Implementation state:
+
+- **Refundability — done.** The seller's cancellation terms are carried through to
+  the per-seller price list instead of being discarded, as three states rather
+  than two: refundable, stated otherwise, and UNKNOWN when the seller is silent.
+  Nil rather than false for unknown, because the upstream flag is a positive
+  badge that is simply absent when there is no offer, and rendering that absence
+  as "not refundable" would be a claim the source never made. This also lifts the
+  self-imposed ceiling described below.
+- **Official property site — NOT STARTED, and deliberately so.** This document's
+  own falsification clause requires one captured live response before any code is
+  written, to check whether the hotel address the source reports resolves to the
+  property's own domain rather than to a booking intermediary. That capture has
+  not happened, and writing the matcher first would be building on the assumption
+  the clause exists to test.
+
 
 ## The question
 

--- a/internal/hotels/serpapi_fallback.go
+++ b/internal/hotels/serpapi_fallback.go
@@ -351,16 +351,39 @@ func providerPricesFromSerpAPIHotel(hotel *serpapi.Hotel, currency string) []mod
 		taxAtCheckout := option.TotalRate.Extracted > 0 &&
 			option.TotalRate.BeforeFeesExtracted > 0 &&
 			pricesEqual(option.TotalRate.Extracted, option.TotalRate.BeforeFeesExtracted)
+		// Carry the seller's cancellation terms through instead of discarding
+		// them (trvl#535). They were already being read here and dropped on the
+		// way into the per-seller list, which is why hotel-price results could
+		// never reach a "ready to book" verdict: refundability was declared
+		// permanently unavailable on this path.
+		//
+		// Set only from an explicit true. The upstream flag is a positive badge
+		// that is absent when there is no free-cancellation offer, so a false
+		// means "the seller said nothing", not "not refundable" -- and rendering
+		// that absence as a negative would be exactly the guess-presented-as-fact
+		// this ticket's lineage exists to prevent.
+		var freeCancel *bool
+		if option.FreeCancellation {
+			yes := true
+			freeCancel = &yes
+		}
+		until := strings.TrimSpace(option.FreeCancellationUntilDate)
+		if t := strings.TrimSpace(option.FreeCancellationUntilTime); until != "" && t != "" {
+			until += " " + t
+		}
+
 		providers = append(providers, models.ProviderPrice{
-			Provider:           serpapiProviderName(option.Source),
-			Price:              price,
-			NightlyPrice:       option.RatePerNight.Extracted,
-			TotalPrice:         option.TotalRate.Extracted,
-			Currency:           currency,
-			ProviderURL:        option.Link,
-			PriceBasis:         basis,
-			PriceConfidence:    models.PriceConfidenceVerified,
-			TaxAddedAtCheckout: taxAtCheckout,
+			Provider:              serpapiProviderName(option.Source),
+			Price:                 price,
+			NightlyPrice:          option.RatePerNight.Extracted,
+			TotalPrice:            option.TotalRate.Extracted,
+			Currency:              currency,
+			ProviderURL:           option.Link,
+			PriceBasis:            basis,
+			PriceConfidence:       models.PriceConfidenceVerified,
+			TaxAddedAtCheckout:    taxAtCheckout,
+			FreeCancellation:      freeCancel,
+			FreeCancellationUntil: until,
 		})
 	}
 	return dedupeAndSortProviderPrices(providers)

--- a/internal/models/hotel.go
+++ b/internal/models/hotel.go
@@ -170,6 +170,23 @@ type ProviderPrice struct {
 	// pre-tax figure, meaning taxes/fees will be added at checkout and the
 	// quoted price will grow. Set only when both figures are known. See #171.
 	TaxAddedAtCheckout bool `json:"tax_added_at_checkout,omitempty"`
+	// FreeCancellation reports whether this seller's rate is refundable, and is
+	// nil when the seller said nothing. Three states, not two: refundable,
+	// stated as non-refundable, and UNKNOWN (trvl#535, TRVL.TRUST.4).
+	//
+	// Nil rather than false for unknown, because the upstream flag is a positive
+	// badge that is simply absent when there is no free-cancellation offer. A
+	// plain bool would render that absence as "not refundable", which is a claim
+	// the source never made -- and the whole of this ticket's lineage is about
+	// not presenting a guess as a fact.
+	//
+	// So this is only ever set to true from an explicit upstream signal. It is
+	// never inferred from price, brand or rate name.
+	FreeCancellation *bool `json:"free_cancellation,omitempty"`
+	// FreeCancellationUntil is the deadline the seller stated, when it gave one.
+	// Free-form as received; trvl does not parse or re-render it, because a
+	// misparsed cancellation deadline is worse than an unparsed one.
+	FreeCancellationUntil string `json:"free_cancellation_until,omitempty"`
 }
 
 // HotelPriceResult is the top-level response for a hotel price lookup.

--- a/internal/pricefeed/pricefeed.go
+++ b/internal/pricefeed/pricefeed.go
@@ -160,6 +160,29 @@ func HotelPricesReadiness(hotelID string, providers []models.ProviderPrice) book
 	case models.PriceConfidenceUnverified:
 		in.Verified = booking.False()
 	}
+	// Refundability is no longer unobtainable on this path (trvl#535). The
+	// seller's cancellation terms were always present upstream and were being
+	// dropped when the per-seller list was built; they are now carried through,
+	// so the ceiling this function used to declare is lifted for any result that
+	// actually carries them.
+	//
+	// The declaration stays for results that do NOT: a hotel-price response
+	// where no seller states its terms still cannot reach "ready", and saying so
+	// is what lets a caller distinguish "this path cannot do better" from a
+	// finding about the property. That distinction is the whole reason the
+	// ceiling was declared rather than left implicit -- an external tester saw
+	// Caution on six properties and could not tell which he was looking at.
+	refundabilityKnown := false
+	for _, p := range providers {
+		if p.FreeCancellation != nil || p.FreeCancellationUntil != "" {
+			refundabilityKnown = true
+			break
+		}
+	}
+	if refundabilityKnown {
+		in.RefundabilityKnown = booking.True()
+		return booking.Evaluate(in)
+	}
 	return booking.EvaluateWith(in, booking.Availability{NoRefundability: true})
 }
 

--- a/internal/pricefeed/refundability_test.go
+++ b/internal/pricefeed/refundability_test.go
@@ -1,0 +1,95 @@
+package pricefeed
+
+import (
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// trvl#535, TRVL.TRUST.4 -- refundability is RECORDED where the seller states
+// it, and marked unknown where the seller is silent. Never inferred.
+//
+// The hotel-price path used to declare refundability permanently unavailable,
+// so every verdict from it was capped at Caution no matter how good the data
+// was. That ceiling was self-imposed: the seller's cancellation terms were
+// present upstream and were being dropped on the way into the per-seller list.
+//
+// The external tester who prompted this saw Caution on six indexed properties
+// and could not tell whether he was looking at six uncertain properties or a
+// scale that never says better. Both halves below matter for that reason: the
+// ceiling must lift when terms exist, and must REMAIN when they do not.
+
+// A seller that states free cancellation lifts the ceiling.
+func TestHotelPricesReadinessUsesStatedRefundability(t *testing.T) {
+	yes := true
+	withTerms := []models.ProviderPrice{{
+		Provider:         "someseller",
+		Price:            180,
+		Currency:         "EUR",
+		PriceConfidence:  models.PriceConfidenceVerified,
+		LinkDurability:   "stable",
+		ProviderURL:      "https://seller.example/book",
+		FreeCancellation: &yes,
+	}}
+
+	got := HotelPricesReadiness("hotel-abc", withTerms)
+
+	if got.Capped() {
+		t.Errorf("verdict still reports a ceiling (%q) when the seller stated its cancellation "+
+			"terms -- Capped means this source could never reach Ready for any property, which "+
+			"stops being true the moment the terms are carried through", got.Ceiling)
+	}
+}
+
+// Silence must NOT lift it. This is the half that keeps the fix honest: a
+// verdict that improved merely because a field exists would be the same
+// guess-as-fact defect in a new place.
+func TestHotelPricesReadinessKeepsTheCeilingWhenNoSellerStatesTerms(t *testing.T) {
+	silent := []models.ProviderPrice{{
+		Provider:        "someseller",
+		Price:           180,
+		Currency:        "EUR",
+		PriceConfidence: models.PriceConfidenceVerified,
+		LinkDurability:  "stable",
+		ProviderURL:     "https://seller.example/book",
+		// No FreeCancellation, no FreeCancellationUntil: the seller said nothing.
+	}}
+
+	got := HotelPricesReadiness("hotel-abc", silent)
+
+	if !got.Capped() {
+		t.Error("the ceiling was lifted when NO seller stated any cancellation terms -- absence of " +
+			"terms is not evidence of refundability, and dropping the ceiling on silence tells a " +
+			"caller the path could do better when it cannot")
+	}
+}
+
+// A deadline alone counts as stated terms, even without the boolean: a seller
+// that says "free cancellation until 3 June" has told us something, and
+// requiring both fields would discard it.
+func TestHotelPricesReadinessAcceptsADeadlineAlone(t *testing.T) {
+	withDeadline := []models.ProviderPrice{{
+		Provider:              "someseller",
+		Price:                 180,
+		Currency:              "EUR",
+		PriceConfidence:       models.PriceConfidenceVerified,
+		LinkDurability:        "stable",
+		ProviderURL:           "https://seller.example/book",
+		FreeCancellationUntil: "2026-06-03",
+	}}
+
+	silent := []models.ProviderPrice{{
+		Provider:        "someseller",
+		Price:           180,
+		Currency:        "EUR",
+		PriceConfidence: models.PriceConfidenceVerified,
+		LinkDurability:  "stable",
+		ProviderURL:     "https://seller.example/book",
+	}}
+
+	if HotelPricesReadiness("hotel-abc", withDeadline).Capped() ==
+		HotelPricesReadiness("hotel-abc", silent).Capped() {
+		t.Error("a stated cancellation deadline changed nothing; a seller that names a date has " +
+			"told us its terms even without the boolean flag")
+	}
+}


### PR DESCRIPTION
Operator approved Design A of the decision document on 2026-08-05. This is its **refundability half**. The official-property-site half is deliberately **not started** — see below.

## The terms were never missing; they were being discarded

`serpapi.PriceOption` already carries `FreeCancellation`, `FreeCancellationUntilDate` and `FreeCancellationUntilTime`. They were read on the room path and **dropped** when the per-seller price list was built. Carrying them through is the whole change.

## Three states, not two

`models.ProviderPrice.FreeCancellation` is `*bool`: **nil means the seller said nothing.**

A plain `bool` would render that silence as "not refundable" — a claim the source never made. The upstream field is a positive badge that is simply absent when there is no free-cancellation offer. So it is set only from an explicit true, and never inferred from price, brand or rate name.

That is `TRVL.TRUST.4`: *recorded where a seller states it, marked unknown where it is silent, never inferred.*

## The ceiling this unblocks matters more than the field

`HotelPricesReadiness` declared refundability **permanently unavailable**, so every verdict from the hotel-price path was capped at Caution no matter how good the data was. That ceiling was self-imposed by the dropped terms.

It now lifts for results that carry terms and **remains** for results that do not — which is the honest half. A ceiling that dropped on silence would tell a caller the path could do better when it cannot.

That distinction is why the ceiling was declared rather than left implicit: an external tester ran six indexed properties, saw Caution every time, and could not tell whether he was looking at six uncertain properties or a scale that never says better.

## Not started, deliberately

The **official-property-site** signal. The decision document's own falsification clause requires one captured live response *before any code is written*, to check whether the hotel address the source reports resolves to the property's own domain rather than to a booking intermediary — particularly for chains, where it plausibly does not.

Writing the matcher first would be building on the exact assumption that clause exists to test. Recorded in the document as not-started, with the reason.

## Evidence

- **V:** sabotage-verified — restoring the unconditional ceiling fails with *"verdict still reports a ceiling when the seller stated its cancellation terms"*.
- **V:** tests cover both directions plus the deadline-only case: a seller naming a date has told us its terms even without the boolean flag.
- **V:** the silence case is pinned separately, so a verdict that improved merely because a field exists would fail. That would be the same guess-as-fact defect in a new place.
- **V:** `make dod` exit 0 on the targeted packages (models, hotels, pricefeed, booking).
- **I:** one full-suite run showed an unrelated failure in `internal/flights/afklm`, which passes alone in 0.845s against 9.63s under load. Investigated and closed as not-a-defect (#577): that test already injects its own budget, and the trigger was pathological load I had created.

Refs #535 — the official-site half keeps it open.
