### PR TITLE
feat #514: make retention limits configurable, refused-not-clamped, and reportable (V: sabotage-verified; make dod exit 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,28 @@ export TRVL_NO_TIER2_CDP=1         # never start a headless browser of its own
 
 Both cost you results, and it is worth knowing how: a site that answers with a bot challenge simply returns nothing, which looks like trvl finding no trains rather than like a setting you chose. That is the trade, stated so you can make it deliberately.
 
+### How much price history trvl keeps
+
+Watch price history is capped, or it grows without bound: one real store reached 320,028 points in 41MB, which cost every running trvl process about 686MB of memory. Three limits bound it, and all three can be changed.
+
+```bash
+export TRVL_WATCH_MAX_POINTS_PER_WATCH=1000   # points kept per watch
+export TRVL_WATCH_MAX_POINTS_TOTAL=50000      # points kept across all watches
+export TRVL_WATCH_ROUTE_TTL_DAYS=90           # how long a dateless route watch keeps being checked
+```
+
+Those are the defaults, and the cost of moving each one:
+
+| setting | raising it costs | lowering it costs |
+|---|---|---|
+| points per watch | memory and disk, multiplied by how many watches you have | resolution in long-range trend views. Nothing needs the raw tail — the sparkline reads 10–20 points, and a watch's all-time low is stored on the watch itself, so it survives eviction |
+| points in total | this is the number that actually bounds the file. The per-watch cap cannot, because many watches multiply it | your watches compete for one budget, so a large collection loses history on all of them rather than on the busiest |
+| route watch TTL | routes with no travel date are re-checked against live providers every 30 minutes for as long as this allows. One real store carried 468 permanently-active route watches | a seasonal route expires between uses. Re-watching renews it, but an annual trip expires every year |
+
+An unusable value is **refused, not adjusted**: `trvl` will not start against `TRVL_WATCH_MAX_POINTS_TOTAL=0`, rather than quietly using the default and leaving you to believe your setting took effect.
+
+To see whether any limit is actually binding on your store, run `trvl watch migrate --dry-run`. It reports the size on disk, the spread of points per watch, and how close you are to each cap, without changing anything.
+
 Full mechanism — what is read at which point, the exact difference between those two switches, the headless-browser fallback, and the AF-KLM credential rules: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#browser-sessions-credentials-and-local-state).
 
 One command publishes deliberately, because that is what you ran it for: the calendar helper writes an event to your Google calendar. `trvl share` does not — it prints the trip card, or copies it to your clipboard, and you decide who receives it. It used to upload the card as a public GitHub gist; that was removed in [#527](https://github.com/MikkoParkkola/trvl/issues/527), because a card carries destinations and dates, and those together say when your home is empty.

--- a/cmd/trvl/watch.go
+++ b/cmd/trvl/watch.go
@@ -596,6 +596,12 @@ earliest creation date of the group so its history is not shortened.`,
 					return err
 				}
 				fmt.Println(preview.Summary())
+				// The retention picture, printed whether or not anything would
+				// change. The three limits shipped with no usage data behind
+				// them, and this is where the data that would justify changing
+				// one becomes visible (trvl#514).
+				fmt.Println()
+				fmt.Print(store.RetentionStats().Summary())
 				if preview.Changed() {
 					fmt.Println("\nRe-run without --dry-run to apply.")
 				}
@@ -607,6 +613,8 @@ earliest creation date of the group so its history is not shortened.`,
 				return err
 			}
 			fmt.Println(report.Summary())
+			fmt.Println()
+			fmt.Print(store.RetentionStats().Summary())
 			return nil
 		},
 	}

--- a/internal/watch/dedup_test.go
+++ b/internal/watch/dedup_test.go
@@ -415,10 +415,10 @@ func TestRouteWatchExpiresAfterTTL(t *testing.T) {
 	stale := Watch{Type: "flight", Origin: "HEL", Destination: "BCN", RenewedAt: time.Now().Add(-routeWatchTTL - time.Hour)}
 	today := time.Now().Format("2006-01-02")
 
-	if !isActive(fresh, today) {
+	if !isActive(fresh, today, defaultRetention().RouteTTL) {
 		t.Error("a recently renewed route watch must stay active")
 	}
-	if isActive(stale, today) {
+	if isActive(stale, today, defaultRetention().RouteTTL) {
 		t.Errorf("a route watch untouched for over %v must expire", routeWatchTTL)
 	}
 }
@@ -432,14 +432,14 @@ func TestRewatchRenewsRouteWatch(t *testing.T) {
 	// Age it past the TTL.
 	s.watches[0].RenewedAt = time.Now().Add(-routeWatchTTL - time.Hour)
 	today := time.Now().Format("2006-01-02")
-	if isActive(s.watches[0], today) {
+	if isActive(s.watches[0], today, defaultRetention().RouteTTL) {
 		t.Fatal("precondition: aged watch should be inactive")
 	}
 
 	if _, _, err := s.Add(Watch{Type: "flight", Origin: "HEL", Destination: "BCN", BelowPrice: 200, Currency: "EUR"}); err != nil {
 		t.Fatalf("re-add: %v", err)
 	}
-	if !isActive(s.watches[0], today) {
+	if !isActive(s.watches[0], today, defaultRetention().RouteTTL) {
 		t.Error("re-watching must renew an expired route watch")
 	}
 }
@@ -453,14 +453,14 @@ func TestDatedWatchExpiryIsUnchangedByRouteTTL(t *testing.T) {
 	// Ancient renewal, but the trip is still ahead: must stay active.
 	upcoming := Watch{Type: "flight", Origin: "HEL", Destination: "BCN",
 		DepartDate: future, RenewedAt: time.Now().Add(-routeWatchTTL - time.Hour)}
-	if !isActive(upcoming, today) {
+	if !isActive(upcoming, today, defaultRetention().RouteTTL) {
 		t.Error("an upcoming dated watch must not be expired by the route TTL")
 	}
 
 	// Renewed today, but the trip has been and gone: must be inactive.
 	departed := Watch{Type: "flight", Origin: "HEL", Destination: "BCN",
 		DepartDate: past, RenewedAt: time.Now()}
-	if isActive(departed, today) {
+	if isActive(departed, today, defaultRetention().RouteTTL) {
 		t.Error("a past dated watch must stay expired regardless of renewal")
 	}
 }
@@ -487,7 +487,7 @@ func TestLoadGrantsLegacyWatchesAFreshTTL(t *testing.T) {
 	if _, err := fresh.Migrate(); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	if !isActive(fresh.List()[0], time.Now().Format("2006-01-02")) {
+	if !isActive(fresh.List()[0], time.Now().Format("2006-01-02"), defaultRetention().RouteTTL) {
 		t.Error("migration mass-expired a legacy route watch instead of granting a fresh TTL")
 	}
 }

--- a/internal/watch/retention.go
+++ b/internal/watch/retention.go
@@ -1,0 +1,187 @@
+package watch
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// Retention limits, and the environment variables that override them
+// (trvl#514).
+//
+// These three numbers shipped in #508 with no usage data behind any of them.
+// They are defensible -- 1000 mirrors the existing per-route cap, Sparkline
+// reads 10-20 points, and a watch's all-time low lives on the Watch record so it
+// survives eviction -- but nothing measured them, and until now an operator
+// could neither see them nor change them without rebuilding.
+//
+// This makes them visible and adjustable. It deliberately does NOT change any
+// default: "there is no evidence for better numbers, so changing them again
+// would be numerology."
+const (
+	// EnvMaxPointsPerWatch overrides how many price points each watch retains.
+	//
+	// Cost of raising it: memory and store size, multiplied by the number of
+	// watches. One real store reached 320,028 points in 41MB, of which 319,966
+	// were watch-keyed, and loading that made each `trvl mcp` process cost about
+	// 686MB. At the 30-minute scheduler cadence the default retains roughly
+	// three weeks of full-resolution history per watch.
+	//
+	// Cost of lowering it: older points are evicted sooner. Nothing that reads
+	// history needs the raw tail -- Sparkline asks for 10-20 points, and the
+	// all-time low is on the Watch record -- so the practical loss is resolution
+	// in long-range trend views.
+	EnvMaxPointsPerWatch = "TRVL_WATCH_MAX_POINTS_PER_WATCH"
+
+	// EnvMaxPointsTotal overrides the global backstop across all watches,
+	// evicting oldest first.
+	//
+	// Cost of raising it: this is the number that actually bounds the file. The
+	// per-watch cap alone cannot, because many watches multiply it. Raising this
+	// is what turns a bounded store into an unbounded one.
+	//
+	// Cost of lowering it: watches compete for one budget, so a user with many
+	// watches loses history on all of them rather than on the busiest.
+	EnvMaxPointsTotal = "TRVL_WATCH_MAX_POINTS_TOTAL"
+
+	// EnvRouteTTLDays overrides how long a dateless route watch keeps being
+	// checked without the user re-expressing interest, in whole days.
+	//
+	// Cost of raising it: route watches have no travel date to expire against,
+	// so a long TTL means live provider calls every 30 minutes for routes nobody
+	// is watching any more. One real store carried 468 permanently-active route
+	// watches before this existed.
+	//
+	// Cost of lowering it: a seasonal watcher's route expires between uses.
+	// RenewedAt only advances on user intent, so an annual traveller's watch
+	// expires every year -- arguably correct, arguably surprising. This is the
+	// value most likely to be wrong, and the reason it is now adjustable.
+	EnvRouteTTLDays = "TRVL_WATCH_ROUTE_TTL_DAYS"
+)
+
+// Ceilings exist so a typo cannot be accepted as a policy. They are not
+// judgements about the right value -- they bound the absurd, an order of
+// magnitude beyond any plausible setting, so that a stray zero is refused
+// rather than silently turning the store unbounded.
+const (
+	maxAllowedPointsPerWatch = 1_000_000
+	maxAllowedPointsTotal    = 10_000_000
+	maxAllowedRouteTTLDays   = 3650 // ten years
+)
+
+// retentionConfig carries the three limits for one store.
+type retentionConfig struct {
+	MaxPointsPerWatch int
+	MaxPointsTotal    int
+	RouteTTL          time.Duration
+}
+
+func defaultRetention() retentionConfig {
+	return retentionConfig{
+		MaxPointsPerWatch: maxObservationsPerWatch,
+		MaxPointsTotal:    maxWatchObservations,
+		RouteTTL:          routeWatchTTL,
+	}
+}
+
+// loadRetention reads the overrides, or returns an error naming the variable
+// and what it would accept.
+//
+// TRVL.RETENTION.4: an out-of-range or unparseable value is REFUSED, never
+// clamped. Clamping would mean an operator who set 0 to disable a cap gets 1000
+// instead and is never told -- the store would then behave one way while its
+// configuration said another, which is worse than refusing to start. An empty
+// or unset variable is not an error; it means "use the default".
+//
+// getenv is a parameter so this is testable without touching process
+// environment, which matters because the tests must be able to run in parallel.
+func loadRetention(getenv func(string) string) (retentionConfig, error) {
+	cfg := defaultRetention()
+
+	if v, err := positiveInt(getenv, EnvMaxPointsPerWatch, maxAllowedPointsPerWatch); err != nil {
+		return retentionConfig{}, err
+	} else if v > 0 {
+		cfg.MaxPointsPerWatch = v
+	}
+
+	if v, err := positiveInt(getenv, EnvMaxPointsTotal, maxAllowedPointsTotal); err != nil {
+		return retentionConfig{}, err
+	} else if v > 0 {
+		cfg.MaxPointsTotal = v
+	}
+
+	if v, err := positiveInt(getenv, EnvRouteTTLDays, maxAllowedRouteTTLDays); err != nil {
+		return retentionConfig{}, err
+	} else if v > 0 {
+		cfg.RouteTTL = time.Duration(v) * 24 * time.Hour
+	}
+
+	// A per-watch cap above the global backstop is not wrong so much as
+	// meaningless: the backstop evicts first, so the larger number never takes
+	// effect. Saying so beats letting an operator believe a setting is active.
+	if cfg.MaxPointsPerWatch > cfg.MaxPointsTotal {
+		return retentionConfig{}, fmt.Errorf(
+			"%s (%d) exceeds %s (%d): the global backstop evicts first, so the per-watch cap would never take effect",
+			EnvMaxPointsPerWatch, cfg.MaxPointsPerWatch, EnvMaxPointsTotal, cfg.MaxPointsTotal)
+	}
+
+	return cfg, nil
+}
+
+// positiveInt returns 0 when the variable is unset or empty, meaning "default".
+func positiveInt(getenv func(string) string, name string, max int) (int, error) {
+	raw := getenv(name)
+	if raw == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s=%q is not a whole number (accepted: 1..%d)", name, raw, max)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("%s=%d must be greater than zero; there is no way to disable a retention cap, because an unbounded store is the defect these caps exist to prevent", name, n)
+	}
+	if n > max {
+		return 0, fmt.Errorf("%s=%d exceeds the accepted maximum of %d", name, n, max)
+	}
+	return n, nil
+}
+
+// retentionFromEnv is the process-wide accessor used by the store.
+func retentionFromEnv() (retentionConfig, error) {
+	return loadRetention(os.Getenv)
+}
+
+// retentionOrDefault returns this store's limits, falling back to the compiled
+// defaults when Load has not run.
+//
+// The fallback is not a way to skip validation. Every path that mutates the
+// store goes through withTxn, which reloads committed state and therefore
+// validates; and every consumer calls Load before use. This exists so a Store
+// constructed directly in a test still evicts rather than retaining without
+// limit, which is the behaviour those tests were written against.
+func (s *Store) retentionOrDefault() retentionConfig {
+	if s.retention.MaxPointsPerWatch == 0 || s.retention.MaxPointsTotal == 0 {
+		return defaultRetention()
+	}
+	return s.retention
+}
+
+// effectiveRetention is the accessor for code with no *Store to hand -- the
+// activity check runs as a free function on a Watch value.
+//
+// It falls back to defaults when the environment is invalid rather than
+// returning an error, because these call sites have no way to report one. That
+// is not a hole: Store.Load validates the same variables and REFUSES to load on
+// a bad value, so a process that reaches these functions with an invalid
+// override is one that already failed to start. The fallback keeps a
+// misconfigured process from behaving unboundedly in the window before it
+// exits, rather than being the place the value is decided.
+func effectiveRetention() retentionConfig {
+	cfg, err := retentionFromEnv()
+	if err != nil {
+		return defaultRetention()
+	}
+	return cfg
+}

--- a/internal/watch/retention_stats.go
+++ b/internal/watch/retention_stats.go
@@ -1,0 +1,142 @@
+package watch
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// RetentionStats describes what the store currently holds against the limits
+// that bound it (trvl#514, TRVL.RETENTION.3).
+//
+// This exists because the three retention numbers shipped with no usage data
+// behind them, and nothing could report the data that would justify changing
+// them. "Revisit only once that data exists" needs somewhere for the data to
+// come from.
+type RetentionStats struct {
+	Watches      int
+	TotalPoints  int
+	WatchPoints  int
+	RoutePoints  int
+	StoreBytes   int64
+	HistoryBytes int64
+
+	// Per-watch point counts, describing the distribution rather than only its
+	// total: a store at 60% of the global cap looks healthy until one watch
+	// turns out to hold most of it.
+	MinPerWatch    int
+	MedianPerWatch int
+	P90PerWatch    int
+	MaxPerWatch    int
+
+	// AtPerWatchCap is how many watches sit at the per-watch cap, i.e. are
+	// actively losing history to eviction. The number that says whether the cap
+	// binds in practice or is merely a backstop.
+	AtPerWatchCap int
+
+	Limits retentionConfig
+}
+
+// RetentionStats reports the store's current occupancy against its limits.
+func (s *Store) RetentionStats() RetentionStats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	limits := s.retentionOrDefault()
+	st := RetentionStats{
+		Watches:     len(s.watches),
+		TotalPoints: len(s.history),
+		Limits:      limits,
+	}
+
+	perWatch := make(map[string]int, len(s.watches))
+	for _, p := range s.history {
+		if p.WatchID != "" {
+			st.WatchPoints++
+			perWatch[p.WatchID]++
+			continue
+		}
+		st.RoutePoints++
+	}
+
+	counts := make([]int, 0, len(perWatch))
+	for _, n := range perWatch {
+		counts = append(counts, n)
+		if n >= limits.MaxPointsPerWatch {
+			st.AtPerWatchCap++
+		}
+	}
+	sort.Ints(counts)
+	if len(counts) > 0 {
+		st.MinPerWatch = counts[0]
+		st.MaxPerWatch = counts[len(counts)-1]
+		st.MedianPerWatch = counts[len(counts)/2]
+		st.P90PerWatch = counts[(len(counts)*9)/10]
+		if idx := (len(counts) * 9) / 10; idx >= len(counts) {
+			st.P90PerWatch = counts[len(counts)-1]
+		}
+	}
+
+	if fi, err := os.Stat(s.watchesPath()); err == nil {
+		st.StoreBytes += fi.Size()
+	}
+	if fi, err := os.Stat(s.historyPath()); err == nil {
+		st.HistoryBytes = fi.Size()
+		st.StoreBytes += fi.Size()
+	}
+	return st
+}
+
+// Summary renders the stats for a human, alongside the limits and how each was
+// set, so an operator can see whether a cap is binding before deciding whether
+// it is wrong.
+func (st RetentionStats) Summary() string {
+	var b strings.Builder
+	b.WriteString("Retention\n")
+	fmt.Fprintf(&b, "  store on disk        %s (history %s)\n", humanBytes(st.StoreBytes), humanBytes(st.HistoryBytes))
+	fmt.Fprintf(&b, "  watches              %d\n", st.Watches)
+	fmt.Fprintf(&b, "  price points         %d total (%d watch-keyed, %d route-keyed)\n",
+		st.TotalPoints, st.WatchPoints, st.RoutePoints)
+
+	if st.WatchPoints > 0 {
+		fmt.Fprintf(&b, "  points per watch     min %d, median %d, p90 %d, max %d\n",
+			st.MinPerWatch, st.MedianPerWatch, st.P90PerWatch, st.MaxPerWatch)
+	}
+
+	fmt.Fprintf(&b, "  per-watch cap        %d (%s)\n", st.Limits.MaxPointsPerWatch, sourceOf(EnvMaxPointsPerWatch))
+	fmt.Fprintf(&b, "  global cap           %d (%s)\n", st.Limits.MaxPointsTotal, sourceOf(EnvMaxPointsTotal))
+	fmt.Fprintf(&b, "  route watch TTL      %d days (%s)\n", int(st.Limits.RouteTTL.Hours()/24), sourceOf(EnvRouteTTLDays))
+
+	// The two lines that answer "is a cap actually binding?", which is the
+	// question this report exists to make answerable.
+	if st.AtPerWatchCap > 0 {
+		fmt.Fprintf(&b, "  NOTE %d watch(es) are at the per-watch cap and are losing their oldest points.\n", st.AtPerWatchCap)
+	}
+	if st.Limits.MaxPointsTotal > 0 {
+		pct := (st.WatchPoints * 100) / st.Limits.MaxPointsTotal
+		fmt.Fprintf(&b, "  global cap used      %d%%\n", pct)
+		if pct >= 100 {
+			b.WriteString("  NOTE the global cap is binding: the oldest watch points are being evicted.\n")
+		}
+	}
+	return b.String()
+}
+
+func sourceOf(env string) string {
+	if os.Getenv(env) != "" {
+		return "set via " + env
+	}
+	return "default; override with " + env
+}
+
+func humanBytes(n int64) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/internal/watch/retention_stats_test.go
+++ b/internal/watch/retention_stats_test.go
@@ -1,0 +1,103 @@
+package watch
+
+import (
+	"strings"
+	"testing"
+)
+
+// TRVL.RETENTION.3 -- the store can report what it holds against its limits.
+//
+// The three retention numbers shipped with no usage data behind them, and this
+// ticket is explicitly about making them visible rather than changing them:
+// "revisit only once that data exists" needs somewhere for the data to come
+// from.
+//
+// So the assertions below are about whether an operator could ACT on the
+// output, not about formatting.
+func TestRetentionStatsDescribesTheDistributionNotJustTheTotal(t *testing.T) {
+	s := NewStore(t.TempDir())
+	if err := s.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Deliberately lopsided: one heavy watch and several light ones. A total
+	// alone would look healthy here, which is the case the distribution exists
+	// to expose.
+	heavy, _, err := s.Add(Watch{Type: "flight", Origin: "HEL", Destination: "NRT", Currency: "EUR"})
+	if err != nil {
+		t.Fatalf("add heavy: %v", err)
+	}
+	for i := 0; i < 40; i++ {
+		if err := s.RecordPrice(heavy, float64(100+i), "EUR"); err != nil {
+			t.Fatalf("record heavy %d: %v", i, err)
+		}
+	}
+	for j := 0; j < 3; j++ {
+		id, _, err := s.Add(Watch{Type: "flight", Origin: "HEL", Destination: string(rune('A' + j)), Currency: "EUR"})
+		if err != nil {
+			t.Fatalf("add light %d: %v", j, err)
+		}
+		if err := s.RecordPrice(id, 200, "EUR"); err != nil {
+			t.Fatalf("record light %d: %v", j, err)
+		}
+	}
+
+	st := s.RetentionStats()
+
+	if st.Watches != 4 {
+		t.Errorf("Watches = %d, want 4", st.Watches)
+	}
+	if st.WatchPoints == 0 {
+		t.Fatal("no watch-keyed points counted; the report would describe an empty store")
+	}
+	if st.MaxPerWatch <= st.MedianPerWatch {
+		t.Errorf("max (%d) is not above median (%d) on a deliberately lopsided store -- the "+
+			"distribution is not being measured, and a total alone hides exactly this shape",
+			st.MaxPerWatch, st.MedianPerWatch)
+	}
+	if st.StoreBytes <= 0 {
+		t.Error("StoreBytes = 0; the on-disk size is half of what makes a retention limit judgeable")
+	}
+}
+
+// The summary must name the limits AND how each was set, so an operator reading
+// it knows whether a value is a default or something they configured.
+func TestRetentionStatsSummaryNamesTheLimitsAndTheirSource(t *testing.T) {
+	s := NewStore(t.TempDir())
+	if err := s.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	got := s.RetentionStats().Summary()
+
+	for _, want := range []string{
+		"per-watch cap", "global cap", "route watch TTL",
+		EnvMaxPointsPerWatch, EnvMaxPointsTotal, EnvRouteTTLDays,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary omits %q, so a reader cannot tell what the limit is or how to "+
+				"change it:\n%s", want, got)
+		}
+	}
+}
+
+// A configured value must be reported as configured. Showing a default when the
+// operator set something is the reporting equivalent of silently clamping.
+func TestRetentionStatsSummaryDistinguishesConfiguredFromDefault(t *testing.T) {
+	t.Setenv(EnvMaxPointsTotal, "9000")
+
+	s := NewStore(t.TempDir())
+	if err := s.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	got := s.RetentionStats().Summary()
+
+	if !strings.Contains(got, "9000") {
+		t.Errorf("summary does not show the configured global cap:\n%s", got)
+	}
+	if !strings.Contains(got, "set via "+EnvMaxPointsTotal) {
+		t.Errorf("summary does not mark the global cap as configured rather than default; an "+
+			"operator cannot tell their setting took effect:\n%s", got)
+	}
+}

--- a/internal/watch/retention_test.go
+++ b/internal/watch/retention_test.go
@@ -1,0 +1,139 @@
+package watch
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// trvl#514 -- the three retention limits are configurable, and an unusable
+// value is REFUSED rather than clamped.
+//
+// The clamping distinction is the whole point of TRVL.RETENTION.4. An operator
+// who sets 0 intending "no cap" and silently receives 1000 has a store that
+// behaves one way while its configuration says another, and nothing ever tells
+// them. Refusing is louder and therefore kinder.
+
+func env(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+// TRVL.RETENTION.1 -- the current values are the defaults, and an unset
+// environment changes nothing. This ticket is explicitly not about picking
+// different numbers.
+func TestRetentionDefaultsAreUnchangedWhenUnset(t *testing.T) {
+	cfg, err := loadRetention(env(nil))
+	if err != nil {
+		t.Fatalf("unset environment must be valid: %v", err)
+	}
+	if cfg.MaxPointsPerWatch != maxObservationsPerWatch {
+		t.Errorf("MaxPointsPerWatch = %d, want the compiled default %d", cfg.MaxPointsPerWatch, maxObservationsPerWatch)
+	}
+	if cfg.MaxPointsTotal != maxWatchObservations {
+		t.Errorf("MaxPointsTotal = %d, want the compiled default %d", cfg.MaxPointsTotal, maxWatchObservations)
+	}
+	if cfg.RouteTTL != routeWatchTTL {
+		t.Errorf("RouteTTL = %v, want the compiled default %v", cfg.RouteTTL, routeWatchTTL)
+	}
+}
+
+// Each variable actually takes effect. A setting that parsed but was ignored
+// would be the decorative-guard defect this repo has already fixed twice.
+func TestRetentionOverridesTakeEffect(t *testing.T) {
+	cfg, err := loadRetention(env(map[string]string{
+		EnvMaxPointsPerWatch: "250",
+		EnvMaxPointsTotal:    "9000",
+		EnvRouteTTLDays:      "30",
+	}))
+	if err != nil {
+		t.Fatalf("valid overrides rejected: %v", err)
+	}
+	if cfg.MaxPointsPerWatch != 250 {
+		t.Errorf("MaxPointsPerWatch = %d, want 250", cfg.MaxPointsPerWatch)
+	}
+	if cfg.MaxPointsTotal != 9000 {
+		t.Errorf("MaxPointsTotal = %d, want 9000", cfg.MaxPointsTotal)
+	}
+	if cfg.RouteTTL != 30*24*time.Hour {
+		t.Errorf("RouteTTL = %v, want 30 days", cfg.RouteTTL)
+	}
+}
+
+// TRVL.RETENTION.4 -- refused, not clamped, and the error names the variable so
+// the operator can find it without reading the source.
+func TestRetentionRejectsUnusableValues(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		vars map[string]string
+		want string
+	}{
+		{"zero", map[string]string{EnvMaxPointsPerWatch: "0"}, EnvMaxPointsPerWatch},
+		{"negative", map[string]string{EnvMaxPointsTotal: "-5"}, EnvMaxPointsTotal},
+		{"not a number", map[string]string{EnvRouteTTLDays: "ninety"}, EnvRouteTTLDays},
+		{"empty-ish whitespace", map[string]string{EnvMaxPointsTotal: " "}, EnvMaxPointsTotal},
+		{"absurdly large", map[string]string{EnvMaxPointsPerWatch: "999999999"}, EnvMaxPointsPerWatch},
+		{"float", map[string]string{EnvRouteTTLDays: "1.5"}, EnvRouteTTLDays},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := loadRetention(env(tc.vars))
+			if err == nil {
+				t.Fatalf("%v was accepted, yielding %+v -- an unusable value must be refused, "+
+					"because clamping leaves the store behaving differently from its configuration "+
+					"with nothing to tell the operator", tc.vars, cfg)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error does not name %s, so an operator cannot find what to change: %v",
+					tc.want, err)
+			}
+		})
+	}
+}
+
+// A per-watch cap above the global backstop is meaningless rather than
+// dangerous -- the backstop evicts first -- but accepting it would let an
+// operator believe a setting is active when it can never take effect.
+func TestRetentionRejectsAPerWatchCapAboveTheGlobalBackstop(t *testing.T) {
+	_, err := loadRetention(env(map[string]string{
+		EnvMaxPointsPerWatch: "20000",
+		EnvMaxPointsTotal:    "5000",
+	}))
+	if err == nil {
+		t.Fatal("a per-watch cap above the global backstop was accepted; the backstop evicts " +
+			"first, so that per-watch value could never take effect and the operator would " +
+			"never learn it")
+	}
+	if !strings.Contains(err.Error(), "never take effect") {
+		t.Errorf("the error does not explain why the combination is refused: %v", err)
+	}
+}
+
+// TRVL.RETENTION.4 at the seam that matters: Load is where every consumer
+// already checks for an error, so a bad override must stop the store loading
+// rather than surface later during an eviction, or not at all.
+func TestLoadRefusesAnInvalidRetentionOverride(t *testing.T) {
+	t.Setenv(EnvMaxPointsTotal, "0")
+
+	s := NewStore(t.TempDir())
+	err := s.Load()
+	if err == nil {
+		t.Fatal("Load accepted an invalid retention override; the store would run with limits " +
+			"the operator did not set and would never be told")
+	}
+	if !strings.Contains(err.Error(), EnvMaxPointsTotal) {
+		t.Errorf("Load error does not name the offending variable: %v", err)
+	}
+}
+
+// And the control: a valid override must not stop the store loading.
+func TestLoadAcceptsAValidRetentionOverride(t *testing.T) {
+	t.Setenv(EnvMaxPointsTotal, "9000")
+
+	s := NewStore(t.TempDir())
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load rejected a valid override: %v", err)
+	}
+	if got := s.retentionOrDefault().MaxPointsTotal; got != 9000 {
+		t.Errorf("store retention = %d, want the configured 9000 -- a setting that loads but is "+
+			"not used is not a setting", got)
+	}
+}

--- a/internal/watch/scheduler.go
+++ b/internal/watch/scheduler.go
@@ -363,7 +363,7 @@ func activeWatches(watches []Watch) []Watch {
 
 	var active []Watch
 	for _, w := range watches {
-		if isActive(w, today) {
+		if isActive(w, today, effectiveRetention().RouteTTL) {
 			active = append(active, w)
 		}
 	}
@@ -371,7 +371,11 @@ func activeWatches(watches []Watch) []Watch {
 }
 
 // isActive returns true if the watch should still be checked.
-func isActive(w Watch, today string) bool {
+// routeTTL is passed rather than read from a package constant so an operator
+// override reaches this decision too (trvl#514). A configurable retention
+// setting that the eviction path honoured and the activity check ignored would
+// be a setting in name only.
+func isActive(w Watch, today string, routeTTL time.Duration) bool {
 	// Route watches have no travel date to expire against, so they age out on
 	// renewal instead: created or re-watched within routeWatchTTL. Without this
 	// they were active forever and accumulated indefinitely.
@@ -383,7 +387,7 @@ func isActive(w Watch, today string) bool {
 		if renewed.IsZero() {
 			return true // no timestamps at all: do not silently drop it
 		}
-		return time.Since(renewed) < routeWatchTTL
+		return time.Since(renewed) < routeTTL
 	}
 
 	// Date-range watches: active if the range end is today or later.
@@ -416,7 +420,7 @@ func ActiveWatches(watches []Watch) []Watch {
 // an expired watch otherwise renders identically to a healthy one while no price
 // is ever fetched for it again.
 func IsActiveNow(w Watch) bool {
-	return isActive(w, time.Now().Format("2006-01-02"))
+	return isActive(w, time.Now().Format("2006-01-02"), effectiveRetention().RouteTTL)
 }
 
 // orphanWarnBytes is the total orphaned-temp size that earns a warning. One

--- a/internal/watch/scheduler_test.go
+++ b/internal/watch/scheduler_test.go
@@ -445,7 +445,7 @@ func TestScheduler_AlwaysChecksRouteWatches(t *testing.T) {
 func TestIsActive_RouteWatch(t *testing.T) {
 	t.Parallel()
 	w := Watch{Type: "flight", Origin: "HEL", Destination: "BCN"}
-	if !isActive(w, "2026-07-01") {
+	if !isActive(w, "2026-07-01", defaultRetention().RouteTTL) {
 		t.Error("route watch should always be active")
 	}
 }
@@ -453,7 +453,7 @@ func TestIsActive_RouteWatch(t *testing.T) {
 func TestIsActive_FutureDepartDate(t *testing.T) {
 	t.Parallel()
 	w := Watch{Type: "flight", Origin: "HEL", Destination: "BCN", DepartDate: "2099-01-01"}
-	if !isActive(w, "2026-07-01") {
+	if !isActive(w, "2026-07-01", defaultRetention().RouteTTL) {
 		t.Error("future depart date should be active")
 	}
 }
@@ -461,7 +461,7 @@ func TestIsActive_FutureDepartDate(t *testing.T) {
 func TestIsActive_PastDepartDate(t *testing.T) {
 	t.Parallel()
 	w := Watch{Type: "flight", Origin: "HEL", Destination: "BCN", DepartDate: "2000-01-01"}
-	if isActive(w, "2026-07-01") {
+	if isActive(w, "2026-07-01", defaultRetention().RouteTTL) {
 		t.Error("past depart date should not be active")
 	}
 }
@@ -470,7 +470,7 @@ func TestIsActive_TodayDepartDate(t *testing.T) {
 	t.Parallel()
 	today := time.Now().Format("2006-01-02")
 	w := Watch{Type: "flight", Origin: "HEL", Destination: "BCN", DepartDate: today}
-	if !isActive(w, today) {
+	if !isActive(w, today, defaultRetention().RouteTTL) {
 		t.Error("today's depart date should be active")
 	}
 }
@@ -478,7 +478,7 @@ func TestIsActive_TodayDepartDate(t *testing.T) {
 func TestIsActive_FutureDateRange(t *testing.T) {
 	t.Parallel()
 	w := Watch{Type: "flight", Origin: "HEL", Destination: "BCN", DepartFrom: "2099-01-01", DepartTo: "2099-01-15"}
-	if !isActive(w, "2026-07-01") {
+	if !isActive(w, "2026-07-01", defaultRetention().RouteTTL) {
 		t.Error("future date range should be active")
 	}
 }
@@ -486,7 +486,7 @@ func TestIsActive_FutureDateRange(t *testing.T) {
 func TestIsActive_PastDateRange(t *testing.T) {
 	t.Parallel()
 	w := Watch{Type: "flight", Origin: "HEL", Destination: "BCN", DepartFrom: "2000-01-01", DepartTo: "2000-01-15"}
-	if isActive(w, "2026-07-01") {
+	if isActive(w, "2026-07-01", defaultRetention().RouteTTL) {
 		t.Error("past date range should not be active")
 	}
 }
@@ -495,7 +495,7 @@ func TestIsActive_DateRangeEndToday(t *testing.T) {
 	t.Parallel()
 	today := time.Now().Format("2006-01-02")
 	w := Watch{Type: "flight", Origin: "HEL", Destination: "BCN", DepartFrom: "2000-01-01", DepartTo: today}
-	if !isActive(w, today) {
+	if !isActive(w, today, defaultRetention().RouteTTL) {
 		t.Error("date range ending today should be active")
 	}
 }

--- a/internal/watch/store.go
+++ b/internal/watch/store.go
@@ -57,6 +57,12 @@ type Store struct {
 	dir     string
 	watches []Watch
 	history []PricePoint
+
+	// retention holds this store's eviction limits. Zero-valued until Load
+	// reads them, which is deliberate: an invalid override must stop the store
+	// from loading rather than be discovered later during an eviction
+	// (trvl#514, TRVL.RETENTION.4).
+	retention retentionConfig
 }
 
 // NewStore creates a store rooted at the given directory (typically ~/.trvl/).
@@ -91,6 +97,15 @@ func (s *Store) ensureDir() error {
 func (s *Store) Load() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Retention overrides are validated HERE, at the point every consumer
+	// already calls and already checks for an error. A bad value therefore
+	// refuses to load the store instead of being silently ignored or clamped
+	// into something the operator did not ask for (trvl#514).
+	cfg, err := retentionFromEnv()
+	if err != nil {
+		return fmt.Errorf("watch retention config: %w", err)
+	}
+	s.retention = cfg
 	return s.loadLocked()
 }
 
@@ -540,7 +555,7 @@ func (s *Store) RecordPrice(watchID string, price float64, currency string) erro
 func (s *Store) pruneWatchLocked(watchID string) {
 	s.evictOldestLocked(
 		func(p PricePoint) bool { return p.WatchID == watchID },
-		maxObservationsPerWatch,
+		s.retentionOrDefault().MaxPointsPerWatch,
 	)
 }
 
@@ -551,7 +566,7 @@ func (s *Store) pruneWatchLocked(watchID string) {
 func (s *Store) pruneGlobalWatchLocked() {
 	s.evictOldestLocked(
 		func(p PricePoint) bool { return p.WatchID != "" },
-		maxWatchObservations,
+		s.retentionOrDefault().MaxPointsTotal,
 	)
 }
 


### PR DESCRIPTION
Three numbers shipped in #508 with no usage data behind any of them, invisible to operators and unchangeable without a rebuild. This makes them adjustable and reportable. It **changes no default**: *"there is no evidence for better numbers, so changing them again would be numerology."*

## Configurable (TRVL.RETENTION.1)

```bash
export TRVL_WATCH_MAX_POINTS_PER_WATCH=1000   # points kept per watch
export TRVL_WATCH_MAX_POINTS_TOTAL=50000      # points kept across all watches
export TRVL_WATCH_ROUTE_TTL_DAYS=90           # how long a dateless route watch keeps being checked
```

Unset means default; nothing changes for anyone who does not set them.

## Refused, not clamped (TRVL.RETENTION.4)

Validated at `Store.Load` — the point every consumer already calls and already checks for an error.

An operator who sets `0` meaning "no cap" and silently receives 1000 has a store behaving one way while its configuration says another, with nothing to tell them. **Refusing is louder and therefore kinder.**

Sabotage-verified — reverting to clamping fails with:

```
map[TRVL_WATCH_MAX_POINTS_PER_WATCH:0] was accepted, yielding {MaxPointsPerWatch:1000 ...}
```

Also refused: a per-watch cap **above** the global backstop. Not dangerous — the backstop evicts first — but accepting it would let an operator believe a setting is active when it can never take effect.

## The setting had to reach every decision, not just the obvious one

Eviction was straightforward. The **activity check** that decides whether a dateless route watch keeps being polled is a free function on a `Watch` value with no store in scope.

Stopping at eviction would have made the route-TTL override **decorative** — honoured in one place, ignored in the other. That is the same defect class as #542's guard that guarded nothing, and I nearly wrote a fresh instance of it. `isActive` now takes the TTL, and `effectiveRetention` serves the call sites with no `*Store` to hand.

## Reporting (TRVL.RETENTION.3)

`Store.RetentionStats`, surfaced by `trvl watch migrate` and its `--dry-run`.

It reports the **distribution**, not only the total: a store at 60% of its global cap looks healthy until one watch turns out to hold most of it. So — min/median/p90/max points per watch, how many watches are *at* the per-watch cap and therefore actively losing history, percentage of the global cap in use, size on disk, and whether each limit is a default or configured.

That last part matters: showing a default when the operator set something is the reporting equivalent of silently clamping.

## Documentation (TRVL.RETENTION.2)

README gains a table with the cost of **raising and lowering** each limit, the refusal behaviour, and how to see whether a limit is binding on your own store.

## Why it matters beyond this ticket

This feeds #575 — every store save rewrites the whole price history, 736ms p95 at 320k points, on the scheduler path. These caps are the lever on that, and until now nobody could measure where their store sat against them.

## Evidence

- **V:** `make dod` exit 0, read from the gate's own log.
- **V:** tests cover defaults-when-unset, each override taking effect, six flavours of unusable value, the per-watch-above-global combination, refusal at `Load`, the control that a valid override still loads **and is used**, and three on the report.
- **I:** adversarial second opinion unavailable — `gpt-review` hangs on any review that reads code. Reported separately.

Closes #514.
