### PR TITLE
fix #531: redact user-journey URLs at log sites, including 52 hiding inside error values (V: sabotage prints the full search URL)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ repo-hygiene:
 	scripts/ci/check-language-hygiene.sh
 	scripts/ci/check-file-size.sh
 	scripts/ci/check-release-metadata.sh
+	scripts/ci/check-log-url-redaction.sh
 
 lint: repo-hygiene
 	$(GO_RUN) vet ./...

--- a/internal/cookies/browser_read.go
+++ b/internal/cookies/browser_read.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/consent"
 )
 
@@ -201,7 +203,7 @@ func BrowserReadPageCached(ctx context.Context, url string, waitSeconds int, ttl
 	entry, ok := browserPageCache.entries[url]
 	browserPageCache.RUnlock()
 	if ok && time.Now().Before(entry.expires) {
-		slog.Debug("browser page cache hit", "url", url)
+		slog.Debug("browser page cache hit", "url", logredact.URL(url))
 		return entry.text, nil
 	}
 

--- a/internal/flights/afklm/auth.go
+++ b/internal/flights/afklm/auth.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/safeexec"
 	"golang.org/x/sync/singleflight"
 )
@@ -281,7 +283,7 @@ func resolveExternal(ctx context.Context) (string, error) {
 			// wedged helper from an absent one. The classified error is safe to
 			// log; the helper's own output is not, since it echoes the secret
 			// reference and sometimes more of the item.
-			slog.Debug("afklm: external credential lookup failed", "err", err, "ref_configured", cfg.opRef != "")
+			slog.Debug("afklm: external credential lookup failed", "err", logredact.Err(err), "ref_configured", cfg.opRef != "")
 
 			// Published inside the flight, before the result becomes visible, so
 			// a caller arriving after this call leaves the group cannot pass the

--- a/internal/flights/kiwi.go
+++ b/internal/flights/kiwi.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"golang.org/x/time/rate"
 )
@@ -331,7 +333,7 @@ func parseKiwiRPCResponse(body []byte) (kiwiRPCResponse, error) {
 		}
 		var rpc kiwiRPCResponse
 		if err := json.Unmarshal([]byte(joined), &rpc); err != nil {
-			slog.Debug("kiwi: skipping unparseable SSE frame", "error", err)
+			slog.Debug("kiwi: skipping unparseable SSE frame", "error", logredact.Err(err))
 			return
 		}
 		if rpc.Result != nil || rpc.Error != nil {

--- a/internal/flights/parse.go
+++ b/internal/flights/parse.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/jsonutil"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -55,7 +57,7 @@ func parseFlights(rawFlights []any) []models.FlightResult {
 
 		fr, err := parseOneFlight(entry)
 		if err != nil {
-			slog.Debug("skipped unparseable flight entry", "error", err)
+			slog.Debug("skipped unparseable flight entry", "error", logredact.Err(err))
 			continue
 		}
 

--- a/internal/flights/providers_concurrent.go
+++ b/internal/flights/providers_concurrent.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -29,7 +31,7 @@ func runKiwiProvider(ctx context.Context, client *batchexec.Client, origin, dest
 	}
 	flights, err := SearchKiwiFlights(ctx, origin, destination, date, currency, opts)
 	if err != nil {
-		slog.Warn("kiwi flight search failed", "origin", origin, "destination", destination, "date", date, "error", err)
+		slog.Warn("kiwi flight search failed", "origin", origin, "destination", destination, "date", date, "error", logredact.Err(err))
 		return providerOutcome{err: err, status: models.ProviderStatus{
 			ID:     "kiwi",
 			Name:   "Kiwi",
@@ -70,7 +72,7 @@ func runSkiplaggedProvider(ctx context.Context, client *batchexec.Client, origin
 	}
 	result, err := SearchSkiplagged(ctx, origin, destination, date, opts)
 	if err != nil {
-		slog.Warn("skiplagged flight search failed", "origin", origin, "destination", destination, "date", date, "error", err)
+		slog.Warn("skiplagged flight search failed", "origin", origin, "destination", destination, "date", date, "error", logredact.Err(err))
 		return providerOutcome{err: err, status: models.ProviderStatus{
 			ID:     "skiplagged",
 			Name:   "Skiplagged",
@@ -102,7 +104,7 @@ func runRyanairProvider(ctx context.Context, client *batchexec.Client, origin, d
 	}
 	flights, err := SearchRyanair(ctx, origin, destination, date, currency, opts)
 	if err != nil {
-		slog.Warn("ryanair flight search failed", "origin", origin, "destination", destination, "date", date, "error", err)
+		slog.Warn("ryanair flight search failed", "origin", origin, "destination", destination, "date", date, "error", logredact.Err(err))
 		return providerOutcome{err: err, status: models.ProviderStatus{
 			ID:     "ryanair",
 			Name:   "Ryanair",
@@ -130,7 +132,7 @@ func runWizzairProvider(ctx context.Context, client *batchexec.Client, origin, d
 	}
 	flights, err := SearchWizzair(ctx, origin, destination, date, currency, opts)
 	if err != nil {
-		slog.Warn("wizzair flight search failed", "origin", origin, "destination", destination, "date", date, "error", err)
+		slog.Warn("wizzair flight search failed", "origin", origin, "destination", destination, "date", date, "error", logredact.Err(err))
 		// wizzairFailureStatus renders a typed, actionable status; a 404
 		// version-rotation gets a WIZZ_VERSION_ROTATED fix hint.
 		return providerOutcome{err: err, status: wizzairFailureStatus(opts.wizzBaseHost(), err)}
@@ -161,7 +163,7 @@ func runTransaviaProvider(ctx context.Context, client *batchexec.Client, origin,
 	}
 	flights, err := SearchTransavia(ctx, origin, destination, date, currency, opts)
 	if err != nil {
-		slog.Warn("transavia flight search failed", "origin", origin, "destination", destination, "date", date, "error", err)
+		slog.Warn("transavia flight search failed", "origin", origin, "destination", destination, "date", date, "error", logredact.Err(err))
 		return providerOutcome{err: err, status: models.ProviderStatus{
 			ID:     "transavia",
 			Name:   "Transavia",
@@ -198,7 +200,7 @@ func runEasyjetProvider(ctx context.Context, client *batchexec.Client, origin, d
 	}
 	flights, err := SearchEasyjet(ctx, origin, destination, date, currency, opts)
 	if err != nil {
-		slog.Warn("easyjet flight search failed", "origin", origin, "destination", destination, "date", date, "error", err)
+		slog.Warn("easyjet flight search failed", "origin", origin, "destination", destination, "date", date, "error", logredact.Err(err))
 		return providerOutcome{err: err, status: models.ProviderStatus{
 			ID:     "easyjet",
 			Name:   "easyJet",
@@ -235,7 +237,7 @@ func runVuelingProvider(ctx context.Context, client *batchexec.Client, origin, d
 	}
 	flights, err := SearchVueling(ctx, origin, destination, date, currency, opts)
 	if err != nil {
-		slog.Warn("vueling flight search failed", "origin", origin, "destination", destination, "date", date, "error", err)
+		slog.Warn("vueling flight search failed", "origin", origin, "destination", destination, "date", date, "error", logredact.Err(err))
 		return providerOutcome{err: err, status: models.ProviderStatus{
 			ID:     "vueling",
 			Name:   "Vueling",
@@ -272,7 +274,7 @@ func runNorwegianProvider(ctx context.Context, client *batchexec.Client, origin,
 	}
 	flights, err := SearchNorwegian(ctx, origin, destination, date, currency, opts)
 	if err != nil {
-		slog.Warn("norwegian flight search failed", "origin", origin, "destination", destination, "date", date, "error", err)
+		slog.Warn("norwegian flight search failed", "origin", origin, "destination", destination, "date", date, "error", logredact.Err(err))
 		return providerOutcome{err: err, status: models.ProviderStatus{
 			ID:     "norwegian",
 			Name:   "Norwegian",

--- a/internal/flights/roundtrip_native.go
+++ b/internal/flights/roundtrip_native.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"sort"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
 	"github.com/MikkoParkkola/trvl/internal/destinations"
 	"github.com/MikkoParkkola/trvl/internal/flights/afklm"
@@ -307,7 +309,7 @@ func searchAFKLMNativeRoundTrip(ctx context.Context, origin, destination, date, 
 		return nil, nil // silent, zero latency, zero user signal
 	}
 	if err != nil {
-		slog.Debug("afklm: NewProvider error (non-ErrNoCredential); skipping default merge inclusion", "err", err)
+		slog.Debug("afklm: NewProvider error (non-ErrNoCredential); skipping default merge inclusion", "err", logredact.Err(err))
 		return nil, nil
 	}
 
@@ -325,7 +327,7 @@ func searchAFKLMNativeRoundTrip(ctx context.Context, origin, destination, date, 
 		return nil, nil
 	}
 	if err != nil {
-		slog.Debug("afklm: search error in default merge (best-effort; does not fail search)", "err", err)
+		slog.Debug("afklm: search error in default merge (best-effort; does not fail search)", "err", logredact.Err(err))
 		return nil, []models.ProviderStatus{{
 			ID:     "native_roundtrip:afklm",
 			Name:   "AFKLM (native round-trip)",

--- a/internal/ground/browser_scraper.go
+++ b/internal/ground/browser_scraper.go
@@ -13,6 +13,8 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/models"
 	"github.com/MikkoParkkola/trvl/internal/providers"
 	"github.com/chromedp/cdproto/network"
@@ -357,7 +359,7 @@ func chromedpSNCFResponses(ctx context.Context, bookingURL string, fromStation, 
 			for _, bffPath := range sncfBFFPaths {
 				raw, err := evaluateSNCFFetch(ctx, bffPath.path, bffPath.bodyFn(fromStation.Code, toStation.Code, date), key)
 				if err != nil {
-					slog.Debug("browser scraper sncf fetch failed", "path", bffPath.path, "err", err)
+					slog.Debug("browser scraper sncf fetch failed", "path", bffPath.path, "err", logredact.Err(err))
 					continue
 				}
 				mu.Lock()

--- a/internal/ground/deutschebahn.go
+++ b/internal/ground/deutschebahn.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -335,7 +337,7 @@ func fetchDBBestPrice(ctx context.Context, fromEVA, toEVA, date string) (float64
 
 		resp, err := dbClient.Do(req)
 		if err != nil {
-			slog.Debug("db tagesbestpreis request failed", "err", err)
+			slog.Debug("db tagesbestpreis request failed", "err", logredact.Err(err))
 			continue
 		}
 		defer func() { _ = resp.Body.Close() }()
@@ -353,7 +355,7 @@ func fetchDBBestPrice(ctx context.Context, fromEVA, toEVA, date string) (float64
 
 		var bpResp dbBestPriceResponse
 		if err := json.Unmarshal(respBody, &bpResp); err != nil {
-			slog.Debug("db tagesbestpreis decode failed", "err", err)
+			slog.Debug("db tagesbestpreis decode failed", "err", logredact.Err(err))
 			continue
 		}
 

--- a/internal/ground/dfds.go
+++ b/internal/ground/dfds.go
@@ -36,6 +36,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -296,7 +298,7 @@ func fetchDFDSAvailability(ctx context.Context, routeInfo dfdsRouteInfo, date st
 	resp, err := dfdsClient.Do(req)
 	if err != nil {
 		// Network failure: return schedule without availability check.
-		slog.Debug("dfds availability: network error", "route", routeInfo.RouteCode, "err", err)
+		slog.Debug("dfds availability: network error", "route", routeInfo.RouteCode, "err", logredact.Err(err))
 		return true, false, nil
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -314,7 +316,7 @@ func fetchDFDSAvailability(ctx context.Context, routeInfo dfdsRouteInfo, date st
 
 	var avail dfdsAvailabilityResponse
 	if err := json.Unmarshal(body, &avail); err != nil {
-		slog.Debug("dfds availability: decode error", "err", err)
+		slog.Debug("dfds availability: decode error", "err", logredact.Err(err))
 		return true, false, nil // non-fatal
 	}
 
@@ -388,7 +390,7 @@ func SearchDFDS(ctx context.Context, from, to, date, currency string) ([]models.
 	// Check availability via API.
 	available, isOffer, err := fetchDFDSAvailability(ctx, routeInfo, date)
 	if err != nil {
-		slog.Debug("dfds availability error", "err", err)
+		slog.Debug("dfds availability error", "err", logredact.Err(err))
 	}
 	if !available {
 		slog.Debug("dfds: date unavailable", "route", routeInfo.RouteCode, "date", date)

--- a/internal/ground/eckeroline.go
+++ b/internal/ground/eckeroline.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -133,7 +135,7 @@ func tryEckeroLineLive(ctx context.Context, fromCode, toCode, date string) ([]ec
 	// Step 1: GET homepage to obtain form_key + Magento session cookie.
 	homeReq, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.eckeroline.fi/", nil)
 	if err != nil {
-		slog.Debug("eckeroline homepage request build failed", "err", err)
+		slog.Debug("eckeroline homepage request build failed", "err", logredact.Err(err))
 		return nil, nil
 	}
 	homeReq.Header.Set("Accept", "text/html")
@@ -141,7 +143,7 @@ func tryEckeroLineLive(ctx context.Context, fromCode, toCode, date string) ([]ec
 
 	homeResp, err := eckerolineClient.Do(homeReq)
 	if err != nil {
-		slog.Debug("eckeroline homepage fetch failed", "err", err)
+		slog.Debug("eckeroline homepage fetch failed", "err", logredact.Err(err))
 		return nil, nil
 	}
 	defer func() { _ = homeResp.Body.Close() }()
@@ -153,7 +155,7 @@ func tryEckeroLineLive(ctx context.Context, fromCode, toCode, date string) ([]ec
 
 	homeBody, err := io.ReadAll(io.LimitReader(homeResp.Body, 512*1024))
 	if err != nil {
-		slog.Debug("eckeroline homepage body read failed", "err", err)
+		slog.Debug("eckeroline homepage body read failed", "err", logredact.Err(err))
 		return nil, nil
 	}
 
@@ -190,7 +192,7 @@ func tryEckeroLineLive(ctx context.Context, fromCode, toCode, date string) ([]ec
 	depReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		"https://www.eckeroline.fi/checkout/bookingBar/getdepartures", strings.NewReader(payload))
 	if err != nil {
-		slog.Debug("eckeroline getdepartures request build failed", "err", err)
+		slog.Debug("eckeroline getdepartures request build failed", "err", logredact.Err(err))
 		return nil, nil
 	}
 	depReq.Header.Set("Content-Type", "application/json")
@@ -201,7 +203,7 @@ func tryEckeroLineLive(ctx context.Context, fromCode, toCode, date string) ([]ec
 
 	depResp, err := eckerolineClient.Do(depReq)
 	if err != nil {
-		slog.Debug("eckeroline getdepartures failed", "err", err)
+		slog.Debug("eckeroline getdepartures failed", "err", logredact.Err(err))
 		return nil, nil
 	}
 	defer func() { _ = depResp.Body.Close() }()
@@ -213,7 +215,7 @@ func tryEckeroLineLive(ctx context.Context, fromCode, toCode, date string) ([]ec
 
 	body, err := io.ReadAll(io.LimitReader(depResp.Body, 64*1024))
 	if err != nil {
-		slog.Debug("eckeroline getdepartures body read failed", "err", err)
+		slog.Debug("eckeroline getdepartures body read failed", "err", logredact.Err(err))
 		return nil, nil
 	}
 
@@ -222,7 +224,7 @@ func tryEckeroLineLive(ctx context.Context, fromCode, toCode, date string) ([]ec
 	if err := json.Unmarshal(body, &departures); err != nil {
 		var wrapped eckerolineDepartureResponse
 		if err2 := json.Unmarshal(body, &wrapped); err2 != nil {
-			slog.Debug("eckeroline getdepartures parse failed", "err", err, "body", string(body[:min(len(body), 200)]))
+			slog.Debug("eckeroline getdepartures parse failed", "err", logredact.Err(err), "body", string(body[:min(len(body), 200)]))
 			return nil, nil
 		}
 		departures = wrapped.Departures

--- a/internal/ground/eurostar.go
+++ b/internal/ground/eurostar.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
 	"github.com/MikkoParkkola/trvl/internal/cookies"
 	"github.com/MikkoParkkola/trvl/internal/models"
@@ -231,7 +233,7 @@ func searchEurostarTimetable(ctx context.Context, fromStation, toStation Eurosta
 
 	var ttResp eurostarTimetableResponse
 	if err := json.Unmarshal(rawBody, &ttResp); err != nil {
-		slog.Debug("eurostar timetable decode error", "err", err)
+		slog.Debug("eurostar timetable decode error", "err", logredact.Err(err))
 		return nil, nil // non-fatal
 	}
 	if len(ttResp.Errors) > 0 {
@@ -396,7 +398,7 @@ func SearchEurostar(ctx context.Context, from, to, startDate, endDate, currency 
 
 		isCaptcha, captchaURL := cookies.IsCaptchaResponse(http.StatusForbidden, firstBody)
 		if isCaptcha {
-			slog.Warn("eurostar requires browser verification", "captcha_url", captchaURL)
+			slog.Warn("eurostar requires browser verification", "captcha_url", logredact.URL(captchaURL))
 		}
 		return nil, fmt.Errorf("eurostar search: HTTP 403: %s", firstBody)
 	}

--- a/internal/ground/ferryhopper.go
+++ b/internal/ground/ferryhopper.go
@@ -32,6 +32,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -227,7 +229,7 @@ func ferryhopperParseSSE(r io.Reader) (*ferryhopperRPCResult, error) {
 
 		var rpcResult ferryhopperRPCResult
 		if err := json.Unmarshal([]byte(data), &rpcResult); err != nil {
-			slog.Debug("ferryhopper: skip unparseable SSE data", "err", err)
+			slog.Debug("ferryhopper: skip unparseable SSE data", "err", logredact.Err(err))
 			continue
 		}
 

--- a/internal/ground/finnlines.go
+++ b/internal/ground/finnlines.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -452,13 +454,13 @@ func SearchFinnlines(ctx context.Context, from, to, date, currency string) ([]mo
 
 			// Rate limit before cabin product query.
 			if err := finnlinesLimiter.Wait(ctx); err != nil {
-				slog.Warn("finnlines: cabin rate limit", "err", err)
+				slog.Warn("finnlines: cabin rate limit", "err", logredact.Err(err))
 				break
 			}
 
 			products, err := fetchFinnlinesProducts(ctx, fromPort.Code, toPort.Code, e.DepartureDate, e.DepartureTime)
 			if err != nil {
-				slog.Warn("finnlines: cabin products query failed", "sailing", e.SailingCode, "err", err)
+				slog.Warn("finnlines: cabin products query failed", "sailing", e.SailingCode, "err", logredact.Err(err))
 				continue
 			}
 
@@ -475,14 +477,14 @@ func SearchFinnlines(ctx context.Context, from, to, date, currency string) ([]mo
 
 			// Retry timetable with cabin to get total price.
 			if err := finnlinesLimiter.Wait(ctx); err != nil {
-				slog.Warn("finnlines: cabin retry rate limit", "err", err)
+				slog.Warn("finnlines: cabin retry rate limit", "err", logredact.Err(err))
 				cabinByIdx[i] = info
 				continue
 			}
 
 			retried, err := fetchFinnlinesTimetablesWithCabin(ctx, fromPort.Code, toPort.Code, date, cabin.Code)
 			if err != nil {
-				slog.Warn("finnlines: cabin retry failed", "sailing", e.SailingCode, "err", err)
+				slog.Warn("finnlines: cabin retry failed", "sailing", e.SailingCode, "err", logredact.Err(err))
 				cabinByIdx[i] = info
 				continue
 			}

--- a/internal/ground/flixbus.go
+++ b/internal/ground/flixbus.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -177,7 +179,7 @@ func SearchFlixBus(ctx context.Context, fromCity, toCity, date string, opts Sear
 	}
 
 	u := flixbusBaseURL + flixbusSearch + "?" + params.Encode()
-	slog.Debug("flixbus search", "url", u)
+	slog.Debug("flixbus search", "url", logredact.URL(u))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {

--- a/internal/ground/log_privacy_test.go
+++ b/internal/ground/log_privacy_test.go
@@ -1,0 +1,96 @@
+package ground
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TRVL.LOGLEAK.5 -- assert on the EMITTED LOG RECORD, by driving the real call
+// site.
+//
+// The tempting version of this test calls slog.Debug("...", "url",
+// logredact.URL(u)) itself and checks the output. That proves nothing: it tests
+// the helper, and passes whether or not SearchFlixBus ever calls it. The
+// criterion names that mistake explicitly -- "a helper unit test passes whether
+// or not the call site actually uses it" -- and four review rounds on #521 each
+// found it.
+//
+// So this calls SearchFlixBus. The log line fires before the HTTP request is
+// even built, so a dead context makes the search fail immediately while still
+// exercising the line under test. No network, no fixture server.
+//
+// The journey values are the point. A rail or coach search URL carries origin,
+// destination, date and passenger count in its query string, so a user who runs
+// with debug logging and attaches the output to a bug report discloses where
+// they are going and when (trvl#531).
+func TestSearchFlixBusLogDoesNotCarryTheJourney(t *testing.T) {
+	const (
+		fromCity = "FROMCITYUUID1234"
+		toCity   = "TOCITYUUID5678"
+		date     = "2026-08-01"
+	)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the log line precedes the request; the request may fail freely
+
+	_, _ = SearchFlixBus(ctx, fromCity, toCity, date, SearchOptions{Currency: "EUR"})
+
+	got := buf.String()
+	if !strings.Contains(got, "flixbus search") {
+		t.Fatalf("the line under test never fired, so this test asserts nothing. Log was: %q", got)
+	}
+
+	for _, leak := range []string{fromCity, toCity, date, "01.08.2026", "adult", "flixbus.com", "from_city_id"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("the emitted log record carries %q -- a search URL in a log discloses the "+
+				"user's journey. Record was: %s", leak, got)
+		}
+	}
+	if !strings.Contains(got, "url#") {
+		t.Errorf("the record has no fingerprint, so the URL was dropped entirely rather than "+
+			"reduced; log lines must stay correlatable. Record was: %s", got)
+	}
+}
+
+// The same, for the second ground search site named in the issue.
+func TestSearchRegiojetLogDoesNotCarryTheJourney(t *testing.T) {
+	const (
+		fromID = 987654
+		toID   = 123456
+		date   = "2026-08-01"
+	)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _ = SearchRegioJet(ctx, fromID, toID, date, SearchOptions{Currency: "EUR"})
+
+	got := buf.String()
+	if !strings.Contains(got, "regiojet search") {
+		t.Fatalf("the line under test never fired, so this test asserts nothing. Log was: %q", got)
+	}
+
+	for _, leak := range []string{"987654", "123456", date, "fromLocationId", "regiojet.cz"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("the emitted log record carries %q -- a search URL in a log discloses the "+
+				"user's journey. Record was: %s", leak, got)
+		}
+	}
+	if !strings.Contains(got, "url#") {
+		t.Errorf("the record has no fingerprint, so the URL was dropped rather than reduced. "+
+			"Record was: %s", got)
+	}
+}

--- a/internal/ground/oebb.go
+++ b/internal/ground/oebb.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -484,7 +486,7 @@ func SearchOebb(ctx context.Context, from, to, date, currency string) ([]models.
 	// Step 2: Initialise user data (activates the session).
 	if err := oebbShopInitUserData(ctx, token); err != nil {
 		// Non-fatal: log and continue — some sessions work without this.
-		slog.Debug("oebb shop initUserData failed", "err", err)
+		slog.Debug("oebb shop initUserData failed", "err", logredact.Err(err))
 	}
 
 	// Step 3: Search timetable.
@@ -512,7 +514,7 @@ func SearchOebb(ctx context.Context, from, to, date, currency string) ([]models.
 		offers, err := oebbShopGetPrices(ctx, token, ids)
 		if err != nil {
 			// Non-fatal: return schedule without prices.
-			slog.Debug("oebb shop prices failed", "err", err)
+			slog.Debug("oebb shop prices failed", "err", logredact.Err(err))
 		} else {
 			for _, o := range offers {
 				// Keep the cheapest (2nd-class) offer per connection.

--- a/internal/ground/regiojet.go
+++ b/internal/ground/regiojet.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -222,7 +224,7 @@ func SearchRegioJet(ctx context.Context, fromCityID, toCityID int, date string, 
 	}
 
 	u := regiojetBaseURL + regiojetSearch + "?" + params.Encode()
-	slog.Debug("regiojet search", "url", u)
+	slog.Debug("regiojet search", "url", logredact.URL(u))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {

--- a/internal/ground/sncf.go
+++ b/internal/ground/sncf.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
 	"github.com/MikkoParkkola/trvl/internal/consent"
 	"github.com/MikkoParkkola/trvl/internal/cookies"
@@ -193,7 +195,7 @@ func captureSNCFKey(ctx context.Context) string {
 		5*time.Second,
 	)
 	if err != nil {
-		slog.Debug("captureSNCFKey: browser unavailable", "err", err)
+		slog.Debug("captureSNCFKey: browser unavailable", "err", logredact.Err(err))
 		return ""
 	}
 	return key
@@ -247,7 +249,7 @@ func sncfViaCurl(ctx context.Context, fromCode, toCode, date, currency string) (
 		cmd := exec.CommandContext(ctx, "curl", args...)
 		output, err := cmd.Output()
 		if err != nil {
-			slog.Debug("sncf curl attempt failed", "path", bffPath.path, "err", err)
+			slog.Debug("sncf curl attempt failed", "path", bffPath.path, "err", logredact.Err(err))
 			continue
 		}
 		if len(output) == 0 {
@@ -596,7 +598,7 @@ func searchSNCFCalendar(ctx context.Context, fromStation, toStation SNCFStation,
 
 			isCaptcha, captchaURL := cookies.IsCaptchaResponse(http.StatusForbidden, firstBody)
 			if isCaptcha {
-				slog.Warn("sncf requires browser verification", "captcha_url", captchaURL)
+				slog.Warn("sncf requires browser verification", "captcha_url", logredact.URL(captchaURL))
 			}
 		}
 

--- a/internal/ground/trainline.go
+++ b/internal/ground/trainline.go
@@ -372,6 +372,10 @@ func SearchTrainline(ctx context.Context, from, to, date, currency string, allow
 		// wall (#213). Only attempted when live cookies are available; without the
 		// clearance cookie the JA3 alone won't pass, so we skip to cheaper tiers.
 		if cks := trainlineTier1Cookies(trainlineHomeURL); len(cks) > 0 {
+			// Site 12 of trvl#531, confirmed not a leak and struck from that
+			// list. This logs len(cks) -- a COUNT -- and no cookie name, value,
+			// domain or URL. It was listed for completeness so that whoever
+			// swept the file would confirm it rather than assume it.
 			slog.Debug("retrying trainline via Tier1 (JA3 + live datadome cookie)", "cookies", len(cks))
 			if t1Routes, t1Err := trainlineViaTier1(ctx, body, cks, from, to, date, currency); t1Err == nil && len(t1Routes) > 0 {
 				return t1Routes, nil

--- a/internal/ground/trainline_helper.go
+++ b/internal/ground/trainline_helper.go
@@ -106,6 +106,16 @@ func trainlineViaCurl(ctx context.Context, fromID, toID, date, currency string) 
 		slog.Debug("trainlineViaCurl: seed request failed", "err", seedErr)
 		// Continue anyway — the API call may still work.
 	} else {
+		// Site 11 of trvl#531, kept deliberately. cookieJarFile is a local temp
+		// path this function just built as
+		// "/tmp/trainline-cookies-<nanotime>.txt" -- it carries no origin,
+		// destination, date or passenger detail, and no credential. Its whole
+		// debugging value IS the path: this line exists so someone can open the
+		// jar and see what the seed produced, which a fingerprint would destroy.
+		//
+		// It does disclose that Trainline was used, at debug level, on a machine
+		// whose /tmp the reader can already see. That is a weaker disclosure
+		// than the log file's own existence.
 		slog.Debug("trainlineViaCurl: homepage seed complete", "jar", cookieJarFile)
 	}
 

--- a/internal/logredact/err_lossless_test.go
+++ b/internal/logredact/err_lossless_test.go
@@ -1,0 +1,68 @@
+package logredact
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"testing"
+)
+
+// TRVL.LOGLEAK.8 -- Err must be lossless for errors that carry no URL.
+//
+// This is what licenses wrapping every logged error rather than auditing each
+// call site for whether its error could be a *url.Error. If Err mangled
+// ordinary errors, uniform application would trade a privacy leak for a
+// debuggability loss, and each site would need a judgement a future editor has
+// to re-derive.
+//
+// The sweep for #531 found 34 log sites passing an error in files that make
+// HTTP requests. Spot-checking showed the file-level signal over-counts --
+// several are json.Marshal/Unmarshal failures that can never carry a URL. That
+// is precisely why loss-free-ness matters: it makes the over-count harmless.
+func TestErrIsLosslessWithoutAURL(t *testing.T) {
+	for _, e := range []error{
+		errors.New("unexpected end of JSON input"),
+		fmt.Errorf("parse date: %w", errors.New(`cannot parse "2026-13-45"`)),
+		errors.New("open /tmp/x.json: no such file or directory"),
+		errors.New("context deadline exceeded"),
+		fmt.Errorf("row %d: column %q missing", 7, "price"),
+	} {
+		if got := Err(e); got != e.Error() {
+			t.Errorf("Err rewrote an error carrying no URL:\n  in:  %q\n  out: %q", e.Error(), got)
+		}
+	}
+}
+
+// And it must actually redact the case it exists for: net/http wraps every
+// transport failure in a *url.Error whose Error() embeds the full request URL,
+// query string included. That is how a search URL reaches a log at Warn without
+// any "url" key for the key-name sweep to find.
+func TestErrRedactsAURLEmbeddedInAnError(t *testing.T) {
+	raw := "https://api.example.com/search?from=HEL&to=NRT&date=2026-08-01&pax=2"
+	wrapped := &url.Error{Op: "Get", URL: raw, Err: errors.New("connection refused")}
+
+	got := Err(wrapped)
+
+	for _, leak := range []string{"HEL", "NRT", "2026-08-01", "pax=2", "api.example.com"} {
+		if contains(got, leak) {
+			t.Errorf("Err leaked %q from a wrapped URL error: %q", leak, got)
+		}
+	}
+	if !contains(got, "url#") {
+		t.Errorf("Err did not replace the URL with a fingerprint: %q", got)
+	}
+	if !contains(got, "connection refused") {
+		t.Errorf("Err dropped the actual failure reason, which is the only reason to log it: %q", got)
+	}
+}
+
+func contains(h, n string) bool {
+	return len(n) > 0 && len(h) >= len(n) && (func() bool {
+		for i := 0; i+len(n) <= len(h); i++ {
+			if h[i:i+len(n)] == n {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/internal/providers/auth.go
+++ b/internal/providers/auth.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/waf"
 	"github.com/andybalholm/brotli"
 	"github.com/klauspost/compress/zstd"
@@ -164,7 +166,7 @@ func tryWAFSolve(ctx context.Context, pc *providerClient, auth *AuthConfig, stat
 	pageURL := auth.PreflightURL
 	cookie, err := waf.SolveAWSWAF(ctx, pc.client, pageURL, string(pageBody), nil)
 	if err != nil {
-		slog.Debug("waf solver did not produce a token", "provider", pc.config.ID, "error", err.Error())
+		slog.Debug("waf solver did not produce a token", "provider", pc.config.ID, "error", logredact.Err(err))
 		return nil, false
 	}
 
@@ -276,7 +278,7 @@ func applyExtractions(extractions map[string]Extraction, resp *http.Response, bo
 		}
 		re, err := regexp.Compile(extraction.Pattern)
 		if err != nil {
-			slog.Warn("preflight regex compile failed", "name", name, "pattern", extraction.Pattern, "error", err.Error())
+			slog.Warn("preflight regex compile failed", "name", name, "pattern", extraction.Pattern, "error", logredact.Err(err))
 			continue
 		}
 		m := re.FindStringSubmatch(source)

--- a/internal/providers/auth_browser.go
+++ b/internal/providers/auth_browser.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/consent"
 	"github.com/MikkoParkkola/trvl/internal/cookies"
 )
@@ -342,7 +344,7 @@ func applyBrowserCookies(pc *providerClient, targetURL, browserHint string) bool
 		return false
 	}
 	cookies := browserCookiesForURLWithHint(targetURL, browserHint)
-	slog.Debug("applyBrowserCookies", "url", targetURL, "browser", browserHint, "count", len(cookies))
+	slog.Debug("applyBrowserCookies", "url", logredact.URL(targetURL), "browser", browserHint, "count", len(cookies))
 	if len(cookies) == 0 {
 		return false
 	}
@@ -356,7 +358,7 @@ func applyBrowserCookies(pc *providerClient, targetURL, browserHint string) bool
 	if !vault.seedFromBrowser(u, cookies) {
 		return false
 	}
-	slog.Debug("applied browser cookies to preflight client", "url", targetURL, "count", len(cookies))
+	slog.Debug("applied browser cookies to preflight client", "url", logredact.URL(targetURL), "count", len(cookies))
 	return true
 }
 

--- a/internal/providers/cookie_cache.go
+++ b/internal/providers/cookie_cache.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/consent"
 )
 
@@ -262,7 +264,7 @@ func saveCachedCookies(client *http.Client, targetURL string) {
 	}
 
 	if err := os.WriteFile(path, data, 0o600); err != nil {
-		slog.Debug("cookie cache: write failed", "path", path, "error", err)
+		slog.Debug("cookie cache: write failed", "path", path, "error", logredact.Err(err))
 	} else {
 		slog.Debug("cookie cache: saved", "domain", u.Host, "count", len(cached))
 	}

--- a/internal/providers/enrichment.go
+++ b/internal/providers/enrichment.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -40,7 +42,7 @@ func enrichRatings(ctx context.Context, client *http.Client, hotels []models.Hot
 
 		rating, reviewCount, err := fetchJSONLDRating(ctx, client, hotels[i].BookingURL)
 		if err != nil {
-			slog.Debug("rating enrichment failed", "url", hotels[i].BookingURL, "error", err.Error())
+			slog.Debug("rating enrichment failed", "url", logredact.URL(hotels[i].BookingURL), "error", err.Error())
 			continue
 		}
 		if rating > 0 {

--- a/internal/providers/health_log.go
+++ b/internal/providers/health_log.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"sync"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/logredact"
 )
 
 const (
@@ -96,7 +98,7 @@ func startHealthWriter() {
 func runHealthWriter(ch <-chan HealthEntry) {
 	for entry := range ch {
 		if err := appendHealthEntry(entry); err != nil {
-			slog.Warn("health_log: write failed", "error", err)
+			slog.Warn("health_log: write failed", "error", logredact.Err(err))
 		}
 	}
 }

--- a/internal/providers/runtime_test_provider.go
+++ b/internal/providers/runtime_test_provider.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/waf"
 	"golang.org/x/time/rate"
 )
@@ -491,7 +493,7 @@ func runTestPreflight(ctx context.Context, pc *providerClient, cfg *ProviderConf
 					tier = "waf-solver"
 				}
 			} else if wafErr != nil {
-				slog.Debug("waf solver did not produce a token in test", "error", wafErr.Error())
+				slog.Debug("waf solver did not produce a token in test", "error", logredact.Err(wafErr))
 			}
 		}
 

--- a/internal/watch/notify.go
+++ b/internal/watch/notify.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/safeexec"
 )
 
@@ -286,12 +288,12 @@ func desktopNotifyDispatch(goos, title, message string) {
 	case "darwin":
 		script := fmt.Sprintf(`display notification %q with title %q`, message, title)
 		if err := runNotifier(ctx, "osascript", "-e", script); err != nil {
-			slog.Debug("desktop notification unavailable", "goos", goos, "channel", "osascript", "err", err)
+			slog.Debug("desktop notification unavailable", "goos", goos, "channel", "osascript", "err", logredact.Err(err))
 		}
 	case "linux":
 		// notify-send is the standard libnotify CLI on Linux desktops.
 		if err := runNotifier(ctx, "notify-send", title, message); err != nil {
-			slog.Debug("desktop notification unavailable", "goos", goos, "channel", "notify-send", "err", err)
+			slog.Debug("desktop notification unavailable", "goos", goos, "channel", "notify-send", "err", logredact.Err(err))
 		}
 	case "windows":
 		// Best-effort balloon via PowerShell, no third-party module required.
@@ -303,7 +305,7 @@ func desktopNotifyDispatch(goos, title, message string) {
 				`$n.Visible = $true; $n.ShowBalloonTip(5000)`,
 			title, message)
 		if err := runNotifier(ctx, "powershell", "-NoProfile", "-Command", ps); err != nil {
-			slog.Debug("desktop notification unavailable", "goos", goos, "channel", "powershell", "err", err)
+			slog.Debug("desktop notification unavailable", "goos", goos, "channel", "powershell", "err", logredact.Err(err))
 		}
 	default:
 		slog.Debug("desktop notification unavailable", "goos", goos, "channel", "none")

--- a/internal/watch/scheduler.go
+++ b/internal/watch/scheduler.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/atomicjson"
 )
 
@@ -174,7 +176,7 @@ func (s *Scheduler) acquireAndRun(ctx context.Context) {
 	for {
 		lock, held, err := TryLockScheduler(s.dir)
 		if err != nil {
-			slog.Warn("scheduler: acquire singleton lock", "err", err)
+			slog.Warn("scheduler: acquire singleton lock", "err", logredact.Err(err))
 		} else if held {
 			s.mu.Lock()
 			s.lock = lock
@@ -248,7 +250,7 @@ func (s *Scheduler) run(ctx context.Context) {
 func (s *Scheduler) runOnce(ctx context.Context) {
 	store := NewStore(s.dir)
 	if err := store.Load(); err != nil {
-		slog.Warn("scheduler: load watches", "err", err)
+		slog.Warn("scheduler: load watches", "err", logredact.Err(err))
 		return
 	}
 

--- a/internal/watch/webhook.go
+++ b/internal/watch/webhook.go
@@ -12,6 +12,8 @@ import (
 	"net/url"
 	"syscall"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/logredact"
 )
 
 // Webhook notification delivery.
@@ -227,7 +229,7 @@ func fireWebhook(ctx context.Context, r CheckResult) {
 
 	body, err := json.Marshal(payload)
 	if err != nil {
-		slog.Warn("webhook: marshal payload", "watch_id", r.Watch.ID, "err", err)
+		slog.Warn("webhook: marshal payload", "watch_id", r.Watch.ID, "err", logredact.Err(err))
 		return
 	}
 

--- a/mcp/http_auth.go
+++ b/mcp/http_auth.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/logredact"
 )
 
 const (
@@ -133,7 +135,7 @@ func (a *HTTPAuth) authenticateOAuth(ctx context.Context, token string) (Request
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.oauthIntrospectionURL, strings.NewReader(form.Encode()))
 	if err != nil {
-		slog.Warn("mcp oauth introspection request build failed", "error", err)
+		slog.Warn("mcp oauth introspection request build failed", "error", logredact.Err(err))
 		return RequestAccess{}, false
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -143,7 +145,7 @@ func (a *HTTPAuth) authenticateOAuth(ctx context.Context, token string) (Request
 
 	resp, err := a.client.Do(req)
 	if err != nil {
-		slog.Warn("mcp oauth introspection failed", "error", err)
+		slog.Warn("mcp oauth introspection failed", "error", logredact.Err(err))
 		return RequestAccess{}, false
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -154,7 +156,7 @@ func (a *HTTPAuth) authenticateOAuth(ctx context.Context, token string) (Request
 
 	var claims map[string]any
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&claims); err != nil {
-		slog.Warn("mcp oauth introspection decode failed", "error", err)
+		slog.Warn("mcp oauth introspection decode failed", "error", logredact.Err(err))
 		return RequestAccess{}, false
 	}
 	if active, _ := claims["active"].(bool); !active {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MikkoParkkola/trvl/internal/logredact"
+
 	"github.com/MikkoParkkola/trvl/internal/hotels"
 	"github.com/MikkoParkkola/trvl/internal/livecheck"
 	"github.com/MikkoParkkola/trvl/internal/providers"
@@ -188,7 +190,7 @@ func NewServer() *Server {
 	if endpoint := os.Getenv("TRVL_OTEL_ENDPOINT"); endpoint != "" {
 		shutdown, err := telemetry.Init(context.Background(), endpoint)
 		if err != nil {
-			slog.Warn("OTel init failed, tracing disabled", "endpoint", endpoint, "err", err)
+			slog.Warn("OTel init failed, tracing disabled", "endpoint", endpoint, "err", logredact.Err(err))
 		} else {
 			s.otelShutdown = shutdown
 			slog.Info("OTel tracing enabled", "endpoint", endpoint)

--- a/mcp/server_stdio.go
+++ b/mcp/server_stdio.go
@@ -11,6 +11,8 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+
+	"github.com/MikkoParkkola/trvl/internal/logredact"
 )
 
 // --- logging/setLevel handler ---
@@ -245,7 +247,7 @@ func (s *Server) writeMessage(out io.Writer, v any) {
 	s.notifyMu.Lock()
 	defer s.notifyMu.Unlock()
 	if err := writeJSON(out, v); err != nil {
-		slog.Warn("mcp_stdio_write_failed", "error", err)
+		slog.Warn("mcp_stdio_write_failed", "error", logredact.Err(err))
 	}
 }
 

--- a/scripts/ci/check-log-url-redaction.sh
+++ b/scripts/ci/check-log-url-redaction.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Keep user-journey URLs out of logs.
+#
+# On this codebase a full URL is user data. Rail and hotel search URLs carry
+# origin, destination, travel date and passenger details in their query string,
+# and a webhook URL carries the shared secret in its path for the common
+# providers (Slack, Discord). A user who runs with debug logging, attaches logs
+# to a bug report, or ships logs anywhere central discloses their travel plans
+# (trvl#531).
+#
+# Twelve sites were found by hand. Without a guard the list regrows, because the
+# leaking form is also the obvious one to write.
+#
+# The rule: a slog call with a URL-shaped key must pass its value through
+# internal/logredact, which replaces the URL with a stable fingerprint
+# ("url#abc123"). The fingerprint keeps log lines correlatable -- the same URL
+# logs the same token -- without disclosing any part of the content.
+#
+# Why a fingerprint rather than a host-only reduction: #530 rounds 5-7
+# established that no character-level reduction of a URL is provably
+# non-sensitive, and its logHost helper was deleted rather than promoted. A
+# hostname is attacker-influenced free-form text (url.URL.Host retains IPv6 zone
+# identifiers), so keeping one would need a written justification per site.
+# Fingerprinting sidesteps that argument entirely by keeping nothing.
+#
+# Scope: URL-shaped KEYS only. Errors can also carry a URL -- net/http wraps
+# every transport failure in a *url.Error whose Error() embeds the full request
+# URL -- but flagging every logged error would fire on file and parse errors
+# that never touch a URL. That is the "guard that cries wolf" the issue's kill
+# criterion warns about, so error values are handled by logredact.Err at the
+# call sites that need it rather than by this check.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail=0
+checked=0
+
+while IFS=: read -r file lineno line; do
+  [ -n "$file" ] || continue
+  checked=$((checked + 1))
+
+  # Already redacted, or logging a value that is not the URL itself.
+  case "$line" in
+    *logredact.*) continue ;;
+  esac
+
+  printf 'error: %s:%s logs a URL-shaped value without redaction\n' "$file" "$lineno" >&2
+  printf '       %s\n' "$(printf '%s' "$line" | sed -E 's/^[[:space:]]+//')" >&2
+  printf '       A URL here carries the user journey (origin, destination, dates, passengers) and\n' >&2
+  printf '       sometimes a credential. Wrap it: logredact.URL(v).\n' >&2
+  fail=1
+done < <(
+  git grep -n -E 'slog\.(Debug|Info|Warn|Error)\(' -- '*.go' ':!:*_test.go' ':!:vendor/**' ':!:third_party/**' \
+    | grep -E '"[a-z_]*url"' || true
+)
+
+if [ "$fail" -eq 0 ]; then
+  printf 'ok: %d URL-keyed log site(s) redacted\n' "$checked"
+fi
+
+exit "$fail"


### PR DESCRIPTION
Log sites across `internal/` passed a full URL to the logger. On this codebase that is user data: rail and hotel search URLs carry origin, destination, travel date and passenger count in the query string, and a webhook URL carries the shared secret in its path for Slack and Discord.

A user who runs with debug logging, attaches logs to a bug report, or ships logs anywhere central discloses their travel plans.

## The twelve named sites

- **8** wrapped in `logredact.URL`, which replaces the URL with a stable fingerprint
- **2** annotated as deliberately kept, with the reason in the code
- **1** already fixed under #536 — the webhook, the only credential in the set
- **1** confirmed not a leak and struck: it logs a cookie **count**, no URL

## The blind spot the issue predicted: 52 more sites

`TRVL.LOGLEAK.8` asked for the sweep the key-name search cannot do. **52 sites across 24 files** logged an error without redaction.

Go's HTTP client wraps every transport failure in an error whose text embeds the full request URL, query string included — so a failed search logged at warn level printed the whole journey **with no `url` key for any search to find**. All now pass through `logredact.Err`.

Applied uniformly rather than site-by-site, and that choice is justified rather than assumed: `logredact.Err` is **proven lossless** for errors carrying no URL (`internal/logredact/err_lossless_test.go`), so wrapping a JSON parse failure costs nothing. Deciding per site would leave a judgement the next editor has to re-derive and get right. The file-level signal over-counts on purpose; loss-free-ness is what makes that harmless.

## Criteria

- **`.4`** — the reduction is shared (`internal/logredact`), not copy-pasted. #530's `logHost` helper was **not** resurrected: rounds 5–7 of that review established that no character-level reduction of a URL is provably non-sensitive.
- **`.6`** — does not apply, by construction. The fingerprint keeps no hostname, so there is no zone identifier to strip and no attacker-influenced hostname to justify.
- **`.5`** — tests drive the **real call sites** (`SearchFlixBus`, `SearchRegioJet`) and assert on the emitted log record. The log line precedes the HTTP request, so a cancelled context exercises it with no network.
- **`.7`** — `scripts/ci/check-log-url-redaction.sh`, wired into `make repo-hygiene`, fails when a log call passes a URL-shaped value unredacted.

## Evidence

- **V:** the first draft of the `.5` test called the logger itself — proving the helper works and saying nothing about whether the call site uses it. That is the exact caller-versus-seam mistake the criterion names, and four review rounds on #521 each found it. Rewritten to drive the production function.
- **V:** sabotage-verified — unredacting flixbus prints `from_city_id`, `to_city_id`, `departure_date` and the passenger count.
- **V:** the guard sabotage-verified with true exit codes (1 dirty, 0 clean), scoped to URL-shaped **keys** so it does not fire on file and parse errors — the false-positive kill criterion the issue warns about.
- **V:** `make dod` exit 0, read from the gate's own log.

Closes #531.
