### PR TITLE
fix #539: make three safety properties enforced instead of incidental (V: each fails without its fix; review caught a real defect in the first attempt)

### DIFF
--- a/.github/gosec-baseline.json
+++ b/.github/gosec-baseline.json
@@ -144,22 +144,8 @@
       "rule": "G703",
       "file": "internal/upgrade/upgrade.go",
       "count": 1,
-      "status": "accepted",
-      "reason": "ACCEPTED RISK (V). Not the download write: internal/upgrade/upgrade.go:242 writes the preferences BACKUP, dst = prefsPathIn(dir)+\".bak.\"+oldVersion (:237, :54-56). dir is ~/.trvl (:40-46; the sole external caller cmd/trvl/upgrade.go passes \"\"), and oldVersion is the trimmed content of ~/.trvl/version.stamp (ReadStamp :59-68), which is only ever written from the compiled-in Version (WriteStamp :71-77). Traversal therefore requires an attacker who can already write inside the user's own ~/.trvl, and the payload is the user's own prefs file at 0600. Hardening candidate, not a live vulnerability: validate the stamp against a semver pattern before using it in a filename."
-    },
-    {
-      "rule": "G703",
-      "file": "internal/watch/migrate.go",
-      "count": 1,
-      "status": "accepted",
-      "reason": "NOT REACHABLE (V). The sink is internal/watch/migrate.go:397, os.WriteFile(dst, ...) where dst = fmt.Sprintf(\"%s.bak-%s\", path, stamp) in backupLocked. Both components are traced: `path` is s.watchesPath() or s.historyPath(), each filepath.Join(s.dir, <literal>) (store.go:77-83); `stamp` is time.Now().Format (:386), not caller data. s.dir has exactly two production origins -- DefaultStore() at store.go:74, filepath.Join(home, \".trvl\"), and NewScheduler's dir, which its sole non-test caller mcp/server.go:159 also builds as filepath.Join(home, \".trvl\") (:154-155). Migrate itself has one non-test caller, cmd/trvl/watch.go:593, on a DefaultStore(). No CLI flag or env var sets the watch store directory: cmd/trvl/tempfiles.go:68's --dir belongs to the orphan-scan command and never reaches watch.Store. So no caller-supplied string reaches the write, and the backup can only land beside the user's own ~/.trvl data files at 0600. New in the release/1.21.0 merge because backupLocked itself is new there -- it did not exist on main when this baseline was generated."
-    },
-    {
-      "rule": "G704",
-      "file": "internal/batchexec/client.go",
-      "count": 1,
-      "status": "accepted",
-      "reason": "NOT REACHABLE (V) as shipped. The sink is inside testRedirectTransport.RoundTrip (internal/batchexec/client.go:128-140), which rewrites every request to a baseURL that can only be set by NewTestClient (:112-120). At 4bf48ee the only callers of NewTestClient are *_test.go files under internal/flights (roundtrip, flights_max, vueling, stealth_wiring, easyjet, eligibility_boost, singleflight_regression, norwegian); a repo-wide search excluding _test.go finds the declaration and its doc comment and nothing else. Caveat, recorded because the (rule, file, count) key cannot see it: this is an exported helper in a non-test file, so a future production caller would make it reachable without changing the count. Hardening candidate: move it behind a _test-only build tag or an export_test.go shim."
+      "status": "mitigated",
+      "reason": "MITIGATED (V, trvl#539 TRVL.HARDEN.3). The sink is the preferences BACKUP write, dst = prefsPathIn(dir)+\".bak.\"+oldVersion. dir is ~/.trvl. The oldVersion component was previously unvalidated: it comes from ReadStamp, i.e. the trimmed contents of a file on disk, NOT from the compiled-in Version, so a corrupted or externally-written stamp chose part of the path. backupPreferences now refuses any stamp failing safeVersionStamp (allowlist of [0-9A-Za-z._+-], no \"..\", non-empty, <=64 chars) and skips the backup rather than sanitising, because a sanitised path is still a path nobody intended. Pinned by TestBackupPreferencesRefusesUnsafeVersionStamp with a control that a valid stamp still produces its backup; sabotage-verified by removing the guard."
     },
     {
       "rule": "G704",
@@ -174,6 +160,13 @@
       "count": 2,
       "status": "accepted",
       "reason": "NOT REACHABLE (V), both findings. doSearchRequest (internal/providers/auth.go:382-407) replays orig.URL of a request that was already built and already sent; the URL originates from substituteVars(cfg.Endpoint, vars) in internal/providers/runtime_provider.go:208. What holds unconditionally is the dial-time guard: guardedDialer/guardedTransport installs dialControl on every provider client (internal/providers/destination.go:137-181, wired in runtime_core.go), and dialControl refuses the connection on the RESOLVED IP - loopback, private, link-local, unspecified and multicast (refusedIP :57-79) - so a redirected or substituted host cannot reach an internal address regardless of how the string was built. The parse-time providers.CheckDestinationURL on Endpoint and Auth.PreflightURL (mcp/tools_providers.go, destination.go:90-125) is a secondary check only: substituteVars is a raw strings.ReplaceAll with no escaping (internal/providers/mapping.go:12-18) and runs after it. Scheme and host are literal in the shipped templates (I, checked by search, not enforced by code). Sole opt-out is the operator-set env var TRVL_ALLOW_LOCAL_PROVIDERS (destination.go:27, :41-48)."
+    },
+    {
+      "rule": "G704",
+      "file": "internal/batchexec/testclient.go",
+      "count": 1,
+      "status": "accepted",
+      "reason": "NOT REACHABLE, AND NOW ENFORCED (V, trvl#539 TRVL.HARDEN.2). The sink is testRedirectTransport.RoundTrip, which rewrites every request to a baseURL settable only by NewTestClient. This entry previously lived on internal/batchexec/client.go and rested on an observation -- 'the only callers are *_test.go files' -- which was true when written and which nothing checked. A future production caller would have made this finding live WITHOUT changing the baseline count, so the gate would have stayed green. The helper now lives in its own file with no production code in it, and scripts/ci/check-test-only-helpers.sh fails if any non-test file references it (sabotage-verified, exits 1). Moving it into a _test.go file would have been stronger still -- a production caller would fail to compile -- but _test.go is built only when testing its own package, and 12 files across internal/flights, internal/hotels and internal/explore need this helper. The issue named the lint rule as the fallback for exactly that case."
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ repo-hygiene:
 	scripts/ci/check-language-hygiene.sh
 	scripts/ci/check-file-size.sh
 	scripts/ci/check-release-metadata.sh
+	scripts/ci/check-test-only-helpers.sh
 
 lint: repo-hygiene
 	$(GO_RUN) vet ./...

--- a/internal/batchexec/client.go
+++ b/internal/batchexec/client.go
@@ -74,6 +74,17 @@ type Client struct {
 	// reused thereafter for connection pooling. Access is guarded by stealthOnce.
 	stealthHTTP *http.Client
 	stealthOnce sync.Once
+
+	// reuseTransportForStealth makes stealthClient reuse this client's existing
+	// transport instead of building the real Chrome fingerprint client.
+	//
+	// It exists so the stealth path can be exercised offline and
+	// deterministically. It replaces a type assertion on a test-only transport
+	// type, which forced that type to live in this production file and made the
+	// exported test constructor reachable from production code (trvl#539).
+	// A behaviour flag says what the branch actually decides; the type
+	// assertion said "am I in a test", which production has no business asking.
+	reuseTransportForStealth bool
 }
 
 // NewClient creates a Client that impersonates Chrome's TLS fingerprint.
@@ -103,40 +114,6 @@ func NewClient() *Client {
 		limiter: rate.NewLimiter(rate.Limit(10), 1),
 		cache:   cache.New(),
 	}
-}
-
-// NewTestClient creates a Client that redirects all requests to the given
-// test server URL. It uses a plain http.Client (no TLS fingerprinting)
-// with high rate limits for fast tests. The URL rewriting transport
-// preserves the original path and query string.
-func NewTestClient(baseURL string) *Client {
-	return &Client{
-		http: &http.Client{
-			Transport: &testRedirectTransport{baseURL: baseURL},
-			Timeout:   5 * time.Second,
-		},
-		limiter: rate.NewLimiter(rate.Limit(1000), 1),
-	}
-}
-
-// testRedirectTransport rewrites request URLs to point at a local test server
-// while preserving the original path and query string.
-type testRedirectTransport struct {
-	baseURL string
-}
-
-func (t *testRedirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Rewrite the URL to point at the test server.
-	newURL := t.baseURL + req.URL.Path
-	if req.URL.RawQuery != "" {
-		newURL += "?" + req.URL.RawQuery
-	}
-	newReq, err := http.NewRequestWithContext(req.Context(), req.Method, newURL, req.Body)
-	if err != nil {
-		return nil, err
-	}
-	newReq.Header = req.Header
-	return http.DefaultTransport.RoundTrip(newReq)
 }
 
 // SetNoCache disables the response cache for this client.
@@ -690,10 +667,10 @@ func (c *Client) transportForStealth(stealthRequested bool, url string) (*http.C
 // allowlist gate has authorized the host, so building it is itself gated.
 func (c *Client) stealthClient() *http.Client {
 	c.stealthOnce.Do(func() {
-		// Test clients route through a redirect transport; reusing it keeps
-		// stealth-engaged tests deterministic and offline. Production clients
-		// build the real Chrome HTTP/2 fingerprint client.
-		if _, ok := c.http.Transport.(*testRedirectTransport); ok {
+		// A client told to reuse its transport keeps it, which is how the
+		// stealth path stays deterministic and offline under test. Production
+		// clients build the real Chrome HTTP/2 fingerprint client.
+		if c.reuseTransportForStealth {
 			c.stealthHTTP = c.http
 			return
 		}

--- a/internal/batchexec/stealth_flag_test.go
+++ b/internal/batchexec/stealth_flag_test.go
@@ -1,0 +1,51 @@
+package batchexec
+
+import (
+	"net/http"
+	"testing"
+)
+
+// trvl#539 TRVL.HARDEN.2 -- stealthClient decides by an explicit flag, not by
+// asking whether its transport is a test type.
+//
+// The production code used to type-assert on the test redirect transport, which
+// is what forced that type to live in a production file and kept the exported
+// test constructor reachable from production. Production has no business asking
+// "am I in a test"; reuseTransportForStealth says what the branch actually
+// decides.
+//
+// Asserted because the flag is the load-bearing half of that change. If it
+// stopped being honoured, the test constructor could be moved back and nothing
+// would notice until a stealth-engaged test started reaching the network.
+func TestStealthClientReusesTheTransportWhenTold(t *testing.T) {
+	own := &http.Client{}
+	c := &Client{http: own, reuseTransportForStealth: true}
+
+	if got := c.stealthClient(); got != own {
+		t.Error("stealthClient built a new client despite reuseTransportForStealth; a " +
+			"stealth-engaged test would leave the fixture and reach the real Chrome fingerprint " +
+			"path, which is exactly what this flag exists to prevent")
+	}
+}
+
+// The control: a production client, which never sets the flag, must still get
+// the real stealth transport. Without this, hard-wiring reuse would pass the
+// test above while silently disabling stealth for every user.
+func TestStealthClientBuildsTheRealOneByDefault(t *testing.T) {
+	own := &http.Client{}
+	c := &Client{http: own}
+
+	if got := c.stealthClient(); got == own {
+		t.Error("stealthClient reused the plain transport for a client that never asked; " +
+			"production would lose the Chrome fingerprint that clears bot detection")
+	}
+}
+
+// NewClient must leave the flag false. It is the constructor every production
+// caller uses, and a default of true would disable stealth everywhere.
+func TestNewClientDoesNotReuseTransportForStealth(t *testing.T) {
+	if NewClient().reuseTransportForStealth {
+		t.Error("NewClient sets reuseTransportForStealth; production clients would skip the real " +
+			"stealth transport entirely")
+	}
+}

--- a/internal/batchexec/testclient.go
+++ b/internal/batchexec/testclient.go
@@ -1,0 +1,74 @@
+package batchexec
+
+import (
+	"net/http"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// TEST-ONLY HELPER (trvl#539, TRVL.HARDEN.2). No production caller, enforced by
+// scripts/ci/check-test-only-helpers.sh.
+//
+// NewTestClient and its redirect transport used to live in client.go alongside
+// production code. Nothing called them from production -- which is exactly why
+// the gosec G704 finding on the transport was unreachable and got baselined --
+// but "nothing calls it today" is a property no gate enforces. A future
+// production caller would make that finding live without changing the baseline
+// count, so the gate would not notice.
+//
+// The first attempt put this in a _test.go file, which would have made a
+// production caller fail to COMPILE. That is the stronger guarantee the
+// criterion asks for, and it does not work here: _test.go is compiled only when
+// testing THIS package, so 12 files across internal/flights, internal/hotels
+// and internal/explore stopped building. The issue anticipated exactly this and
+// named the fallback -- "if NewTestClient cannot be moved behind a test-only
+// build tag without breaking the test layout, item 2 becomes a lint rule
+// instead of a move."
+//
+// So: a dedicated file with no production code in it, and a CI check that fails
+// if any non-test file references the helper. Weaker than a compile error,
+// stronger than the comment-and-hope it replaces, and it fails in CI rather
+// than in review.
+//
+// Separating it also required removing a type assertion in stealthClient that
+// asked whether the transport was this test type. Production code has no
+// business asking "am I in a test"; it now reads a reuseTransportForStealth
+// flag, which says what the branch actually decides.
+
+// NewTestClient creates a Client that redirects all requests to the given test
+// server URL. It uses a plain http.Client (no TLS fingerprinting) with high
+// rate limits for fast tests. The URL rewriting transport preserves the
+// original path and query string.
+func NewTestClient(baseURL string) *Client {
+	return &Client{
+		http: &http.Client{
+			Transport: &testRedirectTransport{baseURL: baseURL},
+			Timeout:   5 * time.Second,
+		},
+		limiter: rate.NewLimiter(rate.Limit(1000), 1),
+		// Keep the redirect transport when the stealth path engages, so
+		// stealth-engaged tests stay offline and deterministic.
+		reuseTransportForStealth: true,
+	}
+}
+
+// testRedirectTransport rewrites request URLs to point at a local test server
+// while preserving the original path and query string.
+type testRedirectTransport struct {
+	baseURL string
+}
+
+func (t *testRedirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Rewrite the URL to point at the test server.
+	newURL := t.baseURL + req.URL.Path
+	if req.URL.RawQuery != "" {
+		newURL += "?" + req.URL.RawQuery
+	}
+	newReq, err := http.NewRequestWithContext(req.Context(), req.Method, newURL, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	newReq.Header = req.Header
+	return http.DefaultTransport.RoundTrip(newReq)
+}

--- a/internal/destinations/http.go
+++ b/internal/destinations/http.go
@@ -3,16 +3,39 @@ package destinations
 import (
 	"net/http"
 	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/providers"
 )
 
 // Shared HTTP clients for the destinations package.
 // Reusing clients enables TCP connection pooling and avoids per-request TLS handshakes.
+//
+// Both route through providers.GuardedTransport, so the destination policy that
+// refuses loopback, private, link-local, unspecified and multicast addresses
+// applies here too (trvl#539, TRVL.HARDEN.1).
+//
+// Before that, these were plain http.Clients. Nothing was exploitable: this
+// package composes its URLs from a constant base and numeric parameters
+// (attractions.go:18-20, :50, :72-73), so no caller-supplied string reached the
+// host. But that made the URL construction the guard rather than the transport
+// -- a safety property resting on nobody adding an endpoint that takes a
+// caller-supplied value. That is the class of defect that arrives silently and
+// passes review, so the transport now carries the guarantee itself.
+//
+// The policy runs at DIAL time rather than on the URL, so it still holds when a
+// redirect or a DNS answer moves the connection somewhere the URL never named.
 var (
 	// destinationsClient is the default client for most destination APIs
 	// (restcountries, wikivoyage, weather, holidays, etc.).
-	destinationsClient = &http.Client{Timeout: 15 * time.Second}
+	destinationsClient = &http.Client{
+		Timeout:   15 * time.Second,
+		Transport: providers.GuardedTransport(),
+	}
 
 	// destinationsSlowClient is for APIs that can be slow under load,
 	// such as the Overpass/OSM API.
-	destinationsSlowClient = &http.Client{Timeout: 30 * time.Second}
+	destinationsSlowClient = &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: providers.GuardedTransport(),
+	}
 )

--- a/internal/destinations/http_guard_test.go
+++ b/internal/destinations/http_guard_test.go
@@ -1,0 +1,62 @@
+package destinations
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/providers"
+)
+
+// TRVL.HARDEN.1 -- the destinations HTTP clients must route through the same
+// guarded transport as providers, so the dial policy that refuses loopback,
+// private, link-local, unspecified and multicast addresses applies here too.
+//
+// This asserts BEHAVIOUR, not wiring. Comparing the Transport field against
+// providers.GuardedTransport() would compare two distinct pointers and prove
+// nothing about what happens on a dial; and a wiring assertion would still pass
+// if the policy inside the transport were later removed. So each client is
+// pointed at a real loopback server and required to refuse the connection.
+//
+// The test server is the point: if the guard is gone, the request SUCCEEDS,
+// because the server is right there and answering. There is no ambiguity
+// between "refused" and "could not connect".
+//
+// Why this matters even though nothing is exploitable today: the destinations
+// package composes its URLs from a constant base and numeric parameters, so no
+// caller string reaches the host. That made URL construction the guard rather
+// than the transport, and a future endpoint taking a caller-supplied value would
+// remove it silently (trvl#539).
+func TestDestinationsClientsRefuseLoopback(t *testing.T) {
+	// Clear the package-wide opt-in from TestMain. Without this the test runs
+	// under TRVL_ALLOW_LOCAL_PROVIDERS=1 and passes for the wrong reason -- or
+	// rather fails to fail, which is worse: it would report the guard working
+	// while the guard was switched off. Adversarial review flagged the same
+	// hazard for a developer with the variable set in their shell.
+	t.Setenv(providers.AllowLocalEnv, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	for name, client := range map[string]*http.Client{
+		"destinationsClient":     destinationsClient,
+		"destinationsSlowClient": destinationsSlowClient,
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, err := client.Get(srv.URL)
+			if err == nil {
+				_ = resp.Body.Close()
+				t.Fatalf("%s connected to a loopback test server (status %s); it is not routing through "+
+					"the guarded transport, so the destination policy does not apply to this package",
+					name, resp.Status)
+			}
+			if !errors.Is(err, providers.ErrDestinationRefused) {
+				t.Errorf("%s failed with %v, want an error wrapping ErrDestinationRefused -- the request "+
+					"must be refused BY POLICY, not merely fail for an unrelated reason", name, err)
+			}
+		})
+	}
+}

--- a/internal/destinations/main_test.go
+++ b/internal/destinations/main_test.go
@@ -1,0 +1,35 @@
+package destinations
+
+import (
+	"os"
+	"testing"
+
+	"github.com/MikkoParkkola/trvl/internal/providers"
+)
+
+// TestMain opts this package's tests back in to local destinations.
+//
+// These clients now route through providers.GuardedTransport (trvl#539,
+// TRVL.HARDEN.1), whose dial policy refuses loopback, private, link-local,
+// unspecified and multicast addresses. Every test in this package points a
+// client at an httptest server, which listens on loopback -- so without this
+// the policy correctly refuses them all and the suite fails wholesale. It did:
+// routing the clients through the guard turned ten passing tests red at once,
+// which is how this file came to exist.
+//
+// Package-wide via os.Setenv in TestMain rather than t.Setenv per test, for the
+// same reason the other packages here do it: t.Setenv panics inside a test that
+// has called t.Parallel, and a package-wide floor also covers tests written
+// later, which a per-test call cannot.
+//
+// The one test that must NOT inherit this floor is
+// TestDestinationsClientsRefuseLoopback, which exercises the production policy
+// and clears the variable itself. That is deliberate and load-bearing: a guard
+// test running under an opt-out proves nothing, and the whole point of #539 is
+// that a safety property nobody enforces is not a safety property.
+func TestMain(m *testing.M) {
+	if err := os.Setenv(providers.AllowLocalEnv, "1"); err != nil {
+		panic("destinations test setup: " + err.Error())
+	}
+	os.Exit(m.Run())
+}

--- a/internal/providers/destination.go
+++ b/internal/providers/destination.go
@@ -177,6 +177,22 @@ func guardedDialer() *net.Dialer {
 	}
 }
 
+// GuardedTransport returns an http.Transport carrying this package's
+// destination policy on its dialer, for use by other packages that make
+// outbound requests.
+//
+// It exists because internal/destinations built a plain http.Client and so did
+// not route through this policy (trvl#539). That was safe only because the
+// destinations package composes its URLs from a constant base and numeric
+// parameters, so no caller string reached the host -- the guard was the URL
+// construction, not the transport. A property nothing enforces is not a guard,
+// and a future destinations endpoint taking a caller-supplied value would
+// remove it silently.
+//
+// Callers get the policy at DIAL time, which is what makes it hold even when a
+// redirect or a DNS answer moves the connection somewhere the URL did not name.
+func GuardedTransport() *http.Transport { return guardedTransport() }
+
 // guardedTransport returns the standard transport this package uses for
 // provider traffic, with the policy installed.
 func guardedTransport() *http.Transport {

--- a/internal/providers/guarded_transport_test.go
+++ b/internal/providers/guarded_transport_test.go
@@ -1,0 +1,63 @@
+package providers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// trvl#539 TRVL.HARDEN.1 -- GuardedTransport is exported so other packages can
+// route through this package's destination policy, and it must actually carry
+// it.
+//
+// Asserted through a real dial rather than by inspecting the returned struct. A
+// transport that merely LOOKS configured proves nothing: the policy lives on the
+// dialer's Control function, and comparing struct fields would still pass if
+// that were later dropped. So the transport is pointed at a live loopback server
+// and required to refuse.
+//
+// The live server is the point. Without the policy the request SUCCEEDS, so
+// there is no ambiguity between "refused" and "could not connect" -- the failure
+// mode that would make this test meaningless.
+func TestGuardedTransportRefusesLoopback(t *testing.T) {
+	t.Setenv(AllowLocalEnv, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: GuardedTransport()}
+
+	resp, err := client.Get(srv.URL)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatalf("GuardedTransport connected to a loopback server (status %s); it is exported for "+
+			"other packages to inherit this policy, so a transport without it hands them a "+
+			"guarantee that does not exist", resp.Status)
+	}
+	if !errors.Is(err, ErrDestinationRefused) {
+		t.Errorf("failed with %v, want an error wrapping ErrDestinationRefused -- the request must "+
+			"be refused BY POLICY, not merely fail for an unrelated reason", err)
+	}
+}
+
+// The control: the opt-in must still work through the exported transport, or
+// every consumer inherits a policy they cannot escape for legitimate local use.
+func TestGuardedTransportHonoursTheLocalOptIn(t *testing.T) {
+	t.Setenv(AllowLocalEnv, "1")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: GuardedTransport()}
+
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("the local opt-in did not reach the exported transport: %v", err)
+	}
+	_ = resp.Body.Close()
+}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -227,9 +227,53 @@ func applicableMigrations(old, current string) []Migration {
 	return out
 }
 
+// safeVersionStamp reports whether a version string may be used to build a
+// filename.
+//
+// The stamp reaching backupPreferences does NOT come from the compiled-in
+// Version. It comes from ReadStamp, which returns the trimmed contents of a
+// file on disk, so its shape is whatever that file contains -- corrupted,
+// hand-edited, or written by another program. Concatenating that into a path
+// puts ".." and "/" one bad file away from writing outside the preferences
+// directory (trvl#539, TRVL.HARDEN.3).
+//
+// An allowlist rather than a denylist of dangerous characters: a version is a
+// small, well-understood shape, and enumerating what is permitted cannot be
+// outflanked by an encoding nobody thought of. Empty is rejected too, since it
+// would silently produce "preferences.json.bak." and collide across upgrades.
+//
+// Callers refuse rather than sanitise. A sanitised path is still a path nobody
+// intended, and there is nothing useful to back up under a name derived from a
+// stamp we do not trust.
+func safeVersionStamp(v string) bool {
+	if v == "" || len(v) > 64 {
+		return false
+	}
+	if strings.Contains(v, "..") {
+		return false
+	}
+	for _, r := range v {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r == '.' || r == '-' || r == '_' || r == '+':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // backupPreferences copies preferences.json to preferences.json.bak.{version}
 // if it exists.
 func backupPreferences(dir, oldVersion string) {
+	if !safeVersionStamp(oldVersion) {
+		// Refuse rather than sanitise: see safeVersionStamp. Skipping the backup
+		// is the safe direction -- the migration still runs, and the alternative
+		// is writing a file to a path the stamp chose.
+		return
+	}
 	src := prefsPathIn(dir)
 	if _, err := os.Stat(src); err != nil {
 		return // no prefs file, nothing to back up

--- a/internal/upgrade/version_stamp_guard_test.go
+++ b/internal/upgrade/version_stamp_guard_test.go
@@ -1,0 +1,93 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TRVL.HARDEN.3 -- a version stamp must be validated before it reaches a path.
+//
+// backupPreferences builds "preferences.json.bak.<version>" by concatenation.
+// The version does NOT come from the compiled-in Version constant: it comes
+// from ReadStamp, which returns the trimmed contents of a file on disk. A
+// corrupted, hand-edited, or externally-written stamp therefore chooses part of
+// a filename.
+//
+// The escape asserted here is the one that matters: a stamp containing "../"
+// walks out of the preferences directory entirely, so the backup lands
+// somewhere nobody intended and may overwrite an unrelated file.
+func TestBackupPreferencesRefusesUnsafeVersionStamp(t *testing.T) {
+	for _, stamp := range []string{
+		"../../escaped",
+		"../sibling",
+		"..",
+		"a/b",
+		`a\b`,
+		"",
+		"has space",
+		"semi;colon",
+	} {
+		t.Run(stamp, func(t *testing.T) {
+			dir := t.TempDir()
+			// A preferences file must exist, or backupPreferences returns early
+			// for an unrelated reason and the test would pass without
+			// exercising the guard at all.
+			if err := os.WriteFile(prefsPathIn(dir), []byte(`{"currency":"EUR"}`), 0o600); err != nil {
+				t.Fatalf("seed prefs: %v", err)
+			}
+
+			backupPreferences(dir, stamp)
+
+			// Nothing may be written anywhere under the parent of dir except
+			// the preferences file we seeded. Walking the parent catches an
+			// escape that a check confined to dir would miss entirely.
+			parent := filepath.Dir(dir)
+			var strays []string
+			_ = filepath.Walk(parent, func(path string, info os.FileInfo, err error) error {
+				if err != nil || info == nil || info.IsDir() {
+					return nil //nolint:nilerr // an unreadable sibling is not this test's business
+				}
+				if path == prefsPathIn(dir) {
+					return nil
+				}
+				if filepath.Dir(path) == dir || filepath.Dir(path) == parent {
+					strays = append(strays, path)
+				}
+				return nil
+			})
+			if len(strays) > 0 {
+				t.Errorf("stamp %q produced %v -- an unvalidated version stamp reached a filename",
+					stamp, strays)
+			}
+		})
+	}
+}
+
+// The control that makes the assertion above mean something: a well-formed
+// stamp must still produce its backup. Without this, deleting backupPreferences
+// entirely would pass the refusal test.
+func TestBackupPreferencesStillBacksUpAValidStamp(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(prefsPathIn(dir), []byte(`{"currency":"EUR"}`), 0o600); err != nil {
+		t.Fatalf("seed prefs: %v", err)
+	}
+
+	backupPreferences(dir, "1.20.3")
+
+	want := prefsPathIn(dir) + ".bak.1.20.3"
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("a valid version stamp produced no backup at %s: %v -- the guard must refuse "+
+			"unsafe stamps, not disable the feature", want, err)
+	}
+}
+
+// Shapes real versions take must all be accepted, so the guard cannot quietly
+// disable backups for a release naming scheme this repo already uses.
+func TestSafeVersionStampAcceptsRealVersions(t *testing.T) {
+	for _, v := range []string{"1.21.0", "v1.21.0", "1.21.0-rc.1", "1.21.0+build.5", "0.0.1", "dev_snapshot"} {
+		if !safeVersionStamp(v) {
+			t.Errorf("safeVersionStamp(%q) = false, want true", v)
+		}
+	}
+}

--- a/scripts/ci/check-test-only-helpers.sh
+++ b/scripts/ci/check-test-only-helpers.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Keep test-only helpers out of production call paths.
+#
+# Some helpers exist purely to let tests drive a package offline -- a client
+# whose transport redirects every request to a local test server, for instance.
+# They are exported because tests in OTHER packages need them, which means the
+# compiler cannot keep production from calling them.
+#
+# That is not academic. gosec's G704 finding on batchexec's redirect transport
+# was baselined as NOT REACHABLE, and the reasoning was "the only callers are
+# *_test.go files". True at the time, and a property nothing enforced: a future
+# production caller would have made the finding live WITHOUT changing the
+# baseline count, so the gate would have stayed green (trvl#539, TRVL.HARDEN.2).
+#
+# The stronger fix -- move the helper into a _test.go file so a production
+# caller fails to compile -- was tried and does not work here. _test.go is
+# compiled only when testing its own package, so importers' tests stop building.
+# The issue named this fallback explicitly: "item 2 becomes a lint rule instead
+# of a move."
+#
+# So this is the rule. A helper listed below may be referenced from *_test.go
+# files and from its own declaration file, and nowhere else.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# symbol:declaring-file
+HELPERS=(
+  "NewTestClient:internal/batchexec/testclient.go"
+)
+
+fail=0
+checked=0
+
+for spec in "${HELPERS[@]}"; do
+  symbol="${spec%%:*}"
+  home="${spec#*:}"
+
+  if [ ! -f "$home" ]; then
+    printf 'error: %s is declared to live in %s, which does not exist\n' "$symbol" "$home" >&2
+    printf '       Update scripts/ci/check-test-only-helpers.sh if the helper moved.\n' >&2
+    fail=1
+    continue
+  fi
+  checked=$((checked + 1))
+
+  while IFS= read -r file; do
+    case "$file" in
+      *_test.go) continue ;;   # tests are the whole point
+      "$home") continue ;;     # its own declaration
+    esac
+    printf 'error: %s references the test-only helper %s\n' "$file" "$symbol" >&2
+    printf '       That helper redirects requests to a local test server and exists for tests only.\n' >&2
+    printf '       A production caller makes a baselined gosec finding live without changing the\n' >&2
+    printf '       baseline count, so the security gate would not notice.\n' >&2
+    fail=1
+  done < <(git grep -l -F -e "$symbol" -- '*.go' ':!:vendor/**' ':!:third_party/**' 2>/dev/null || true)
+done
+
+if [ "$fail" -eq 0 ]; then
+  printf 'ok: %d test-only helper(s) referenced from tests only\n' "$checked"
+fi
+
+exit "$fail"


### PR DESCRIPTION
Each of these was safe only because of something nobody was checking. None was exploitable as shipped; all three would have become live findings on a reasonable-looking future change — the class of defect that arrives silently and passes review.

## 1. A plain HTTP client bypassing the dial policy

`internal/destinations` built plain HTTP clients and so did not route through the policy that refuses loopback, private, link-local, unspecified and multicast addresses. It was safe because the package composes URLs from a constant base and numeric parameters — so **the guard was the URL construction, not the transport.**

Both clients now use `providers.GuardedTransport`. The policy runs at **dial** time, so it holds even when a redirect or a DNS answer moves the connection somewhere the URL never named.

The test asserts **behaviour, not wiring**: each client is pointed at a real loopback server and must be refused. Comparing transport fields would compare two pointers and prove nothing about a dial, and would still pass if the policy inside were later removed. The live server is the point — without the guard the request *succeeds* (200 OK), so there is no ambiguity between "refused" and "could not connect".

Consequence handled: every existing test in that package points at a local server, so the guard correctly refused all of them and turned **ten tests red at once**. `TestMain` now sets the allow-local variable package-wide, the same seam `internal/providers` already uses — and the guard test **clears it explicitly**, because a guard test running under an opt-out proves nothing. Verified the guard test still fails against plain clients with that opt-in in place.

## 2. A test helper exported from a production file

`NewTestClient` was exported from production code. Nothing called it — which is exactly why the security finding on its transport was unreachable and got baselined. But *"nothing calls it today"* is a property no gate enforces, and a future production caller would make that finding live **without changing the baseline count**.

First attempt moved it into a test-only file so a production caller would fail to compile. That is the stronger guarantee, and it does not work here: test files are built only when testing their own package, and **12 files across three other packages need this helper**. Caught by adversarial review after I checked callers with a truncated search and read the absence of other packages as evidence.

The issue anticipated exactly this and named the fallback: *"if it cannot be moved behind a build tag without breaking the test layout, item 2 becomes a lint rule instead of a move."* So: a dedicated file with no production code, plus `scripts/ci/check-test-only-helpers.sh`, which fails if any non-test file references it. Weaker than a compile error, stronger than the comment-and-hope it replaces, and it fails in CI rather than in review.

This required removing a type assertion asking whether the transport was the test type. **Production has no business asking "am I in a test"**; it now reads a flag that says what the branch actually decides.

## 3. A version stamp reaching a filename unvalidated

The issue recorded this as safe because the stamp comes from the compiled-in version. True of the *write* path, not the read: the value comes from a **file on disk**, so a corrupted or externally-written stamp chose part of a path. A stamp containing `../` walks out of the preferences directory.

An allowlist rather than a denylist, because a version is a small well-understood shape and enumerating what is permitted cannot be outflanked by an encoding nobody thought of. Callers **refuse rather than sanitise**: a sanitised path is still a path nobody intended.

Tested with traversal, separator and empty stamps, plus **two controls** — a valid stamp must still produce its backup, and real version shapes must all be accepted — so the guard cannot pass by disabling the feature.

## Baseline hygiene, part of the fix

- Removed a stale entry the gate itself reported as "allows 1, found 0".
- Rewrote another from **accepted risk** to **mitigated**: it was accepted precisely *because* the version stamp was unvalidated, so the recorded verdict had become false.
- Re-pointed the third and rewrote its reason. It used to rest on the observation "the only callers are test files" — true when written, checked by nothing. It now cites the CI check that enforces it, which is the whole point of the issue.

## Evidence

- **V:** each item fails without its fix, sabotage-verified.
- **V:** `make dod` exit 0 — read from the gate's own log. That distinction is not pedantry: an earlier revision of this work claimed a green gate while `make` was exiting 1, because the status being read belonged to a trailing command.
- **V:** adversarial review returned DO-NOT-SHIP on the first attempt and was right; the finding is fixed here.

Closes #539.
