### PR TITLE
fix: make the 1.21 release path warning-free

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,16 @@ jobs:
         run: scripts/ci/check-file-size.sh
       - name: Check release metadata
         run: scripts/ci/check-release-metadata.sh
+      - name: Install GoReleaser for configuration validation
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          install-only: true
+      - name: Validate GoReleaser configuration
+        run: goreleaser check
+      - name: Test Homebrew Formula updater
+        run: ruby scripts/release/update-homebrew-formula_test.rb
       # These were written as merge guards and wired only into the local
       # `make repo-hygiene`, which no workflow invokes -- so they gated nothing
       # on the merge path while both PRs described them as CI-enforced
@@ -231,7 +241,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     # Disabled: the canonical release pipeline lives in release.yml (macOS
-    # codesign + cosign + Homebrew + docker + npm + mcp-registry). Running
+    # codesign + cosign + Formula sync + docker + npm + mcp-registry). Running
     # goreleaser here too raced release.yml to create the same GitHub release.
     if: ${{ github.repository == 'MikkoParkkola/trvl-disabled' }}
     permissions:
@@ -264,12 +274,6 @@ jobs:
           # may still ship 1.26.3, so pin the toolchain so go fetches 1.26.5
           # for the hooks and the release build.
           GOTOOLCHAIN: "go1.26.5"
-          # HOMEBREW_TAP_TOKEN: a GitHub personal access token (classic) with
-          # `repo` scope, stored as a repository secret. Goreleaser uses it to
-          # push the auto-generated Homebrew formula to
-          # MikkoParkkola/homebrew-tap. Until the secret is created the brews
-          # step is skipped gracefully (goreleaser treats empty token as skip).
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
   npm-publish:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@
 #
 # Optional secrets:
 #   HOMEBREW_TAP_TOKEN — PAT with `contents: write` on
-#     MikkoParkkola/homebrew-tap, enabling goreleaser's `brews` block to
-#     auto-bump the formula. Casks stay disabled until notarization is proven.
+#     MikkoParkkola/homebrew-tap, enabling the post-release Formula update.
+#     Casks stay disabled until notarization is proven.
 name: Release
 
 on:
@@ -73,6 +73,9 @@ jobs:
           distribution: goreleaser
           version: "~> v2"
           install-only: true
+
+      - name: Validate GoReleaser configuration
+        run: goreleaser check
 
       # Install cosign for hybrid release signing — see signs: block in
       # .goreleaser.yaml. Keyless mode uses the workflow's OIDC token
@@ -158,25 +161,42 @@ jobs:
           echo "git status after reset:"
           git status --porcelain
 
-      - name: Run GoReleaser with Homebrew tap
-        if: env.HAS_HOMEBREW_TAP_TOKEN == 'true'
-        # Docker is published by the Linux docker job below. Homebrew is
-        # published here when HOMEBREW_TAP_TOKEN can push to the tap repo.
-        run: goreleaser release --clean --skip=docker
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          # Hybrid PQC signing: ML-DSA-65 private key. Pubkey is embedded
-          # in trvl at build time from internal/selfupdate/keys/. Fingerprint
-          # of the active trust anchor is shown by `trvl version --verify`.
-          TRVL_MLDSA_PRIVKEY_V1: ${{ secrets.TRVL_MLDSA_PRIVKEY_V1 }}
-
-      - name: Run GoReleaser without Homebrew tap
-        if: env.HAS_HOMEBREW_TAP_TOKEN != 'true'
+      - name: Run GoReleaser
+        # Docker and Homebrew are published by dedicated, gated steps below.
         run: goreleaser release --clean --skip=docker --skip=homebrew
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRVL_MLDSA_PRIVKEY_V1: ${{ secrets.TRVL_MLDSA_PRIVKEY_V1 }}
+
+      - name: Checkout Homebrew tap
+        if: env.HAS_HOMEBREW_TAP_TOKEN == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: MikkoParkkola/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Publish Homebrew Formula
+        if: env.HAS_HOMEBREW_TAP_TOKEN == 'true'
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          ruby scripts/release/update-homebrew-formula.rb \
+            homebrew-tap/Formula/trvl.rb \
+            "${VERSION}" \
+            dist/checksums.txt
+          ruby -c homebrew-tap/Formula/trvl.rb
+          grep -F "version \"${VERSION}\"" homebrew-tap/Formula/trvl.rb
+          git -C homebrew-tap diff --check
+          if git -C homebrew-tap diff --quiet -- Formula/trvl.rb; then
+            echo "Formula/trvl.rb already matches ${VERSION}."
+            exit 0
+          fi
+          git -C homebrew-tap config user.name github-actions[bot]
+          git -C homebrew-tap config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git -C homebrew-tap add Formula/trvl.rb
+          git -C homebrew-tap commit -m "Update trvl formula to v${VERSION}"
+          git -C homebrew-tap push origin HEAD:main
 
   docker:
     runs-on: ubuntu-latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,8 +84,10 @@ checksum:
 # against the embedded trust anchor. ALL THREE must pass before binary
 # replacement. See internal/selfupdate/verify_mldsa.go for the verifier.
 #
-# Local snapshot builds (`goreleaser release --snapshot`) skip signs by
-# default — only `goreleaser release` (tag-driven, in CI) runs them.
+# Local snapshot releases must pass `--skip=sign`; GoReleaser 2.17 snapshots
+# skip publication but still run signers by default. The release workflow's
+# smoke test uses `goreleaser build`, while the tag-driven release has both
+# signing credentials available and intentionally runs the signers.
 signs:
   - id: cosign-keyless
     cmd: cosign
@@ -145,39 +147,12 @@ release:
     go install github.com/MikkoParkkola/trvl/cmd/trvl@v{{ .Version }}
     ```
 
-# Publish a Homebrew *Formula* (not a Cask). A CLI binary belongs in a Formula:
-# `brew install` of a formula relocates the binary and strips the
-# com.apple.quarantine xattr, so the adhoc-signed binary launches cleanly on
-# Apple Silicon. A Cask, by contrast, keeps quarantine on the downloaded
-# artifact, and Gatekeeper then SIGKILLs the adhoc-signed binary (the trvl#203
-# "non-functional release" + the Gatekeeper "Not Opened" popup). Formula-only
-# is the zero-cost, zero-popup distribution path until/unless Developer ID
-# notarization is wired in (tracked separately).
-#
-# NOTE: goreleaser v2 marks `brews` deprecated and steers pre-built binaries to
-# `homebrew_casks`. That is INTENTIONALLY rejected here: a cask keeps the
-# com.apple.quarantine xattr, which Gatekeeper uses to SIGKILL our adhoc-signed
-# binary. Do NOT "modernize" this back to homebrew_casks without first wiring
-# Developer ID notarization, or you reintroduce the trvl#203 popup. The action is
-# pinned to `~> v2`, where `brews` remains functional; release/build never run
-# `goreleaser check`, so the deprecation warning does not fail the pipeline.
-brews:
-  - name: trvl
-    ids:
-      - trvl
-    repository:
-      owner: MikkoParkkola
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Formula
-    homepage: https://github.com/MikkoParkkola/trvl
-    description: "AI travel agent: flights, hotels and transport via MCP, no API keys"
-    license: "PolyForm-Noncommercial-1.0.0"
-    test: |
-      system "#{bin}/trvl", "version"
-    caveats: |
-      Run `trvl mcp install` to connect trvl to Claude Desktop, Cursor,
-      Windsurf, Codex, VS Code Copilot, Zed, or another MCP client.
+# Homebrew remains Formula-only until the Darwin artifacts are Developer-ID
+# signed and notarized. GoReleaser's legacy `brews` publisher is deprecated,
+# while its replacement publishes Casks, so the release workflow updates the
+# existing Formula/trvl.rb directly from the generated checksums instead. This
+# preserves macOS and Linuxbrew support without accepting a release-time
+# deprecation warning or reintroducing the quarantined-Cask failure from #203.
 
 # Docker images are published by .github/workflows/release.yml so release CI can
 # build multi-arch images with Dockerfile.release, scan them with Trivy, and push

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOSEC_VERSION ?= v2.28.0
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS := -ldflags "-s -w -X main.Version=$(VERSION) -X github.com/MikkoParkkola/trvl/mcp.serverVersion=$(VERSION)"
 
-.PHONY: build test test-proof test-coverage test-live-integrations test-live-probes lint repo-hygiene security-gosec dod distribution-metrics clean cross install safe-clean force-clean
+.PHONY: build test test-proof test-coverage test-live-integrations test-live-probes lint repo-hygiene release-config security-gosec dod distribution-metrics clean cross install safe-clean force-clean
 
 lint security-gosec: export PATH := $(GO_TOOLS_BIN):$(PATH)
 
@@ -47,6 +47,14 @@ repo-hygiene:
 	scripts/ci/check-home-isolation.sh
 	scripts/ci/check-log-url-redaction.sh
 	scripts/ci/check-test-only-helpers.sh
+
+release-config:
+	@if ! command -v goreleaser >/dev/null 2>&1; then \
+		echo "goreleaser not installed. Install with: brew install goreleaser" >&2; \
+		exit 1; \
+	fi
+	goreleaser check
+	ruby scripts/release/update-homebrew-formula_test.rb
 
 lint: repo-hygiene
 	$(GO_RUN) vet ./...
@@ -102,7 +110,7 @@ security-gosec:
 # Known gap worth stating: scripts/ci/check-file-size.sh inspects TRACKED files
 # only, so a newly added file reports clean until it is `git add`ed. Stage first,
 # then run this.
-dod: lint security-gosec test
+dod: release-config lint security-gosec test
 	@echo
 	@echo "dod: lint, gosec and tests all clean -- safe to commit."
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ repo-hygiene:
 
 release-config:
 	@if ! command -v goreleaser >/dev/null 2>&1; then \
-		echo "goreleaser not installed. Install with: brew install goreleaser" >&2; \
+		echo "goreleaser not installed. Install it from: https://goreleaser.com/install/" >&2; \
 		exit 1; \
 	fi
 	goreleaser check

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -54,13 +54,16 @@ The 2026-05-12 baseline captured 337 GitHub release asset downloads and 0 npm `t
 
 Decision: Formula-only until Developer ID notarization is proven in release CI.
 
-trvl intentionally publishes a Homebrew Formula through GoReleaser's `brews`
-configuration, not a Cask. The Formula install path relocates the CLI binary in
-a way that avoids the `com.apple.quarantine` launch failure that affected the
-prior Cask-style distribution attempt. A Cask must not be introduced unless the
-release workflow first signs and notarizes Darwin artifacts with a Developer ID
-certificate, staples the notarization ticket when applicable, and verifies a
-quarantined install can run `trvl version` on macOS before publishing.
+trvl intentionally publishes a Homebrew Formula, not a Cask. The release
+workflow updates `MikkoParkkola/homebrew-tap` directly from the checksums emitted
+by GoReleaser because GoReleaser's legacy Formula publisher is deprecated and
+its supported replacement publishes Casks. The Formula install path relocates
+the CLI binary in a way that avoids the `com.apple.quarantine` launch failure
+that affected the prior Cask-style distribution attempt. A Cask must not be
+introduced unless the release workflow first signs and notarizes Darwin
+artifacts with a Developer ID certificate, staples the notarization ticket when
+applicable, and verifies a quarantined install can run `trvl version` on macOS
+before publishing.
 
 The existing Formula path stays the supported Homebrew channel until that full
 notarized-Cask path is implemented and proven. `scripts/ci/check-workflow-hygiene.sh`

--- a/scripts/ci/check-workflow-hygiene.sh
+++ b/scripts/ci/check-workflow-hygiene.sh
@@ -77,9 +77,9 @@ release_goreleaser_action_uses_node24_pin() {
   ! grep -qF 'goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a' .github/workflows/release.yml &&
     [ "$(grep -cF 'goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3' .github/workflows/release.yml)" -eq 1 ] &&
     grep -qF 'install-only: true' .github/workflows/release.yml &&
+    grep -qF 'run: goreleaser check' .github/workflows/release.yml &&
     grep -qF 'run: goreleaser build --single-target --snapshot --clean' .github/workflows/release.yml &&
-    grep -qF 'run: goreleaser release --clean --skip=docker' .github/workflows/release.yml &&
-    grep -qF 'run: goreleaser release --clean --skip=docker --skip=homebrew' .github/workflows/release.yml
+    [ "$(grep -cF 'run: goreleaser release --clean --skip=docker --skip=homebrew' .github/workflows/release.yml)" -eq 1 ]
 }
 
 release_docker_job_has_timeout() {
@@ -109,10 +109,12 @@ release_docker_trivy_blocks_before_push() {
 }
 
 release_homebrew_stays_formula_only_until_notarized() {
-  grep -q '^brews:' .goreleaser.yaml &&
+  ! grep -q '^brews:' .goreleaser.yaml &&
     ! grep -q '^homebrew_casks:' .goreleaser.yaml &&
     ! grep -q 'homebrew_casks' .github/workflows/release.yml &&
-    grep -q 'release/build never run' .goreleaser.yaml &&
+    grep -qF 'scripts/release/update-homebrew-formula.rb' .github/workflows/release.yml &&
+    grep -qF 'homebrew-tap/Formula/trvl.rb' .github/workflows/release.yml &&
+    grep -qF 'git -C homebrew-tap push origin HEAD:main' .github/workflows/release.yml &&
     grep -q 'Formula-only until Developer ID notarization is proven in release CI' docs/DISTRIBUTION.md
 }
 

--- a/scripts/release/update-homebrew-formula.rb
+++ b/scripts/release/update-homebrew-formula.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+formula_path, version, checksums_path = ARGV
+
+if !formula_path || !version || !checksums_path
+  warn "usage: update-homebrew-formula.rb FORMULA_PATH VERSION CHECKSUMS_PATH"
+  exit 2
+end
+
+unless File.file?(formula_path)
+  warn "formula not found: #{formula_path}"
+  exit 2
+end
+
+unless File.file?(checksums_path)
+  warn "checksums not found: #{checksums_path}"
+  exit 2
+end
+
+platforms = %w[
+  darwin_amd64
+  darwin_arm64
+  linux_amd64
+  linux_arm64
+].freeze
+
+checksums = {}
+File.readlines(checksums_path, chomp: true).each do |line|
+  hash, name = line.split(/\s+/, 2)
+  checksums[name] = hash if hash && name
+end
+
+content = File.read(formula_path)
+
+unless content.sub!(/version "[^"]+"/, %Q(version "#{version}"))
+  warn "failed to update version in #{formula_path}"
+  exit 1
+end
+
+platforms.each do |platform|
+  filename = "trvl_#{version}_#{platform}.tar.gz"
+  sha256 = checksums[filename]
+  unless sha256&.match?(/\A[0-9a-f]{64}\z/)
+    warn "missing checksum for #{filename}"
+    exit 1
+  end
+
+  pattern = %r{
+    url\ "https://github\.com/MikkoParkkola/trvl/releases/download/v[^/]+/trvl_[^"]+_#{Regexp.escape(platform)}\.tar\.gz"
+    \n(\s+)sha256\ "[0-9a-f]{64}"
+  }x
+
+  replacement = %Q(url "https://github.com/MikkoParkkola/trvl/releases/download/v#{version}/#{filename}"\n\\1sha256 "#{sha256}")
+  unless content.gsub!(pattern, replacement)
+    warn "failed to update #{platform} block in #{formula_path}"
+    exit 1
+  end
+end
+
+File.write(formula_path, content)

--- a/scripts/release/update-homebrew-formula_test.rb
+++ b/scripts/release/update-homebrew-formula_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+
+class UpdateHomebrewFormulaTest < Minitest::Test
+  SCRIPT = File.expand_path("update-homebrew-formula.rb", __dir__)
+  PLATFORMS = %w[darwin_amd64 darwin_arm64 linux_amd64 linux_arm64].freeze
+
+  def test_updates_version_urls_and_all_checksums
+    with_fixture do |formula, checksums|
+      _stdout, stderr, status = Open3.capture3(
+        RbConfig.ruby, SCRIPT, formula, "1.21.0", checksums
+      )
+
+      assert status.success?, stderr
+      content = File.read(formula)
+      assert_includes content, 'version "1.21.0"'
+      PLATFORMS.each_with_index do |platform, index|
+        filename = "trvl_1.21.0_#{platform}.tar.gz"
+        assert_includes content, "/v1.21.0/#{filename}"
+        assert_includes content, %(sha256 "#{(index + 1).to_s * 64}")
+      end
+    end
+  end
+
+  def test_missing_platform_checksum_fails_without_rewriting_formula
+    with_fixture(omit: "linux_arm64") do |formula, checksums|
+      before = File.read(formula)
+      _stdout, stderr, status = Open3.capture3(
+        RbConfig.ruby, SCRIPT, formula, "1.21.0", checksums
+      )
+
+      refute status.success?
+      assert_includes stderr, "missing checksum for trvl_1.21.0_linux_arm64.tar.gz"
+      assert_equal before, File.read(formula)
+    end
+  end
+
+  private
+
+  def with_fixture(omit: nil)
+    Dir.mktmpdir("trvl-homebrew-formula-test") do |dir|
+      formula = File.join(dir, "trvl.rb")
+      checksums = File.join(dir, "checksums.txt")
+      File.write(formula, formula_fixture)
+      File.write(checksums, checksum_fixture(omit: omit))
+      yield formula, checksums
+    end
+  end
+
+  def formula_fixture
+    blocks = PLATFORMS.map do |platform|
+      %(      url "https://github.com/MikkoParkkola/trvl/releases/download/v1.20.0/trvl_1.20.0_#{platform}.tar.gz"\n) \
+        + %(      sha256 "#{'0' * 64}"\n)
+    end.join("\n")
+
+    <<~RUBY
+      class Trvl < Formula
+        version "1.20.0"
+      #{blocks}
+      end
+    RUBY
+  end
+
+  def checksum_fixture(omit:)
+    lines = []
+    PLATFORMS.each_with_index do |platform, index|
+      next if platform == omit
+
+      lines << "#{(index + 1).to_s * 64}  trvl_1.21.0_#{platform}.tar.gz"
+    end
+    lines.join("\n")
+  end
+end

--- a/scripts/release/update-homebrew-formula_test.rb
+++ b/scripts/release/update-homebrew-formula_test.rb
@@ -20,8 +20,11 @@ class UpdateHomebrewFormulaTest < Minitest::Test
       assert_includes content, 'version "1.21.0"'
       PLATFORMS.each_with_index do |platform, index|
         filename = "trvl_1.21.0_#{platform}.tar.gz"
-        assert_includes content, "/v1.21.0/#{filename}"
-        assert_includes content, %(sha256 "#{(index + 1).to_s * 64}")
+        expected_pair = %r{
+          url\ "https://github\.com/MikkoParkkola/trvl/releases/download/v1\.21\.0/#{Regexp.escape(filename)}"
+          \n\s+sha256\ "#{(index + 1).to_s * 64}"
+        }x
+        assert_match expected_pair, content
       end
     end
   end


### PR DESCRIPTION
Closes #590.

## What changed

- remove GoReleaser's deprecated `brews` publisher so `goreleaser check` is clean on v2.17;
- keep the documented Formula-only policy instead of switching to a quarantined Cask;
- update `MikkoParkkola/homebrew-tap/Formula/trvl.rb` synchronously from GoReleaser's checksums after the GitHub release is created;
- make Formula publication fail closed when any Darwin/Linux checksum is absent;
- gate both PR CI and local `make dod` on `goreleaser check` and the Formula updater tests;
- correct the local snapshot guidance: GoReleaser 2.17 requires `--skip=sign` explicitly.

## Evidence

- `make dod` — clean at head `2e9fafc`;
- GoReleaser configuration — 1 file validated, no deprecation;
- Formula updater — 2 tests / 15 assertions, including missing-checksum refusal and exact URL/checksum pairing per platform;
- gosec Darwin/Linux/Windows — HIGH=0, MEDIUM=0, LOW=0;
- `govulncheck ./...` — 0 reachable vulnerabilities;
- isolated `goreleaser release --snapshot --clean --skip=sign` — succeeded;
- six archives produced and all six checksums verified;
- Darwin arm64 smoke binary prints its version, rejects an invalid command, and reports ad-hoc signature identifier `com.mikkoparkkola.trvl`.

The existing `release/1.21.0` branch is intentionally not merged: its work was reconciled by squash integrations #559/#588 and a synthetic merge now conflicts broadly. Release publication is tag-driven; after this PR, `main` is the audited release candidate.