### PR TITLE
ci: update artifact upload runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -230,8 +230,8 @@ jobs:
           done
       - name: Upload gosec report
         if: always()
-        # v5.0.0
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: gosec-report
           path: bin/gosec-report.*.json


### PR DESCRIPTION
## Summary

- update the CI artifact uploader from the deprecated Node 20 runtime to v7.0.1
- reuse the same reviewed, SHA-pinned action version already used by the GitNexus workflow

## Verification

- `scripts/ci/check-workflow-hygiene.sh`
- `git diff --check`

