### PR TITLE
release: prepare v1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.1] - 2026-08-10
+
 ### Fixed
 
 - Hotel room fallbacks now require a strong property-name match before merging

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,8 +1,8 @@
 {
   "name": "trvl-mcp",
   "mcpName": "io.github.MikkoParkkola/trvl",
-  "version": "1.21.0",
-  "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as legacy-compatible capabilities.",
+  "version": "1.21.1",
+  "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips — no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as legacy-compatible capabilities.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {
     "type": "git",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
   "description": "Door-to-door travel MCP + CLI: flights, hotels, trains, cars, ferries. No API keys, Go binary.",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",
     "source": "github"
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mikkoparkkola/trvl:1.21.0",
+      "identifier": "ghcr.io/mikkoparkkola/trvl:1.21.1",
       "transport": {
         "type": "stdio"
       }
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "identifier": "trvl-mcp",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "version": "1.21.0",
+      "version": "1.21.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- move the hotel-integrity fixes from Unreleased into v1.21.1 dated 2026-08-10
- align `server.json` and `npm/package.json` with v1.21.1
- prepare the tag-driven release pipeline for GitHub binaries, Homebrew, GHCR, npm, and the MCP Registry

The release contains the fix for #593 merged in #594. PR #595 is unrelated and intentionally excluded.

## Validation

- `make dod` passed on the fixed source commit
- `make test-proof` passed with the race detector on the fixed source commit
- this PR's CI must pass before merge and tagging
