### PR TITLE
release: prepare reviewed v1.21.1 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.1] - 2026-08-10
+
 ### Fixed
 
 - Hotel room fallbacks now require a strong property-name match before merging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1173,7 +1173,8 @@ Trust & Discoverability release. The gaps surfaced by @RobertoReale's "Budget Tr
 - Single static binary, zero runtime dependencies
 - MIT license
 
-[Unreleased]: https://github.com/MikkoParkkola/trvl/compare/v1.21.0...HEAD
+[Unreleased]: https://github.com/MikkoParkkola/trvl/compare/v1.21.1...HEAD
+[1.21.1]: https://github.com/MikkoParkkola/trvl/compare/v1.21.0...v1.21.1
 [1.21.0]: https://github.com/MikkoParkkola/trvl/compare/v1.20.0...v1.21.0
 [1.20.0]: https://github.com/MikkoParkkola/trvl/compare/v1.19.1...v1.20.0
 [1.19.1]: https://github.com/MikkoParkkola/trvl/compare/v1.19.0...v1.19.1

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,8 +1,8 @@
 {
   "name": "trvl-mcp",
   "mcpName": "io.github.MikkoParkkola/trvl",
-  "version": "1.21.0",
-  "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as legacy-compatible capabilities.",
+  "version": "1.21.1",
+  "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips — no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as legacy-compatible capabilities.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {
     "type": "git",

--- a/npm/package.json
+++ b/npm/package.json
@@ -2,7 +2,7 @@
   "name": "trvl-mcp",
   "mcpName": "io.github.MikkoParkkola/trvl",
   "version": "1.21.1",
-  "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips — no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as legacy-compatible capabilities.",
+  "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as legacy-compatible capabilities.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {
     "type": "git",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
   "description": "Door-to-door travel MCP + CLI: flights, hotels, trains, cars, ferries. No API keys, Go binary.",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",
     "source": "github"
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mikkoparkkola/trvl:1.21.0",
+      "identifier": "ghcr.io/mikkoparkkola/trvl:1.21.1",
       "transport": {
         "type": "stdio"
       }
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "identifier": "trvl-mcp",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "version": "1.21.0",
+      "version": "1.21.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- move the hotel-integrity fixes from Unreleased into v1.21.1 dated 2026-08-10
- align `server.json` and `npm/package.json` with v1.21.1
- update the changelog comparison links so `Unreleased` starts at v1.21.1 and v1.21.1 compares against v1.21.0
- preserve the existing npm description representation so the diff remains release-focused

This supersedes #596 and incorporates its Copilot review finding. The release contains the fix for #593 merged in #594. PR #595 is unrelated and intentionally excluded.

## Validation

- metadata transformations were parser-checked before commit
- `make dod` and `make test-proof` passed on the underlying fixed source
- this PR's fresh CI and regression gate must pass before merge and tagging
