### PR TITLE
fix: reject past hotel search dates

### DIFF
--- a/cmd/trvl/cmd_test.go
+++ b/cmd/trvl/cmd_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
@@ -152,6 +153,29 @@ func TestHotelsCmd_RequiresCheckinCheckout(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Error("expected error when --checkin/--checkout missing")
+	}
+}
+
+func TestHotelsCmd_RejectsPastStay(t *testing.T) {
+	checkIn := time.Now().AddDate(0, 0, -10).Format("2006-01-02")
+	checkOut := time.Now().AddDate(0, 0, -5).Format("2006-01-02")
+
+	cmd := hotelsCmd()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{
+		"Ischia Italy",
+		"--checkin", checkIn,
+		"--checkout", checkOut,
+		"--enrich-rooms=false",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected wholly past stay %s to %s to be rejected", checkIn, checkOut)
+	}
+	if !strings.Contains(err.Error(), "invalid start date") || !strings.Contains(err.Error(), "in the past") {
+		t.Fatalf("expected past-date validation error, got %v", err)
 	}
 }
 

--- a/cmd/trvl/cmd_test.go
+++ b/cmd/trvl/cmd_test.go
@@ -157,8 +157,9 @@ func TestHotelsCmd_RequiresCheckinCheckout(t *testing.T) {
 }
 
 func TestHotelsCmd_RejectsPastStay(t *testing.T) {
-	checkIn := time.Now().AddDate(0, 0, -10).Format("2006-01-02")
-	checkOut := time.Now().AddDate(0, 0, -5).Format("2006-01-02")
+	now := time.Now()
+	checkIn := now.AddDate(0, 0, -10).Format("2006-01-02")
+	checkOut := now.AddDate(0, 0, -5).Format("2006-01-02")
 
 	cmd := hotelsCmd()
 	cmd.SilenceUsage = true
@@ -170,12 +171,15 @@ func TestHotelsCmd_RejectsPastStay(t *testing.T) {
 		"--enrich-rooms=false",
 	})
 
-	err := cmd.Execute()
+	stdout, stderr, err := captureTripCostOutput(t, cmd.Execute)
 	if err == nil {
 		t.Fatalf("expected wholly past stay %s to %s to be rejected", checkIn, checkOut)
 	}
 	if !strings.Contains(err.Error(), "invalid start date") || !strings.Contains(err.Error(), "in the past") {
 		t.Fatalf("expected past-date validation error, got %v", err)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("past stay reached provider/output work: stdout=%q stderr=%q", stdout, stderr)
 	}
 }
 

--- a/cmd/trvl/hotels.go
+++ b/cmd/trvl/hotels.go
@@ -120,6 +120,10 @@ func runHotels(cmd *cobra.Command, args []string) error {
 	explain, _ := cmd.Flags().GetBool("explain")
 	stealth, _ := cmd.Flags().GetBool("stealth")
 
+	if err := models.ValidateDateRange(checkin, checkout); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	ctx = providers.WithInteractive(ctx) // allow browser escape hatch for WAF challenges


### PR DESCRIPTION
## Summary

- reject wholly past `trvl hotels` stays at the CLI boundary
- reuse the existing `models.ValidateDateRange` contract already used by `rooms`, `prices`, and MCP hotel search
- add a dynamic command-level regression test that proves rejection occurs before provider work

## Root cause

`runHotels` read `--checkin` and `--checkout` but did not call `models.ValidateDateRange` before invoking the provider search. The published v1.21.1 binary therefore accepted past stays, queried providers, and could merge unrelated fallback inventory.

The shared `SearchHotelsWithClient` boundary was deliberately not changed. GitNexus classified it CRITICAL risk with 178 affected symbols, while `runHotels` is the narrow command boundary and matches the established validation pattern.

## Evidence

The regression test was observed RED before implementation:

```text
expected wholly past stay 2026-07-31 to 2026-08-05 to be rejected
--- FAIL: TestHotelsCmd_RejectsPastStay (32.61s)
```

It queried providers and rendered unrelated Flatio inventory before failing.

After the fix:

- `TestHotelsCmd_RejectsPastStay` passes in 0.00s
- a locally built binary exits 1, emits zero stdout, and reports only `invalid start date: date "2026-07-30" is in the past`
- no provider warning appears
- `make dod` passes in full, including release checks, hygiene, vet, golangci-lint, staticcheck, govulncheck, three-platform gosec, and all Go tests

Fixes #606