### PR TITLE
release: prepare v1.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.2] - 2026-08-10
+
+### Fixed
+
+- `trvl hotels` now rejects stays whose check-in date is in the past before
+  contacting providers or writing search results, matching the validation
+  already used by the other hotel command paths. ([#606](https://github.com/MikkoParkkola/trvl/issues/606))
+
 ## [1.21.1] - 2026-08-10
 
 ### Fixed
@@ -1173,7 +1181,8 @@ Trust & Discoverability release. The gaps surfaced by @RobertoReale's "Budget Tr
 - Single static binary, zero runtime dependencies
 - MIT license
 
-[Unreleased]: https://github.com/MikkoParkkola/trvl/compare/v1.21.1...HEAD
+[Unreleased]: https://github.com/MikkoParkkola/trvl/compare/v1.21.2...HEAD
+[1.21.2]: https://github.com/MikkoParkkola/trvl/compare/v1.21.1...v1.21.2
 [1.21.1]: https://github.com/MikkoParkkola/trvl/compare/v1.21.0...v1.21.1
 [1.21.0]: https://github.com/MikkoParkkola/trvl/compare/v1.20.0...v1.21.0
 [1.20.0]: https://github.com/MikkoParkkola/trvl/compare/v1.19.1...v1.20.0

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl-mcp",
   "mcpName": "io.github.MikkoParkkola/trvl",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as legacy-compatible capabilities.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
   "description": "Door-to-door travel MCP + CLI: flights, hotels, trains, cars, ferries. No API keys, Go binary.",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",
     "source": "github"
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mikkoparkkola/trvl:1.21.1",
+      "identifier": "ghcr.io/mikkoparkkola/trvl:1.21.2",
       "transport": {
         "type": "stdio"
       }
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "identifier": "trvl-mcp",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "version": "1.21.1",
+      "version": "1.21.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- document the trvl hotels past-date fix from #606
- align checked-in npm, OCI, and MCP metadata on version 1.21.2
- prepare the patch tag that will deliver the fix from #607

## Validation

- scripts/ci/check-release-metadata.sh
- GOTOOLCHAIN=go1.26.5 go test ./cmd/trvl -run ^TestHotelsCmd_RejectsPastStay$ -count=1 -v
- goreleaser check
- make dod

Closes #606 after release publication; the implementation issue is already closed by #607.