### PR TITLE
fix: prevent automated tests from opening Nab Keychain dialogs

### DIFF
--- a/internal/cookies/announce_test.go
+++ b/internal/cookies/announce_test.go
@@ -88,6 +88,7 @@ func TestCookieReadIsAnnouncedBeforeTheHelperStarts(t *testing.T) {
 		t.Fatalf("writing the fake nab: %v", err)
 	}
 	t.Setenv("PATH", dir)
+	useNabPath(t, filepath.Join(dir, "nab"))
 	t.Setenv(DisableEnv, "")
 
 	rec := &noticeRecorder{marker: notice}
@@ -153,6 +154,7 @@ func TestCookieReadNoticeIsSaidOnceAndNotAtAllOnADecline(t *testing.T) {
 		t.Fatalf("writing the fake nab: %v", err)
 	}
 	t.Setenv("PATH", dir)
+	useNabPath(t, filepath.Join(dir, "nab"))
 
 	count := func(rec *noticeRecorder) int {
 		n := 0

--- a/internal/cookies/browser.go
+++ b/internal/cookies/browser.go
@@ -334,6 +334,7 @@ func extractViaNab(ctx context.Context, browser, domain string) (string, error) 
 	cmd, _, cancel := safeexec.Command(ctx, nabCookieTimeout,
 		nabPath, "cookies", "export", domain, "--cookies", browser)
 	defer cancel()
+	trvlnab.ForbidKeychainInteraction(cmd)
 
 	out, err := safeexec.Output(cmd)
 	if err != nil {

--- a/internal/cookies/browser.go
+++ b/internal/cookies/browser.go
@@ -37,6 +37,7 @@ const nabCookieBudget = 6 * time.Second
 
 var (
 	browserAuthNow   = time.Now
+	lookupNabPath    = trvlnab.LookupPath
 	browserAuthStart = func(name string, args ...string) error {
 		// #nosec G204 -- production callers select fixed browser launcher names;
 		// the variable signature exists solely as a test seam and never uses a shell.
@@ -322,7 +323,7 @@ func extractViaNab(ctx context.Context, browser, domain string) (string, error) 
 		return "", nil
 	}
 
-	nabPath, err := trvlnab.LookupPath()
+	nabPath, err := lookupNabPath()
 	if err != nil {
 		return "", fmt.Errorf("%w: %w", errNabUnavailable, err)
 	}

--- a/internal/cookies/browser_bounded_test.go
+++ b/internal/cookies/browser_bounded_test.go
@@ -21,6 +21,7 @@ func writeFakeNab(t *testing.T, body string) (dir string) {
 		t.Fatalf("write fake nab: %v", err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	useNabPath(t, filepath.Join(dir, "nab"))
 	resetCookieCache()
 	return dir
 }

--- a/internal/cookies/browser_test.go
+++ b/internal/cookies/browser_test.go
@@ -3,7 +3,6 @@ package cookies
 import (
 	"errors"
 	"net/http"
-	"os/exec"
 	"testing"
 	"time"
 )
@@ -111,10 +110,7 @@ func TestIsCaptchaResponse(t *testing.T) {
 }
 
 func TestBrowserCookiesEmpty(t *testing.T) {
-	// When nab is not in PATH, BrowserCookies must return empty string without panicking.
-	if _, err := exec.LookPath("nab"); err == nil {
-		t.Skip("nab is installed; skipping no-nab path test")
-	}
+	// Package tests default the nab lookup seam to unavailable.
 	got := BrowserCookies("example.com")
 	if got != "" {
 		t.Errorf("BrowserCookies without nab = %q, want empty", got)
@@ -156,9 +152,6 @@ func TestApplyCookies(t *testing.T) {
 	})
 
 	t.Run("ApplyCookies no-op when nab absent", func(t *testing.T) {
-		if _, err := exec.LookPath("nab"); err == nil {
-			t.Skip("nab is installed; result depends on live browser cookies")
-		}
 		req, err := http.NewRequest(http.MethodGet, "https://example.com/", nil)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/cookies/nab_seam_test.go
+++ b/internal/cookies/nab_seam_test.go
@@ -35,6 +35,7 @@ func TestExtractViaNabRefusesWhenDeclined(t *testing.T) {
 		t.Fatalf("writing the fake nab: %v", err)
 	}
 	t.Setenv("PATH", dir)
+	useNabPath(t, filepath.Join(dir, "nab"))
 
 	ran := func() bool {
 		_, err := os.Stat(marker)
@@ -78,6 +79,7 @@ printf '%s\n' '.example.com	TRUE	/	TRUE	0	session	controlled'
 		t.Fatalf("writing fake nab: %v", err)
 	}
 	t.Setenv("PATH", dir)
+	useNabPath(t, filepath.Join(dir, "nab"))
 
 	got, err := extractViaNab(context.Background(), "brave", "example.com")
 	if err != nil {

--- a/internal/cookies/nab_seam_test.go
+++ b/internal/cookies/nab_seam_test.go
@@ -62,3 +62,28 @@ func TestExtractViaNabRefusesWhenDeclined(t *testing.T) {
 		t.Fatal("nab was not started without a decline; the gate refuses more than it should")
 	}
 }
+
+func TestExtractViaNabForbidsKeychainInteractionInChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the fake nab is a shell script")
+	}
+	t.Setenv(DisableEnv, "")
+	t.Setenv("NAB_KEYCHAIN_INTERACTION", "allow")
+	dir := t.TempDir()
+	script := `#!/bin/sh
+[ "$NAB_KEYCHAIN_INTERACTION" = "never" ] || exit 31
+printf '%s\n' '.example.com	TRUE	/	TRUE	0	session	controlled'
+`
+	if err := os.WriteFile(filepath.Join(dir, "nab"), []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fake nab: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	got, err := extractViaNab(context.Background(), "brave", "example.com")
+	if err != nil {
+		t.Fatalf("extractViaNab: %v", err)
+	}
+	if got != "session=controlled" {
+		t.Fatalf("cookie header = %q, want session=controlled", got)
+	}
+}

--- a/internal/cookies/nab_signal_test.go
+++ b/internal/cookies/nab_signal_test.go
@@ -53,6 +53,7 @@ func captureWarnings(t *testing.T) func() []string {
 func hideNab(t *testing.T) {
 	t.Helper()
 	t.Setenv("PATH", t.TempDir())
+	hideNabAtLookupSeam(t)
 	resetCookieCache()
 }
 
@@ -186,6 +187,7 @@ func TestExtractViaNab_DistinguishesItsOutcomes(t *testing.T) {
 			t.Fatalf("write fake nab: %v", err)
 		}
 		t.Setenv("PATH", dir)
+		useNabPath(t, filepath.Join(dir, "nab"))
 		resetCookieCache()
 
 		got, err := extractViaNab(context.Background(), "brave", testDomain)

--- a/internal/cookies/testmain_test.go
+++ b/internal/cookies/testmain_test.go
@@ -1,0 +1,73 @@
+package cookies
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestMain removes developer-installed nab executables from the package test
+// process's PATH. Tests that exercise the helper contract put their own
+// controlled fake first; every other test must remain offline and must never
+// reach a real browser cookie store or macOS Keychain.
+func TestMain(m *testing.M) {
+	originalPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", pathWithoutNab(originalPath)); err != nil {
+		_, _ = os.Stderr.WriteString("internal/cookies: isolate nab from PATH: " + err.Error() + "\n")
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	_ = os.Setenv("PATH", originalPath)
+	os.Exit(code)
+}
+
+// pathWithoutNab preserves normal system tools while removing any PATH entry
+// that could resolve the real nab helper. This is safer than replacing PATH
+// with an empty directory because several controlled fake-helper tests use
+// shell utilities such as sleep.
+func pathWithoutNab(pathValue string) string {
+	entries := filepath.SplitList(pathValue)
+	kept := entries[:0]
+	for _, entry := range entries {
+		if entry == "" || !directoryContainsNab(entry) {
+			kept = append(kept, entry)
+		}
+	}
+	return strings.Join(kept, string(os.PathListSeparator))
+}
+
+func directoryContainsNab(dir string) bool {
+	candidates := []string{"nab"}
+	if runtime.GOOS == "windows" {
+		candidates = append(candidates, "nab.exe", "nab.com", "nab.bat", "nab.cmd")
+	}
+	for _, name := range candidates {
+		if info, err := os.Stat(filepath.Join(dir, name)); err == nil && !info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPathWithoutNabRemovesHelperDirectoryAndPreservesSystemTools(t *testing.T) {
+	withNab := t.TempDir()
+	withoutNab := t.TempDir()
+	name := "nab"
+	if runtime.GOOS == "windows" {
+		name = "nab.exe"
+	}
+	if err := os.WriteFile(filepath.Join(withNab, name), []byte("controlled test helper"), 0o600); err != nil {
+		t.Fatalf("write controlled nab marker: %v", err)
+	}
+
+	got := filepath.SplitList(pathWithoutNab(strings.Join(
+		[]string{withoutNab, withNab},
+		string(os.PathListSeparator),
+	)))
+	if len(got) != 1 || got[0] != withoutNab {
+		t.Fatalf("sanitized PATH entries = %q, want only %q", got, withoutNab)
+	}
+}

--- a/internal/cookies/testmain_test.go
+++ b/internal/cookies/testmain_test.go
@@ -1,73 +1,43 @@
 package cookies
 
 import (
+	"errors"
 	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
+	"os/exec"
 	"testing"
 )
 
-// TestMain removes developer-installed nab executables from the package test
-// process's PATH. Tests that exercise the helper contract put their own
-// controlled fake first; every other test must remain offline and must never
-// reach a real browser cookie store or macOS Keychain.
+var originalTestProcessPATH = os.Getenv("PATH")
+
+// TestMain keeps the package offline by default without changing PATH. A
+// developer-installed nab may share its directory with unrelated tools, so
+// removing that directory would make otherwise-valid tests environment
+// dependent. Tests that exercise the helper contract opt into their exact fake
+// executable with useNabPath.
 func TestMain(m *testing.M) {
-	originalPath := os.Getenv("PATH")
-	if err := os.Setenv("PATH", pathWithoutNab(originalPath)); err != nil {
-		_, _ = os.Stderr.WriteString("internal/cookies: isolate nab from PATH: " + err.Error() + "\n")
-		os.Exit(1)
-	}
-
-	code := m.Run()
-	_ = os.Setenv("PATH", originalPath)
-	os.Exit(code)
+	lookupNabPath = func() (string, error) { return "", exec.ErrNotFound }
+	os.Exit(m.Run())
 }
 
-// pathWithoutNab preserves normal system tools while removing any PATH entry
-// that could resolve the real nab helper. This is safer than replacing PATH
-// with an empty directory because several controlled fake-helper tests use
-// shell utilities such as sleep.
-func pathWithoutNab(pathValue string) string {
-	entries := filepath.SplitList(pathValue)
-	kept := entries[:0]
-	for _, entry := range entries {
-		if entry == "" || !directoryContainsNab(entry) {
-			kept = append(kept, entry)
-		}
-	}
-	return strings.Join(kept, string(os.PathListSeparator))
+func useNabPath(t *testing.T, path string) {
+	t.Helper()
+	previous := lookupNabPath
+	lookupNabPath = func() (string, error) { return path, nil }
+	t.Cleanup(func() { lookupNabPath = previous })
 }
 
-func directoryContainsNab(dir string) bool {
-	candidates := []string{"nab"}
-	if runtime.GOOS == "windows" {
-		candidates = append(candidates, "nab.exe", "nab.com", "nab.bat", "nab.cmd")
-	}
-	for _, name := range candidates {
-		if info, err := os.Stat(filepath.Join(dir, name)); err == nil && !info.IsDir() {
-			return true
-		}
-	}
-	return false
+func hideNabAtLookupSeam(t *testing.T) {
+	t.Helper()
+	previous := lookupNabPath
+	lookupNabPath = func() (string, error) { return "", errors.New("controlled nab lookup failure") }
+	t.Cleanup(func() { lookupNabPath = previous })
 }
 
-func TestPathWithoutNabRemovesHelperDirectoryAndPreservesSystemTools(t *testing.T) {
-	withNab := t.TempDir()
-	withoutNab := t.TempDir()
-	name := "nab"
-	if runtime.GOOS == "windows" {
-		name = "nab.exe"
+func TestPackageIsolationPreservesPATH(t *testing.T) {
+	if originalTestProcessPATH == "" {
+		t.Skip("PATH is empty in this test environment")
 	}
-	if err := os.WriteFile(filepath.Join(withNab, name), []byte("controlled test helper"), 0o600); err != nil {
-		t.Fatalf("write controlled nab marker: %v", err)
-	}
-
-	got := filepath.SplitList(pathWithoutNab(strings.Join(
-		[]string{withoutNab, withNab},
-		string(os.PathListSeparator),
-	)))
-	if len(got) != 1 || got[0] != withoutNab {
-		t.Fatalf("sanitized PATH entries = %q, want only %q", got, withoutNab)
+	if got := os.Getenv("PATH"); got != originalTestProcessPATH {
+		t.Fatalf("package isolation changed PATH from %q to %q", originalTestProcessPATH, got)
 	}
 }

--- a/internal/ground/ground_cov5_test.go
+++ b/internal/ground/ground_cov5_test.go
@@ -457,18 +457,11 @@ func TestSearchSNCF_403_NoBrowserFallback_v2(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestSearchTrainline_403_WithBrowserFallbackAllowed(t *testing.T) {
-	// When allowBrowserFallbacks=true and 403, it tries multiple fallbacks.
-	// Since nab/curl/browser aren't available, eventually returns 403 error.
-	origDo := trainlineDo
-	origLimiter := trainlineLimiter
-	origTier1Cookies := trainlineTier1Cookies
-	t.Cleanup(func() {
-		trainlineDo = origDo
-		trainlineLimiter = origLimiter
-		trainlineTier1Cookies = origTier1Cookies
-	})
-	trainlineLimiter = rate.NewLimiter(rate.Limit(1000), 1)
-	trainlineTier1Cookies = func(string) []*http.Cookie { return nil }
+	// When allowBrowserFallbacks=true and 403, it tries every fallback.
+	// Stub the complete escalation chain: availability of nab, curl, browser
+	// profiles, or Keychain access on the developer machine must not change this
+	// deterministic test or trigger external UI.
+	resetTrainlineSeams(t)
 
 	callCount := 0
 	trainlineDo = func(req *http.Request) (*http.Response, error) {

--- a/internal/nab/client.go
+++ b/internal/nab/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -25,6 +26,8 @@ import (
 func BrowserCookiesDeclined() bool { return consent.CookiesDeclined() }
 
 var ErrNotAvailable = errors.New("nab not available")
+
+const keychainInteractionEnv = "NAB_KEYCHAIN_INTERACTION"
 
 var (
 	lookPath       = exec.LookPath
@@ -45,6 +48,29 @@ type FetchOptions struct {
 type fetchResponse struct {
 	Status   int    `json:"status"`
 	Markdown string `json:"markdown"`
+}
+
+// ForbidKeychainInteraction configures a background nab child so supported nab
+// versions cannot open macOS Keychain authorization UI. Existing values are
+// replaced rather than duplicated; older nab versions ignore the variable and
+// keep their existing CLI compatibility.
+func ForbidKeychainInteraction(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	environ := cmd.Env
+	if environ == nil {
+		environ = os.Environ()
+	}
+	filtered := make([]string, 0, len(environ)+1)
+	for _, entry := range environ {
+		name, _, _ := strings.Cut(entry, "=")
+		if strings.EqualFold(name, keychainInteractionEnv) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	cmd.Env = append(filtered, keychainInteractionEnv+"=never")
 }
 
 func LookupPath() (string, error) {
@@ -125,6 +151,7 @@ func (c *Client) Fetch(ctx context.Context, rawURL string, opts FetchOptions) ([
 	}
 
 	cmd := commandContext(ctx, c.path, args...)
+	ForbidKeychainInteraction(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError

--- a/internal/nab/client_test.go
+++ b/internal/nab/client_test.go
@@ -133,6 +133,41 @@ printf '%s' '{"status":200,"markdown":"non-interactive"}'
 	}
 }
 
+func TestForbidKeychainInteractionReplacesValuesWithoutChangingOtherEnvironment(t *testing.T) {
+	cmd := exec.Command("controlled-nab")
+	cmd.Env = []string{
+		"KEEP=value",
+		"NAB_KEYCHAIN_INTERACTION=allow",
+		"nab_keychain_interaction=on",
+		"ALSO_KEEP=another",
+	}
+
+	ForbidKeychainInteraction(cmd)
+
+	var policyValues []string
+	for _, entry := range cmd.Env {
+		name, value, _ := strings.Cut(entry, "=")
+		if strings.EqualFold(name, keychainInteractionEnv) {
+			policyValues = append(policyValues, value)
+		}
+	}
+	if len(policyValues) != 1 || policyValues[0] != "never" {
+		t.Fatalf("keychain policy values = %q, want exactly [never]", policyValues)
+	}
+	if !containsString(cmd.Env, "KEEP=value") || !containsString(cmd.Env, "ALSO_KEEP=another") {
+		t.Fatalf("unrelated environment was changed: %q", cmd.Env)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 func writeMockNab(t *testing.T, script string) string {
 	t.Helper()
 

--- a/internal/nab/client_test.go
+++ b/internal/nab/client_test.go
@@ -115,6 +115,24 @@ printf '%s' '{"status":200,"markdown":"{\"ok\":true}"}'
 	}
 }
 
+func TestClientFetchForbidsKeychainInteractionInChild(t *testing.T) {
+	skipOnWindows(t)
+	t.Setenv("NAB_KEYCHAIN_INTERACTION", "allow")
+	script := writeMockNab(t, `#!/bin/sh
+[ "$NAB_KEYCHAIN_INTERACTION" = "never" ] || { echo "keychain interaction was not disabled" >&2; exit 31; }
+printf '%s' '{"status":200,"markdown":"non-interactive"}'
+`)
+
+	client := &Client{path: script}
+	body, err := client.Fetch(context.Background(), "https://example.com", FetchOptions{})
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if got := string(body); got != "non-interactive" {
+		t.Fatalf("body = %q, want non-interactive", got)
+	}
+}
+
 func writeMockNab(t *testing.T, script string) string {
 	t.Helper()
 


### PR DESCRIPTION
Closes #611.

## What changed

- Remove any developer-installed `nab` executable from the cookie package test process PATH while preserving ordinary system tools and test-controlled helpers.
- Stub the complete Trainline escalation chain in its 403 fallback test so local helper availability cannot change test behavior.
- Set `NAB_KEYCHAIN_INTERACTION=never` on every Trvl-launched Nab fetch or cookie-export child, replacing any inherited value.
- Add child-process tests proving the non-interactive environment reaches both Nab invocation paths.

## Root cause and impact

Default tests inherited the developer PATH and could invoke the installed Nab binary. A single cookie-package run reached it 17 times, while the broader suite also reached Trainline's Nab escalation path. On macOS those short-lived test callers could trigger repeated Keychain authorization dialogs.

The tests are now hermetic, and production/background Nab calls opt into the non-interactive contract introduced by MikkoParkkola/nab#257. Older Nab versions safely ignore the environment variable.

## Validation

- RED: guarded `go test ./internal/cookies` recorded 17 Nab invocations before isolation.
- RED: the Trainline fallback test reached cookie export and fetch helpers before all seams were reset.
- `GOTOOLCHAIN=go1.26.5 go test -race -count=1 ./internal/nab ./internal/cookies ./internal/ground`
- `make dod` with a failing Nab sentinel first in PATH: passed, with `sentinel_invocations=0`.
- `git diff --check`
