### PR TITLE
fix: enforce destination integrity across rental providers

### DIFF
--- a/internal/hotels/anyplace.go
+++ b/internal/hotels/anyplace.go
@@ -265,6 +265,9 @@ func anyplaceGet(ctx context.Context, url, accept string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if err := validateDestinationResponseURL(req.URL, resp.Request.URL); err != nil {
+		return nil, fmt.Errorf("destination scope: %w", err)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
 	}

--- a/internal/hotels/anyplace.go
+++ b/internal/hotels/anyplace.go
@@ -265,7 +265,7 @@ func anyplaceGet(ctx context.Context, url, accept string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if err := validateDestinationResponseURL(req.URL, resp.Request.URL); err != nil {
+	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
 		return nil, fmt.Errorf("destination scope: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/internal/hotels/anyplace.go
+++ b/internal/hotels/anyplace.go
@@ -265,11 +265,11 @@ func anyplaceGet(ctx context.Context, url, accept string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
-		return nil, fmt.Errorf("destination scope: %w", err)
-	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
+	}
+	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
+		return nil, err
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20)) // 8 MiB cap
 	if err != nil {

--- a/internal/hotels/blueground.go
+++ b/internal/hotels/blueground.go
@@ -43,6 +43,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"sync"
@@ -268,13 +269,60 @@ func bluegroundGet(ctx context.Context, url string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if err := validateDestinationResponseURL(req.URL, resp.Request.URL); err != nil {
+	if err := validateBluegroundDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
 		return nil, fmt.Errorf("destination scope: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
 	}
 	return io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+}
+
+func validateBluegroundDestinationResponseURL(requested, effective *url.URL) error {
+	if err := validateDestinationResponseURL(requested, effective); err == nil {
+		return nil
+	} else if requested == nil || effective == nil {
+		return err
+	}
+
+	requestedCity, requestedCountry, requestedOK := splitBluegroundDestinationPath(requested.Path)
+	effectiveCity, effectiveCountry, effectiveOK := splitBluegroundDestinationPath(effective.Path)
+	if !requestedOK || !effectiveOK || requestedCity != effectiveCity || requestedCountry != effectiveCountry {
+		return validateDestinationResponseURL(requested, effective)
+	}
+
+	canonical := *requested
+	canonical.Path = effective.Path
+	return validateDestinationResponseURL(&canonical, effective)
+}
+
+func splitBluegroundDestinationPath(rawPath string) (city, country string, ok bool) {
+	const prefix = "/furnished-apartments-"
+	slug := strings.TrimSuffix(rawPath, "/")
+	slug, found := strings.CutPrefix(slug, prefix)
+	if !found || slug == "" {
+		return "", "", false
+	}
+
+	bestToken := ""
+	bestCountry := ""
+	for name, iso := range bluegroundCountryISO2 {
+		for _, token := range []string{bluegroundToken(name), iso} {
+			if len(token) <= len(bestToken) || !strings.HasSuffix(slug, "-"+token) {
+				continue
+			}
+			bestToken = token
+			bestCountry = iso
+		}
+	}
+	if bestToken == "" {
+		return "", "", false
+	}
+	city = strings.TrimSuffix(slug, "-"+bestToken)
+	if city == "" {
+		return "", "", false
+	}
+	return city, bestCountry, true
 }
 
 // parseBluegroundList extracts properties from the list page __INITIAL_STATE__.

--- a/internal/hotels/blueground.go
+++ b/internal/hotels/blueground.go
@@ -270,11 +270,11 @@ func bluegroundGet(ctx context.Context, url string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if err := validateBluegroundDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
-		return nil, fmt.Errorf("destination scope: %w", err)
-	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
+	}
+	if err := validateBluegroundDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
+		return nil, err
 	}
 	return io.ReadAll(io.LimitReader(resp.Body, 16<<20))
 }

--- a/internal/hotels/blueground.go
+++ b/internal/hotels/blueground.go
@@ -176,10 +176,11 @@ func SearchBlueground(ctx context.Context, location string, opts HotelSearchOpti
 
 // bluegroundCountryISO2 maps full country names (the trailing token of a
 // "City, Country" location) to the ISO 3166-1 alpha-2 code Blueground now uses
-// in its listing slugs. As of 2026-06 the live pattern is
-// "furnished-apartments-{city}-{iso2}" (e.g. "...-paris-fr"); the older
-// full-country form ("...-paris-france") 404s. Covers Blueground's served
-// markets; unmapped countries fall through to the verbatim token.
+// in its requested listing slugs. Blueground may canonicalize that URL to a
+// full-country path (for example, athens-gr to athens-greece); the response URL
+// validator accepts only aliases that preserve both the exact city and country.
+// Covers Blueground's served markets; unmapped countries fall through to the
+// verbatim token.
 var bluegroundCountryISO2 = map[string]string{
 	"usa": "us", "united states": "us", "united states of america": "us",
 	"uk": "gb", "united kingdom": "gb", "england": "gb",

--- a/internal/hotels/blueground.go
+++ b/internal/hotels/blueground.go
@@ -268,6 +268,9 @@ func bluegroundGet(ctx context.Context, url string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if err := validateDestinationResponseURL(req.URL, resp.Request.URL); err != nil {
+		return nil, fmt.Errorf("destination scope: %w", err)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
 	}

--- a/internal/hotels/hometogo.go
+++ b/internal/hotels/hometogo.go
@@ -221,7 +221,7 @@ func hometogoGet(ctx context.Context, url, accept string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if err := validateDestinationResponseURL(req.URL, resp.Request.URL); err != nil {
+	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
 		return nil, fmt.Errorf("destination scope: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/internal/hotels/hometogo.go
+++ b/internal/hotels/hometogo.go
@@ -221,6 +221,9 @@ func hometogoGet(ctx context.Context, url, accept string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if err := validateDestinationResponseURL(req.URL, resp.Request.URL); err != nil {
+		return nil, fmt.Errorf("destination scope: %w", err)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
 	}

--- a/internal/hotels/hometogo.go
+++ b/internal/hotels/hometogo.go
@@ -221,11 +221,11 @@ func hometogoGet(ctx context.Context, url, accept string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
-		return nil, fmt.Errorf("destination scope: %w", err)
-	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
+	}
+	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
+		return nil, err
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20)) // 8 MiB cap
 	if err != nil {

--- a/internal/hotels/housinganywhere.go
+++ b/internal/hotels/housinganywhere.go
@@ -310,17 +310,44 @@ func haIndexForSort(sort string) string {
 // the Algolia city facet, e.g. "Berlin, Germany" -> "Berlin", "  Paris " ->
 // "Paris".
 func haCityFromLocation(location string) string {
-	city := location
-	if i := strings.IndexAny(location, ",-"); i >= 0 {
-		city = location[:i]
+	city, _ := haDestinationFromLocation(location)
+	return city
+}
+
+func haDestinationFromLocation(location string) (city, country string) {
+	parts := strings.Split(location, ",")
+	city = strings.TrimSpace(parts[0])
+	if len(parts) > 1 {
+		country = strings.TrimSpace(parts[len(parts)-1])
 	}
-	return strings.TrimSpace(city)
+	return city, country
 }
 
 func haHitMatchesRequestedCity(hitCity, requestedCity string) bool {
 	hitCity = strings.TrimSpace(hitCity)
 	requestedCity = strings.TrimSpace(requestedCity)
 	return hitCity != "" && requestedCity != "" && strings.EqualFold(hitCity, requestedCity)
+}
+
+func haHitMatchesRequestedDestination(hitCity, hitCountry, requestedCity, requestedCountry string) bool {
+	if !haHitMatchesRequestedCity(hitCity, requestedCity) {
+		return false
+	}
+	if strings.TrimSpace(requestedCountry) == "" {
+		return true
+	}
+	return haCountryMatchKey(hitCountry) != "" && haCountryMatchKey(hitCountry) == haCountryMatchKey(requestedCountry)
+}
+
+func haCountryMatchKey(country string) string {
+	country = strings.ToLower(strings.TrimSpace(country))
+	if iso, ok := bluegroundCountryISO2[country]; ok {
+		return iso
+	}
+	if len(country) == 2 {
+		return country
+	}
+	return bluegroundToken(country)
 }
 
 // buildAlgoliaParams assembles the URL-encoded Algolia params string: empty
@@ -443,7 +470,7 @@ func SearchHousingAnywhere(ctx context.Context, location string, opts HotelSearc
 		return nil, fmt.Errorf("housinganywhere: location is required")
 	}
 
-	city := haCityFromLocation(location)
+	city, country := haDestinationFromLocation(location)
 	index := haIndexForSort(opts.Sort)
 	hitsPerPage := 20
 	params := buildAlgoliaParams(city, hitsPerPage, 0, opts.MinPrice, opts.MaxPrice)
@@ -464,7 +491,7 @@ func SearchHousingAnywhere(ctx context.Context, location string, opts HotelSearc
 	currency := strings.TrimSpace(opts.Currency)
 	results := make([]models.HotelResult, 0, len(res.Hits))
 	for _, h := range res.Hits {
-		if !haHitMatchesRequestedCity(h.City, city) {
+		if !haHitMatchesRequestedDestination(h.City, h.Country, city, country) {
 			continue
 		}
 		if mapped, ok := mapHAHit(h, currency); ok {

--- a/internal/hotels/housinganywhere.go
+++ b/internal/hotels/housinganywhere.go
@@ -317,6 +317,12 @@ func haCityFromLocation(location string) string {
 	return strings.TrimSpace(city)
 }
 
+func haHitMatchesRequestedCity(hitCity, requestedCity string) bool {
+	hitCity = strings.TrimSpace(hitCity)
+	requestedCity = strings.TrimSpace(requestedCity)
+	return hitCity != "" && requestedCity != "" && strings.EqualFold(hitCity, requestedCity)
+}
+
 // buildAlgoliaParams assembles the URL-encoded Algolia params string: empty
 // query, hitsPerPage/page, a city facet filter, and optional priceEUR numeric
 // bounds. priceEUR is whole EUR (not cents), so min/max map straight through.
@@ -458,6 +464,9 @@ func SearchHousingAnywhere(ctx context.Context, location string, opts HotelSearc
 	currency := strings.TrimSpace(opts.Currency)
 	results := make([]models.HotelResult, 0, len(res.Hits))
 	for _, h := range res.Hits {
+		if !haHitMatchesRequestedCity(h.City, city) {
+			continue
+		}
 		if mapped, ok := mapHAHit(h, currency); ok {
 			results = append(results, mapped)
 		}

--- a/internal/hotels/housinganywhere_test.go
+++ b/internal/hotels/housinganywhere_test.go
@@ -173,6 +173,28 @@ func TestHACityFromLocation(t *testing.T) {
 	}
 }
 
+func TestHAHitMatchesRequestedCity(t *testing.T) {
+	tests := []struct {
+		name      string
+		hitCity   string
+		requested string
+		want      bool
+	}{
+		{name: "exact", hitCity: "Berlin", requested: "Berlin", want: true},
+		{name: "case and whitespace", hitCity: " berlin ", requested: "Berlin", want: true},
+		{name: "sibling city", hitCity: "Potsdam", requested: "Berlin"},
+		{name: "lookalike", hitCity: "Berlinchen", requested: "Berlin"},
+		{name: "missing payload city", requested: "Berlin"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := haHitMatchesRequestedCity(tt.hitCity, tt.requested); got != tt.want {
+				t.Fatalf("haHitMatchesRequestedCity(%q, %q) = %v, want %v", tt.hitCity, tt.requested, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHAListingURL(t *testing.T) {
 	cases := map[string]string{
 		"":                              "",

--- a/internal/hotels/housinganywhere_test.go
+++ b/internal/hotels/housinganywhere_test.go
@@ -161,15 +161,51 @@ func TestHAIndexForSort(t *testing.T) {
 
 func TestHACityFromLocation(t *testing.T) {
 	cases := map[string]string{
-		"Berlin":          "Berlin",
-		"Berlin, Germany": "Berlin",
-		"  Paris ":        "Paris",
-		"Den Haag":        "Den Haag",
+		"Berlin":                  "Berlin",
+		"Berlin, Germany":         "Berlin",
+		"Aix-en-Provence, France": "Aix-en-Provence",
+		"  Paris ":                "Paris",
+		"Den Haag":                "Den Haag",
 	}
 	for in, want := range cases {
 		if got := haCityFromLocation(in); got != want {
 			t.Errorf("haCityFromLocation(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestHADestinationFromLocation(t *testing.T) {
+	for _, tt := range []struct {
+		location, city, country string
+	}{
+		{location: "Berlin, Germany", city: "Berlin", country: "Germany"},
+		{location: "Aix-en-Provence, France", city: "Aix-en-Provence", country: "France"},
+		{location: "Den Haag", city: "Den Haag"},
+	} {
+		city, country := haDestinationFromLocation(tt.location)
+		if city != tt.city || country != tt.country {
+			t.Fatalf("haDestinationFromLocation(%q) = (%q,%q), want (%q,%q)", tt.location, city, country, tt.city, tt.country)
+		}
+	}
+}
+
+func TestHAHitMatchesRequestedDestination(t *testing.T) {
+	for _, tt := range []struct {
+		name                               string
+		hitCity, hitCountry, city, country string
+		want                               bool
+	}{
+		{name: "exact", hitCity: "Berlin", hitCountry: "Germany", city: "Berlin", country: "Germany", want: true},
+		{name: "country alias", hitCity: "New York", hitCountry: "United States", city: "New York", country: "USA", want: true},
+		{name: "same city wrong country", hitCity: "Berlin", hitCountry: "United States", city: "Berlin", country: "Germany"},
+		{name: "missing payload country", hitCity: "Berlin", city: "Berlin", country: "Germany"},
+		{name: "country omitted by caller", hitCity: "Berlin", hitCountry: "Germany", city: "Berlin", want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := haHitMatchesRequestedDestination(tt.hitCity, tt.hitCountry, tt.city, tt.country); got != tt.want {
+				t.Fatalf("match = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -307,13 +343,14 @@ func TestSearchHousingAnywhereEndToEnd(t *testing.T) {
 
 	// Mock Algolia host: assert auth headers + body shape, return the fixture.
 	var gotAppID, gotAPIKey, gotBody string
+	algoliaBody := raw
 	algolia := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAppID = r.Header.Get("X-Algolia-Application-Id")
 		gotAPIKey = r.Header.Get("X-Algolia-API-Key")
 		b, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		gotBody = string(b)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(raw)
+		_, _ = w.Write(algoliaBody)
 	}))
 	defer algolia.Close()
 
@@ -353,6 +390,15 @@ func TestSearchHousingAnywhereEndToEnd(t *testing.T) {
 	}
 	if !strings.Contains(gotBody, "city%3ABerlin") {
 		t.Errorf("body missing Berlin city facet: %q", gotBody)
+	}
+
+	algoliaBody = []byte(`{"results":[{"hits":[{"objectID":"wrong-country","priceEUR":1200,"currency":"EUR","city":"Berlin","country":"United States","path":"/listing/wrong-country"}],"nbHits":1}]}`)
+	hotels, err = SearchHousingAnywhere(context.Background(), "Berlin, Germany", HotelSearchOptions{Currency: "EUR"})
+	if err != nil {
+		t.Fatalf("same-city wrong-country search: %v", err)
+	}
+	if len(hotels) != 0 {
+		t.Fatalf("same-city wrong-country payload returned %d results, want 0", len(hotels))
 	}
 
 	// Disabled -> nil, nil.

--- a/internal/hotels/landing.go
+++ b/internal/hotels/landing.go
@@ -43,6 +43,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -206,8 +207,8 @@ func resolveLandingBuild(ctx context.Context, slug string) (buildID, market stri
 	if slug == "" {
 		return "", "", fmt.Errorf("empty slug")
 	}
-	url := landingBaseURL + "/s/" + slug + "/apartments/furnished"
-	body, err := landingGet(ctx, url, "text/html,application/xhtml+xml")
+	rawURL := landingBaseURL + "/s/" + slug + "/apartments/furnished"
+	body, effectiveURL, err := landingGetWithEffectiveURL(ctx, rawURL, "text/html,application/xhtml+xml")
 	if err != nil {
 		return "", "", err
 	}
@@ -223,6 +224,20 @@ func resolveLandingBuild(ctx context.Context, slug string) (buildID, market stri
 	market = slug
 	if m := landingMarketRe.FindSubmatch(body); m != nil {
 		market = string(m[1])
+	}
+	if market != slug && !strings.HasPrefix(market, slug+"-") {
+		return "", "", fmt.Errorf("destination scope: canonical market %q does not match requested slug %q", market, slug)
+	}
+	canonicalURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", "", err
+	}
+	if err := validateDestinationResponseURL(canonicalURL, effectiveURL); err == nil {
+		return buildID, market, nil
+	}
+	canonicalURL.Path = "/s/" + market + "/apartments/furnished"
+	if err := validateDestinationResponseURL(canonicalURL, effectiveURL); err != nil {
+		return "", "", fmt.Errorf("landing destination scope: %w", err)
 	}
 	return buildID, market, nil
 }
@@ -262,29 +277,47 @@ func fetchLandingSearch(ctx context.Context, buildID, market string) (json.RawMe
 
 // landingGet performs a rate-limited GET with the desktop UA and returns the
 // response body. Non-2xx responses are errors.
-func landingGet(ctx context.Context, url, accept string) ([]byte, error) {
-	if err := landingLimiter.Wait(ctx); err != nil {
-		return nil, fmt.Errorf("rate limiter: %w", err)
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+func landingGet(ctx context.Context, rawURL, accept string) ([]byte, error) {
+	body, effectiveURL, err := landingGetWithEffectiveURL(ctx, rawURL, accept)
 	if err != nil {
 		return nil, err
+	}
+	requestedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateDestinationResponseURL(requestedURL, effectiveURL); err != nil {
+		return nil, fmt.Errorf("destination scope: %w", err)
+	}
+	return body, nil
+}
+
+func landingGetWithEffectiveURL(ctx context.Context, rawURL, accept string) ([]byte, *url.URL, error) {
+	if err := landingLimiter.Wait(ctx); err != nil {
+		return nil, nil, fmt.Errorf("rate limiter: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, nil, err
 	}
 	req.Header.Set("User-Agent", landingUserAgent)
 	req.Header.Set("Accept", accept)
 	resp, err := landingHTTPClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
+		return nil, nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, rawURL)
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20)) // 8 MiB cap
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return body, nil
+	if resp.Request == nil {
+		return body, nil, nil
+	}
+	return body, resp.Request.URL, nil
 }
 
 // parseLandingHomes maps a Landing _next/data search payload to HotelResults.

--- a/internal/hotels/landing.go
+++ b/internal/hotels/landing.go
@@ -303,7 +303,7 @@ func landingGet(ctx context.Context, rawURL, accept string) ([]byte, error) {
 		return nil, err
 	}
 	if err := validateDestinationResponseURL(requestedURL, effectiveURL); err != nil {
-		return nil, fmt.Errorf("destination scope: %w", err)
+		return nil, err
 	}
 	return body, nil
 }

--- a/internal/hotels/landing.go
+++ b/internal/hotels/landing.go
@@ -237,7 +237,7 @@ func resolveLandingBuild(ctx context.Context, slug string) (buildID, market stri
 	}
 	canonicalURL.Path = "/s/" + market + "/apartments/furnished"
 	if err := validateDestinationResponseURL(canonicalURL, effectiveURL); err != nil {
-		return "", "", fmt.Errorf("landing destination scope: %w", err)
+		return "", "", fmt.Errorf("landing: %w", err)
 	}
 	return buildID, market, nil
 }

--- a/internal/hotels/landing.go
+++ b/internal/hotels/landing.go
@@ -225,7 +225,7 @@ func resolveLandingBuild(ctx context.Context, slug string) (buildID, market stri
 	if m := landingMarketRe.FindSubmatch(body); m != nil {
 		market = string(m[1])
 	}
-	if market != slug && !strings.HasPrefix(market, slug+"-") {
+	if !landingCanonicalMarketMatches(slug, market) {
 		return "", "", fmt.Errorf("destination scope: canonical market %q does not match requested slug %q", market, slug)
 	}
 	canonicalURL, err := url.Parse(rawURL)
@@ -240,6 +240,22 @@ func resolveLandingBuild(ctx context.Context, slug string) (buildID, market stri
 		return "", "", fmt.Errorf("landing destination scope: %w", err)
 	}
 	return buildID, market, nil
+}
+
+func landingCanonicalMarketMatches(requested, canonical string) bool {
+	if canonical == requested {
+		return true
+	}
+	suffix, ok := strings.CutPrefix(canonical, requested+"-")
+	if !ok || len(suffix) != 2 {
+		return false
+	}
+	for _, r := range suffix {
+		if r < 'a' || r > 'z' {
+			return false
+		}
+	}
+	return true
 }
 
 // landingExtractBuildID pulls the buildId out of a city page, decoding the

--- a/internal/hotels/landing_test.go
+++ b/internal/hotels/landing_test.go
@@ -38,6 +38,7 @@ func TestResolveLandingBuildRejectsUnrelatedCanonicalDestination(t *testing.T) {
 	}{
 		{name: "exact", effectivePath: "/s/austin/apartments/furnished", market: "austin"},
 		{name: "canonical suffix", effectivePath: "/s/austin-tx/apartments/furnished", market: "austin-tx"},
+		{name: "unrecognized canonical suffix", effectivePath: "/s/austin-heights/apartments/furnished", market: "austin-heights", wantError: true},
 		{name: "generic parent", effectivePath: "/s", market: "austin", wantError: true},
 		{name: "sibling destination", effectivePath: "/s/dallas-tx/apartments/furnished", market: "dallas-tx", wantError: true},
 		{name: "lookalike prefix", effectivePath: "/s/austinite/apartments/furnished", market: "austinite", wantError: true},

--- a/internal/hotels/landing_test.go
+++ b/internal/hotels/landing_test.go
@@ -64,6 +64,9 @@ func TestResolveLandingBuildRejectsUnrelatedCanonicalDestination(t *testing.T) {
 				if err == nil {
 					t.Fatalf("accepted effective path %q with build=%q market=%q", tt.effectivePath, buildID, market)
 				}
+				if count := strings.Count(err.Error(), "destination scope:"); count != 1 {
+					t.Fatalf("destination scope prefix count = %d in %q, want 1", count, err)
+				}
 				return
 			}
 			if err != nil {

--- a/internal/hotels/landing_test.go
+++ b/internal/hotels/landing_test.go
@@ -3,6 +3,7 @@ package hotels
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/MikkoParkkola/trvl/internal/testutil"
+	"golang.org/x/time/rate"
 )
 
 // loadLandingFixture reads the saved Landing _next/data search payload.
@@ -20,6 +22,57 @@ func loadLandingFixture(t *testing.T) json.RawMessage {
 		t.Fatalf("read fixture: %v", err)
 	}
 	return json.RawMessage(b)
+}
+
+func TestResolveLandingBuildRejectsUnrelatedCanonicalDestination(t *testing.T) {
+	originalClient, originalLimiter := landingHTTPClient, landingLimiter
+	t.Cleanup(func() {
+		landingHTTPClient, landingLimiter = originalClient, originalLimiter
+	})
+
+	tests := []struct {
+		name          string
+		effectivePath string
+		market        string
+		wantError     bool
+	}{
+		{name: "exact", effectivePath: "/s/austin/apartments/furnished", market: "austin"},
+		{name: "canonical suffix", effectivePath: "/s/austin-tx/apartments/furnished", market: "austin-tx"},
+		{name: "generic parent", effectivePath: "/s", market: "austin", wantError: true},
+		{name: "sibling destination", effectivePath: "/s/dallas-tx/apartments/furnished", market: "dallas-tx", wantError: true},
+		{name: "lookalike prefix", effectivePath: "/s/austinite/apartments/furnished", market: "austinite", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			landingLimiter = rate.NewLimiter(rate.Inf, 1)
+			landingHTTPClient = &http.Client{Transport: destinationScopeRoundTripper(func(req *http.Request) (*http.Response, error) {
+				effective := *req.URL
+				effective.Path = tt.effectivePath
+				body := `<script id="__NEXT_DATA__" type="application/json">{"buildId":"build-123"}</script>` +
+					`{"market":"` + tt.market + `"}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Request:    &http.Request{URL: &effective},
+				}, nil
+			})}
+
+			buildID, market, err := resolveLandingBuild(context.Background(), "austin")
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("accepted effective path %q with build=%q market=%q", tt.effectivePath, buildID, market)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveLandingBuild: %v", err)
+			}
+			if buildID != "build-123" || market != tt.market {
+				t.Fatalf("got build=%q market=%q", buildID, market)
+			}
+		})
+	}
 }
 
 // TestParseLandingHomesFixture asserts the saved Austin search payload maps to

--- a/internal/hotels/provider_destination_contract_test.go
+++ b/internal/hotels/provider_destination_contract_test.go
@@ -33,12 +33,16 @@ func TestDestinationScopedProviderGettersRejectUnscopedResponses(t *testing.T) {
 	})
 
 	providers := []struct {
-		name string
-		get  func(context.Context, string) ([]byte, error)
-		set  func(*http.Client)
+		name      string
+		path      string
+		generic   string
+		sibling   string
+		lookalike string
+		get       func(context.Context, string) ([]byte, error)
+		set       func(*http.Client)
 	}{
 		{
-			name: "hometogo",
+			name: "hometogo", path: "/lisbon/", generic: "/", sibling: "/porto/", lookalike: "/lisbon-cheap/",
 			get: func(ctx context.Context, rawURL string) ([]byte, error) {
 				return hometogoGet(ctx, rawURL, "text/html")
 			},
@@ -48,7 +52,7 @@ func TestDestinationScopedProviderGettersRejectUnscopedResponses(t *testing.T) {
 			},
 		},
 		{
-			name: "uniplaces",
+			name: "uniplaces", path: "/accommodation/lisbon", generic: "/accommodation", sibling: "/accommodation/porto", lookalike: "/accommodation/lisbon-cheap",
 			get: func(ctx context.Context, rawURL string) ([]byte, error) {
 				return uniplacesGet(ctx, rawURL, "text/html")
 			},
@@ -58,31 +62,31 @@ func TestDestinationScopedProviderGettersRejectUnscopedResponses(t *testing.T) {
 			},
 		},
 		{
-			name: "wunderflats",
-			get:  wunderflatsGet,
+			name: "wunderflats", path: "/en/furnished-apartments/lisbon", generic: "/en/furnished-apartments", sibling: "/en/furnished-apartments/porto", lookalike: "/en/furnished-apartments/lisbon-cheap",
+			get: wunderflatsGet,
 			set: func(client *http.Client) {
 				wunderflatsHTTPClient = client
 				wunderflatsLimiter = rate.NewLimiter(rate.Inf, 1)
 			},
 		},
 		{
-			name: "spotahome",
-			get:  spotahomeGet,
+			name: "spotahome", path: "/s/lisbon/for-rent:apartments.data", generic: "/s", sibling: "/s/porto/for-rent:apartments.data", lookalike: "/s/lisbon-cheap/for-rent:apartments.data",
+			get: spotahomeGet,
 			set: func(client *http.Client) {
 				spotahomeClient = client
 				spotahomeLimiter = rate.NewLimiter(rate.Inf, 1)
 			},
 		},
 		{
-			name: "blueground",
-			get:  bluegroundGet,
+			name: "blueground", path: "/furnished-apartments-athens-gr", generic: "/", sibling: "/furnished-apartments-paris-fr", lookalike: "/furnished-apartments-athens-gr-cheap",
+			get: bluegroundGet,
 			set: func(client *http.Client) {
 				bluegroundClient = client
 				bluegroundLimiter = rate.NewLimiter(rate.Inf, 1)
 			},
 		},
 		{
-			name: "anyplace",
+			name: "anyplace", path: "/listings/lisbon", generic: "/listings", sibling: "/listings/porto", lookalike: "/listings/lisbon-cheap",
 			get: func(ctx context.Context, rawURL string) ([]byte, error) {
 				return anyplaceGet(ctx, rawURL, "text/html")
 			},
@@ -94,32 +98,43 @@ func TestDestinationScopedProviderGettersRejectUnscopedResponses(t *testing.T) {
 	}
 
 	scenarios := []struct {
-		name          string
-		effectivePath string
-		wantError     bool
-		missingURL    bool
+		name           string
+		path           func(providerPath, generic, sibling, lookalike string) string
+		wantError      bool
+		missingRequest bool
+		missingURL     bool
 	}{
-		{name: "exact", effectivePath: "/s/lisbon"},
-		{name: "trailing slash", effectivePath: "/s/lisbon/"},
-		{name: "query only", effectivePath: "/s/lisbon?campaign=summer"},
-		{name: "generic parent", effectivePath: "/s", wantError: true},
-		{name: "sibling destination", effectivePath: "/s/porto", wantError: true},
-		{name: "lookalike prefix", effectivePath: "/s/lisbon-cheap", wantError: true},
-		{name: "missing effective URL", wantError: true, missingURL: true},
+		{name: "exact", path: func(p, _, _, _ string) string { return p }},
+		{name: "trailing slash", path: func(p, _, _, _ string) string {
+			if strings.HasSuffix(p, "/") {
+				return strings.TrimSuffix(p, "/")
+			}
+			return p + "/"
+		}},
+		{name: "query only", path: func(p, _, _, _ string) string { return p + "?campaign=summer" }},
+		{name: "generic parent", path: func(_, generic, _, _ string) string { return generic }, wantError: true},
+		{name: "sibling destination", path: func(_, _, sibling, _ string) string { return sibling }, wantError: true},
+		{name: "lookalike prefix", path: func(_, _, _, lookalike string) string { return lookalike }, wantError: true},
+		{name: "missing response request", path: func(p, _, _, _ string) string { return p }, wantError: true, missingRequest: true},
+		{name: "missing effective URL", path: func(p, _, _, _ string) string { return p }, wantError: true, missingURL: true},
 	}
 
 	for _, provider := range providers {
 		for _, scenario := range scenarios {
 			t.Run(provider.name+"/"+scenario.name, func(t *testing.T) {
+				effectivePath := scenario.path(provider.path, provider.generic, provider.sibling, provider.lookalike)
 				client := &http.Client{Transport: destinationScopeRoundTripper(func(req *http.Request) (*http.Response, error) {
 					effective := *req.URL
-					parts := strings.SplitN(scenario.effectivePath, "?", 2)
+					parts := strings.SplitN(effectivePath, "?", 2)
 					effective.Path = parts[0]
 					effective.RawQuery = ""
 					if len(parts) == 2 {
 						effective.RawQuery = parts[1]
 					}
 					effectiveRequest := &http.Request{URL: &effective}
+					if scenario.missingRequest {
+						effectiveRequest = nil
+					}
 					if scenario.missingURL {
 						effectiveRequest.URL = nil
 					}
@@ -131,15 +146,15 @@ func TestDestinationScopedProviderGettersRejectUnscopedResponses(t *testing.T) {
 				})}
 				provider.set(client)
 
-				body, err := provider.get(context.Background(), "https://provider.example/s/lisbon")
+				body, err := provider.get(context.Background(), "https://provider.example"+provider.path)
 				if scenario.wantError {
 					if err == nil {
-						t.Fatalf("accepted %q response body %q", scenario.effectivePath, body)
+						t.Fatalf("accepted %q response body %q", effectivePath, body)
 					}
 					return
 				}
 				if err != nil {
-					t.Fatalf("rejected safe effective path %q: %v", scenario.effectivePath, err)
+					t.Fatalf("rejected safe effective path %q: %v", effectivePath, err)
 				}
 				if string(body) != "destination inventory" {
 					t.Fatalf("body = %q", body)

--- a/internal/hotels/provider_destination_contract_test.go
+++ b/internal/hotels/provider_destination_contract_test.go
@@ -23,6 +23,7 @@ func TestDestinationScopedProviderGettersRejectUnscopedResponses(t *testing.T) {
 	originalSpotahomeClient, originalSpotahomeLimiter := spotahomeClient, spotahomeLimiter
 	originalBluegroundClient, originalBluegroundLimiter := bluegroundClient, bluegroundLimiter
 	originalAnyplaceClient, originalAnyplaceLimiter := anyplaceHTTPClient, anyplaceLimiter
+	originalLandingClient, originalLandingLimiter := landingHTTPClient, landingLimiter
 	t.Cleanup(func() {
 		hometogoHTTPClient, hometogoLimiter = originalHomeToGoClient, originalHomeToGoLimiter
 		uniplacesHTTPClient, uniplacesLimiter = originalUniplacesClient, originalUniplacesLimiter
@@ -30,6 +31,7 @@ func TestDestinationScopedProviderGettersRejectUnscopedResponses(t *testing.T) {
 		spotahomeClient, spotahomeLimiter = originalSpotahomeClient, originalSpotahomeLimiter
 		bluegroundClient, bluegroundLimiter = originalBluegroundClient, originalBluegroundLimiter
 		anyplaceHTTPClient, anyplaceLimiter = originalAnyplaceClient, originalAnyplaceLimiter
+		landingHTTPClient, landingLimiter = originalLandingClient, originalLandingLimiter
 	})
 
 	providers := []struct {
@@ -95,12 +97,24 @@ func TestDestinationScopedProviderGettersRejectUnscopedResponses(t *testing.T) {
 				anyplaceLimiter = rate.NewLimiter(rate.Inf, 1)
 			},
 		},
+		{
+			name: "landing", path: "/s/austin/apartments/furnished", generic: "/s", sibling: "/s/dallas/apartments/furnished", lookalike: "/s/austinite/apartments/furnished",
+			get: func(ctx context.Context, rawURL string) ([]byte, error) {
+				return landingGet(ctx, rawURL, "text/html")
+			},
+			set: func(client *http.Client) {
+				landingHTTPClient = client
+				landingLimiter = rate.NewLimiter(rate.Inf, 1)
+			},
+		},
 	}
 
 	scenarios := []struct {
 		name           string
 		path           func(providerPath, generic, sibling, lookalike string) string
 		wantError      bool
+		wantErrorText  string
+		statusCode     int
 		missingRequest bool
 		missingURL     bool
 	}{
@@ -112,11 +126,12 @@ func TestDestinationScopedProviderGettersRejectUnscopedResponses(t *testing.T) {
 			return p + "/"
 		}},
 		{name: "query only", path: func(p, _, _, _ string) string { return p + "?campaign=summer" }},
-		{name: "generic parent", path: func(_, generic, _, _ string) string { return generic }, wantError: true},
-		{name: "sibling destination", path: func(_, _, sibling, _ string) string { return sibling }, wantError: true},
-		{name: "lookalike prefix", path: func(_, _, _, lookalike string) string { return lookalike }, wantError: true},
-		{name: "missing response request", path: func(p, _, _, _ string) string { return p }, wantError: true, missingRequest: true},
-		{name: "missing effective URL", path: func(p, _, _, _ string) string { return p }, wantError: true, missingURL: true},
+		{name: "generic parent", path: func(_, generic, _, _ string) string { return generic }, wantError: true, wantErrorText: "destination scope:"},
+		{name: "sibling destination", path: func(_, _, sibling, _ string) string { return sibling }, wantError: true, wantErrorText: "destination scope:"},
+		{name: "lookalike prefix", path: func(_, _, _, lookalike string) string { return lookalike }, wantError: true, wantErrorText: "destination scope:"},
+		{name: "missing response request", path: func(p, _, _, _ string) string { return p }, wantError: true, wantErrorText: "destination scope:", missingRequest: true},
+		{name: "missing effective URL", path: func(p, _, _, _ string) string { return p }, wantError: true, wantErrorText: "destination scope:", missingURL: true},
+		{name: "non-2xx status takes precedence", path: func(_, _, sibling, _ string) string { return sibling }, wantError: true, wantErrorText: "unexpected status 502", statusCode: http.StatusBadGateway},
 	}
 
 	for _, provider := range providers {
@@ -138,8 +153,12 @@ func TestDestinationScopedProviderGettersRejectUnscopedResponses(t *testing.T) {
 					if scenario.missingURL {
 						effectiveRequest.URL = nil
 					}
+					statusCode := scenario.statusCode
+					if statusCode == 0 {
+						statusCode = http.StatusOK
+					}
 					return &http.Response{
-						StatusCode: http.StatusOK,
+						StatusCode: statusCode,
 						Body:       io.NopCloser(strings.NewReader("destination inventory")),
 						Request:    effectiveRequest,
 					}, nil
@@ -150,6 +169,12 @@ func TestDestinationScopedProviderGettersRejectUnscopedResponses(t *testing.T) {
 				if scenario.wantError {
 					if err == nil {
 						t.Fatalf("accepted %q response body %q", effectivePath, body)
+					}
+					if !strings.Contains(err.Error(), scenario.wantErrorText) {
+						t.Fatalf("error = %q, want text %q", err, scenario.wantErrorText)
+					}
+					if strings.Count(err.Error(), "destination scope:") > 1 {
+						t.Fatalf("destination scope prefix duplicated in %q", err)
 					}
 					return
 				}

--- a/internal/hotels/provider_destination_contract_test.go
+++ b/internal/hotels/provider_destination_contract_test.go
@@ -1,0 +1,150 @@
+package hotels
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"golang.org/x/time/rate"
+)
+
+type destinationScopeRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f destinationScopeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestDestinationScopedProviderGettersRejectUnscopedResponses(t *testing.T) {
+	originalHomeToGoClient, originalHomeToGoLimiter := hometogoHTTPClient, hometogoLimiter
+	originalUniplacesClient, originalUniplacesLimiter := uniplacesHTTPClient, uniplacesLimiter
+	originalWunderflatsClient, originalWunderflatsLimiter := wunderflatsHTTPClient, wunderflatsLimiter
+	originalSpotahomeClient, originalSpotahomeLimiter := spotahomeClient, spotahomeLimiter
+	originalBluegroundClient, originalBluegroundLimiter := bluegroundClient, bluegroundLimiter
+	originalAnyplaceClient, originalAnyplaceLimiter := anyplaceHTTPClient, anyplaceLimiter
+	t.Cleanup(func() {
+		hometogoHTTPClient, hometogoLimiter = originalHomeToGoClient, originalHomeToGoLimiter
+		uniplacesHTTPClient, uniplacesLimiter = originalUniplacesClient, originalUniplacesLimiter
+		wunderflatsHTTPClient, wunderflatsLimiter = originalWunderflatsClient, originalWunderflatsLimiter
+		spotahomeClient, spotahomeLimiter = originalSpotahomeClient, originalSpotahomeLimiter
+		bluegroundClient, bluegroundLimiter = originalBluegroundClient, originalBluegroundLimiter
+		anyplaceHTTPClient, anyplaceLimiter = originalAnyplaceClient, originalAnyplaceLimiter
+	})
+
+	providers := []struct {
+		name string
+		get  func(context.Context, string) ([]byte, error)
+		set  func(*http.Client)
+	}{
+		{
+			name: "hometogo",
+			get: func(ctx context.Context, rawURL string) ([]byte, error) {
+				return hometogoGet(ctx, rawURL, "text/html")
+			},
+			set: func(client *http.Client) {
+				hometogoHTTPClient = client
+				hometogoLimiter = rate.NewLimiter(rate.Inf, 1)
+			},
+		},
+		{
+			name: "uniplaces",
+			get: func(ctx context.Context, rawURL string) ([]byte, error) {
+				return uniplacesGet(ctx, rawURL, "text/html")
+			},
+			set: func(client *http.Client) {
+				uniplacesHTTPClient = client
+				uniplacesLimiter = rate.NewLimiter(rate.Inf, 1)
+			},
+		},
+		{
+			name: "wunderflats",
+			get:  wunderflatsGet,
+			set: func(client *http.Client) {
+				wunderflatsHTTPClient = client
+				wunderflatsLimiter = rate.NewLimiter(rate.Inf, 1)
+			},
+		},
+		{
+			name: "spotahome",
+			get:  spotahomeGet,
+			set: func(client *http.Client) {
+				spotahomeClient = client
+				spotahomeLimiter = rate.NewLimiter(rate.Inf, 1)
+			},
+		},
+		{
+			name: "blueground",
+			get:  bluegroundGet,
+			set: func(client *http.Client) {
+				bluegroundClient = client
+				bluegroundLimiter = rate.NewLimiter(rate.Inf, 1)
+			},
+		},
+		{
+			name: "anyplace",
+			get: func(ctx context.Context, rawURL string) ([]byte, error) {
+				return anyplaceGet(ctx, rawURL, "text/html")
+			},
+			set: func(client *http.Client) {
+				anyplaceHTTPClient = client
+				anyplaceLimiter = rate.NewLimiter(rate.Inf, 1)
+			},
+		},
+	}
+
+	scenarios := []struct {
+		name          string
+		effectivePath string
+		wantError     bool
+		missingURL    bool
+	}{
+		{name: "exact", effectivePath: "/s/lisbon"},
+		{name: "trailing slash", effectivePath: "/s/lisbon/"},
+		{name: "query only", effectivePath: "/s/lisbon?campaign=summer"},
+		{name: "generic parent", effectivePath: "/s", wantError: true},
+		{name: "sibling destination", effectivePath: "/s/porto", wantError: true},
+		{name: "lookalike prefix", effectivePath: "/s/lisbon-cheap", wantError: true},
+		{name: "missing effective URL", wantError: true, missingURL: true},
+	}
+
+	for _, provider := range providers {
+		for _, scenario := range scenarios {
+			t.Run(provider.name+"/"+scenario.name, func(t *testing.T) {
+				client := &http.Client{Transport: destinationScopeRoundTripper(func(req *http.Request) (*http.Response, error) {
+					effective := *req.URL
+					parts := strings.SplitN(scenario.effectivePath, "?", 2)
+					effective.Path = parts[0]
+					effective.RawQuery = ""
+					if len(parts) == 2 {
+						effective.RawQuery = parts[1]
+					}
+					effectiveRequest := &http.Request{URL: &effective}
+					if scenario.missingURL {
+						effectiveRequest.URL = nil
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader("destination inventory")),
+						Request:    effectiveRequest,
+					}, nil
+				})}
+				provider.set(client)
+
+				body, err := provider.get(context.Background(), "https://provider.example/s/lisbon")
+				if scenario.wantError {
+					if err == nil {
+						t.Fatalf("accepted %q response body %q", scenario.effectivePath, body)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("rejected safe effective path %q: %v", scenario.effectivePath, err)
+				}
+				if string(body) != "destination inventory" {
+					t.Fatalf("body = %q", body)
+				}
+			})
+		}
+	}
+}

--- a/internal/hotels/provider_destination_scope.go
+++ b/internal/hotels/provider_destination_scope.go
@@ -26,6 +26,11 @@ func validateDestinationResponseURL(requested, effective *url.URL) error {
 	if effective == nil {
 		return fmt.Errorf("destination scope: effective URL is missing")
 	}
+	sameScheme := strings.EqualFold(requested.Scheme, effective.Scheme)
+	safeUpgrade := strings.EqualFold(requested.Scheme, "http") && strings.EqualFold(effective.Scheme, "https")
+	if !sameScheme && !safeUpgrade {
+		return fmt.Errorf("destination scope: response scheme %q is not a safe continuation of requested scheme %q", effective.Scheme, requested.Scheme)
+	}
 	if !strings.EqualFold(requested.Hostname(), effective.Hostname()) {
 		return fmt.Errorf("destination scope: response hostname %q differs from requested hostname %q", effective.Hostname(), requested.Hostname())
 	}

--- a/internal/hotels/provider_destination_scope.go
+++ b/internal/hotels/provider_destination_scope.go
@@ -2,10 +2,18 @@ package hotels
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"path"
 	"strings"
 )
+
+func effectiveResponseURL(resp *http.Response) *url.URL {
+	if resp == nil || resp.Request == nil {
+		return nil
+	}
+	return resp.Request.URL
+}
 
 // validateDestinationResponseURL fails closed when a destination-scoped HTTP
 // request is redirected to a generic page, another destination, or another

--- a/internal/hotels/provider_destination_scope_test.go
+++ b/internal/hotels/provider_destination_scope_test.go
@@ -103,3 +103,32 @@ func TestValidateDestinationResponseURL(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateBluegroundDestinationResponseURL(t *testing.T) {
+	parse := func(raw string) *url.URL {
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return u
+	}
+	requested := parse("https://www.theblueground.com/furnished-apartments-athens-gr")
+	for _, tt := range []struct {
+		name      string
+		effective string
+		wantErr   bool
+	}{
+		{name: "exact ISO path", effective: "https://www.theblueground.com/furnished-apartments-athens-gr"},
+		{name: "canonical country name", effective: "https://www.theblueground.com/furnished-apartments-athens-greece"},
+		{name: "different city", effective: "https://www.theblueground.com/furnished-apartments-paris-greece", wantErr: true},
+		{name: "different country", effective: "https://www.theblueground.com/furnished-apartments-athens-portugal", wantErr: true},
+		{name: "lookalike suffix", effective: "https://www.theblueground.com/furnished-apartments-athens-greece-cheap", wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBluegroundDestinationResponseURL(requested, parse(tt.effective))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/hotels/provider_destination_scope_test.go
+++ b/internal/hotels/provider_destination_scope_test.go
@@ -42,6 +42,29 @@ func TestValidateDestinationResponseURL(t *testing.T) {
 			effective: parse("https://www.flatio.com/s/Lisbon"),
 		},
 		{
+			name:      "scheme upgrade with explicit defaults",
+			requested: parse("http://www.flatio.com:80/s/Lisbon"),
+			effective: parse("https://www.flatio.com:443/s/Lisbon"),
+		},
+		{
+			name:      "https downgrade",
+			requested: parse("https://www.flatio.com/s/Lisbon"),
+			effective: parse("http://www.flatio.com/s/Lisbon"),
+			wantErr:   true,
+		},
+		{
+			name:      "https downgrade with explicit defaults",
+			requested: parse("https://www.flatio.com:443/s/Lisbon"),
+			effective: parse("http://www.flatio.com:80/s/Lisbon"),
+			wantErr:   true,
+		},
+		{
+			name:      "unrelated scheme",
+			requested: parse("https://www.flatio.com/s/Lisbon"),
+			effective: parse("ftp://www.flatio.com/s/Lisbon"),
+			wantErr:   true,
+		},
+		{
 			name:      "explicit default port",
 			requested: parse("https://www.flatio.com:443/s/Lisbon"),
 			effective: parse("https://www.flatio.com/s/Lisbon"),

--- a/internal/hotels/providers_cf_trio_test.go
+++ b/internal/hotels/providers_cf_trio_test.go
@@ -210,11 +210,16 @@ func TestSearchBlueground_MockServer(t *testing.T) {
 	detailBody, _ := os.ReadFile("testdata/blueground_detail_ath327.html")
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		if strings.HasPrefix(r.URL.Path, "/p/") {
+		switch {
+		case r.URL.Path == "/furnished-apartments-athens-gr":
+			http.Redirect(w, r, "/furnished-apartments-athens-greece", http.StatusMovedPermanently)
+		case r.URL.Path == "/furnished-apartments-athens-greece":
+			_, _ = w.Write(listBody)
+		case strings.HasPrefix(r.URL.Path, "/p/"):
 			_, _ = w.Write(detailBody)
-			return
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
 		}
-		_, _ = w.Write(listBody)
 	}))
 	defer ts.Close()
 	prevEnabled, prevURL, prevClient := bluegroundEnabled, bluegroundBaseURL, bluegroundClient

--- a/internal/hotels/spotahome.go
+++ b/internal/hotels/spotahome.go
@@ -184,7 +184,7 @@ func spotahomeGet(ctx context.Context, url string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if err := validateDestinationResponseURL(req.URL, resp.Request.URL); err != nil {
+	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
 		return nil, fmt.Errorf("destination scope: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/internal/hotels/spotahome.go
+++ b/internal/hotels/spotahome.go
@@ -184,6 +184,9 @@ func spotahomeGet(ctx context.Context, url string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if err := validateDestinationResponseURL(req.URL, resp.Request.URL); err != nil {
+		return nil, fmt.Errorf("destination scope: %w", err)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
 	}

--- a/internal/hotels/spotahome.go
+++ b/internal/hotels/spotahome.go
@@ -184,11 +184,11 @@ func spotahomeGet(ctx context.Context, url string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
-		return nil, fmt.Errorf("destination scope: %w", err)
-	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
+	}
+	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
+		return nil, err
 	}
 	return io.ReadAll(io.LimitReader(resp.Body, 16<<20)) // 16 MiB cap
 }

--- a/internal/hotels/uniplaces.go
+++ b/internal/hotels/uniplaces.go
@@ -235,7 +235,7 @@ func uniplacesGet(ctx context.Context, url, accept string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if err := validateDestinationResponseURL(req.URL, resp.Request.URL); err != nil {
+	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
 		return nil, fmt.Errorf("destination scope: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/internal/hotels/uniplaces.go
+++ b/internal/hotels/uniplaces.go
@@ -235,6 +235,9 @@ func uniplacesGet(ctx context.Context, url, accept string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if err := validateDestinationResponseURL(req.URL, resp.Request.URL); err != nil {
+		return nil, fmt.Errorf("destination scope: %w", err)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
 	}

--- a/internal/hotels/uniplaces.go
+++ b/internal/hotels/uniplaces.go
@@ -235,11 +235,11 @@ func uniplacesGet(ctx context.Context, url, accept string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
-		return nil, fmt.Errorf("destination scope: %w", err)
-	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
+	}
+	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
+		return nil, err
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20)) // 8 MiB cap
 	if err != nil {

--- a/internal/hotels/wunderflats.go
+++ b/internal/hotels/wunderflats.go
@@ -230,6 +230,9 @@ func wunderflatsGet(ctx context.Context, url string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if err := validateDestinationResponseURL(req.URL, resp.Request.URL); err != nil {
+		return nil, fmt.Errorf("destination scope: %w", err)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
 	}

--- a/internal/hotels/wunderflats.go
+++ b/internal/hotels/wunderflats.go
@@ -230,7 +230,7 @@ func wunderflatsGet(ctx context.Context, url string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if err := validateDestinationResponseURL(req.URL, resp.Request.URL); err != nil {
+	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
 		return nil, fmt.Errorf("destination scope: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/internal/hotels/wunderflats.go
+++ b/internal/hotels/wunderflats.go
@@ -230,11 +230,11 @@ func wunderflatsGet(ctx context.Context, url string) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
-		return nil, fmt.Errorf("destination scope: %w", err)
-	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
+	}
+	if err := validateDestinationResponseURL(req.URL, effectiveResponseURL(resp)); err != nil {
+		return nil, err
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20)) // 16 MiB cap
 	if err != nil {


### PR DESCRIPTION
Closes #612.

## What changed

- Enforce effective-destination URL scope for HomeToGo, Uniplaces, Wunderflats, Spotahome, Blueground, and Anyplace.
- Exercise each provider's real route shape across exact, trailing-slash, query-only, generic-parent, sibling, lookalike, missing-request, and missing-URL responses.
- Accept Blueground's verified ISO-country to full-country canonical redirect only when both city and normalized country remain exact.
- Preserve Landing's austin to austin-tx canonicalization while rejecting arbitrary suffixes such as austin-heights.
- Preserve hyphenated HousingAnywhere cities and validate both city and requested country on every Algolia hit.

## Root cause and impact

Roberto's Flatio report exposed a broader acquisition pattern: destination-scoped providers follow redirects, but several discarded resp.Request.URL and trusted the returned body. A provider replacing a missing destination with generic or nearby-city inventory could therefore be mislabeled as a successful destination hit. Nil response metadata could also panic six getters.

The guards now fail closed before parsing inventory, while retaining provider-specific canonical redirects that are proven to preserve the exact destination.

## Validation

- RED: all six sibling getters accepted generic-parent, sibling-city, and lookalike bodies before the guards.
- RED: the current branch rejected Blueground's legitimate /furnished-apartments-athens-gr to /furnished-apartments-athens-greece redirect.
- RED: Landing accepted austin-heights; HousingAnywhere truncated Aix-en-Provence and did not reject same-city/wrong-country payloads.
- Focused provider/category and end-to-end tests: passed.
- After rebasing onto merged #613, focused destination validators passed 25 repeated race-enabled runs.
- Copilot's seven review comments were addressed in 30386b3: non-2xx HTTP status errors now take precedence, and destination-scope errors carry one prefix. The seven-provider contract test failed before the fix, then passed 25 race-enabled repetitions and the full hotel package.
- A final independent review found the same duplicated prefix in Landing's higher-level resolver; 2f01a47 adds resolver-level coverage and preserves exactly one scope prefix. Re-review approved with no remaining findings.
- GOTOOLCHAIN=go1.26.5 go test -count=1 ./internal/hotels: passed in 82.220s.
- GOTOOLCHAIN=go1.26.5 go test -race -count=1 ./internal/hotels: passed in 84.865s.
- Formal make dod after the rebase: passed, including release checks, vet, lint, staticcheck, govulncheck, gosec, and the full repository test suite.
- Formal make dod was rerun after the review fix and passed again.
- Formal make dod was rerun after the final Landing fix and passed a third time.
- Formal DoD ran with a failing Nab sentinel first on PATH: zero Nab invocations.
- GitNexus change detection: MEDIUM aggregate scope, limited to expected provider code and Blueground flows.
- git diff --check: passed.
