### PR TITLE
release: prepare v1.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.3] - 2026-08-11
+
+### Fixed
+
+- Rental-provider results are now accepted only when the provider's effective
+  response URL and page metadata still match the requested destination. The
+  shared guard covers HomeToGo, Uniplaces, Wunderflats, Spotahome, Blueground,
+  Anyplace, Landing, and HousingAnywhere, including redirects, generic landing
+  pages, sibling cities, and lookalike names. ([#612](https://github.com/MikkoParkkola/trvl/issues/612))
+- Flatio fallback results now fail closed when the returned page is for a
+  different destination instead of presenting a global or unrelated listing
+  pool as local inventory. ([#609](https://github.com/MikkoParkkola/trvl/issues/609))
+- Background Nab fetches explicitly disable prompt-capable Keychain access, and
+  automated tests isolate ambient Nab binaries, preventing unattended hotel
+  searches and the formal test suite from displaying repeated macOS password
+  dialogs. ([#611](https://github.com/MikkoParkkola/trvl/issues/611))
+
 ## [1.21.2] - 2026-08-10
 
 ### Fixed
@@ -1181,7 +1198,8 @@ Trust & Discoverability release. The gaps surfaced by @RobertoReale's "Budget Tr
 - Single static binary, zero runtime dependencies
 - MIT license
 
-[Unreleased]: https://github.com/MikkoParkkola/trvl/compare/v1.21.2...HEAD
+[Unreleased]: https://github.com/MikkoParkkola/trvl/compare/v1.21.3...HEAD
+[1.21.3]: https://github.com/MikkoParkkola/trvl/compare/v1.21.2...v1.21.3
 [1.21.2]: https://github.com/MikkoParkkola/trvl/compare/v1.21.1...v1.21.2
 [1.21.1]: https://github.com/MikkoParkkola/trvl/compare/v1.21.0...v1.21.1
 [1.21.0]: https://github.com/MikkoParkkola/trvl/compare/v1.20.0...v1.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rental-provider results are now accepted only when the provider's effective
   response URL and page metadata still match the requested destination. The
   shared guard covers HomeToGo, Uniplaces, Wunderflats, Spotahome, Blueground,
-  Anyplace, Landing, and HousingAnywhere, including redirects, generic landing
-  pages, sibling cities, and lookalike names. ([#612](https://github.com/MikkoParkkola/trvl/issues/612))
+  Anyplace, and Landing, including redirects, generic landing pages, sibling
+  cities, and lookalike names. HousingAnywhere applies the same fail-closed
+  destination rule to its Algolia payload hits. ([#612](https://github.com/MikkoParkkola/trvl/issues/612))
 - Flatio fallback results now fail closed when the returned page is for a
   different destination instead of presenting a global or unrelated listing
   pool as local inventory. ([#609](https://github.com/MikkoParkkola/trvl/issues/609))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ trvl is a travel MCP server + CLI that gives any AI assistant (Claude, Cursor, W
 - Flight providers: the default path merges Google Flights, Kiwi, and Skiplagged. Solo or opt-in integrations cover Ryanair, Wizz Air, Air France–KLM, Transavia, easyJet, Vueling, and Norwegian; protected or credentialed paths return typed setup/block statuses when unavailable. Travelpayouts/Aviasales price signals are opt-in through `trvl pricetrends` and are not part of the bookable merge.
 - Enrichment (free, unauthenticated): weather (Open-Meteo), air quality (`trvl air`), sun times (`trvl sun`, sunrise-sunset.org), bike-share (`trvl bikes`, CityBikes)
 - CI: build, vet, and race tests on Ubuntu and Windows; staticcheck, golangci-lint, govulncheck, and the >=80% coverage gate run on Ubuntu
-- Current release: v1.21.0, published 2026-08-08 from `main` to GitHub Releases, Homebrew, npm, GHCR, the Go module proxy, and the official MCP Registry.
-- v1.21.0 carries source-backed hotel cancellation/refundability evidence, browser privacy opt-outs, source-only optional provider definitions, bounded transactional watch storage, private-proxy support, and warning-free release automation.
+- Current release: v1.21.3, published 2026-08-11 from `main` to GitHub Releases, Homebrew, npm, GHCR, the Go module proxy, and the official MCP Registry.
+- v1.21.3 carries rental-provider destination-integrity guards, fail-closed Flatio fallback results, and noninteractive background Nab cookie access.
 
 ## Plan Forward (near-term, technical)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,8 @@ Living roadmap. Sequenced by ROI and dependency, not by wishlist size. Each item
 
 ## Shipped
 
-- **v1.21.0** (2026-08-08): current release line. Added source-backed cancellation and refundability evidence, an offer-specific booking-readiness ceiling, browser-cookie and headless-browser opt-outs, source-only optional provider definitions, bounded transactional price-watch storage, private-proxy handling, and release/security hardening. See [CHANGELOG.md](CHANGELOG.md) and the [GitHub release](https://github.com/MikkoParkkola/trvl/releases/tag/v1.21.0).
+- **v1.21.3** (2026-08-11): current release line. Fixed destination-integrity failures across rental providers, made Flatio fallback results fail closed on unrelated inventory, and disabled prompt-capable Keychain access for background Nab fetches. See [CHANGELOG.md](CHANGELOG.md) and the [GitHub release](https://github.com/MikkoParkkola/trvl/releases/tag/v1.21.3).
+- **v1.21.0** (2026-08-08): added source-backed cancellation and refundability evidence, an offer-specific booking-readiness ceiling, browser-cookie and headless-browser opt-outs, source-only optional provider definitions, bounded transactional price-watch storage, private-proxy handling, and release/security hardening.
 - **v1.18.0** (2026-06-28): booking-readiness verdict from composed trust signals, per-package weather/holidays/events enrichment with typed status, native Google round-trip flight queries, and a privacy-preserving daily active-user heartbeat.
 - **v1.10 — Trust & Discoverability** (shipped, v1.10.0 2026-06-14): the batch surfaced by @RobertoReale's "Budget Travel Pipeline" blog. All five items landed and their issues are closed:
   - #167 (P1) — docs surfacing `find_trip_window`, multi-pax, verified accommodation.

--- a/cmd/trvl/docs_freshness_test.go
+++ b/cmd/trvl/docs_freshness_test.go
@@ -48,10 +48,10 @@ func TestReleaseFacingDocsStayAligned(t *testing.T) {
 			"no personal keys for default search",
 		},
 		"ROADMAP.md": {
-			"v1.21.0** (2026-08-08): current release line",
+			"v1.21.3** (2026-08-11): current release line",
 		},
 		"CHANGELOG.md": {
-			"## [1.21.0] - 2026-08-08",
+			"## [1.21.3] - 2026-08-11",
 		},
 	}
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl-mcp",
   "mcpName": "io.github.MikkoParkkola/trvl",
-  "version": "1.21.2",
+  "version": "1.21.3",
   "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as legacy-compatible capabilities.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
   "description": "Door-to-door travel MCP + CLI: flights, hotels, trains, cars, ferries. No API keys, Go binary.",
-  "version": "1.21.2",
+  "version": "1.21.3",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",
     "source": "github"
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mikkoparkkola/trvl:1.21.2",
+      "identifier": "ghcr.io/mikkoparkkola/trvl:1.21.3",
       "transport": {
         "type": "stdio"
       }
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "identifier": "trvl-mcp",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "version": "1.21.2",
+      "version": "1.21.3",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Release v1.21.3

This patch release contains the destination-integrity fixes and the non-interactive Nab integration needed to validate Roberto's reported cases safely.

### Included

- #609: Flatio fallback destination scoping
- #611: prompt-free background Nab use and ambient-binary test isolation
- #612: shared destination integrity enforcement across rental providers

### Metadata

- add the `1.21.3` changelog entry and comparison link
- update `server.json` OCI/npm metadata to `1.21.3`
- update `npm/package.json` to `1.21.3`

### Validation

- `scripts/ci/check-release-metadata.sh`
- `make dod`
  - GoReleaser configuration and Homebrew formula tests
  - workflow, language, file-size, release, HOME-isolation, URL-redaction, and test-helper hygiene
  - `go vet`, `golangci-lint`, `staticcheck`, and `govulncheck`
  - gosec gates for Darwin, Linux, and Windows with zero HIGH/MEDIUM findings
  - full `go test ./...`
- fresh fail-closed Nab sentinel recorded zero invocations during `make dod`

The release tag will be created only after this PR and post-merge CI pass. Roberto's exact Ischia and Reykjavik cases will then be run against the downloaded official release artifact before any response is sent.
