### PR TITLE
fix: return partial hotel results at auxiliary deadline

### DIFF
--- a/internal/hotels/aux_collector.go
+++ b/internal/hotels/aux_collector.go
@@ -1,0 +1,73 @@
+package hotels
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+// hotelAuxTask is one independently bounded auxiliary-provider search. Its run
+// function returns owned slices: workers never mutate state retained by the
+// caller after the auxiliary budget expires.
+type hotelAuxTask struct {
+	id   string
+	name string
+	run  func(context.Context) hotelAuxOutcome
+}
+
+type hotelAuxOutcome struct {
+	results  []models.HotelResult
+	statuses []models.ProviderStatus
+}
+
+type indexedHotelAuxOutcome struct {
+	index   int
+	outcome hotelAuxOutcome
+}
+
+// collectHotelAuxTasks returns one outcome per task, in declaration order. A
+// buffered channel lets a non-cooperative worker finish after this function
+// returns without blocking or writing into the caller's result state.
+func collectHotelAuxTasks(ctx context.Context, timeout time.Duration, tasks []hotelAuxTask) []hotelAuxOutcome {
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	auxCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	outcomeCh := make(chan indexedHotelAuxOutcome, len(tasks))
+	for index, task := range tasks {
+		go func() {
+			outcomeCh <- indexedHotelAuxOutcome{index: index, outcome: task.run(auxCtx)}
+		}()
+	}
+
+	outcomes := make([]hotelAuxOutcome, len(tasks))
+	completed := make([]bool, len(tasks))
+	remaining := len(tasks)
+	for remaining > 0 {
+		select {
+		case received := <-outcomeCh:
+			if completed[received.index] {
+				continue
+			}
+			outcomes[received.index] = received.outcome
+			completed[received.index] = true
+			remaining--
+		case <-auxCtx.Done():
+			for index, task := range tasks {
+				if completed[index] {
+					continue
+				}
+				outcomes[index].statuses = []models.ProviderStatus{
+					hotelProviderStatusFromError(task.id, task.name, fmt.Errorf("auxiliary provider budget exceeded: %w", auxCtx.Err())),
+				}
+			}
+			return outcomes
+		}
+	}
+	return outcomes
+}

--- a/internal/hotels/aux_collector.go
+++ b/internal/hotels/aux_collector.go
@@ -12,19 +12,41 @@ import (
 // function returns owned slices: workers never mutate state retained by the
 // caller after the auxiliary budget expires.
 type hotelAuxTask struct {
-	id   string
-	name string
-	run  func(context.Context) hotelAuxOutcome
+	id        string
+	name      string
+	breakerID string
+	run       func(context.Context) hotelAuxOutcome
 }
 
+type hotelAuxBreakerAction uint8
+
+const (
+	hotelAuxBreakerNone hotelAuxBreakerAction = iota
+	hotelAuxBreakerSuccess
+	hotelAuxBreakerFailure
+)
+
 type hotelAuxOutcome struct {
-	results  []models.HotelResult
-	statuses []models.ProviderStatus
+	results       []models.HotelResult
+	statuses      []models.ProviderStatus
+	breakerAction hotelAuxBreakerAction
 }
 
 type indexedHotelAuxOutcome struct {
 	index   int
 	outcome hotelAuxOutcome
+}
+
+func applyHotelAuxBreakerOutcome(task hotelAuxTask, outcome hotelAuxOutcome) {
+	if task.breakerID == "" {
+		return
+	}
+	switch outcome.breakerAction {
+	case hotelAuxBreakerSuccess:
+		hotelBreaker.RecordSuccess(task.breakerID)
+	case hotelAuxBreakerFailure:
+		hotelBreaker.RecordFailure(task.breakerID)
+	}
 }
 
 // collectHotelAuxTasks returns one outcome per task, in declaration order. A
@@ -64,6 +86,9 @@ func collectHotelAuxTasks(ctx context.Context, timeout time.Duration, tasks []ho
 				}
 				outcomes[index].statuses = []models.ProviderStatus{
 					hotelProviderStatusFromError(task.id, task.name, fmt.Errorf("auxiliary provider budget exceeded: %w", auxCtx.Err())),
+				}
+				if task.breakerID != "" {
+					outcomes[index].breakerAction = hotelAuxBreakerFailure
 				}
 			}
 			return outcomes

--- a/internal/hotels/aux_timeout_test.go
+++ b/internal/hotels/aux_timeout_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/breaker"
 	"github.com/MikkoParkkola/trvl/internal/models"
 )
 
@@ -13,11 +14,14 @@ func TestSearchHotels_ReturnsPartialResultsWhenAuxProviderIgnoresCancellation(t 
 	origFetch := fetchHotelPageFullFn
 	origBooking := SearchBooking
 	origTimeout := hotelAuxProviderTimeout
+	origBreaker := hotelBreaker
 	t.Cleanup(func() {
 		fetchHotelPageFullFn = origFetch
 		SearchBooking = origBooking
 		hotelAuxProviderTimeout = origTimeout
+		hotelBreaker = origBreaker
 	})
+	hotelBreaker = breaker.NewWithConfig(1, time.Minute)
 
 	fetchHotelPageFullFn = func(_ context.Context, _ *batchexec.Client, _ string, _ HotelSearchOptions, _ int, _ string) (parseResult, error) {
 		return parseResult{Hotels: []models.HotelResult{{
@@ -63,9 +67,13 @@ func TestSearchHotels_ReturnsPartialResultsWhenAuxProviderIgnoresCancellation(t 
 		<-slowProviderReturned
 		t.Fatal("SearchHotels still waited for an auxiliary provider after its budget")
 	}
+	bookingBreakerTrippedBeforeLateReturn := hotelBreaker.Tripped("booking")
 	close(releaseSlowProvider)
 	<-slowProviderReturned
 	result, err := response.result, response.err
+	if !bookingBreakerTrippedBeforeLateReturn {
+		t.Fatal("booking breaker was not tripped when the collector synthesized its timeout")
+	}
 
 	if err != nil {
 		t.Fatalf("SearchHotels returned an error despite a completed primary result: %v", err)

--- a/internal/hotels/aux_timeout_test.go
+++ b/internal/hotels/aux_timeout_test.go
@@ -1,0 +1,89 @@
+package hotels
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MikkoParkkola/trvl/internal/batchexec"
+	"github.com/MikkoParkkola/trvl/internal/models"
+)
+
+func TestSearchHotels_ReturnsPartialResultsWhenAuxProviderIgnoresCancellation(t *testing.T) {
+	origFetch := fetchHotelPageFullFn
+	origBooking := SearchBooking
+	origTimeout := hotelAuxProviderTimeout
+	t.Cleanup(func() {
+		fetchHotelPageFullFn = origFetch
+		SearchBooking = origBooking
+		hotelAuxProviderTimeout = origTimeout
+	})
+
+	fetchHotelPageFullFn = func(_ context.Context, _ *batchexec.Client, _ string, _ HotelSearchOptions, _ int, _ string) (parseResult, error) {
+		return parseResult{Hotels: []models.HotelResult{{
+			Name:     "Fast Ischia Hotel",
+			Price:    120,
+			Currency: "EUR",
+		}}}, nil
+	}
+
+	releaseSlowProvider := make(chan struct{})
+	slowProviderReturned := make(chan struct{})
+	SearchBooking = func(_ context.Context, _ string, _ HotelSearchOptions) ([]models.HotelResult, error) {
+		defer close(slowProviderReturned)
+		<-releaseSlowProvider // deliberately ignores cancellation
+		return []models.HotelResult{{Name: "Late Hotel", Price: 90, Currency: "EUR"}}, nil
+	}
+	hotelAuxProviderTimeout = 40 * time.Millisecond
+
+	type searchResponse struct {
+		result *models.HotelSearchResult
+		err    error
+	}
+	responseCh := make(chan searchResponse, 1)
+	go func() {
+		result, err := SearchHotels(context.Background(), "Ischia timeout regression", HotelSearchOptions{
+			CheckIn:   "2026-09-03",
+			CheckOut:  "2026-09-08",
+			Currency:  "EUR",
+			MaxPages:  1,
+			CenterLat: 40.73,
+			CenterLon: 13.96,
+		})
+		responseCh <- searchResponse{result: result, err: err}
+	}()
+
+	var response searchResponse
+	select {
+	case response = <-responseCh:
+		// The bounded collector returned while the deliberately non-cooperative
+		// provider was still blocked.
+	case <-time.After(5 * time.Second):
+		close(releaseSlowProvider)
+		<-slowProviderReturned
+		t.Fatal("SearchHotels still waited for an auxiliary provider after its budget")
+	}
+	close(releaseSlowProvider)
+	<-slowProviderReturned
+	result, err := response.result, response.err
+
+	if err != nil {
+		t.Fatalf("SearchHotels returned an error despite a completed primary result: %v", err)
+	}
+	if len(result.Hotels) != 1 || result.Hotels[0].Name != "Fast Ischia Hotel" {
+		t.Fatalf("hotels = %+v, want only the completed primary result", result.Hotels)
+	}
+	var bookingStatus *models.ProviderStatus
+	for i := range result.ProviderStatuses {
+		if result.ProviderStatuses[i].ID == "booking" {
+			bookingStatus = &result.ProviderStatuses[i]
+			break
+		}
+	}
+	if bookingStatus == nil || bookingStatus.Status != models.StatusTimeout {
+		t.Fatalf("booking status = %+v, want timeout", bookingStatus)
+	}
+	if result.Completeness.State != models.CompletenessPartial {
+		t.Fatalf("completeness = %+v, want partial", result.Completeness)
+	}
+}

--- a/internal/hotels/booking_search.go
+++ b/internal/hotels/booking_search.go
@@ -182,7 +182,7 @@ func acquireBookingWAFToken(ctx context.Context, searchURL string, forceRefresh 
 		if tok := awsWAFToken(providers.CachedCookiesForURL(bookingBaseURL)); tok != "" {
 			return tok, nil
 		}
-		if tok := awsWAFToken(providers.BrowserCookiesForURL(bookingBaseURL)); tok != "" {
+		if tok := awsWAFToken(providers.BrowserCookiesForURLContext(ctx, bookingBaseURL)); tok != "" {
 			return tok, nil
 		}
 	}

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -360,8 +360,9 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	// successful probe. Zero results without an error counts as success.
 	addAux := func(id, name, source string, search func(context.Context, string, HotelSearchOptions) ([]models.HotelResult, error)) {
 		auxTasks = append(auxTasks, hotelAuxTask{
-			id:   id,
-			name: name,
+			id:        id,
+			name:      name,
+			breakerID: id,
 			run: func(providerCtx context.Context) hotelAuxOutcome {
 				if hotelBreaker.Tripped(id) {
 					return hotelAuxOutcome{statuses: []models.ProviderStatus{{
@@ -374,22 +375,26 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 				}
 				res, err := search(providerCtx, location, auxOpts)
 				if ctxErr := providerCtx.Err(); ctxErr != nil {
-					hotelBreaker.RecordFailure(id)
 					slog.Warn(id+" search failed", "error", logredact.Err(ctxErr))
-					return hotelAuxOutcome{statuses: []models.ProviderStatus{hotelProviderStatusFromError(id, name, ctxErr)}}
+					return hotelAuxOutcome{
+						statuses:      []models.ProviderStatus{hotelProviderStatusFromError(id, name, ctxErr)},
+						breakerAction: hotelAuxBreakerFailure,
+					}
 				}
 				if err != nil {
-					hotelBreaker.RecordFailure(id)
 					slog.Warn(id+" search failed", "error", logredact.Err(err))
-					return hotelAuxOutcome{statuses: []models.ProviderStatus{hotelProviderStatusFromError(id, name, err)}}
+					return hotelAuxOutcome{
+						statuses:      []models.ProviderStatus{hotelProviderStatusFromError(id, name, err)},
+						breakerAction: hotelAuxBreakerFailure,
+					}
 				}
-				hotelBreaker.RecordSuccess(id)
 				if source != "" {
 					res = tagHotelSource(res, source)
 				}
 				return hotelAuxOutcome{
-					results:  res,
-					statuses: []models.ProviderStatus{hotelProviderStatusFromResults(id, name, len(res))},
+					results:       res,
+					statuses:      []models.ProviderStatus{hotelProviderStatusFromResults(id, name, len(res))},
+					breakerAction: hotelAuxBreakerSuccess,
 				}
 			},
 		})
@@ -458,7 +463,7 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	// unconfigured we surface an honest not_configured status (with the
 	// AKAMAI_BLOCK root cause and a fix hint) rather than a silent skip or a
 	// fabricated empty result. Non-fatal in all cases.
-	auxTasks = append(auxTasks, hotelAuxTask{id: "expedia", name: "Expedia", run: func(providerCtx context.Context) hotelAuxOutcome {
+	auxTasks = append(auxTasks, hotelAuxTask{id: "expedia", name: "Expedia", breakerID: "expedia", run: func(providerCtx context.Context) hotelAuxOutcome {
 		if !expediaConfigured() {
 			return hotelAuxOutcome{statuses: []models.ProviderStatus{{
 				ID:          "expedia",
@@ -480,19 +485,23 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 		}
 		res, err := SearchExpedia(providerCtx, location, auxOpts)
 		if ctxErr := providerCtx.Err(); ctxErr != nil {
-			hotelBreaker.RecordFailure("expedia")
 			slog.Warn("expedia search failed", "error", logredact.Err(ctxErr))
-			return hotelAuxOutcome{statuses: []models.ProviderStatus{hotelProviderStatusFromError("expedia", "Expedia", ctxErr)}}
+			return hotelAuxOutcome{
+				statuses:      []models.ProviderStatus{hotelProviderStatusFromError("expedia", "Expedia", ctxErr)},
+				breakerAction: hotelAuxBreakerFailure,
+			}
 		}
 		if err != nil {
-			hotelBreaker.RecordFailure("expedia")
 			slog.Warn("expedia search failed", "error", logredact.Err(err))
-			return hotelAuxOutcome{statuses: []models.ProviderStatus{hotelProviderStatusFromError("expedia", "Expedia", err)}}
+			return hotelAuxOutcome{
+				statuses:      []models.ProviderStatus{hotelProviderStatusFromError("expedia", "Expedia", err)},
+				breakerAction: hotelAuxBreakerFailure,
+			}
 		}
-		hotelBreaker.RecordSuccess("expedia")
 		return hotelAuxOutcome{
-			results:  tagHotelSource(res, "expedia"),
-			statuses: []models.ProviderStatus{hotelProviderStatusFromResults("expedia", "Expedia", len(res))},
+			results:       tagHotelSource(res, "expedia"),
+			statuses:      []models.ProviderStatus{hotelProviderStatusFromResults("expedia", "Expedia", len(res))},
+			breakerAction: hotelAuxBreakerSuccess,
 		}
 	}})
 
@@ -557,6 +566,7 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	auxOutcomes := collectHotelAuxTasks(ctx, hotelAuxProviderTimeout, auxTasks)
 	var externalResults []models.HotelResult
 	for index, outcome := range auxOutcomes {
+		applyHotelAuxBreakerOutcome(auxTasks[index], outcome)
 		if len(outcome.results) > 0 {
 			rawBatches = append(rawBatches, outcome.results)
 			if auxTasks[index].id == "external" {

--- a/internal/hotels/search.go
+++ b/internal/hotels/search.go
@@ -44,8 +44,11 @@ var hotelGroup singleflight.Group
 
 const (
 	sharedHotelSearchTimeout = 60 * time.Second
-	hotelAuxProviderTimeout  = 10 * time.Second
 )
+
+// hotelAuxProviderTimeout is a variable so timeout behavior can be exercised
+// deterministically without making regression tests wait ten seconds.
+var hotelAuxProviderTimeout = 10 * time.Second
 
 // externalProviderRuntime is set by the MCP server when providers are configured.
 // It is nil when no external providers are available.
@@ -348,61 +351,55 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	// user-configured external providers. All auxiliary providers are non-fatal:
 	// failures log a warning and contribute zero results.
 	auxOpts := opts
-	var trivagoResults []models.HotelResult
-	var hometogoResults []models.HotelResult
-	var anyplaceResults []models.HotelResult
-	var uniplacesResults []models.HotelResult
-	var wunderflatsResults []models.HotelResult
-	var housinganywhereResults []models.HotelResult
-	var landingResults []models.HotelResult
-	var spotahomeResults []models.HotelResult
-	var flatioResults []models.HotelResult
-	var bluegroundResults []models.HotelResult
-	var agodaResults []models.HotelResult
-	var expediaResults []models.HotelResult
-	var bookingResults []models.HotelResult
-	var externalResults []models.HotelResult
-	var auxWg sync.WaitGroup
+	auxTasks := make([]hotelAuxTask, 0, 14)
 
-	// runAux launches one auxiliary scraper under the shared circuit breaker.
+	// addAux registers one auxiliary scraper under the shared circuit breaker.
 	// A provider whose breaker is tripped is skipped (and surfaces an honest
 	// circuit_broken status) rather than retried; otherwise its result/error is
 	// recorded so the breaker trips after repeated failures and recovers on a
 	// successful probe. Zero results without an error counts as success.
-	runAux := func(id, name string, search func(context.Context, string, HotelSearchOptions) ([]models.HotelResult, error), assign func([]models.HotelResult)) {
-		auxWg.Add(1)
-		go func() {
-			defer auxWg.Done()
-			if hotelBreaker.Tripped(id) {
-				addProviderStatus(models.ProviderStatus{
-					ID:      id,
-					Name:    name,
-					Status:  models.StatusCircuitBroken,
-					Error:   "skipped: recent failures tripped the circuit breaker",
-					FixHint: "wait for the cooldown to elapse, then it retries automatically",
-				})
-				return
-			}
-			providerCtx, cancel := context.WithTimeout(ctx, hotelAuxProviderTimeout)
-			defer cancel()
-			res, err := search(providerCtx, location, auxOpts)
-			if err != nil {
-				hotelBreaker.RecordFailure(id)
-				slog.Warn(id+" search failed", "error", logredact.Err(err))
-				addProviderStatus(hotelProviderStatusFromError(id, name, err))
-				return
-			}
-			hotelBreaker.RecordSuccess(id)
-			assign(res)
-			addProviderStatus(hotelProviderStatusFromResults(id, name, len(res)))
-		}()
+	addAux := func(id, name, source string, search func(context.Context, string, HotelSearchOptions) ([]models.HotelResult, error)) {
+		auxTasks = append(auxTasks, hotelAuxTask{
+			id:   id,
+			name: name,
+			run: func(providerCtx context.Context) hotelAuxOutcome {
+				if hotelBreaker.Tripped(id) {
+					return hotelAuxOutcome{statuses: []models.ProviderStatus{{
+						ID:      id,
+						Name:    name,
+						Status:  models.StatusCircuitBroken,
+						Error:   "skipped: recent failures tripped the circuit breaker",
+						FixHint: "wait for the cooldown to elapse, then it retries automatically",
+					}}}
+				}
+				res, err := search(providerCtx, location, auxOpts)
+				if ctxErr := providerCtx.Err(); ctxErr != nil {
+					hotelBreaker.RecordFailure(id)
+					slog.Warn(id+" search failed", "error", logredact.Err(ctxErr))
+					return hotelAuxOutcome{statuses: []models.ProviderStatus{hotelProviderStatusFromError(id, name, ctxErr)}}
+				}
+				if err != nil {
+					hotelBreaker.RecordFailure(id)
+					slog.Warn(id+" search failed", "error", logredact.Err(err))
+					return hotelAuxOutcome{statuses: []models.ProviderStatus{hotelProviderStatusFromError(id, name, err)}}
+				}
+				hotelBreaker.RecordSuccess(id)
+				if source != "" {
+					res = tagHotelSource(res, source)
+				}
+				return hotelAuxOutcome{
+					results:  res,
+					statuses: []models.ProviderStatus{hotelProviderStatusFromResults(id, name, len(res))},
+				}
+			},
+		})
 	}
 
-	runAux("trivago", "Trivago", SearchTrivago, func(r []models.HotelResult) { trivagoResults = r })
+	addAux("trivago", "Trivago", "", SearchTrivago)
 
 	// HomeToGo vacation-rental aggregator (Airbnb/Vrbo/Booking + local hosts).
 	// Non-fatal: failures log a warning and contribute zero results.
-	runAux("hometogo", "HomeToGo", SearchHomeToGo, func(r []models.HotelResult) { hometogoResults = r })
+	addAux("hometogo", "HomeToGo", "hometogo", SearchHomeToGo)
 
 	// Anyplace mid-term / nomad furnished-apartment provider (monthly-priced
 	// furnished rentals, 30-night minimum — the relocation/nomad segment).
@@ -413,12 +410,12 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	// HousingAnywhere mid-term rental marketplace (furnished monthly lettings).
 	// Algolia-backed; credentials are runtime-harvested. Non-fatal: failures log
 	// a warning and contribute zero results.
-	runAux("anyplace", "Anyplace", SearchAnyplace, func(r []models.HotelResult) { anyplaceResults = r })
+	addAux("anyplace", "Anyplace", "anyplace", SearchAnyplace)
 
 	// Uniplaces mid-term / student-housing provider (rooms, studios, apartments
 	// for weeks-to-months stays that nightly-rate providers miss). Non-fatal:
 	// failures log a warning and contribute zero results.
-	runAux("uniplaces", "Uniplaces", SearchUniplaces, func(r []models.HotelResult) { uniplacesResults = r })
+	addAux("uniplaces", "Uniplaces", "uniplaces", SearchUniplaces)
 
 	// Wunderflats mid-term furnished-apartment provider (Germany & Europe,
 	// monthly-priced furnished flats). Non-fatal: failures log a warning and
@@ -426,33 +423,33 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	// US month-to-month furnished apartments — fills the monthly-stay gap that
 	// hotel/short-let providers miss. Non-fatal: failures log a warning and
 	// contribute zero results.
-	runAux("wunderflats", "Wunderflats", SearchWunderflats, func(r []models.HotelResult) { wunderflatsResults = r })
+	addAux("wunderflats", "Wunderflats", "wunderflats", SearchWunderflats)
 
 	// HousingAnywhere mid-term marketplace (largest EU furnished-rental
 	// inventory, Algolia-backed). Non-fatal: failures log a warning and
 	// contribute zero results.
-	runAux("housinganywhere", "HousingAnywhere", SearchHousingAnywhere, func(r []models.HotelResult) { housinganywhereResults = r })
+	addAux("housinganywhere", "HousingAnywhere", "housinganywhere", SearchHousingAnywhere)
 
 	// Landing (hellolanding.com) US furnished month-to-month apartments.
 	// Non-fatal: failures log a warning and contribute zero results.
-	runAux("landing", "Landing", SearchLanding, func(r []models.HotelResult) { landingResults = r })
+	addAux("landing", "Landing", "landing", SearchLanding)
 
 	// Spotahome mid-term furnished apartments (turbo-stream single-fetch .data).
 	// Non-fatal: failures log a warning and contribute zero results.
-	runAux("spotahome", "Spotahome", SearchSpotahome, func(r []models.HotelResult) { spotahomeResults = r })
+	addAux("spotahome", "Spotahome", "spotahome", SearchSpotahome)
 
 	// Flatio monthly furnished apartments (SSR markerData JSON). Non-fatal.
-	runAux("flatio", "Flatio", SearchFlatio, func(r []models.HotelResult) { flatioResults = r })
+	addAux("flatio", "Flatio", "flatio", SearchFlatio)
 
 	// Blueground monthly furnished apartments (__INITIAL_STATE__ list + detail
 	// hop for price). Non-fatal: failures log a warning and contribute zero.
-	runAux("blueground", "Blueground", SearchBlueground, func(r []models.HotelResult) { bluegroundResults = r })
+	addAux("blueground", "Blueground", "blueground", SearchBlueground)
 
 	// Agoda OTA hotel search (GraphQL citySearch; resolve cityId via public
 	// autocomplete, then a self-constructed x-gate-meta header — no API key,
 	// cookies, or signature). Non-fatal: failures log a warning and contribute
 	// zero results.
-	runAux("agoda", "Agoda", SearchAgoda, func(r []models.HotelResult) { agodaResults = r })
+	addAux("agoda", "Agoda", "agoda", SearchAgoda)
 
 	// Expedia OTA (opt-in, endpoint-gated). Expedia's hotel search surface is
 	// Akamai Bot Manager-defended (HTTP 429 + captcha challenge for plain
@@ -461,65 +458,59 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 	// unconfigured we surface an honest not_configured status (with the
 	// AKAMAI_BLOCK root cause and a fix hint) rather than a silent skip or a
 	// fabricated empty result. Non-fatal in all cases.
-	auxWg.Add(1)
-	go func() {
-		defer auxWg.Done()
+	auxTasks = append(auxTasks, hotelAuxTask{id: "expedia", name: "Expedia", run: func(providerCtx context.Context) hotelAuxOutcome {
 		if !expediaConfigured() {
-			addProviderStatus(models.ProviderStatus{
+			return hotelAuxOutcome{statuses: []models.ProviderStatus{{
 				ID:          "expedia",
 				Name:        "Expedia",
 				Status:      models.StatusNotConfigured,
 				Error:       "Expedia's public hotel search is Akamai Bot Manager-defended (HTTP 429 + captcha challenge); it is opt-in and requires a reachable endpoint",
 				FixHint:     "set EXPEDIA_API_BASE to an authorised partner/Rapid API endpoint or a self-hosted proxy that returns the JSON availability API",
 				FixHintCode: "AKAMAI_BLOCK",
-			})
-			return
+			}}}
 		}
 		if hotelBreaker.Tripped("expedia") {
-			addProviderStatus(models.ProviderStatus{
+			return hotelAuxOutcome{statuses: []models.ProviderStatus{{
 				ID:      "expedia",
 				Name:    "Expedia",
 				Status:  models.StatusCircuitBroken,
 				Error:   "skipped: recent failures tripped the circuit breaker",
 				FixHint: "wait for the cooldown to elapse, then it retries automatically",
-			})
-			return
+			}}}
 		}
-		providerCtx, cancel := context.WithTimeout(ctx, hotelAuxProviderTimeout)
-		defer cancel()
 		res, err := SearchExpedia(providerCtx, location, auxOpts)
+		if ctxErr := providerCtx.Err(); ctxErr != nil {
+			hotelBreaker.RecordFailure("expedia")
+			slog.Warn("expedia search failed", "error", logredact.Err(ctxErr))
+			return hotelAuxOutcome{statuses: []models.ProviderStatus{hotelProviderStatusFromError("expedia", "Expedia", ctxErr)}}
+		}
 		if err != nil {
 			hotelBreaker.RecordFailure("expedia")
 			slog.Warn("expedia search failed", "error", logredact.Err(err))
-			addProviderStatus(hotelProviderStatusFromError("expedia", "Expedia", err))
-			return
+			return hotelAuxOutcome{statuses: []models.ProviderStatus{hotelProviderStatusFromError("expedia", "Expedia", err)}}
 		}
 		hotelBreaker.RecordSuccess("expedia")
-		expediaResults = res
-		addProviderStatus(hotelProviderStatusFromResults("expedia", "Expedia", len(res)))
-	}()
+		return hotelAuxOutcome{
+			results:  tagHotelSource(res, "expedia"),
+			statuses: []models.ProviderStatus{hotelProviderStatusFromResults("expedia", "Expedia", len(res))},
+		}
+	}})
 
 	// Booking.com search — parallel with Google + Trivago + HomeToGo.
 	// Booking.com uses AWS WAF which blocks automated requests. The search
 	// is attempted but failures are expected and handled silently — the
 	// function falls back gracefully to Google + Trivago results.
-	runAux("booking", "Booking.com", SearchBooking, func(r []models.HotelResult) {
-		if len(r) > 0 {
-			bookingResults = tagHotelSource(r, "booking.com")
-		}
-	})
+	addAux("booking", "Booking.com", "booking.com", SearchBooking)
 
 	// External providers (user-configured via configure_provider MCP tool).
 	// This includes any provider the user has set up: Booking.com, Airbnb,
 	// Hostelworld, VRBO, etc. — all configured through the provider system.
 	if eprt := getExternalProviderRuntime(); eprt != nil {
-		auxWg.Add(1)
-		go func() {
-			defer auxWg.Done()
-			lat, lon, err := ResolveLocation(ctx, location)
+		auxTasks = append(auxTasks, hotelAuxTask{id: "external", name: "Configured hotel providers", run: func(providerCtx context.Context) hotelAuxOutcome {
+			lat, lon, err := ResolveLocation(providerCtx, location)
 			if err != nil {
 				slog.Warn("external providers: geocode failed", "error", logredact.Err(err))
-				return
+				return hotelAuxOutcome{statuses: []models.ProviderStatus{hotelProviderStatusFromError("external", "Configured hotel providers", err)}}
 			}
 			filters := &providers.HotelFilterParams{
 				MinPrice:          opts.MinPrice,
@@ -547,38 +538,39 @@ func searchHotelsCore(ctx context.Context, client *batchexec.Client, location st
 				MustHaveWifi:      opts.MustHaveWifi,
 				MustHaveWorkspace: opts.MustHaveWorkspace,
 			}
-			res, statuses, err := eprt.SearchHotels(ctx, location, lat, lon,
+			res, statuses, err := eprt.SearchHotels(providerCtx, location, lat, lon,
 				auxOpts.CheckIn, auxOpts.CheckOut, auxOpts.Currency, auxOpts.Guests, filters)
+			if providerCtx.Err() != nil {
+				return hotelAuxOutcome{statuses: []models.ProviderStatus{hotelProviderStatusFromError("external", "Configured hotel providers", providerCtx.Err())}}
+			}
 			if err != nil {
 				slog.Warn("external providers search failed", "error", logredact.Err(err))
-				addProviderStatuses(statuses) // keep statuses even on error
-				return
+				if len(statuses) == 0 {
+					statuses = []models.ProviderStatus{hotelProviderStatusFromError("external", "Configured hotel providers", err)}
+				}
+				return hotelAuxOutcome{statuses: statuses}
 			}
-			externalResults = res
-			addProviderStatuses(statuses)
-		}()
+			return hotelAuxOutcome{results: res, statuses: statuses}
+		}})
 	}
 
-	auxWg.Wait()
+	auxOutcomes := collectHotelAuxTasks(ctx, hotelAuxProviderTimeout, auxTasks)
+	var externalResults []models.HotelResult
+	for index, outcome := range auxOutcomes {
+		if len(outcome.results) > 0 {
+			rawBatches = append(rawBatches, outcome.results)
+			if auxTasks[index].id == "external" {
+				externalResults = outcome.results
+			}
+		}
+		addProviderStatuses(outcome.statuses)
+	}
 
 	// Deduplicate across all pages, sort orders, Trivago, and external
 	// providers using name-normalisation + geo-proximity. MergeHotelResults
 	// preserves all provider price sources and keeps the lowest price as the
 	// primary.
-	allBatches := append(rawBatches, trivagoResults)
-	allBatches = append(allBatches, tagHotelSource(hometogoResults, "hometogo"))
-	allBatches = append(allBatches, tagHotelSource(anyplaceResults, "anyplace"))
-	allBatches = append(allBatches, tagHotelSource(uniplacesResults, "uniplaces"))
-	allBatches = append(allBatches, tagHotelSource(wunderflatsResults, "wunderflats"))
-	allBatches = append(allBatches, tagHotelSource(housinganywhereResults, "housinganywhere"))
-	allBatches = append(allBatches, tagHotelSource(landingResults, "landing"))
-	allBatches = append(allBatches, tagHotelSource(spotahomeResults, "spotahome"))
-	allBatches = append(allBatches, tagHotelSource(flatioResults, "flatio"))
-	allBatches = append(allBatches, tagHotelSource(bluegroundResults, "blueground"))
-	allBatches = append(allBatches, tagHotelSource(agodaResults, "agoda"))
-	allBatches = append(allBatches, tagHotelSource(expediaResults, "expedia"))
-	allBatches = append(allBatches, bookingResults)
-	allBatches = append(allBatches, externalResults)
+	allBatches := rawBatches
 	if len(externalResults) > 0 {
 		slog.Info("external providers contributed results", "count", len(externalResults))
 	}

--- a/internal/providers/cookie_context_test.go
+++ b/internal/providers/cookie_context_test.go
@@ -1,0 +1,35 @@
+package providers
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/browserutils/kooky"
+)
+
+func TestBrowserCookiesForURLContext_CancelledBeforeRead(t *testing.T) {
+	t.Setenv("TRVL_ALLOW_BROWSER_COOKIES", "1")
+	targetURL := "https://booking.example.test"
+
+	warmCache.mu.Lock()
+	delete(warmCache.entries, warmCacheKey(targetURL, ""))
+	warmCache.mu.Unlock()
+
+	originalRead := readCookies
+	t.Cleanup(func() { readCookies = originalRead })
+	var reads atomic.Int32
+	readCookies = func(context.Context, ...kooky.Filter) (kooky.Cookies, error) {
+		reads.Add(1)
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if got := BrowserCookiesForURLContext(ctx, targetURL); got != nil {
+		t.Fatalf("cookies = %v, want nil for cancelled lookup", got)
+	}
+	if got := reads.Load(); got != 0 {
+		t.Fatalf("browser cookie reads = %d, want zero after cancellation", got)
+	}
+}

--- a/internal/providers/cookie_context_test.go
+++ b/internal/providers/cookie_context_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -26,10 +27,15 @@ func TestBrowserCookiesForURLContext_CancelledBeforeRead(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if got := BrowserCookiesForURLContext(ctx, targetURL); got != nil {
-		t.Fatalf("cookies = %v, want nil for cancelled lookup", got)
-	}
+	logs := captureLogs(t, func() {
+		if got := BrowserCookiesForURLContext(ctx, targetURL); got != nil {
+			t.Fatalf("cookies = %v, want nil for cancelled lookup", got)
+		}
+	})
 	if got := reads.Load(); got != 0 {
 		t.Fatalf("browser cookie reads = %d, want zero after cancellation", got)
+	}
+	if strings.Contains(logs, "browser cookie lookup timed out") {
+		t.Fatalf("cancelled lookup emitted a misleading timeout warning: %s", logs)
 	}
 }

--- a/internal/providers/cookie_outcome.go
+++ b/internal/providers/cookie_outcome.go
@@ -244,6 +244,10 @@ func hostForLog(targetURL string) string {
 var readCookies = kooky.ReadCookies
 
 func browserCookiesForURLWithOutcome(targetURL string) (out []*http.Cookie, outcome browserCookieOutcome, readErr error) {
+	return browserCookiesForURLWithOutcomeContext(context.Background(), targetURL)
+}
+
+func browserCookiesForURLWithOutcomeContext(parentCtx context.Context, targetURL string) (out []*http.Cookie, outcome browserCookieOutcome, readErr error) {
 	// The outcome must agree with what is actually returned.
 	//
 	// permittedAfterRead re-asks for consent AFTER the seconds-long read, so it
@@ -284,9 +288,12 @@ func browserCookiesForURLWithOutcome(targetURL string) (out []*http.Cookie, outc
 	if cookies.Disabled() {
 		return nil, outcomeDeclined, nil
 	}
+	if err := parentCtx.Err(); err != nil {
+		return nil, outcomeTimedOut, err
+	}
 
 	// Check warm cache first — returns instantly if pre-warmed.
-	if cached := warmBrowserCookiesResult(targetURL, "", browserCookieLookupTimeout); cached != nil {
+	if cached := warmBrowserCookiesResultContext(parentCtx, targetURL, "", browserCookieLookupTimeout); cached != nil {
 		// len, not nil. readBrowserCookiesDirect builds its result with
 		// make([]*http.Cookie, 0, n), so a CLEAN read that matched no cookies for
 		// this domain returns a slice that is empty but not nil -- and the warm
@@ -306,6 +313,9 @@ func browserCookiesForURLWithOutcome(targetURL string) (out []*http.Cookie, outc
 			return nil, outcomeNoMatch, nil
 		}
 		return cached, outcomeFound, nil
+	}
+	if err := parentCtx.Err(); err != nil {
+		return nil, outcomeTimedOut, err
 	}
 
 	// Skip browser cookie lookups during `go test` to avoid macOS Keychain
@@ -336,7 +346,7 @@ func browserCookiesForURLWithOutcome(targetURL string) (out []*http.Cookie, outc
 		return nil, outcomeBadURL, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), browserCookieLookupTimeout)
+	ctx, cancel := context.WithTimeout(parentCtx, browserCookieLookupTimeout)
 	defer cancel()
 
 	host := u.Hostname()

--- a/internal/providers/cookies.go
+++ b/internal/providers/cookies.go
@@ -313,6 +313,10 @@ func WarmBrowserCookies(targetURL, browserHint string) {
 // (up to the given timeout) and returns the cached cookies. Returns nil if
 // no warm-up was started or the timeout expires.
 func warmBrowserCookiesResult(targetURL, browserHint string, timeout time.Duration) (out []*http.Cookie) {
+	return warmBrowserCookiesResultContext(context.Background(), targetURL, browserHint, timeout)
+}
+
+func warmBrowserCookiesResultContext(ctx context.Context, targetURL, browserHint string, timeout time.Duration) (out []*http.Cookie) {
 	defer func() { out = permittedAfterRead(out) }()
 
 	key := warmCacheKey(targetURL, browserHint)
@@ -328,6 +332,8 @@ func warmBrowserCookiesResult(targetURL, browserHint string, timeout time.Durati
 	select {
 	case <-entry.done:
 		return entry.cookies
+	case <-ctx.Done():
+		return nil
 	case <-time.After(timeout):
 		return nil
 	}
@@ -493,6 +499,15 @@ func permittedAfterRead(list []*http.Cookie) []*http.Cookie {
 // same bounded, test-guarded path as provider search recovery.
 func BrowserCookiesForURL(targetURL string) []*http.Cookie {
 	return browserCookiesForURL(targetURL)
+}
+
+// BrowserCookiesForURLContext is the caller-cancellable form used by bounded
+// provider searches. The legacy wrapper remains for callers without a request
+// context.
+func BrowserCookiesForURLContext(ctx context.Context, targetURL string) []*http.Cookie {
+	out, outcome, readErr := browserCookiesForURLWithOutcomeContext(ctx, targetURL)
+	reportOutcome(targetURL, outcome, readErr)
+	return out
 }
 
 // browserCookiesForURLWithHint reads cookies from a specific browser's cookie

--- a/internal/providers/cookies.go
+++ b/internal/providers/cookies.go
@@ -505,6 +505,9 @@ func BrowserCookiesForURL(targetURL string) []*http.Cookie {
 // provider searches. The legacy wrapper remains for callers without a request
 // context.
 func BrowserCookiesForURLContext(ctx context.Context, targetURL string) []*http.Cookie {
+	if ctx.Err() != nil {
+		return nil
+	}
 	out, outcome, readErr := browserCookiesForURLWithOutcomeContext(ctx, targetURL)
 	reportOutcome(targetURL, outcome, readErr)
 	return out


### PR DESCRIPTION
Closes #616.

## What changed

- Replace the unbounded auxiliary-provider `WaitGroup` with a deadline-bounded collector that retains completed partial results and emits explicit timeout statuses for unfinished providers.
- Run configured external-provider geocoding/search under the same auxiliary deadline.
- Propagate the Booking search context into browser-cookie lookup and make warm-cache waits caller-cancellable.
- Keep worker outcomes immutable and use a buffered result channel so late non-cooperative providers cannot block or mutate an already returned response.

## Root cause and impact

The hotel fanout created a 10-second context for most auxiliary providers but then waited unconditionally for every goroutine. Cancellation therefore could not release the aggregate when a provider ignored its context. Configured external providers also received the outer 60-second context, and Booking's cookie read created an independent background timeout. A single slow path could consume the aggregate deadline and discard valid Google, Trivago, or Agoda results as a top-level `context deadline exceeded`.

The collector now returns completed hotel batches at the auxiliary deadline, marks unfinished providers as timed out, and reports partial completeness instead of losing usable results.

## Validation

- Regression test failed on main because `SearchHotels` waited for a deliberately non-cooperative Booking provider; it now proves the search returns while that provider remains blocked, retains the fast Ischia result, reports Booking `timeout`, and remains `partial`.
- Caller-cancelled browser-cookie regression performs zero cookie-store reads.
- `go test -count=1 ./internal/hotels ./internal/providers`
- `go test -race -count=1 ./internal/hotels ./internal/providers`
- Blast-radius package tests and vet for CLI, MCP, trip, livecheck, hacks, trip-window, hotels, and providers.
- GitNexus compare against `origin/main`: medium risk, expected hotel and cookie execution flows.
- `make dod`: release checks, repository hygiene, vet, golangci-lint, staticcheck, govulncheck, three-platform gosec, and full `go test ./...` all pass.
- Locally built fixed binary, exact Roberto Ischia dates: exit 0, 119 hotels, 2,776 total available, completed Google/Trivago/Agoda results retained, Booking timed out explicitly, completeness partial, and no Keychain interaction.

Official release-artifact validation for Ischia, Reykjavik, and Lisbon remains required after merge and release before replying to Roberto.
