### PR TITLE
release: prepare v1.21.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.4] - 2026-08-12
+
+### Fixed
+
+- Hotel searches now return completed primary and auxiliary results when the
+  shared auxiliary-provider deadline expires instead of waiting for a provider
+  that ignores cancellation until the whole request times out. Unfinished
+  providers receive explicit timeout statuses, completeness remains partial,
+  and collector timeouts count toward each provider's circuit breaker so stuck
+  workers are not launched indefinitely. ([#616](https://github.com/MikkoParkkola/trvl/issues/616))
+- Configured hotel providers and Booking browser-cookie reads now inherit the
+  same request deadline. Already-cancelled cookie lookups do no work and emit no
+  misleading timeout warning.
+
 ## [1.21.3] - 2026-08-11
 
 ### Fixed
@@ -1199,7 +1213,8 @@ Trust & Discoverability release. The gaps surfaced by @RobertoReale's "Budget Tr
 - Single static binary, zero runtime dependencies
 - MIT license
 
-[Unreleased]: https://github.com/MikkoParkkola/trvl/compare/v1.21.3...HEAD
+[Unreleased]: https://github.com/MikkoParkkola/trvl/compare/v1.21.4...HEAD
+[1.21.4]: https://github.com/MikkoParkkola/trvl/compare/v1.21.3...v1.21.4
 [1.21.3]: https://github.com/MikkoParkkola/trvl/compare/v1.21.2...v1.21.3
 [1.21.2]: https://github.com/MikkoParkkola/trvl/compare/v1.21.1...v1.21.2
 [1.21.1]: https://github.com/MikkoParkkola/trvl/compare/v1.21.0...v1.21.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,12 +13,12 @@ trvl is a travel MCP server + CLI that gives any AI assistant (Claude, Cursor, W
 - Flight providers: the default path merges Google Flights, Kiwi, and Skiplagged. Solo or opt-in integrations cover Ryanair, Wizz Air, Air France–KLM, Transavia, easyJet, Vueling, and Norwegian; protected or credentialed paths return typed setup/block statuses when unavailable. Travelpayouts/Aviasales price signals are opt-in through `trvl pricetrends` and are not part of the bookable merge.
 - Enrichment (free, unauthenticated): weather (Open-Meteo), air quality (`trvl air`), sun times (`trvl sun`, sunrise-sunset.org), bike-share (`trvl bikes`, CityBikes)
 - CI: build, vet, and race tests on Ubuntu and Windows; staticcheck, golangci-lint, govulncheck, and the >=80% coverage gate run on Ubuntu
-- Current release: v1.21.3, published 2026-08-11 from `main` to GitHub Releases, Homebrew, npm, GHCR, the Go module proxy, and the official MCP Registry.
-- v1.21.3 carries rental-provider destination-integrity guards, fail-closed Flatio fallback results, and noninteractive background Nab cookie access.
+- Current release: v1.21.4, published 2026-08-12 from `main` to GitHub Releases, Homebrew, npm, GHCR, the Go module proxy, and the official MCP Registry.
+- v1.21.4 returns completed hotel results at the auxiliary-provider deadline, reports unfinished providers as partial timeouts, and propagates cancellation into configured providers and Booking cookie access.
 
 ## Plan Forward (near-term, technical)
 
-- No GitHub issues are open as of 2026-08-09. Do not invent release scope from this file; use the live issue tracker.
+- No GitHub issues are open as of 2026-08-12. Do not invent release scope from this file; use the live issue tracker.
 - Keep provider-version self-healing and typed failure states healthy as upstream endpoints change.
 - Keep public counts, release metadata, the README, and the wiki aligned whenever a provider, command, or MCP capability changes.
 - New work needs a scoped issue with acceptance criteria before implementation.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,8 @@ Living roadmap. Sequenced by ROI and dependency, not by wishlist size. Each item
 
 ## Shipped
 
-- **v1.21.3** (2026-08-11): current release line. Fixed destination-integrity failures across rental providers, made Flatio fallback results fail closed on unrelated inventory, and disabled prompt-capable Keychain access for background Nab fetches. See [CHANGELOG.md](CHANGELOG.md) and the [GitHub release](https://github.com/MikkoParkkola/trvl/releases/tag/v1.21.3).
+- **v1.21.4** (2026-08-12): current release line. Hotel search now returns completed results at the auxiliary-provider deadline, marks unfinished providers as partial timeouts, and propagates cancellation into configured providers and Booking cookie access. See [CHANGELOG.md](CHANGELOG.md) and the [GitHub release](https://github.com/MikkoParkkola/trvl/releases/tag/v1.21.4).
+- **v1.21.3** (2026-08-11): fixed destination-integrity failures across rental providers, made Flatio fallback results fail closed on unrelated inventory, and disabled prompt-capable Keychain access for background Nab fetches.
 - **v1.21.0** (2026-08-08): added source-backed cancellation and refundability evidence, an offer-specific booking-readiness ceiling, browser-cookie and headless-browser opt-outs, source-only optional provider definitions, bounded transactional price-watch storage, private-proxy handling, and release/security hardening.
 - **v1.18.0** (2026-06-28): booking-readiness verdict from composed trust signals, per-package weather/holidays/events enrichment with typed status, native Google round-trip flight queries, and a privacy-preserving daily active-user heartbeat.
 - **v1.10 — Trust & Discoverability** (shipped, v1.10.0 2026-06-14): the batch surfaced by @RobertoReale's "Budget Travel Pipeline" blog. All five items landed and their issues are closed:

--- a/cmd/trvl/docs_freshness_test.go
+++ b/cmd/trvl/docs_freshness_test.go
@@ -48,10 +48,10 @@ func TestReleaseFacingDocsStayAligned(t *testing.T) {
 			"no personal keys for default search",
 		},
 		"ROADMAP.md": {
-			"v1.21.3** (2026-08-11): current release line",
+			"v1.21.4** (2026-08-12): current release line",
 		},
 		"CHANGELOG.md": {
-			"## [1.21.3] - 2026-08-11",
+			"## [1.21.4] - 2026-08-12",
 		},
 	}
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trvl-mcp",
   "mcpName": "io.github.MikkoParkkola/trvl",
-  "version": "1.21.3",
+  "version": "1.21.4",
   "description": "Travel MCP server + CLI for flights, hotels, trains, cars, ferries, and door-to-door multimodal trips \u2014 no API keys required, single Go binary, works with any MCP client (Claude, Cursor, Windsurf, Codex). 1 smart travel MCP tool, natural language; legacy per-domain tool names still work as legacy-compatible capabilities.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.MikkoParkkola/trvl",
   "title": "trvl",
   "description": "Door-to-door travel MCP + CLI: flights, hotels, trains, cars, ferries. No API keys, Go binary.",
-  "version": "1.21.3",
+  "version": "1.21.4",
   "repository": {
     "url": "https://github.com/MikkoParkkola/trvl",
     "source": "github"
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/mikkoparkkola/trvl:1.21.3",
+      "identifier": "ghcr.io/mikkoparkkola/trvl:1.21.4",
       "transport": {
         "type": "stdio"
       }
@@ -21,7 +21,7 @@
       "registryType": "npm",
       "identifier": "trvl-mcp",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "version": "1.21.3",
+      "version": "1.21.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- document the bounded hotel auxiliary-provider collector fix from #616
- bump release metadata to v1.21.4
- align release-facing documentation and freshness checks

## Validation
- `go test ./cmd/trvl -run ^TestReleaseFacingDocsStayAligned$ -count=1`
- `make dod`