### PR TITLE
fix(flights): recover Wizz sentinel version bumps

### DIFF
--- a/.github/workflows/wizzair-version-sentinel.yml
+++ b/.github/workflows/wizzair-version-sentinel.yml
@@ -88,7 +88,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git switch -c "$branch"
           git commit -am "fix(flights): bump Wizz Air API version ${CUR} -> ${NEW} (auto, #430)"
-          git push -u origin "$branch"
+          scripts/ci/push-wizzair-version-branch.sh "$branch"
 
           body="Automated by the Wizz Air version sentinel.
 

--- a/internal/flights/wizzair.go
+++ b/internal/flights/wizzair.go
@@ -119,16 +119,13 @@ var ErrWizzRejected = errors.New("wizzair declined the request (validationCodes)
 // success to anything. Whether it survives a datacenter IP is unestablished: it
 // is CloudFront-fronted like the timetable endpoint, and only a CI run settles
 // that.
-// Bumped 29.8.0 -> 29.10.0 on 2026-08-04 (trvl#506). 29.8.0 had rotated away
-// and was returning 404 on the oracle, so every Wizz search on main was failing
-// at the time of the bump -- this is a live-breakage fix, not housekeeping.
-//
-// 29.10.0 rather than the 29.9.0 the sentinel reports: the walk stops at the
-// first live candidate, and probing found BOTH 29.9.0 and 29.10.0 live (405 on
-// GET, 200 on POST to /Api/asset/culture). Taking the newer one buys more time
-// before the next rotation. 29.10.1, 29.11.0 and 29.12.0 were absent, so
-// 29.10.0 is the newest that exists rather than merely the first that answers.
-const wizzDefaultVersion = "29.10.0"
+// 2026-08-04: rotated "29.8.0" -> "29.10.0". The prior path returned 404 and
+// the new path answered the asset/culture oracle.
+// 2026-08-12: rotated "29.10.0" -> "29.11.0". The scheduled sentinel observed
+// the old path returning 404 and the new path live, but its pre-existing orphan
+// branch caused a non-fast-forward push failure. The sentinel push path now
+// recovers that exact automation-owned branch with a force-with-lease.
+const wizzDefaultVersion = "29.11.0"
 
 // wizzVersion is the active API version. Overridable in tests; the env var
 // WIZZAIR_API_VERSION takes precedence at request time via wizzResolvedVersion.

--- a/internal/flights/wizzair_test.go
+++ b/internal/flights/wizzair_test.go
@@ -36,14 +36,14 @@ func TestWizzDefaultVersionWellFormed(t *testing.T) {
 // guards against is silent: a downgrade produces a perfectly well-formed URL
 // that 404s on every single search, so the semver-shape test above passes while
 // flight search is dead. The floor records the oldest value known to be live —
-// probed 2026-07-28, when GET /<version>/Api/asset/map returned 200 with the
-// full route graph on 29.8.0 and 404 on 29.4.0, 29.7.0 and 29.9.0.
+// probed by the scheduled sentinel on 2026-08-12, when 29.10.0 returned 404 and
+// 29.11.0 answered the asset/culture oracle.
 //
 // Raise the floor only alongside evidence that the new value is live. It is not
 // a staleness check: nothing offline can tell that a version has rotated away,
 // which is the sentinel's job.
 func TestWizzDefaultVersionNeverGoesBackwards(t *testing.T) {
-	const floor = "29.8.0"
+	const floor = "29.11.0"
 	if wizzDefaultVersion != floor && !wizzVersionNewer(wizzDefaultVersion, floor) {
 		t.Fatalf("wizzDefaultVersion = %q, older than the known-live floor %q — every search would 404", wizzDefaultVersion, floor)
 	}

--- a/internal/flights/wizzair_version_discovery_test.go
+++ b/internal/flights/wizzair_version_discovery_test.go
@@ -129,13 +129,13 @@ func TestWizzDiscoverFromConfig(t *testing.T) {
 	}
 }
 
-// TestWizzDefaultVersionRatchet is a downgrade guard, not a behaviour test: #506
-// verified 29.8.0 live, so a later edit that lowers the compiled default below it
-// would ship users a known-dead version on first run.
+// TestWizzDefaultVersionRatchet is a downgrade guard, not a behaviour test: the
+// scheduled sentinel verified 29.11.0 live on 2026-08-12, so a later edit that
+// lowers the compiled default would ship users a known-dead version on first run.
 func TestWizzDefaultVersionRatchet(t *testing.T) {
-	const verified = "29.8.0"
+	const verified = "29.11.0"
 	if wizzDefaultVersion != verified && !wizzVersionNewer(wizzDefaultVersion, verified) {
-		t.Errorf("wizzDefaultVersion = %q, must not be older than the #506-verified %q", wizzDefaultVersion, verified)
+		t.Errorf("wizzDefaultVersion = %q, must not be older than the sentinel-verified %q", wizzDefaultVersion, verified)
 	}
 }
 

--- a/scripts/ci/check-workflow-hygiene.sh
+++ b/scripts/ci/check-workflow-hygiene.sh
@@ -120,6 +120,7 @@ release_homebrew_stays_formula_only_until_notarized() {
 
 check "workflow action uses refs are pinned to commit SHAs" all_workflow_uses_are_sha_pinned
 check "setup-node jobs use Node 24" all_setup_node_jobs_use_node24
+check "Wizz sentinel safely recovers orphaned automation branches" scripts/ci/push-wizzair-version-branch_test.sh
 check "GitNexus CLI calls include an explicit npm package version" no_unpinned_gitnexus_cli_calls
 check "GitNexus CI and local refresh use the same pinned CLI version" gitnexus_version_is_pinned_consistently
 check "GitNexus cached-index docs use a SHA-pinned cache action example" gitnexus_docs_use_sha_pinned_cache_example

--- a/scripts/ci/push-wizzair-version-branch.sh
+++ b/scripts/ci/push-wizzair-version-branch.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+branch=${1:?usage: push-wizzair-version-branch.sh <auto/wizzair-version-X.Y.Z>}
+if [[ ! $branch =~ ^auto/wizzair-version-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "refusing to update non-sentinel branch: $branch" >&2
+  exit 2
+fi
+
+remote_ref="refs/heads/$branch"
+remote_sha="$(git ls-remote --heads origin "$remote_ref" | awk 'NR == 1 { print $1 }')"
+if [ -z "$remote_sha" ]; then
+  git push -u origin "HEAD:$remote_ref"
+  exit 0
+fi
+
+# A prior run may have pushed the version bump and then failed before opening a
+# PR. Refresh that sentinel-owned orphan from the current main checkout without
+# weakening the lease: if another process updates it after ls-remote, this push
+# fails instead of overwriting the newer work.
+git push -u origin "HEAD:$remote_ref" \
+  --force-with-lease="$remote_ref:$remote_sha"

--- a/scripts/ci/push-wizzair-version-branch_test.sh
+++ b/scripts/ci/push-wizzair-version-branch_test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+helper="$repo_root/scripts/ci/push-wizzair-version-branch.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+git init --bare "$tmp/remote.git" >/dev/null
+git init -b main "$tmp/work" >/dev/null
+git -C "$tmp/work" config user.name test
+git -C "$tmp/work" config user.email test@example.com
+git -C "$tmp/work" remote add origin "$tmp/remote.git"
+
+printf 'base\n' >"$tmp/work/value"
+git -C "$tmp/work" add value
+git -C "$tmp/work" commit -m base >/dev/null
+
+branch="auto/wizzair-version-99.1.0"
+git -C "$tmp/work" switch -c "$branch" >/dev/null
+
+# A missing automation branch is created normally.
+(cd "$tmp/work" && "$helper" "$branch")
+local_sha="$(git -C "$tmp/work" rev-parse HEAD)"
+remote_sha="$(git --git-dir="$tmp/remote.git" rev-parse "refs/heads/$branch")"
+test "$remote_sha" = "$local_sha"
+
+# Simulate an orphan branch advancing independently after a failed workflow.
+git clone --branch "$branch" "$tmp/remote.git" "$tmp/rival" >/dev/null 2>&1
+git -C "$tmp/rival" config user.name rival
+git -C "$tmp/rival" config user.email rival@example.com
+printf 'rival\n' >>"$tmp/rival/value"
+git -C "$tmp/rival" commit -am rival >/dev/null
+git -C "$tmp/rival" push origin "$branch" >/dev/null
+rival_sha="$(git -C "$tmp/rival" rev-parse HEAD)"
+git -C "$tmp/work" fetch origin "$branch" >/dev/null
+
+printf 'current-main\n' >>"$tmp/work/value"
+git -C "$tmp/work" commit -am current-main >/dev/null
+replacement_sha="$(git -C "$tmp/work" rev-parse HEAD)"
+test "$replacement_sha" != "$rival_sha"
+git -C "$tmp/work" merge-base --is-ancestor "$rival_sha" "$replacement_sha" && {
+  echo "test setup error: replacement unexpectedly descends from orphan branch" >&2
+  exit 1
+}
+
+(cd "$tmp/work" && "$helper" "$branch")
+remote_sha="$(git --git-dir="$tmp/remote.git" rev-parse "refs/heads/$branch")"
+test "$remote_sha" = "$replacement_sha"
+
+# The lease-based force path is restricted to the sentinel-owned namespace.
+if (cd "$tmp/work" && "$helper" "feature/not-automation"); then
+  echo "helper accepted a non-sentinel branch" >&2
+  exit 1
+fi
+
+echo "ok: Wizz sentinel branch push handles new and orphaned branches safely"


### PR DESCRIPTION
## What changed

- bump the compiled Wizz Air fallback from 29.10.0 to the sentinel-verified 29.11.0
- recover pre-existing orphaned sentinel branches with an exact force-with-lease instead of failing a non-fast-forward push
- exercise new-branch, orphan-recovery, and namespace-rejection behavior with a real bare Git remote in workflow hygiene

## Root cause

The scheduled sentinel correctly detected the 29.10.0 to 29.11.0 rotation, but an orphaned auto/wizzair-version-29.11.0 branch from an earlier partial run already existed. The workflow only checked for an open PR and then used a plain push, so it failed before creating a PR.

## Validation

- bash scripts/wizzair-discover-version.sh: STATUS=ok CURRENT=29.11.0
- TDD red: both version ratchets failed against 29.10.0; branch test failed because the recovery helper did not exist
- TDD green: branch test passes against a real bare remote; version ratchets and full internal/flights package pass
- make dod: repository hygiene, vet, golangci-lint, staticcheck, govulncheck, gosec, and full tests pass
- GitNexus staged change detection: LOW risk, 7 files, 2 test symbols, 0 affected processes