### PR TITLE
fix(deals): do not abort --from when one RSS source is down

### DIFF
--- a/cmd/trvl/deals.go
+++ b/cmd/trvl/deals.go
@@ -77,6 +77,9 @@ func printDealsTable(ctx context.Context, targetCurrency string, result *deals.D
 		}
 		return nil
 	}
+	if result.Error != "" {
+		_, _ = fmt.Fprintf(os.Stderr, "Some sources failed: %s\n", result.Error)
+	}
 
 	// Convert prices if --currency specified.
 	if targetCurrency != "" {

--- a/cmd/trvl/display_coverage_test.go
+++ b/cmd/trvl/display_coverage_test.go
@@ -30,6 +30,24 @@ func captureStdout(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	return buf.String()
+}
+
 // ---------------------------------------------------------------------------
 // printFlightsTable
 // ---------------------------------------------------------------------------
@@ -461,6 +479,33 @@ func TestPrintDealsTable_Success(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q", want)
 		}
+	}
+}
+
+func TestPrintDealsTable_PartialSourceFailure(t *testing.T) {
+	models.UseColor = false
+	result := &deals.DealsResult{
+		Success: true,
+		Count:   1,
+		Error:   "parse RSS (secretflying): expected element type <rss> but have <html>",
+		Deals: []deals.Deal{
+			{
+				Title:     "Helsinki to Tokyo",
+				Origin:    "HEL",
+				Type:      "deal",
+				Source:    "fly4free",
+				Published: time.Now(),
+			},
+		},
+	}
+	stderr := captureStderr(t, func() {
+		_ = printDealsTable(context.Background(), "", result)
+	})
+	if !strings.Contains(stderr, "Some sources failed") {
+		t.Fatalf("expected source-failure warning on stderr, got %q", stderr)
+	}
+	if strings.Contains(stderr, "No deals found") {
+		t.Fatalf("must not abort the command: %q", stderr)
 	}
 }
 

--- a/internal/deals/deals_extra_test.go
+++ b/internal/deals/deals_extra_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -102,6 +103,49 @@ func TestFetchDeals_MockHTTP(t *testing.T) {
 			t.Error("deals should be sorted newest first")
 			break
 		}
+	}
+}
+
+func TestFetchDeals_OriginFilterDoesNotPromoteSourceError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/bad", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+		_, _ = fmt.Fprint(w, "<html><body>bot wall</body></html>")
+	})
+	mux.HandleFunc("/good", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = fmt.Fprint(w, sampleRSS)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	origFeeds := make(map[string]string)
+	for k, v := range SourceFeeds {
+		origFeeds[k] = v
+	}
+	SourceFeeds["secretflying"] = srv.URL + "/bad"
+	SourceFeeds["fly4free"] = srv.URL + "/good"
+	defer func() {
+		for k, v := range origFeeds {
+			SourceFeeds[k] = v
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := FetchDeals(ctx, []string{"secretflying", "fly4free"}, DealFilter{
+		Origins:  []string{"WAW"},
+		HoursAgo: 999999,
+	})
+	if err != nil {
+		t.Fatalf("FetchDeals error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("healthy feeds must keep Success=true when --from filters them to empty; got error %q", result.Error)
+	}
+	if !strings.Contains(result.Error, "secretflying") {
+		t.Errorf("failed source should still be named in Error, got %q", result.Error)
 	}
 }
 

--- a/internal/deals/deals_extra_test.go
+++ b/internal/deals/deals_extra_test.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/time/rate"
 )
 
 func TestClassifyDeal_ErrorFare(t *testing.T) {
@@ -130,6 +132,10 @@ func TestFetchDeals_OriginFilterDoesNotPromoteSourceError(t *testing.T) {
 			SourceFeeds[k] = v
 		}
 	}()
+
+	origLimiter := limiter
+	limiter = rate.NewLimiter(rate.Inf, 8)
+	defer func() { limiter = origLimiter }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/internal/deals/filter.go
+++ b/internal/deals/filter.go
@@ -52,6 +52,28 @@ func originMatchesDeal(dealOrigin string, filterOrigins []string) bool {
 	return false
 }
 
+// originMatchesText reports whether title/summary text names a filter origin
+// (IATA code or aliased city). Used when RSS left Deal.Origin empty.
+func originMatchesText(text string, filterOrigins []string) bool {
+	hay := strings.ToLower(text)
+	if strings.TrimSpace(hay) == "" {
+		return false
+	}
+	for _, filter := range filterOrigins {
+		f := strings.ToLower(strings.TrimSpace(filter))
+		if f == "" {
+			continue
+		}
+		if strings.Contains(hay, f) {
+			return true
+		}
+		if alias, ok := cityAliases[strings.ToUpper(filter)]; ok && strings.Contains(hay, alias) {
+			return true
+		}
+	}
+	return false
+}
+
 // FilterDeals applies the given filter to a slice of deals.
 func FilterDeals(deals []Deal, f DealFilter) []Deal {
 	hoursAgo := f.HoursAgo
@@ -66,9 +88,10 @@ func FilterDeals(deals []Deal, f DealFilter) []Deal {
 		if !d.Published.IsZero() && d.Published.Before(cutoff) {
 			continue
 		}
-		// Origin filter.
+		// Origin filter. Empty Origin is common on RSS items; fall back to
+		// title/summary so --from still matches "Warsaw to Barcelona" headlines.
 		if len(f.Origins) > 0 {
-			if d.Origin == "" || !originMatchesDeal(d.Origin, f.Origins) {
+			if !originMatchesDeal(d.Origin, f.Origins) && !originMatchesText(d.Title+" "+d.Summary, f.Origins) {
 				continue
 			}
 		}

--- a/internal/deals/filter_test.go
+++ b/internal/deals/filter_test.go
@@ -1,6 +1,7 @@
 package deals
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -76,4 +77,21 @@ func TestFilterDealsOriginFlexible(t *testing.T) {
 			t.Errorf("expected 5 deals, got %d", len(result))
 		}
 	})
+}
+
+func TestFilterDeals_TitleFallbackWhenOriginEmpty(t *testing.T) {
+	now := time.Now()
+	deals := []Deal{
+		{Title: "Warsaw to Barcelona from EUR49", Origin: "", Published: now},
+		{Title: "getaway easier cities", Origin: "", Published: now},
+		{Title: "HEL-BCN flash sale", Origin: "", Published: now},
+	}
+	got := FilterDeals(deals, DealFilter{Origins: []string{"WAW"}})
+	if len(got) != 1 || !strings.Contains(got[0].Title, "Warsaw") {
+		t.Fatalf("expected the Warsaw headline, got %+v", got)
+	}
+	hel := FilterDeals(deals, DealFilter{Origins: []string{"HEL"}})
+	if len(hel) != 1 || !strings.Contains(hel[0].Title, "HEL-BCN") {
+		t.Fatalf("expected HEL-BCN headline, got %+v", hel)
+	}
 }

--- a/internal/deals/rss.go
+++ b/internal/deals/rss.go
@@ -104,9 +104,14 @@ func FetchDeals(ctx context.Context, sources []string, filter DealFilter) (*Deal
 		Count:   len(filtered),
 		Deals:   filtered,
 	}
-	if len(errs) > 0 && len(filtered) == 0 {
-		result.Success = false
+	if len(errs) > 0 {
 		result.Error = strings.Join(errs, "; ")
+		// Only fail the whole command when no source produced deals.
+		// An origin/price filter that empties an otherwise healthy set
+		// must not promote a single dead feed into "no deals found".
+		if len(allDeals) == 0 {
+			result.Success = false
+		}
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Summary
Fixes #632 (reporter: @krzysztofgos-pixel).

`trvl deals --from WAW` turned a single Secret Flying HTML 403 into a hard failure because FetchDeals treated \`len(filtered)==0 && any source error\` as total failure. Unfiltered \`trvl deals\` already skipped the dead feed.

- Success is false only when **no** source produced deals.
- Source errors stay in \`Error\` and print as \`Some sources failed:\` when other feeds worked.
- \`--from\` also matches title/summary so empty Origin (most RSS items) still hits Warsaw/WAW headlines.

## Test plan
- [x] \`go test ./internal/deals/\` (95 passed)
- [x] \`go test ./cmd/trvl/ -run Deal\` (19 passed)
- [ ] CI green