### PR TITLE
fix(release): finish docker/npm after a GitHub Release exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,15 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing git tag to finish publishing (docker, npm, MCP registry). Skips GoReleaser.
+        required: true
+        type: string
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
 
 permissions:
   contents: write
@@ -35,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.inputs.tag || github.sha }}
       - name: Scan Go dependencies against OSV
         uses: google/osv-scanner-action/osv-scanner-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
         with:
@@ -47,6 +58,7 @@ jobs:
             ./
 
   goreleaser:
+    if: github.event_name != 'workflow_dispatch'
     needs: security-gate
     runs-on: macos-14
     env:
@@ -180,7 +192,7 @@ jobs:
         if: env.HAS_HOMEBREW_TAP_TOKEN == 'true'
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
           ruby scripts/release/update-homebrew-formula.rb \
             homebrew-tap/Formula/trvl.rb \
             "${VERSION}" \
@@ -201,6 +213,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: goreleaser
+    if: always() && !cancelled() && (needs.goreleaser.result == 'success' || github.event_name == 'workflow_dispatch')
     timeout-minutes: 45
     permissions:
       contents: read
@@ -208,6 +221,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.inputs.tag || github.sha }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
@@ -237,7 +252,7 @@ jobs:
       - name: Build amd64 image for vulnerability scan
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
           start="$(date -u +%s)"
           echo "Docker scan image build started at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
           docker buildx build \
@@ -266,7 +281,7 @@ jobs:
       - name: Build and push multi-arch image
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
           start="$(date -u +%s)"
           echo "Docker multi-arch build/push started at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
           docker buildx build \
@@ -292,6 +307,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.inputs.tag || github.sha }}
 
       - name: Install mcp-publisher
         run: |
@@ -299,7 +316,7 @@ jobs:
 
       - name: Stamp server.json for release tag
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
           jq --arg v "${VERSION}" '
             .version = $v |
             .packages[0].identifier = "ghcr.io/mikkoparkkola/trvl:" + $v |
@@ -337,12 +354,15 @@ jobs:
   npm:
     runs-on: ubuntu-latest
     needs: goreleaser
+    if: always() && !cancelled() && (needs.goreleaser.result == 'success' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
       id-token: write  # OIDC token for npm trusted publishing + provenance
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.inputs.tag || github.sha }}
 
       # OIDC trusted publishing needs npm >= 11.5.1. Node 24 bundles a recent
       # npm; using setup-node avoids the permission error from globally
@@ -356,6 +376,6 @@ jobs:
       - name: Stamp version from tag and publish (OIDC, no token)
         working-directory: npm
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
           npm version "${VERSION}" --no-git-tag-version --allow-same-version
           npm publish --provenance --access public

--- a/scripts/ci/check-release-metadata.sh
+++ b/scripts/ci/check-release-metadata.sh
@@ -53,7 +53,8 @@ check_equal "server.json npm identifier" "$server_npm_identifier" "$npm_name"
 check_equal "server.json npm version" "$server_npm_version" "$latest_version"
 check_equal "npm/package.json version" "$npm_version" "$latest_version"
 
-check_contains "release workflow derives metadata from the pushed tag" 'VERSION="${GITHUB_REF_NAME#v}"' .github/workflows/release.yml
+check_contains "release workflow derives metadata from RELEASE_TAG" 'VERSION="${RELEASE_TAG#v}"' .github/workflows/release.yml
+check_contains "RELEASE_TAG comes from dispatch tag or github.ref_name" 'github.event.inputs.tag || github.ref_name' .github/workflows/release.yml
 check_contains "release workflow stamps server.json version" '.version = $v' .github/workflows/release.yml
 check_contains "release workflow stamps OCI identifier" '.packages[0].identifier = "ghcr.io/mikkoparkkola/trvl:" + $v' .github/workflows/release.yml
 check_contains "release workflow stamps npm package version" 'select(.registryType=="npm") | .version' .github/workflows/release.yml

--- a/scripts/release/update-homebrew-formula.rb
+++ b/scripts/release/update-homebrew-formula.rb
@@ -34,8 +34,10 @@ end
 content = File.read(formula_path)
 
 unless content.sub!(/version "[^"]+"/, %Q(version "#{version}"))
-  warn "failed to update version in #{formula_path}"
-  exit 1
+  unless content.sub!(/^(  license .+)\n/, %Q(\\1\n  version "#{version}"\n))
+    warn "failed to update version in #{formula_path}"
+    exit 1
+  end
 end
 
 platforms.each do |platform|

--- a/scripts/release/update-homebrew-formula_test.rb
+++ b/scripts/release/update-homebrew-formula_test.rb
@@ -29,6 +29,18 @@ class UpdateHomebrewFormulaTest < Minitest::Test
     end
   end
 
+  def test_inserts_version_when_formula_has_none
+    with_fixture(include_version: false) do |formula, checksums|
+      _stdout, stderr, status = Open3.capture3(
+        RbConfig.ruby, SCRIPT, formula, "1.21.0", checksums
+      )
+
+      assert status.success?, stderr
+      content = File.read(formula)
+      assert_includes content, "license \"PolyForm-Noncommercial-1.0.0\"\n  version \"1.21.0\"\n"
+    end
+  end
+
   def test_missing_platform_checksum_fails_without_rewriting_formula
     with_fixture(omit: "linux_arm64") do |formula, checksums|
       before = File.read(formula)
@@ -44,26 +56,27 @@ class UpdateHomebrewFormulaTest < Minitest::Test
 
   private
 
-  def with_fixture(omit: nil)
+  def with_fixture(omit: nil, include_version: true)
     Dir.mktmpdir("trvl-homebrew-formula-test") do |dir|
       formula = File.join(dir, "trvl.rb")
       checksums = File.join(dir, "checksums.txt")
-      File.write(formula, formula_fixture)
+      File.write(formula, formula_fixture(include_version: include_version))
       File.write(checksums, checksum_fixture(omit: omit))
       yield formula, checksums
     end
   end
 
-  def formula_fixture
+  def formula_fixture(include_version: true)
     blocks = PLATFORMS.map do |platform|
       %(      url "https://github.com/MikkoParkkola/trvl/releases/download/v1.20.0/trvl_1.20.0_#{platform}.tar.gz"\n) \
         + %(      sha256 "#{'0' * 64}"\n)
     end.join("\n")
+    version_line = include_version ? "  version \"1.20.0\"\n" : ""
 
     <<~RUBY
       class Trvl < Formula
-        version "1.20.0"
-      #{blocks}
+        license "PolyForm-Noncommercial-1.0.0"
+      #{version_line}#{blocks}
       end
     RUBY
   end


### PR DESCRIPTION
## Summary
v1.21.5 GitHub Release is up; goreleaser then failed updating Homebrew (no \`version\` line in the formula), so docker/npm/MCP registry were skipped. Homebrew was patched in the tap (#12).

This:
- Makes the formula updater insert \`version\` when missing (the live formula shape)
- Adds \`workflow_dispatch\` with a tag input so we can publish docker/npm/MCP for an existing tag without re-running GoReleaser

After merge, dispatch this workflow with tag \`v1.21.5\`.

## Test plan
- [ ] \`ruby scripts/release/update-homebrew-formula_test.rb\` (3 runs)
- [ ] Dispatch Release with tag v1.21.5; docker/npm run; goreleaser skipped