### PR TITLE
fix(release): run MCP registry after a skipped GoReleaser job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,6 +301,7 @@ jobs:
   mcp-registry:
     runs-on: ubuntu-latest
     needs: [docker, npm]
+    if: always() && !cancelled() && needs.docker.result == 'success' && needs.npm.result == 'success'
     permissions:
       contents: read
       id-token: write
@@ -378,4 +379,14 @@ jobs:
         run: |
           VERSION="${RELEASE_TAG#v}"
           npm version "${VERSION}" --no-git-tag-version --allow-same-version
-          npm publish --provenance --access public
+          set +e
+          out="$(npm publish --provenance --access public 2>&1)"
+          code=$?
+          echo "$out"
+          if [ "$code" -ne 0 ]; then
+            if echo "$out" | grep -Eqi 'cannot publish over|previously published|you cannot publish over the previously published versions'; then
+              echo "::notice::npm already has trvl-mcp@${VERSION} — treating as published."
+              exit 0
+            fi
+            exit "$code"
+          fi


### PR DESCRIPTION
## Summary
Dispatch of v1.21.5 published docker and npm, then skipped mcp-registry because GoReleaser was skipped. GitHub skips that descendant unless the job has its own \`if:\`.

Continue mcp-registry when docker and npm succeeded. Treat an already-published npm version as success so re-dispatch can reach the registry.

## Test plan
- [ ] After merge, dispatch Release with tag v1.21.5
- [ ] goreleaser skipped, npm notices already published, mcp-registry runs