### PR TITLE
fix(release): keep security-gate in front of dispatch publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,10 @@ jobs:
   # Release backstop for the dependency-vulnerability gate. ci.yaml scans on
   # every PR/push; this re-scans at tag time so a vuln that landed between the
   # last green CI run and the release tag (or via a path that skipped CI) cannot
-  # ship. Every publishing job below is transitively `needs:`-ed to goreleaser,
-  # which `needs:` this gate — so GitHub release, Homebrew, Docker, npm, and the
-  # MCP registry all block if a known fixable vuln is present. Exceptions are
-  # time-boxed in .github/osv-scanner.toml.
+  # ship. Tag-push publishing is transitively `needs:`-ed to goreleaser, which
+  # `needs:` this gate. workflow_dispatch skips goreleaser, so docker and npm
+  # `needs:` this gate directly and require `needs.security-gate.result ==
+  # 'success'`. Exceptions are time-boxed in .github/osv-scanner.toml.
   security-gate:
     name: Security gate (block release on known vulns)
     runs-on: ubuntu-latest
@@ -212,8 +212,8 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
-    needs: goreleaser
-    if: always() && !cancelled() && (needs.goreleaser.result == 'success' || github.event_name == 'workflow_dispatch')
+    needs: [security-gate, goreleaser]
+    if: always() && !cancelled() && needs.security-gate.result == 'success' && (needs.goreleaser.result == 'success' || github.event_name == 'workflow_dispatch')
     timeout-minutes: 45
     permissions:
       contents: read
@@ -354,8 +354,8 @@ jobs:
   # goreleaser job above, so the release is not blocked.
   npm:
     runs-on: ubuntu-latest
-    needs: goreleaser
-    if: always() && !cancelled() && (needs.goreleaser.result == 'success' || github.event_name == 'workflow_dispatch')
+    needs: [security-gate, goreleaser]
+    if: always() && !cancelled() && needs.security-gate.result == 'success' && (needs.goreleaser.result == 'success' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
       id-token: write  # OIDC token for npm trusted publishing + provenance


### PR DESCRIPTION
## Summary
Copilot on #637: on workflow_dispatch, goreleaser is skipped, so docker/npm no longer waited on security-gate. They now need both security-gate and goreleaser, and require security-gate success.

## Test plan
- [ ] Tag-push path still needs goreleaser success
- [ ] Dispatch path still skips goreleaser but blocks docker/npm if security-gate fails