### PR TITLE
fix(release): use bracket notation for hyphenated job id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,9 @@ jobs:
   # last green CI run and the release tag (or via a path that skipped CI) cannot
   # ship. Tag-push publishing is transitively `needs:`-ed to goreleaser, which
   # `needs:` this gate. workflow_dispatch skips goreleaser, so docker and npm
-  # `needs:` this gate directly and require `needs.security-gate.result ==
-  # 'success'`. Exceptions are time-boxed in .github/osv-scanner.toml.
+  # `needs:` this gate directly and require
+  # `needs['security-gate'].result == 'success'`. Exceptions are time-boxed
+  # in .github/osv-scanner.toml.
   security-gate:
     name: Security gate (block release on known vulns)
     runs-on: ubuntu-latest
@@ -213,7 +214,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: [security-gate, goreleaser]
-    if: always() && !cancelled() && needs.security-gate.result == 'success' && (needs.goreleaser.result == 'success' || github.event_name == 'workflow_dispatch')
+    if: always() && !cancelled() && needs['security-gate'].result == 'success' && (needs.goreleaser.result == 'success' || github.event_name == 'workflow_dispatch')
     timeout-minutes: 45
     permissions:
       contents: read
@@ -355,7 +356,7 @@ jobs:
   npm:
     runs-on: ubuntu-latest
     needs: [security-gate, goreleaser]
-    if: always() && !cancelled() && needs.security-gate.result == 'success' && (needs.goreleaser.result == 'success' || github.event_name == 'workflow_dispatch')
+    if: always() && !cancelled() && needs['security-gate'].result == 'success' && (needs.goreleaser.result == 'success' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
       id-token: write  # OIDC token for npm trusted publishing + provenance


### PR DESCRIPTION
## Summary
Copilot on #639: job id security-gate contains a hyphen, so \`needs.security-gate.result\` is invalid. Switch docker and npm \`if:\` (and the comment) to \`needs['security-gate'].result\`.

## Test plan
- [ ] workflow YAML uses bracket notation for the hyphenated job id