### PR TITLE
feat(mcp): publish OAuth Protected Resource Metadata (RFC 9728)

### DIFF
--- a/cmd/trvl/mcp.go
+++ b/cmd/trvl/mcp.go
@@ -17,6 +17,8 @@ func mcpCmd() *cobra.Command {
 		oauthClientID         string
 		oauthClientSecret     string
 		oauthAudience         string
+		oauthIssuer           string
+		publicURL             string
 	)
 
 	cmd := &cobra.Command{
@@ -48,6 +50,8 @@ refused before binding a listener. See docs/REMOTE-MCP-OAUTH.md.`,
 					OAuthClientID:         oauthClientID,
 					OAuthClientSecret:     oauthClientSecret,
 					OAuthAudience:         oauthAudience,
+					OAuthIssuer:           oauthIssuer,
+					PublicURL:             publicURL,
 				})
 			}
 			return mcp.Run()
@@ -63,7 +67,9 @@ refused before binding a listener. See docs/REMOTE-MCP-OAUTH.md.`,
 	cmd.Flags().StringVar(&oauthIntrospectionURL, "oauth-introspection-url", "", "OAuth 2.1 token introspection URL for HTTP mode (default: TRVL_MCP_OAUTH_INTROSPECTION_URL)")
 	cmd.Flags().StringVar(&oauthClientID, "oauth-client-id", "", "OAuth introspection client ID (default: TRVL_MCP_OAUTH_CLIENT_ID)")
 	cmd.Flags().StringVar(&oauthClientSecret, "oauth-client-secret", "", "OAuth introspection client secret (default: TRVL_MCP_OAUTH_CLIENT_SECRET)")
-	cmd.Flags().StringVar(&oauthAudience, "oauth-audience", "", "Required OAuth audience claim for HTTP mode (default: TRVL_MCP_OAUTH_AUDIENCE)")
+	cmd.Flags().StringVar(&oauthAudience, "oauth-audience", "", "Required OAuth audience claim for HTTP mode (default: TRVL_MCP_OAUTH_AUDIENCE; derived from --public-url when unset)")
+	cmd.Flags().StringVar(&oauthIssuer, "oauth-issuer", "", "OAuth authorization server issuer URL, required with --oauth-introspection-url (default: TRVL_MCP_OAUTH_ISSUER)")
+	cmd.Flags().StringVar(&publicURL, "public-url", "", "Public URL clients use to reach this server, required with --oauth-introspection-url (default: TRVL_MCP_PUBLIC_URL)")
 
 	cmd.AddCommand(mcpInstallCmd())
 

--- a/cmd/trvl/mcp_prm_flags_test.go
+++ b/cmd/trvl/mcp_prm_flags_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMCPCmdWiresOAuthPRMFlags guards the seam between this package and mcp:
+// --oauth-issuer and --public-url are declared here but validated in
+// requireOAuthPRMConfig, so dropping either assignment into HTTPServerOptions
+// still compiles and no mcp-package test can observe it.
+//
+// Each case discriminates wired-but-rejected from never-wired. An unwired flag
+// reaches the validator as the empty string and is reported as "is required";
+// a wired one is rejected on its own content. Asserting only "returns an error"
+// would pass in both directions and prove nothing.
+//
+// Both paths refuse in RunHTTPWithOptions before ListenAndServe, so no listener
+// binds and the test needs no port.
+func TestMCPCmdWiresOAuthPRMFlags(t *testing.T) {
+	for _, key := range []string{
+		"TRVL_MCP_TOKEN",
+		"TRVL_MCP_READ_TOKEN",
+		"TRVL_MCP_WRITE_TOKEN",
+		"TRVL_MCP_OAUTH_INTROSPECTION_URL",
+		"TRVL_MCP_OAUTH_CLIENT_ID",
+		"TRVL_MCP_OAUTH_CLIENT_SECRET",
+		"TRVL_MCP_OAUTH_AUDIENCE",
+		"TRVL_MCP_OAUTH_ISSUER",
+		"TRVL_MCP_PUBLIC_URL",
+	} {
+		t.Setenv(key, "")
+	}
+
+	const introspection = "https://idp.example/introspect"
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "issuer value reaches the validator",
+			args: []string{
+				"--http",
+				"--oauth-introspection-url", introspection,
+				"--oauth-issuer", "http://idp.example",
+				"--public-url", "https://trvl.example/mcp",
+			},
+			want: "must be an absolute https:// URL",
+		},
+		{
+			name: "public URL value reaches the validator",
+			args: []string{
+				"--http",
+				"--oauth-introspection-url", introspection,
+				"--oauth-issuer", "https://idp.example",
+				"--public-url", "http://trvl.example/mcp",
+			},
+			want: "must be an https:// URL",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := mcpCmd()
+			cmd.SetArgs(tc.args)
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected the server to refuse to start, got nil")
+			}
+			if strings.Contains(err.Error(), "is required") {
+				t.Fatalf("flag never reached HTTPServerOptions, validator saw it as unset: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("got %q, want it to contain %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/docs/REMOTE-MCP-OAUTH.md
+++ b/docs/REMOTE-MCP-OAUTH.md
@@ -89,18 +89,30 @@ trvl mcp --http \
   --oauth-introspection-url "https://idp.example.org/oauth/introspect" \
   --oauth-client-id "trvl-mcp" \
   --oauth-client-secret "$INTROSPECTION_SECRET" \
-  --oauth-audience "trvl-mcp"
+  --oauth-issuer "https://tenant.auth0.com/" \
+  --public-url "https://travel.example.org"
 ```
 
 Environment variables: `TRVL_MCP_OAUTH_INTROSPECTION_URL`,
 `TRVL_MCP_OAUTH_CLIENT_ID`, `TRVL_MCP_OAUTH_CLIENT_SECRET`,
-`TRVL_MCP_OAUTH_AUDIENCE`.
+`TRVL_MCP_OAUTH_ISSUER`, `TRVL_MCP_PUBLIC_URL`, `TRVL_MCP_OAUTH_AUDIENCE`.
 
-**Required for production.** Set `--oauth-audience` to the resource identifier
-you registered for trvl so a token minted for a different service at the same
-IdP is rejected (confused-deputy protection, RFC 7662 §2.2). Without it, trvl
-accepts any active token from the introspection endpoint and logs a startup
-warning.
+**`--oauth-issuer` and `--public-url` are required** whenever
+`--oauth-introspection-url` is set — trvl refuses to start without them.
+They back the OAuth 2.0 Protected Resource Metadata (RFC 9728) document trvl
+serves at `/.well-known/oauth-protected-resource`, so a client can discover
+which authorization server protects this deployment. `--public-url` must be
+an `https://` URL reachable at the address clients actually use (a plain
+`http://localhost`/`http://127.0.0.1` is allowed for local development only).
+
+**`--oauth-audience` defaults to `<public-url>/mcp`** — the resource
+identifier trvl publishes, and the value an RFC 8707-compliant client will
+request as the token's audience. You normally don't need to set it
+yourself: leave it unset and it matches by construction (confused-deputy
+protection, RFC 7662 §2.2). If you set it explicitly, it must equal
+`<public-url>/mcp` or trvl refuses to start — a mismatched audience would
+otherwise reject every token after a successful IdP consent, which is a
+confusing failure to hit at request time instead of startup.
 
 ### Client-side flow: Authorization Code + PKCE
 
@@ -158,8 +170,8 @@ for per-decision detail.
 
 - Keep the default loopback bind unless you genuinely need remote access.
 - Never expose a remote host without auth; trvl refuses this by design.
-- Use OAuth introspection with a pinned `--oauth-audience` (required for production) over static tokens
-  for multi-user deployments.
+- Use OAuth introspection (with `--oauth-issuer` and `--public-url`, which
+  are required) over static tokens for multi-user deployments.
 - Hand out `trvl:read` by default; grant `trvl:write` only to clients that must
   mutate `~/.trvl` state.
 - Terminate TLS at a reverse proxy/load balancer in front of trvl.

--- a/docs/design/oauth-protected-resource-metadata.md
+++ b/docs/design/oauth-protected-resource-metadata.md
@@ -47,12 +47,28 @@ not fail-closed; `NewHTTPAuth` (`:57-61`) only logs a startup warning for the
 gap today, it does not refuse to start. That warn-only posture predates this
 spec requirement and no longer satisfies it.
 
-**Decision:** when `--oauth-introspection-url` is configured, require
-`--oauth-audience` too, and refuse to start without it — the same
-fail-closed treatment `--oauth-issuer` gets above, replacing today's
-warning. Audience *matching* itself (`audienceMatches`) is already correctly
-enforced whenever an audience value is present; only the "is one present"
-gate needs to become mandatory.
+**Decision: derive `--oauth-audience` from the PRM `resource` when unset, and
+refuse to start when both are set and differ.** Requiring the flag separately
+would leave a correct config and a broken one looking identical. A client that
+follows RFC 8707 does exactly what the PRM document tells it to: it sends
+`resource=<public-url>/mcp` to the authorization server and receives a token
+whose `aud` is that URI. Today `docs/REMOTE-MCP-OAUTH.md:87-92` documents the
+flag as `--oauth-audience "trvl-mcp"`, an opaque string, and that is the value
+`audienceMatches` compares against — so the token is rejected and the user
+sees a 401 immediately after a successful consent flow, which is the worst
+place to put a failure. Defaulting the audience to the published `resource`
+collapses the two values into one; an explicit `--oauth-audience` that
+disagrees with `resource` is a misconfiguration, not a preference, so it fails
+at startup rather than at the first request.
+
+This replaces today's warn-only posture. `NewHTTPAuth` (`:57-61`) currently
+logs a startup warning when OAuth is configured with no audience and does not
+refuse to start; with the audience always derived, that gap closes and the
+warning goes away. Audience *matching* itself (`audienceMatches`) is already
+correctly enforced whenever a value is present.
+
+`docs/REMOTE-MCP-OAUTH.md` must be updated in the same change: its worked
+example currently teaches the value that breaks.
 
 ## (b) Where does `resource` come from?
 
@@ -78,6 +94,14 @@ https requirement on issuer/resource identifiers). trvl cannot default to
 `resource` in the served document is `<public-url>/mcp` — the MCP endpoint
 itself, not the bare host — because that's the identifier a client actually
 holds a token for.
+
+**Normalization.** `resource` must equal the URL clients actually call,
+byte for byte, because it is compared as a string by both the client's
+resource indicator and this server's audience check. So: strip any trailing
+slash from `--public-url` before appending `/mcp`; preserve IPv6 literal
+brackets (`https://[::1]:8080`); and do not treat `localhost` and `127.0.0.1`
+as interchangeable — RFC 9728 §3.3 does not, and a token minted for one will
+not match the other.
 
 ## (c) Static bearer tokens have no authorization server — PRM is meaningless there
 
@@ -117,6 +141,18 @@ Example: `--public-url=https://host/base` gives the path-suffixed URL
 
 Both well-known routes serve the identical document.
 
+**The document.** `GET` only — any other method gets `405`. Served as
+`Content-Type: application/json`. Exactly two fields, both mandatory here per
+(a) and RFC 9728 §2; `authorization_servers` is a JSON array of strings, not a
+bare string:
+
+```json
+{
+  "resource": "https://travel.example.org/mcp",
+  "authorization_servers": ["https://tenant.auth0.com/"]
+}
+```
+
 **401 challenge scope.** The initial challenge must not push a read-only
 client into consenting to write access. `mcp/http_auth.go:281
 toolWriteRequirement` / `:290 toolRequiresWrite` already know, given a
@@ -142,6 +178,14 @@ per (c)):
 A discovery document behind auth can't be discovered — a client with no
 token yet is precisely who needs to fetch it to learn where to get one. Both
 well-known routes, like `/health`, run before/outside `h.authorize()`.
+
+## Migration: this is a breaking startup change
+
+Anyone already running with `--oauth-introspection-url` will fail to start
+after this lands until they also pass `--oauth-issuer` and `--public-url`.
+That is deliberate — both are required to serve a compliant PRM document, and
+starting without them means advertising OAuth support the server cannot back
+up. Call it out in the release notes and in `docs/REMOTE-MCP-OAUTH.md`.
 
 ## What's out of scope
 

--- a/docs/design/oauth-protected-resource-metadata.md
+++ b/docs/design/oauth-protected-resource-metadata.md
@@ -1,6 +1,6 @@
 # OAuth Protected Resource Metadata (RFC 9728) for HTTP MCP mode
 
-Status: **implemented**
+Status: designed, implementation pending
 Date: 2026-09-09
 
 ## Why
@@ -13,8 +13,10 @@ at all. This doc settles the open questions before writing code.
 
 ## (a) Where does `authorization_servers` come from?
 
-RFC 9728 requires the PRM document to name at least one authorization-server
-issuer URL. trvl's existing `--oauth-introspection-url` is a token
+The MCP spec (rev 2025-11-25) requires the PRM document to name at least one
+authorization-server issuer URL for an OAuth-protected server; RFC 9728 §2
+itself lists `authorization_servers` as OPTIONAL, so this requirement comes
+from MCP, not the RFC. trvl's existing `--oauth-introspection-url` is a token
 *introspection* endpoint, not the issuer identifier — the two are often on
 different hosts/paths at real IdPs (e.g. Auth0's introspection endpoint is
 `https://tenant.auth0.com/oauth/introspect`, but the issuer clients discover
@@ -32,9 +34,25 @@ spec; serving a PRM document without it (or not serving PRM at all while
 claiming OAuth support) is worse than refusing to start, because it looks
 compliant to a client's discovery probe while failing to name an issuer. This
 mirrors the codebase's existing convention: missing *required* config fails
-closed at startup (`requireHTTPAuth`); a missing *recommended* field
-(`--oauth-audience`) only warns, because that one is a defense-in-depth
-extra, not something the spec's response format requires you to emit.
+closed at startup (`requireHTTPAuth`).
+
+**`--oauth-audience` moves into that same required-and-fail-closed bucket.**
+MCP 2025-11-25 requires resource servers to bind and validate token
+audience: a token issued for another service must not be accepted. Today
+(`mcp/http_auth.go:224` `audienceMatches`, called from `authenticateOAuth` at
+`:168`) audience checking only runs when `--oauth-audience` is set — with no
+audience configured, `authenticateOAuth` accepts any active token from the
+introspection endpoint regardless of its `aud` claim. That is fail-*open*,
+not fail-closed; `NewHTTPAuth` (`:57-61`) only logs a startup warning for the
+gap today, it does not refuse to start. That warn-only posture predates this
+spec requirement and no longer satisfies it.
+
+**Decision:** when `--oauth-introspection-url` is configured, require
+`--oauth-audience` too, and refuse to start without it — the same
+fail-closed treatment `--oauth-issuer` gets above, replacing today's
+warning. Audience *matching* itself (`audienceMatches`) is already correctly
+enforced whenever an audience value is present; only the "is one present"
+gate needs to become mandatory.
 
 ## (b) Where does `resource` come from?
 
@@ -43,10 +61,19 @@ MCP server. trvl binds `--host`/`--port`, but that's the bind address, not
 necessarily the address a client sees (reverse proxy, container port
 mapping, etc).
 
-**Decision: add `--public-url` / `TRVL_MCP_PUBLIC_URL`, defaulting to
-`http://<host>:<port>`.** The default is honest for the common local/direct
-case; anyone fronting trvl with a proxy sets it explicitly, same posture as
-every other "trvl behind a proxy" concern in `docs/REMOTE-MCP-OAUTH.md`.
+**Decision: add `--public-url` / `TRVL_MCP_PUBLIC_URL`.** RFC 9728 §2
+requires `resource` to be an https URI (it borrows the well-known-URI
+construction and identifier rules of RFC 8414 §3.3, which impose the same
+https requirement on issuer/resource identifiers). trvl cannot default to
+`http://<host>:<port>` and stay compliant, so:
+
+- When `--oauth-introspection-url` is configured, `--public-url` is
+  required and must be an `https://` URL — refuse to start otherwise, same
+  fail-closed treatment as `--oauth-issuer` and `--oauth-audience` above.
+- **Exception:** `http://localhost` and `http://127.0.0.1` public URLs are
+  accepted without erroring, for local development only. This is a known,
+  documented non-compliant convenience (an RFC 9728 client is free to reject
+  an http resource identifier) — not a general http allowance.
 
 `resource` in the served document is `<public-url>/mcp` — the MCP endpoint
 itself, not the bare host — because that's the identifier a client actually
@@ -64,22 +91,51 @@ When only static tokens are configured, both well-known routes return `404`
 feature. No PRM document, no `WWW-Authenticate: resource_metadata=...` on
 401s either — nothing here claims OAuth support it can't back up.
 
-## (d) Which routes, and the 401 header
+## (d) Which routes, the well-known URL, and the 401 header
 
 The spec requires implementing *one* of: the `WWW-Authenticate` header
 mechanism, or a well-known URI (either path-suffixed or root form).
 
 **Decision: do all three; it's one extra route and costs nothing.**
 
-- `GET /.well-known/oauth-protected-resource/mcp` (path-suffixed to the MCP
-  endpoint — the form MCP clients try first for a path-mounted server)
-- `GET /.well-known/oauth-protected-resource` (root form, for clients that
-  don't know to try the path-suffixed form first)
-- Every `401` from `POST /mcp` gets
-  `WWW-Authenticate: Bearer resource_metadata="<public-url>/.well-known/oauth-protected-resource/mcp", scope="trvl:read trvl:write"`
-  when OAuth is configured (omitted in static-token-only mode, per (c)).
+**Well-known URL construction (RFC 9728 §3).** The well-known path segment
+goes immediately after the authority; any path component `--public-url`
+carries (e.g. a reverse-proxy mount prefix) comes *after* the well-known
+segment, not before it. With `<base>` the path component of `--public-url`
+(empty by default):
+
+- `GET <scheme>://<authority>/.well-known/oauth-protected-resource<base>/mcp`
+  (path-suffixed to the MCP endpoint — the form MCP clients try first for a
+  path-mounted server)
+- `GET <scheme>://<authority>/.well-known/oauth-protected-resource` (root
+  form, unconditional — no `<base>/mcp` suffix — for clients that don't try
+  the path-suffixed form first)
+
+Example: `--public-url=https://host/base` gives the path-suffixed URL
+`https://host/.well-known/oauth-protected-resource/base/mcp` — **not**
+`https://host/base/.well-known/oauth-protected-resource/mcp`.
 
 Both well-known routes serve the identical document.
+
+**401 challenge scope.** The initial challenge must not push a read-only
+client into consenting to write access. `mcp/http_auth.go:281
+toolWriteRequirement` / `:290 toolRequiresWrite` already know, given a
+parsed request, whether the called tool requires write — reuse them:
+
+- Default challenge scope is `trvl:read`.
+- Escalate to `scope="trvl:write"` only when the request is a `tools/call`
+  for a tool `toolRequiresWrite` reports as write.
+
+The unauthenticated-request 401 currently fires at the top of `handleMCP`
+(`mcp/http.go:108-114`), before the body is read, so the tool being called
+isn't known yet at that point. Restructure so the body is read and parsed
+before the missing/invalid-token check runs, so it can pick the scope; a
+request with no body, an unparseable body, or a call to a read-only tool
+falls back to `scope="trvl:read"`.
+
+Full header when OAuth is configured (omitted in static-token-only mode,
+per (c)):
+`WWW-Authenticate: Bearer resource_metadata="<path-suffixed well-known URL>", scope="<trvl:read|trvl:write>"`
 
 ## (e) Discovery endpoints are unauthenticated
 

--- a/docs/design/oauth-protected-resource-metadata.md
+++ b/docs/design/oauth-protected-resource-metadata.md
@@ -1,0 +1,95 @@
+# OAuth Protected Resource Metadata (RFC 9728) for HTTP MCP mode
+
+Status: **implemented**
+Date: 2026-09-09
+
+## Why
+
+MCP spec rev 2025-11-25 requires an HTTP MCP server to implement OAuth 2.0
+Protected Resource Metadata (RFC 9728) so clients can discover which
+authorization server(s) protect it. trvl's HTTP transport (`mcp/http.go`)
+serves only `/mcp`, `/health`, `/dashboard` today and has no RFC 9728 support
+at all. This doc settles the open questions before writing code.
+
+## (a) Where does `authorization_servers` come from?
+
+RFC 9728 requires the PRM document to name at least one authorization-server
+issuer URL. trvl's existing `--oauth-introspection-url` is a token
+*introspection* endpoint, not the issuer identifier — the two are often on
+different hosts/paths at real IdPs (e.g. Auth0's introspection endpoint is
+`https://tenant.auth0.com/oauth/introspect`, but the issuer clients discover
+against is exactly `https://tenant.auth0.com/`). Deriving one from the other
+would be a guess trvl has no basis for.
+
+**Decision: add `--oauth-issuer` / `TRVL_MCP_OAUTH_ISSUER`.** It is the
+`authorization_servers[0]` value verbatim.
+
+**When OAuth is configured but the issuer is not set: refuse to start.**
+Same failure shape as `requireHTTPAuth`/`requireRemoteAuth` (GH-89.AUTH.4) —
+trvl already treats "started with an incomplete security config" as fatal,
+not a silent degrade. `authorization_servers` is a MUST field per the MCP
+spec; serving a PRM document without it (or not serving PRM at all while
+claiming OAuth support) is worse than refusing to start, because it looks
+compliant to a client's discovery probe while failing to name an issuer. This
+mirrors the codebase's existing convention: missing *required* config fails
+closed at startup (`requireHTTPAuth`); a missing *recommended* field
+(`--oauth-audience`) only warns, because that one is a defense-in-depth
+extra, not something the spec's response format requires you to emit.
+
+## (b) Where does `resource` come from?
+
+RFC 9728 §2 requires `resource`: the canonical URI clients use to reach this
+MCP server. trvl binds `--host`/`--port`, but that's the bind address, not
+necessarily the address a client sees (reverse proxy, container port
+mapping, etc).
+
+**Decision: add `--public-url` / `TRVL_MCP_PUBLIC_URL`, defaulting to
+`http://<host>:<port>`.** The default is honest for the common local/direct
+case; anyone fronting trvl with a proxy sets it explicitly, same posture as
+every other "trvl behind a proxy" concern in `docs/REMOTE-MCP-OAUTH.md`.
+
+`resource` in the served document is `<public-url>/mcp` — the MCP endpoint
+itself, not the bare host — because that's the identifier a client actually
+holds a token for.
+
+## (c) Static bearer tokens have no authorization server — PRM is meaningless there
+
+trvl also supports `--token`/`--read-token`/`--write-token` with no OAuth
+server involved at all. RFC 9728 exists to point a client at *an
+authorization server*; there isn't one to name in static-token mode.
+
+**Decision: serve PRM only when `--oauth-introspection-url` is configured.**
+When only static tokens are configured, both well-known routes return `404`
+(not registered) exactly as they would on any build that predates this
+feature. No PRM document, no `WWW-Authenticate: resource_metadata=...` on
+401s either — nothing here claims OAuth support it can't back up.
+
+## (d) Which routes, and the 401 header
+
+The spec requires implementing *one* of: the `WWW-Authenticate` header
+mechanism, or a well-known URI (either path-suffixed or root form).
+
+**Decision: do all three; it's one extra route and costs nothing.**
+
+- `GET /.well-known/oauth-protected-resource/mcp` (path-suffixed to the MCP
+  endpoint — the form MCP clients try first for a path-mounted server)
+- `GET /.well-known/oauth-protected-resource` (root form, for clients that
+  don't know to try the path-suffixed form first)
+- Every `401` from `POST /mcp` gets
+  `WWW-Authenticate: Bearer resource_metadata="<public-url>/.well-known/oauth-protected-resource/mcp", scope="trvl:read trvl:write"`
+  when OAuth is configured (omitted in static-token-only mode, per (c)).
+
+Both well-known routes serve the identical document.
+
+## (e) Discovery endpoints are unauthenticated
+
+A discovery document behind auth can't be discovered — a client with no
+token yet is precisely who needs to fetch it to learn where to get one. Both
+well-known routes, like `/health`, run before/outside `h.authorize()`.
+
+## What's out of scope
+
+- No dynamic client registration (RFC 7591) — not requested, no client here needs it.
+- No `bearer_methods_supported`/`resource_signing_alg_values_supported` etc. —
+  RFC 9728 optional fields trvl doesn't have an opinion on; omitted rather
+  than guessed.

--- a/docs/design/oauth-protected-resource-metadata.md
+++ b/docs/design/oauth-protected-resource-metadata.md
@@ -109,8 +109,14 @@ as interchangeable — RFC 9728 §3.3 does not, and a token minted for one will
 not match the other. A `--public-url` carrying a query or fragment is
 refused at startup (RFC 9728 §1.2 prohibits both in a resource identifier);
 so is one whose path contains `{` or `}` — those are reserved wildcard
-syntax in the `http.ServeMux` route patterns built from it, and registering
-one unvalidated panics the server at startup instead of failing closed.
+syntax in the `http.ServeMux` route patterns built from it, and an
+unvalidated one would register as a live wildcard route instead of a
+literal path match, silently serving the PRM document under
+attacker-controlled path segments rather than failing closed. A path whose
+percent-encoding changes segment structure (`%2F` for a literal `/`) is
+also refused, because the well-known route registered from the decoded
+path and the resource identifier published from the encoded string would
+then disagree.
 
 ## (c) Static bearer tokens have no authorization server — PRM is meaningless there
 

--- a/docs/design/oauth-protected-resource-metadata.md
+++ b/docs/design/oauth-protected-resource-metadata.md
@@ -1,6 +1,6 @@
 # OAuth Protected Resource Metadata (RFC 9728) for HTTP MCP mode
 
-Status: designed, implementation pending
+Status: implemented
 Date: 2026-09-09
 
 ## Why
@@ -24,7 +24,9 @@ against is exactly `https://tenant.auth0.com/`). Deriving one from the other
 would be a guess trvl has no basis for.
 
 **Decision: add `--oauth-issuer` / `TRVL_MCP_OAUTH_ISSUER`.** It is the
-`authorization_servers[0]` value verbatim.
+`authorization_servers[0]` value verbatim, validated as an absolute
+`https://` URL (RFC 8414 §2 — the issuer identifier's format requirement)
+before the server starts.
 
 **When OAuth is configured but the issuer is not set: refuse to start.**
 Same failure shape as `requireHTTPAuth`/`requireRemoteAuth` (GH-89.AUTH.4) —
@@ -102,7 +104,11 @@ resource indicator and this server's audience check. So: strip any trailing
 slash from `--public-url` before appending `/mcp`; preserve IPv6 literal
 brackets (`https://[::1]:8080`); and do not treat `localhost` and `127.0.0.1`
 as interchangeable — RFC 9728 §3.3 does not, and a token minted for one will
-not match the other.
+not match the other. A `--public-url` carrying a query or fragment is
+refused at startup (RFC 9728 §1.2 prohibits both in a resource identifier);
+so is one whose path contains `{` or `}` — those are reserved wildcard
+syntax in the `http.ServeMux` route patterns built from it, and registering
+one unvalidated panics the server at startup instead of failing closed.
 
 ## (c) Static bearer tokens have no authorization server — PRM is meaningless there
 
@@ -173,6 +179,17 @@ falls back to `scope="trvl:read"`.
 Full header when OAuth is configured (omitted in static-token-only mode,
 per (c)):
 `WWW-Authenticate: Bearer resource_metadata="<path-suffixed well-known URL>", scope="<trvl:read|trvl:write>"`
+
+**Insufficient scope on an authenticated request.** A request that
+authenticates but whose token lacks the scope a `tools/call` needs (e.g. a
+`trvl:read`-only token calling a write tool) is a distinct case from the
+missing/invalid-token 401 above: RFC 6750 §3.1 requires this to be `403`, not
+`200` with a JSON-RPC error body — a `200` tells an HTTP-layer client the call
+succeeded. The response is `403` with a JSON-RPC error body (so an MCP client
+still gets the same machine-readable detail) and:
+`WWW-Authenticate: Bearer resource_metadata="<path-suffixed well-known URL>", error="insufficient_scope", scope="<trvl:read|trvl:write>"`
+(the `resource_metadata` parameter is omitted in static-token-only mode, same
+as the 401 case — there is no authorization server to point a client at).
 
 ## (e) Discovery endpoints are unauthenticated
 

--- a/docs/design/oauth-protected-resource-metadata.md
+++ b/docs/design/oauth-protected-resource-metadata.md
@@ -106,17 +106,21 @@ resource indicator and this server's audience check. So: strip any trailing
 slash from `--public-url` before appending `/mcp`; preserve IPv6 literal
 brackets (`https://[::1]:8080`); and do not treat `localhost` and `127.0.0.1`
 as interchangeable — RFC 9728 §3.3 does not, and a token minted for one will
-not match the other. A `--public-url` carrying a query or fragment is
-refused at startup (RFC 9728 §1.2 prohibits both in a resource identifier);
-so is one whose path contains `{` or `}` — those are reserved wildcard
-syntax in the `http.ServeMux` route patterns built from it, and an
+not match the other. A `--public-url` with an empty hostname (e.g. a
+port-only authority like `https://:443/x`) or carrying a query or fragment
+is refused at startup (an empty hostname isn't a valid identifier at all;
+RFC 9728 §1.2 prohibits both a query and a fragment in a resource
+identifier); so is one whose path contains `{` or `}` — those are reserved
+wildcard syntax in the `http.ServeMux` route patterns built from it, and an
 unvalidated one would register as a live wildcard route instead of a
 literal path match, silently serving the PRM document under
 attacker-controlled path segments rather than failing closed. A path whose
-percent-encoding changes segment structure (`%2F` for a literal `/`) is
-also refused, because the well-known route registered from the decoded
-path and the resource identifier published from the encoded string would
-then disagree.
+percent-encoding is non-default (`u.RawPath != ""`) is also refused — this
+is a deliberately conservative proxy for encodings that would change segment
+structure (`%2F` for a literal `/`) and make the well-known route registered
+from the decoded path disagree with the resource identifier published from
+the encoded string; it also rejects some benign encodings that don't change
+segment structure (e.g. `%41` for `A`), an accepted false positive.
 
 ## (c) Static bearer tokens have no authorization server — PRM is meaningless there
 

--- a/docs/design/oauth-protected-resource-metadata.md
+++ b/docs/design/oauth-protected-resource-metadata.md
@@ -36,7 +36,7 @@ compliant to a client's discovery probe while failing to name an issuer. This
 mirrors the codebase's existing convention: missing *required* config fails
 closed at startup (`requireHTTPAuth`).
 
-**`--oauth-audience` moves into that same required-and-fail-closed bucket.**
+**`--oauth-audience` needs to stop being silently optional.**
 MCP 2025-11-25 requires resource servers to bind and validate token
 audience: a token issued for another service must not be accepted. Today
 (`mcp/http_auth.go:224` `audienceMatches`, called from `authenticateOAuth` at
@@ -85,7 +85,8 @@ https requirement on issuer/resource identifiers). trvl cannot default to
 
 - When `--oauth-introspection-url` is configured, `--public-url` is
   required and must be an `https://` URL — refuse to start otherwise, same
-  fail-closed treatment as `--oauth-issuer` and `--oauth-audience` above.
+  fail-closed treatment as `--oauth-issuer` above (`--oauth-audience`
+  itself now defaults rather than requiring an explicit value, per (a)).
 - **Exception:** `http://localhost` and `http://127.0.0.1` public URLs are
   accepted without erroring, for local development only. This is a known,
   documented non-compliant convenience (an RFC 9728 client is free to reject

--- a/docs/design/oauth-protected-resource-metadata.md
+++ b/docs/design/oauth-protected-resource-metadata.md
@@ -1,6 +1,8 @@
 # OAuth Protected Resource Metadata (RFC 9728) for HTTP MCP mode
 
-Status: implemented
+Status: implemented, with one known residual (see (d) 403 note) — an
+authenticated token holding only unrecognized scopes returns 401 instead of
+403; tracked as a follow-up, not fixed here.
 Date: 2026-09-09
 
 ## Why
@@ -190,6 +192,12 @@ still gets the same machine-readable detail) and:
 `WWW-Authenticate: Bearer resource_metadata="<path-suffixed well-known URL>", error="insufficient_scope", scope="<trvl:read|trvl:write>"`
 (the `resource_metadata` parameter is omitted in static-token-only mode, same
 as the 401 case — there is no authorization server to point a client at).
+
+**Known residual.** A token that is active and audience-valid but carries
+only unrecognized scopes (neither `trvl:read` nor `trvl:write`) still falls
+into the pre-existing `mcp/http_auth.go` scope check and returns `401`, not
+the `403` above — that check predates this change and is out of scope for
+it. Tracked as a follow-up.
 
 ## (e) Discovery endpoints are unauthenticated
 

--- a/mcp/http.go
+++ b/mcp/http.go
@@ -47,6 +47,8 @@ type HTTPServerOptions struct {
 	OAuthClientID         string
 	OAuthClientSecret     string
 	OAuthAudience         string
+	OAuthIssuer           string
+	PublicURL             string
 	HTTPClient            *http.Client
 }
 
@@ -326,7 +328,16 @@ func RunHTTPWithOptions(opts HTTPServerOptions) error {
 	if strings.TrimSpace(opts.OAuthAudience) == "" {
 		opts.OAuthAudience = strings.TrimSpace(os.Getenv("TRVL_MCP_OAUTH_AUDIENCE"))
 	}
+	if strings.TrimSpace(opts.OAuthIssuer) == "" {
+		opts.OAuthIssuer = strings.TrimSpace(os.Getenv("TRVL_MCP_OAUTH_ISSUER"))
+	}
+	if strings.TrimSpace(opts.PublicURL) == "" {
+		opts.PublicURL = strings.TrimSpace(os.Getenv("TRVL_MCP_PUBLIC_URL"))
+	}
 	if err := requireHTTPAuth(opts.Host, httpAuthConfigured(opts)); err != nil {
+		return err
+	}
+	if err := requireOAuthPRMConfig(opts); err != nil {
 		return err
 	}
 	if strings.TrimSpace(opts.OAuthIntrospectionURL) != "" {

--- a/mcp/http.go
+++ b/mcp/http.go
@@ -34,6 +34,7 @@ type HTTPServer struct {
 	port   int
 	auth   *HTTPAuth
 	audit  authAudit
+	prm    *protectedResourceMetadata
 }
 
 // HTTPServerOptions configures the HTTP MCP transport.
@@ -68,6 +69,7 @@ func NewHTTPServerWithOptions(opts HTTPServerOptions) *HTTPServer {
 		host:   host,
 		port:   opts.Port,
 		auth:   NewHTTPAuth(opts),
+		prm:    buildProtectedResourceMetadata(opts),
 	}
 }
 
@@ -76,10 +78,7 @@ func NewHTTPServerWithOptions(opts HTTPServerOptions) *HTTPServer {
 // Coverage exclusion: blocking HTTP server entry point.
 // The handler logic (handleMCP, handleHealth) is tested via httptest in server_extra_test.go.
 func (h *HTTPServer) ListenAndServe() error {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/mcp", h.handleMCP)
-	mux.HandleFunc("/health", h.handleHealth)
-	mux.HandleFunc("/dashboard", h.handleDashboard)
+	mux := h.newMux()
 
 	addr := net.JoinHostPort(h.host, strconv.Itoa(h.port))
 	log.Printf("trvl MCP server listening on http://%s/mcp", addr)
@@ -91,6 +90,39 @@ func (h *HTTPServer) ListenAndServe() error {
 		IdleTimeout:  120 * time.Second,
 	}
 	return srv.ListenAndServe()
+}
+
+// newMux builds the route table. Split out from ListenAndServe so tests can
+// exercise routing (well-known 404s in static-token-only mode) without
+// binding a socket.
+func (h *HTTPServer) newMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", h.handleMCP)
+	mux.HandleFunc("/health", h.handleHealth)
+	mux.HandleFunc("/dashboard", h.handleDashboard)
+	if h.prm != nil {
+		mux.HandleFunc(h.prm.rootPath, h.handleProtectedResourceMetadata)
+		if h.prm.suffixedPath != h.prm.rootPath {
+			mux.HandleFunc(h.prm.suffixedPath, h.handleProtectedResourceMetadata)
+		}
+	}
+	return mux
+}
+
+// handleProtectedResourceMetadata serves the RFC 9728 PRM document. Both
+// well-known routes are unregistered (404) unless OAuth introspection, an
+// issuer, and a valid public URL are all configured (design doc (c)).
+func (h *HTTPServer) handleProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) {
+	if h.prm == nil {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(h.prm.doc)
 }
 
 func (h *HTTPServer) handleMCP(w http.ResponseWriter, r *http.Request) {

--- a/mcp/http.go
+++ b/mcp/http.go
@@ -139,10 +139,21 @@ func (h *HTTPServer) handleMCP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Limit request body to 1MB to prevent abuse. Read before the auth check
+	// so a 401 can pick the right WWW-Authenticate challenge scope from the
+	// tool being called (design doc (d)); a read failure still 401s below,
+	// and is reported as a body error only once the request is authorized.
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	body, bodyErr := io.ReadAll(r.Body)
+	defer func() { _ = r.Body.Close() }()
+
 	access, ok := h.authorize(r)
 	if !ok {
 		h.audit.denied.Add(1)
 		slogHTTPAuthDecision("deny", "", "", "missing or invalid bearer token")
+		if challenge := h.wwwAuthenticateChallenge(body); challenge != "" {
+			w.Header().Set("WWW-Authenticate", challenge)
+		}
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
@@ -152,14 +163,10 @@ func (h *HTTPServer) handleMCP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Limit request body to 1MB to prevent abuse.
-	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
+	if bodyErr != nil {
 		http.Error(w, "failed to read body", http.StatusBadRequest)
 		return
 	}
-	defer func() { _ = r.Body.Close() }()
 
 	var req Request
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -198,6 +205,34 @@ func (h *HTTPServer) handleMCP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// challengeScope picks the WWW-Authenticate scope for an unauthenticated
+// request (design doc (d)): trvl:write only for a tools/call naming a tool
+// toolRequiresWrite reports as write; trvl:read for everything else,
+// including no body, an unparseable body, or a non-tools/call method.
+func (h *HTTPServer) challengeScope(body []byte) string {
+	if len(body) == 0 {
+		return scopeRead
+	}
+	var req Request
+	if err := json.Unmarshal(body, &req); err != nil || req.Method != "tools/call" {
+		return scopeRead
+	}
+	if _, requiresWrite, ok := h.server.toolWriteRequirement(&req); ok && requiresWrite {
+		return scopeWrite
+	}
+	return scopeRead
+}
+
+// wwwAuthenticateChallenge returns the 401 challenge header value, or "" when
+// PRM is disabled (static-token-only mode has no authorization server to
+// point a client at — design doc (c)).
+func (h *HTTPServer) wwwAuthenticateChallenge(body []byte) string {
+	if h.prm == nil {
+		return ""
+	}
+	return fmt.Sprintf(`Bearer resource_metadata="%s", scope=%q`, h.prm.challengeURL, h.challengeScope(body))
 }
 
 func (h *HTTPServer) authorize(r *http.Request) (RequestAccess, bool) {

--- a/mcp/http.go
+++ b/mcp/http.go
@@ -118,6 +118,7 @@ func (h *HTTPServer) handleProtectedResourceMetadata(w http.ResponseWriter, r *h
 		return
 	}
 	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
@@ -180,11 +181,12 @@ func (h *HTTPServer) handleMCP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if errResp := h.authorizeJSONRPC(&req, access); errResp != nil {
+	if errResp, requiredScope := h.authorizeJSONRPC(&req, access); errResp != nil {
 		h.audit.denied.Add(1)
 		slogHTTPAuthDecision("deny", req.Method, scopeSummary(access), errResp.Message)
+		w.Header().Set("WWW-Authenticate", h.insufficientScopeChallenge(requiredScope))
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusForbidden)
 		_ = json.NewEncoder(w).Encode(Response{
 			JSONRPC: "2.0",
 			ID:      req.ID,
@@ -235,6 +237,17 @@ func (h *HTTPServer) wwwAuthenticateChallenge(body []byte) string {
 	return fmt.Sprintf(`Bearer resource_metadata="%s", scope=%q`, h.prm.challengeURL, h.challengeScope(body))
 }
 
+// insufficientScopeChallenge returns the 403 WWW-Authenticate value for an
+// authenticated request whose token lacks requiredScope (RFC 6750 §3.1). It
+// omits resource_metadata in static-token-only mode (design doc (c) — no
+// authorization server to point a client at there).
+func (h *HTTPServer) insufficientScopeChallenge(requiredScope string) string {
+	if h.prm == nil {
+		return fmt.Sprintf(`Bearer error="insufficient_scope", scope=%q`, requiredScope)
+	}
+	return fmt.Sprintf(`Bearer resource_metadata="%s", error="insufficient_scope", scope=%q`, h.prm.challengeURL, requiredScope)
+}
+
 func (h *HTTPServer) authorize(r *http.Request) (RequestAccess, bool) {
 	if h.auth == nil || !h.auth.Configured() {
 		return FullAccess("anonymous", "disabled"), true
@@ -247,21 +260,21 @@ func (h *HTTPServer) authorize(r *http.Request) (RequestAccess, bool) {
 	return h.auth.Authenticate(r.Context(), strings.TrimSpace(strings.TrimPrefix(auth, prefix)))
 }
 
-func (h *HTTPServer) authorizeJSONRPC(req *Request, access RequestAccess) *Error {
+func (h *HTTPServer) authorizeJSONRPC(req *Request, access RequestAccess) (*Error, string) {
 	if !access.CanRead() {
-		return &Error{Code: -32001, Message: "permission denied: token requires trvl:read scope"}
+		return &Error{Code: -32001, Message: "permission denied: token requires trvl:read scope"}, scopeRead
 	}
 	if req.Method != "tools/call" {
-		return nil
+		return nil, ""
 	}
 	tool, requiresWrite, ok := h.server.toolWriteRequirement(req)
 	if !ok {
-		return nil
+		return nil, ""
 	}
 	if requiresWrite && !access.CanWrite() {
-		return &Error{Code: -32001, Message: fmt.Sprintf("permission denied: tool %s requires trvl:write scope", tool)}
+		return &Error{Code: -32001, Message: fmt.Sprintf("permission denied: tool %s requires trvl:write scope", tool)}, scopeWrite
 	}
-	return nil
+	return nil, ""
 }
 
 func (h *HTTPServer) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/mcp/http_auth.go
+++ b/mcp/http_auth.go
@@ -55,10 +55,20 @@ func NewHTTPAuth(opts HTTPServerOptions) *HTTPAuth {
 		client:                client,
 	}
 	if a.oauthIntrospectionURL != "" && a.oauthAudience == "" {
-		// Confused-deputy guard (RFC 7662 §2.2): without a pinned audience, any
-		// valid token at this IdP — including tokens minted for other services —
-		// is accepted. Warn loudly; do not hard-fail (single-tenant dev setups).
-		slog.Warn("mcp oauth: no --oauth-audience configured; tokens issued for any client at this introspection endpoint will be accepted (set --oauth-audience for production)")
+		// Derive the confused-deputy guard (RFC 7662 §2.2) from the published
+		// PRM resource: an RFC 8707 client requests resource=<public-url>/mcp
+		// and gets a token with that aud, so this is the value trvl should
+		// pin by construction rather than require the operator to repeat.
+		if publicURL := strings.TrimSpace(opts.PublicURL); publicURL != "" {
+			if u, err := normalizePublicURL(publicURL); err == nil {
+				a.oauthAudience = resourceIdentifier(u)
+			}
+		}
+	}
+	if a.oauthIntrospectionURL != "" && a.oauthAudience == "" {
+		// No --public-url either: nothing to derive from. Warn loudly; do not
+		// hard-fail (single-tenant dev setups).
+		slog.Warn("mcp oauth: no --oauth-audience/--public-url configured; tokens issued for any client at this introspection endpoint will be accepted (set --public-url for production)")
 	}
 	return a
 }

--- a/mcp/http_auth_remote_test.go
+++ b/mcp/http_auth_remote_test.go
@@ -234,8 +234,8 @@ func TestOAuthIntrospection_ScopeEnforcement(t *testing.T) {
 
 	// Read-only OAuth token denied on a write tool.
 	resp, status := postHTTPToolCall(t, hs, "ro", "update_preferences", map[string]any{"display_currency": "EUR"})
-	if status != http.StatusOK {
-		t.Fatalf("ro write-tool status = %d, want 200 JSON-RPC error", status)
+	if status != http.StatusForbidden {
+		t.Fatalf("ro write-tool status = %d, want 403 (RFC 6750 §3.1 insufficient_scope)", status)
 	}
 	if resp.Error == nil || resp.Error.Code != -32001 {
 		t.Fatalf("ro write-tool expected -32001 scope error, got %#v", resp.Error)

--- a/mcp/http_prm.go
+++ b/mcp/http_prm.go
@@ -131,6 +131,7 @@ func buildProtectedResourceMetadata(opts HTTPServerOptions) *protectedResourceMe
 	challenge.Path = suffixed
 	challenge.RawQuery = ""
 	challenge.Fragment = ""
+	challenge.ForceQuery = false
 	return &protectedResourceMetadata{
 		doc: prmDocument{
 			Resource:             resourceIdentifier(u),

--- a/mcp/http_prm.go
+++ b/mcp/http_prm.go
@@ -105,6 +105,8 @@ func buildProtectedResourceMetadata(opts HTTPServerOptions) *protectedResourceMe
 		challengeURL: challenge.String(),
 	}
 }
+
+// requireOAuthPRMConfig enforces the design's fail-closed startup gate: OAuth
 // configured without a usable --oauth-issuer/--public-url is fatal, same
 // shape as requireHTTPAuth. A no-op when OAuth introspection isn't configured.
 func requireOAuthPRMConfig(opts HTTPServerOptions) error {

--- a/mcp/http_prm.go
+++ b/mcp/http_prm.go
@@ -55,7 +55,56 @@ func wellKnownPaths(publicURL string) (root, suffixed string, err error) {
 	return wellKnownPRMRoot, wellKnownPRMRoot + u.Path + "/mcp", nil
 }
 
-// requireOAuthPRMConfig enforces the design's fail-closed startup gate: OAuth
+// prmDocument is the RFC 9728 Protected Resource Metadata document: exactly
+// the two fields the design settled on, nothing optional guessed at.
+type prmDocument struct {
+	Resource             string   `json:"resource"`
+	AuthorizationServers []string `json:"authorization_servers"`
+}
+
+// protectedResourceMetadata holds an HTTPServer's PRM config: the document to
+// serve, the routes to serve it on, and the absolute URL used in the
+// WWW-Authenticate challenge.
+type protectedResourceMetadata struct {
+	doc          prmDocument
+	rootPath     string
+	suffixedPath string
+	challengeURL string
+}
+
+// buildProtectedResourceMetadata returns nil (PRM disabled) unless OAuth
+// introspection, an issuer, and a valid public URL are all configured — the
+// same fields requireOAuthPRMConfig enforces at startup. NewHTTPServerWithOptions
+// is also called directly by tests that don't go through that gate, so this
+// stays lenient rather than panicking on incomplete config.
+func buildProtectedResourceMetadata(opts HTTPServerOptions) *protectedResourceMetadata {
+	issuer := strings.TrimSpace(opts.OAuthIssuer)
+	publicURL := strings.TrimSpace(opts.PublicURL)
+	if strings.TrimSpace(opts.OAuthIntrospectionURL) == "" || issuer == "" || publicURL == "" {
+		return nil
+	}
+	u, err := normalizePublicURL(publicURL)
+	if err != nil {
+		return nil
+	}
+	root, suffixed, err := wellKnownPaths(publicURL)
+	if err != nil {
+		return nil
+	}
+	challenge := *u
+	challenge.Path = suffixed
+	challenge.RawQuery = ""
+	challenge.Fragment = ""
+	return &protectedResourceMetadata{
+		doc: prmDocument{
+			Resource:             resourceIdentifier(u),
+			AuthorizationServers: []string{issuer},
+		},
+		rootPath:     root,
+		suffixedPath: suffixed,
+		challengeURL: challenge.String(),
+	}
+}
 // configured without a usable --oauth-issuer/--public-url is fatal, same
 // shape as requireHTTPAuth. A no-op when OAuth introspection isn't configured.
 func requireOAuthPRMConfig(opts HTTPServerOptions) error {

--- a/mcp/http_prm.go
+++ b/mcp/http_prm.go
@@ -10,7 +10,12 @@ const wellKnownPRMRoot = "/.well-known/oauth-protected-resource"
 
 // normalizePublicURL parses --public-url and strips any trailing slash from
 // its path, so the value is stable to append "/mcp" or a well-known segment
-// to (RFC 9728 §3.3: resource must equal the URL clients actually call).
+// to (RFC 9728 §3.3: resource must equal the URL clients actually call). A
+// query or fragment is rejected (RFC 9728 §1.2 prohibits both in a resource
+// identifier); a `{` or `}` in the path is rejected because it would be
+// registered verbatim as an http.ServeMux pattern (net/http, Go 1.22+
+// wildcard syntax), panicking at route-registration time instead of failing
+// closed here.
 func normalizePublicURL(raw string) (*url.URL, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -22,6 +27,12 @@ func normalizePublicURL(raw string) (*url.URL, error) {
 	}
 	if u.Scheme == "" || u.Host == "" {
 		return nil, fmt.Errorf("--public-url %q must be an absolute URL", trimmed)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return nil, fmt.Errorf("--public-url %q must not contain a query or fragment", trimmed)
+	}
+	if strings.ContainsAny(u.Path, "{}") {
+		return nil, fmt.Errorf("--public-url %q path must not contain '{' or '}'", trimmed)
 	}
 	u.Path = strings.TrimSuffix(u.Path, "/")
 	return u, nil
@@ -117,6 +128,13 @@ func requireOAuthPRMConfig(opts HTTPServerOptions) error {
 		return fmt.Errorf(
 			"refusing to start: --oauth-issuer (or TRVL_MCP_OAUTH_ISSUER) is required when " +
 				"--oauth-introspection-url is set, to publish RFC 9728 Protected Resource Metadata",
+		)
+	}
+	issuer := strings.TrimSpace(opts.OAuthIssuer)
+	if iu, err := url.Parse(issuer); err != nil || iu.Scheme != "https" || iu.Host == "" {
+		return fmt.Errorf(
+			"refusing to start: --oauth-issuer %q must be an absolute https:// URL (RFC 8414 §2)",
+			issuer,
 		)
 	}
 	publicURL := strings.TrimSpace(opts.PublicURL)

--- a/mcp/http_prm.go
+++ b/mcp/http_prm.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 )
@@ -12,10 +13,18 @@ const wellKnownPRMRoot = "/.well-known/oauth-protected-resource"
 // its path, so the value is stable to append "/mcp" or a well-known segment
 // to (RFC 9728 §3.3: resource must equal the URL clients actually call). A
 // query or fragment is rejected (RFC 9728 §1.2 prohibits both in a resource
-// identifier); a `{` or `}` in the path is rejected because it would be
-// registered verbatim as an http.ServeMux pattern (net/http, Go 1.22+
-// wildcard syntax), panicking at route-registration time instead of failing
-// closed here.
+// identifier) — including a bare "?" with no key=value, which net/url
+// tracks as ForceQuery rather than a nonempty RawQuery but which
+// (*url.URL).String() still re-emits, so it would otherwise leak into the
+// resource identifier undetected. A `{` or `}` in the decoded path is
+// rejected because the well-known pattern built from it
+// (wellKnownPRMRoot+path+"/mcp") would register as a live http.ServeMux
+// wildcard route (Go 1.22+ wildcard syntax) instead of a literal path match
+// — it does not panic, it silently serves the PRM document under attacker-
+// controlled path segments. Any other path that is well-formed URL-wise but
+// that http.ServeMux itself refuses to register (e.g. embedded whitespace)
+// is caught by patternRegistrable below, so a bad --public-url fails here
+// rather than panicking the server at route-registration time.
 func normalizePublicURL(raw string) (*url.URL, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -28,14 +37,30 @@ func normalizePublicURL(raw string) (*url.URL, error) {
 	if u.Scheme == "" || u.Host == "" {
 		return nil, fmt.Errorf("--public-url %q must be an absolute URL", trimmed)
 	}
-	if u.RawQuery != "" || u.Fragment != "" {
+	if u.RawQuery != "" || u.Fragment != "" || u.ForceQuery {
 		return nil, fmt.Errorf("--public-url %q must not contain a query or fragment", trimmed)
 	}
 	if strings.ContainsAny(u.Path, "{}") {
 		return nil, fmt.Errorf("--public-url %q path must not contain '{' or '}'", trimmed)
 	}
 	u.Path = strings.TrimSuffix(u.Path, "/")
+	if err := patternRegistrable(wellKnownPRMRoot + u.Path + "/mcp"); err != nil {
+		return nil, fmt.Errorf("--public-url %q produces an unregistrable route: %v", trimmed, err)
+	}
 	return u, nil
+}
+
+// patternRegistrable reports whether pattern can be registered on an
+// http.ServeMux without panicking (net/http panics at registration time for
+// a malformed pattern, e.g. one containing whitespace).
+func patternRegistrable(pattern string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+	http.NewServeMux().HandleFunc(pattern, func(http.ResponseWriter, *http.Request) {})
+	return nil
 }
 
 // resourceIdentifier is the RFC 9728 `resource` value: the MCP endpoint
@@ -131,9 +156,10 @@ func requireOAuthPRMConfig(opts HTTPServerOptions) error {
 		)
 	}
 	issuer := strings.TrimSpace(opts.OAuthIssuer)
-	if iu, err := url.Parse(issuer); err != nil || iu.Scheme != "https" || iu.Host == "" {
+	iu, err := url.Parse(issuer)
+	if err != nil || iu.Scheme != "https" || iu.Host == "" || iu.RawQuery != "" || iu.Fragment != "" || iu.ForceQuery {
 		return fmt.Errorf(
-			"refusing to start: --oauth-issuer %q must be an absolute https:// URL (RFC 8414 §2)",
+			"refusing to start: --oauth-issuer %q must be an absolute https:// URL with no query or fragment (RFC 8414 §2)",
 			issuer,
 		)
 	}

--- a/mcp/http_prm.go
+++ b/mcp/http_prm.go
@@ -1,0 +1,98 @@
+package mcp
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const wellKnownPRMRoot = "/.well-known/oauth-protected-resource"
+
+// normalizePublicURL parses --public-url and strips any trailing slash from
+// its path, so the value is stable to append "/mcp" or a well-known segment
+// to (RFC 9728 §3.3: resource must equal the URL clients actually call).
+func normalizePublicURL(raw string) (*url.URL, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, fmt.Errorf("--public-url is empty")
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("--public-url %q is not a valid URL: %w", trimmed, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("--public-url %q must be an absolute URL", trimmed)
+	}
+	u.Path = strings.TrimSuffix(u.Path, "/")
+	return u, nil
+}
+
+// resourceIdentifier is the RFC 9728 `resource` value: the MCP endpoint
+// itself, not the bare host.
+func resourceIdentifier(u *url.URL) string {
+	return u.String() + "/mcp"
+}
+
+// isDevLoopbackHTTP reports the documented non-compliant convenience:
+// http://localhost and http://127.0.0.1 are accepted unerrored, local
+// development only.
+func isDevLoopbackHTTP(u *url.URL) bool {
+	if u.Scheme != "http" {
+		return false
+	}
+	host := u.Hostname()
+	return strings.EqualFold(host, "localhost") || host == "127.0.0.1"
+}
+
+// wellKnownPaths returns the root and path-suffixed well-known routes for
+// publicURL (RFC 9728 §3). The well-known segment goes immediately after the
+// authority; any path component publicURL carries comes after it.
+func wellKnownPaths(publicURL string) (root, suffixed string, err error) {
+	u, err := normalizePublicURL(publicURL)
+	if err != nil {
+		return "", "", err
+	}
+	return wellKnownPRMRoot, wellKnownPRMRoot + u.Path + "/mcp", nil
+}
+
+// requireOAuthPRMConfig enforces the design's fail-closed startup gate: OAuth
+// configured without a usable --oauth-issuer/--public-url is fatal, same
+// shape as requireHTTPAuth. A no-op when OAuth introspection isn't configured.
+func requireOAuthPRMConfig(opts HTTPServerOptions) error {
+	if strings.TrimSpace(opts.OAuthIntrospectionURL) == "" {
+		return nil
+	}
+	if strings.TrimSpace(opts.OAuthIssuer) == "" {
+		return fmt.Errorf(
+			"refusing to start: --oauth-issuer (or TRVL_MCP_OAUTH_ISSUER) is required when " +
+				"--oauth-introspection-url is set, to publish RFC 9728 Protected Resource Metadata",
+		)
+	}
+	publicURL := strings.TrimSpace(opts.PublicURL)
+	if publicURL == "" {
+		return fmt.Errorf(
+			"refusing to start: --public-url (or TRVL_MCP_PUBLIC_URL) is required when " +
+				"--oauth-introspection-url is set, to publish RFC 9728 Protected Resource Metadata",
+		)
+	}
+	u, err := normalizePublicURL(publicURL)
+	if err != nil {
+		return fmt.Errorf("refusing to start: %w", err)
+	}
+	if u.Scheme != "https" && !isDevLoopbackHTTP(u) {
+		return fmt.Errorf(
+			"refusing to start: --public-url %q must be an https:// URL "+
+				"(http://localhost or http://127.0.0.1 is allowed for local development only)",
+			publicURL,
+		)
+	}
+	resource := resourceIdentifier(u)
+	if audience := strings.TrimSpace(opts.OAuthAudience); audience != "" && audience != resource {
+		return fmt.Errorf(
+			"refusing to start: --oauth-audience %q does not match the published resource %q "+
+				"(leave --oauth-audience unset to derive it from --public-url)",
+			audience, resource,
+		)
+	}
+	return nil
+}

--- a/mcp/http_prm.go
+++ b/mcp/http_prm.go
@@ -43,6 +43,12 @@ func normalizePublicURL(raw string) (*url.URL, error) {
 	if strings.ContainsAny(u.Path, "{}") {
 		return nil, fmt.Errorf("--public-url %q path must not contain '{' or '}'", trimmed)
 	}
+	if u.RawPath != "" {
+		return nil, fmt.Errorf(
+			"--public-url %q path encoding changes segment structure (e.g. %%2F); "+
+				"the published resource and the registered route would disagree", trimmed,
+		)
+	}
 	u.Path = strings.TrimSuffix(u.Path, "/")
 	if err := patternRegistrable(wellKnownPRMRoot + u.Path + "/mcp"); err != nil {
 		return nil, fmt.Errorf("--public-url %q produces an unregistrable route: %v", trimmed, err)
@@ -129,9 +135,6 @@ func buildProtectedResourceMetadata(opts HTTPServerOptions) *protectedResourceMe
 	}
 	challenge := *u
 	challenge.Path = suffixed
-	challenge.RawQuery = ""
-	challenge.Fragment = ""
-	challenge.ForceQuery = false
 	return &protectedResourceMetadata{
 		doc: prmDocument{
 			Resource:             resourceIdentifier(u),
@@ -158,7 +161,8 @@ func requireOAuthPRMConfig(opts HTTPServerOptions) error {
 	}
 	issuer := strings.TrimSpace(opts.OAuthIssuer)
 	iu, err := url.Parse(issuer)
-	if err != nil || iu.Scheme != "https" || iu.Host == "" || iu.RawQuery != "" || iu.Fragment != "" || iu.ForceQuery {
+	if err != nil || iu.Scheme != "https" || iu.Host == "" || iu.Hostname() == "" ||
+		iu.RawQuery != "" || iu.Fragment != "" || iu.ForceQuery || strings.Contains(issuer, "#") {
 		return fmt.Errorf(
 			"refusing to start: --oauth-issuer %q must be an absolute https:// URL with no query or fragment (RFC 8414 §2)",
 			issuer,

--- a/mcp/http_prm.go
+++ b/mcp/http_prm.go
@@ -9,14 +9,35 @@ import (
 
 const wellKnownPRMRoot = "/.well-known/oauth-protected-resource"
 
+// validateAuthorityAndQuery enforces, on any absolute URL regardless of
+// scheme, the checks RFC 9728 §1.2 / RFC 8414 §2 impose on a resource or
+// issuer identifier that a field comparison alone can miss: an empty
+// hostname (u.Host can be non-empty for a port-only authority like ":443"
+// while u.Hostname() is ""), a query — including a bare "?" with no
+// key=value, which net/url tracks as ForceQuery rather than a nonempty
+// RawQuery — and a fragment — including a bare "#", which parses to
+// Fragment=="" and so has to be checked against the raw string, not the
+// field. raw is the original (trimmed) string, used only for that string
+// check and for the error message.
+func validateAuthorityAndQuery(u *url.URL, raw string) error {
+	if u.Hostname() == "" {
+		return fmt.Errorf("%q has an empty hostname (a port-only authority is not a valid identifier)", raw)
+	}
+	if u.RawQuery != "" || u.ForceQuery {
+		return fmt.Errorf("%q must not contain a query", raw)
+	}
+	if u.Fragment != "" || strings.Contains(raw, "#") {
+		return fmt.Errorf("%q must not contain a fragment", raw)
+	}
+	return nil
+}
+
 // normalizePublicURL parses --public-url and strips any trailing slash from
 // its path, so the value is stable to append "/mcp" or a well-known segment
-// to (RFC 9728 §3.3: resource must equal the URL clients actually call). A
-// query or fragment is rejected (RFC 9728 §1.2 prohibits both in a resource
-// identifier) — including a bare "?" with no key=value, which net/url
-// tracks as ForceQuery rather than a nonempty RawQuery but which
-// (*url.URL).String() still re-emits, so it would otherwise leak into the
-// resource identifier undetected. A `{` or `}` in the decoded path is
+// to (RFC 9728 §3.3: resource must equal the URL clients actually call).
+// validateAuthorityAndQuery rejects an empty hostname, a query, or a
+// fragment (RFC 9728 §1.2 prohibits both of the latter in a resource
+// identifier). A `{` or `}` in the decoded path is
 // rejected because the well-known pattern built from it
 // (wellKnownPRMRoot+path+"/mcp") would register as a live http.ServeMux
 // wildcard route (Go 1.22+ wildcard syntax) instead of a literal path match
@@ -37,16 +58,18 @@ func normalizePublicURL(raw string) (*url.URL, error) {
 	if u.Scheme == "" || u.Host == "" {
 		return nil, fmt.Errorf("--public-url %q must be an absolute URL", trimmed)
 	}
-	if u.RawQuery != "" || u.Fragment != "" || u.ForceQuery {
-		return nil, fmt.Errorf("--public-url %q must not contain a query or fragment", trimmed)
+	if err := validateAuthorityAndQuery(u, trimmed); err != nil {
+		return nil, fmt.Errorf("--public-url %w", err)
 	}
 	if strings.ContainsAny(u.Path, "{}") {
 		return nil, fmt.Errorf("--public-url %q path must not contain '{' or '}'", trimmed)
 	}
 	if u.RawPath != "" {
 		return nil, fmt.Errorf(
-			"--public-url %q path encoding changes segment structure (e.g. %%2F); "+
-				"the published resource and the registered route would disagree", trimmed,
+			"--public-url %q path uses a non-default percent-encoding; rejected as a "+
+				"deliberately conservative proxy for encodings that would change segment "+
+				"structure (e.g. %%2F) and make the published resource and the registered "+
+				"route disagree", trimmed,
 		)
 	}
 	u.Path = strings.TrimSuffix(u.Path, "/")
@@ -161,12 +184,14 @@ func requireOAuthPRMConfig(opts HTTPServerOptions) error {
 	}
 	issuer := strings.TrimSpace(opts.OAuthIssuer)
 	iu, err := url.Parse(issuer)
-	if err != nil || iu.Scheme != "https" || iu.Host == "" || iu.Hostname() == "" ||
-		iu.RawQuery != "" || iu.Fragment != "" || iu.ForceQuery || strings.Contains(issuer, "#") {
+	if err != nil || iu.Scheme != "https" || iu.Host == "" {
 		return fmt.Errorf(
-			"refusing to start: --oauth-issuer %q must be an absolute https:// URL with no query or fragment (RFC 8414 §2)",
+			"refusing to start: --oauth-issuer %q must be an absolute https:// URL (RFC 8414 §2)",
 			issuer,
 		)
+	}
+	if verr := validateAuthorityAndQuery(iu, issuer); verr != nil {
+		return fmt.Errorf("refusing to start: --oauth-issuer %w", verr)
 	}
 	publicURL := strings.TrimSpace(opts.PublicURL)
 	if publicURL == "" {

--- a/mcp/oauth_prm_test.go
+++ b/mcp/oauth_prm_test.go
@@ -1,0 +1,55 @@
+package mcp
+
+import "testing"
+
+// RFC 9728 §3: the well-known path segment goes immediately after the
+// authority; any path component --public-url carries (a reverse-proxy mount
+// prefix) comes after the well-known segment, not before it.
+func TestWellKnownPaths_PathMountedPublicURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		publicURL    string
+		wantRoot     string
+		wantSuffixed string
+	}{
+		{
+			name:         "no path component",
+			publicURL:    "https://travel.example.org",
+			wantRoot:     "/.well-known/oauth-protected-resource",
+			wantSuffixed: "/.well-known/oauth-protected-resource/mcp",
+		},
+		{
+			name:         "path-mounted public url",
+			publicURL:    "https://host/base",
+			wantRoot:     "/.well-known/oauth-protected-resource",
+			wantSuffixed: "/.well-known/oauth-protected-resource/base/mcp",
+		},
+		{
+			name:         "trailing slash stripped before mount",
+			publicURL:    "https://host/base/",
+			wantRoot:     "/.well-known/oauth-protected-resource",
+			wantSuffixed: "/.well-known/oauth-protected-resource/base/mcp",
+		},
+		{
+			name:         "ipv6 literal, no path",
+			publicURL:    "https://[::1]:8080",
+			wantRoot:     "/.well-known/oauth-protected-resource",
+			wantSuffixed: "/.well-known/oauth-protected-resource/mcp",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, suffixed, err := wellKnownPaths(tt.publicURL)
+			if err != nil {
+				t.Fatalf("wellKnownPaths(%q) error = %v", tt.publicURL, err)
+			}
+			if root != tt.wantRoot {
+				t.Errorf("root = %q, want %q", root, tt.wantRoot)
+			}
+			if suffixed != tt.wantSuffixed {
+				t.Errorf("suffixed = %q, want %q", suffixed, tt.wantSuffixed)
+			}
+		})
+	}
+}

--- a/mcp/oauth_prm_test.go
+++ b/mcp/oauth_prm_test.go
@@ -29,6 +29,48 @@ func TestChallengeScope_ReadVsWriteViaToolRequiresWrite(t *testing.T) {
 	}
 }
 
+// Startup refusals (design doc (a)/(b)): OAuth configured but --oauth-issuer
+// or a valid --public-url missing is fatal, same shape as requireHTTPAuth.
+// http://localhost and http://127.0.0.1 are an explicit dev-only exception.
+func TestRequireOAuthPRMConfig_StartupRefusals(t *testing.T) {
+	t.Parallel()
+	introspection := "https://idp.example.org/oauth/introspect"
+	issuer := "https://tenant.auth0.com/"
+	tests := []struct {
+		name      string
+		issuer    string
+		publicURL string
+		wantErr   bool
+	}{
+		{"missing issuer refused", "", "https://travel.example.org", true},
+		{"missing public-url refused", issuer, "", true},
+		{"http non-loopback public-url refused", issuer, "http://travel.example.org", true},
+		{"https public-url accepted", issuer, "https://travel.example.org", false},
+		{"http localhost accepted (dev exception)", issuer, "http://localhost", false},
+		{"http 127.0.0.1 accepted (dev exception)", issuer, "http://127.0.0.1:8080", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireOAuthPRMConfig(HTTPServerOptions{
+				OAuthIntrospectionURL: introspection,
+				OAuthIssuer:           tt.issuer,
+				PublicURL:             tt.publicURL,
+			})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("requireOAuthPRMConfig(issuer=%q, publicURL=%q) err=%v, wantErr=%v", tt.issuer, tt.publicURL, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// No OAuth configured: PRM validation is a no-op regardless of issuer/public-url.
+func TestRequireOAuthPRMConfig_NoOAuthConfiguredIsNoop(t *testing.T) {
+	t.Parallel()
+	if err := requireOAuthPRMConfig(HTTPServerOptions{}); err != nil {
+		t.Fatalf("unexpected error with no OAuth configured: %v", err)
+	}
+}
+
 // RFC 9728 §3: the well-known path segment goes immediately after the
 // authority; any path component --public-url carries (a reverse-proxy mount
 // prefix) comes after the well-known segment, not before it.

--- a/mcp/oauth_prm_test.go
+++ b/mcp/oauth_prm_test.go
@@ -2,6 +2,33 @@ package mcp
 
 import "testing"
 
+// 401 challenge scope (design doc (d)): default trvl:read, escalate to
+// trvl:write only for a tools/call naming a write tool; anything else
+// (no body, unparseable body, read-only tool) falls back to trvl:read.
+func TestChallengeScope_ReadVsWriteViaToolRequiresWrite(t *testing.T) {
+	t.Parallel()
+	hs := NewHTTPServer(0)
+
+	tests := []struct {
+		name string
+		body []byte
+		want string
+	}{
+		{"no body", nil, scopeRead},
+		{"unparseable body", []byte("not json"), scopeRead},
+		{"tools/call read-only tool", []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_preferences","arguments":{}}}`), scopeRead},
+		{"tools/call write tool", []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"update_preferences","arguments":{"display_currency":"EUR"}}}`), scopeWrite},
+		{"non-tools/call method", []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`), scopeRead},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hs.challengeScope(tt.body); got != tt.want {
+				t.Errorf("challengeScope(%s) = %q, want %q", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
 // RFC 9728 §3: the well-known path segment goes immediately after the
 // authority; any path component --public-url carries (a reverse-proxy mount
 // prefix) comes after the well-known segment, not before it.

--- a/mcp/oauth_prm_test.go
+++ b/mcp/oauth_prm_test.go
@@ -210,6 +210,125 @@ func TestWellKnownPaths_PathMountedPublicURL(t *testing.T) {
 	}
 }
 
+// Insufficient scope on an authenticated request (design doc (d)): a
+// trvl:read-only token calling a write tool gets 403, not 200, with a
+// WWW-Authenticate insufficient_scope challenge (RFC 6750 §3.1).
+func TestHandleMCP_InsufficientScopeReturns403(t *testing.T) {
+	t.Parallel()
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{Port: 0, ReadToken: "read-only-token"})
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"update_preferences","arguments":{"display_currency":"EUR"}}}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer read-only-token")
+	rr := httptest.NewRecorder()
+	hs.handleMCP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("insufficient-scope tools/call = %d, want 403; body=%s", rr.Code, rr.Body.String())
+	}
+	want := `Bearer error="insufficient_scope", scope="trvl:write"`
+	if got := rr.Header().Get("WWW-Authenticate"); got != want {
+		t.Errorf("WWW-Authenticate = %q, want %q", got, want)
+	}
+	if !strings.Contains(rr.Body.String(), "requires trvl:write scope") {
+		t.Errorf("body = %s, want JSON-RPC error detail", rr.Body.String())
+	}
+}
+
+// Same insufficient-scope case, but with OAuth/PRM configured: the challenge
+// carries resource_metadata too, matching the 401 challenge shape.
+func TestHandleMCP_InsufficientScopeChallengeCarriesResourceMetadataWhenPRMConfigured(t *testing.T) {
+	t.Parallel()
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{
+		Port:                  0,
+		OAuthIntrospectionURL: "https://idp.example.org/oauth/introspect",
+		OAuthIssuer:           "https://tenant.auth0.com/",
+		PublicURL:             "https://travel.example.org",
+		ReadToken:             "read-only-token",
+	})
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"update_preferences","arguments":{"display_currency":"EUR"}}}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer read-only-token")
+	rr := httptest.NewRecorder()
+	hs.handleMCP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("insufficient-scope tools/call = %d, want 403", rr.Code)
+	}
+	want := `Bearer resource_metadata="https://travel.example.org/.well-known/oauth-protected-resource/mcp", error="insufficient_scope", scope="trvl:write"`
+	if got := rr.Header().Get("WWW-Authenticate"); got != want {
+		t.Errorf("WWW-Authenticate = %q, want %q", got, want)
+	}
+}
+
+// GET/POST etc. on the well-known routes: 405 must carry an Allow header
+// (RFC 9110 §15.5.6).
+func TestHandleProtectedResourceMetadata_405HasAllowHeader(t *testing.T) {
+	t.Parallel()
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{
+		Port:                  0,
+		OAuthIntrospectionURL: "https://idp.example.org/oauth/introspect",
+		OAuthIssuer:           "https://tenant.auth0.com/",
+		PublicURL:             "https://travel.example.org",
+	})
+	mux := hs.newMux()
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/.well-known/oauth-protected-resource", nil))
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST well-known = %d, want 405", rr.Code)
+	}
+	if got := rr.Header().Get("Allow"); got != http.MethodGet {
+		t.Errorf("Allow = %q, want %q", got, http.MethodGet)
+	}
+}
+
+// RFC 9728 §1.2: a --public-url with a query or fragment, or a `{`/`}` in
+// its path (reserved http.ServeMux wildcard syntax — registering one
+// unvalidated panics at startup), is refused rather than accepted.
+func TestNormalizePublicURL_RejectsQueryFragmentAndBraces(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{
+		"https://host/base?x=1",
+		"https://host/base#frag",
+		"https://host/{id}",
+		"https://host/}",
+	} {
+		if _, err := normalizePublicURL(raw); err == nil {
+			t.Errorf("normalizePublicURL(%q) = nil error, want rejection", raw)
+		}
+	}
+}
+
+// RFC 8414 §2: --oauth-issuer must be an absolute https:// URL, not any
+// nonempty string.
+func TestRequireOAuthPRMConfig_OAuthIssuerMustBeAbsoluteHTTPSURL(t *testing.T) {
+	t.Parallel()
+	base := HTTPServerOptions{
+		OAuthIntrospectionURL: "https://idp.example.org/oauth/introspect",
+		PublicURL:             "https://travel.example.org",
+	}
+	for _, tt := range []struct {
+		name    string
+		issuer  string
+		wantErr bool
+	}{
+		{"bare word rejected", "auth0", true},
+		{"http scheme rejected", "http://tenant.auth0.com/", true},
+		{"absolute https accepted", "https://tenant.auth0.com/", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := base
+			opts.OAuthIssuer = tt.issuer
+			err := requireOAuthPRMConfig(opts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("requireOAuthPRMConfig(issuer=%q) err=%v, wantErr=%v", tt.issuer, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // Audience derivation (design doc (a)): --oauth-audience defaults to the
 // published resource (<public-url>/mcp) when unset; an explicit value that
 // agrees is accepted; one that disagrees is refused at startup.

--- a/mcp/oauth_prm_test.go
+++ b/mcp/oauth_prm_test.go
@@ -285,18 +285,56 @@ func TestHandleProtectedResourceMetadata_405HasAllowHeader(t *testing.T) {
 }
 
 // RFC 9728 §1.2: a --public-url with a query or fragment, or a `{`/`}` in
-// its path (reserved http.ServeMux wildcard syntax — registering one
-// unvalidated panics at startup), is refused rather than accepted.
+// its path (Go 1.22+ http.ServeMux wildcard syntax — a brace segment in the
+// decoded path becomes a live wildcard route in the well-known pattern, not
+// a literal path match), is refused rather than accepted. A bare `?` with no
+// key=value (net/url's ForceQuery) is refused the same way a real query is:
+// RawQuery is empty but u.String() still re-emits the `?`.
 func TestNormalizePublicURL_RejectsQueryFragmentAndBraces(t *testing.T) {
 	t.Parallel()
 	for _, raw := range []string{
 		"https://host/base?x=1",
 		"https://host/base#frag",
+		"https://host/base?",
 		"https://host/{id}",
 		"https://host/}",
+		"https://host/%7Bid%7D", // decodes to /{id} — still a wildcard, still rejected
 	} {
 		if _, err := normalizePublicURL(raw); err == nil {
 			t.Errorf("normalizePublicURL(%q) = nil error, want rejection", raw)
+		}
+	}
+}
+
+// A --public-url path with a bare `?` must not leak into the resource
+// identifier or the challenge URL served in WWW-Authenticate.
+func TestBuildProtectedResourceMetadata_RejectsForceQueryPublicURL(t *testing.T) {
+	t.Parallel()
+	prm := buildProtectedResourceMetadata(HTTPServerOptions{
+		OAuthIntrospectionURL: "https://idp.example.org/oauth/introspect",
+		OAuthIssuer:           "https://tenant.auth0.com/",
+		PublicURL:             "https://host/base?",
+	})
+	if prm != nil {
+		t.Fatalf("buildProtectedResourceMetadata with ForceQuery public-url = %+v, want nil", prm)
+	}
+}
+
+// RFC 9728 §1.2 / the http.ServeMux route these paths build (see design doc
+// (b)): a --public-url path that is well-formed URL-wise but produces a
+// pattern http.ServeMux itself refuses to register (whitespace) must be
+// caught here, not left to panic the server at route-registration time. A
+// bare brace segment (no whitespace) is caught by the wildcard check above,
+// not this one — it registers fine, it just means something other than a
+// literal path.
+func TestNormalizePublicURL_RejectsUnregistrablePatterns(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{
+		"https://host/a b",
+		"https://host/a\tb",
+	} {
+		if _, err := normalizePublicURL(raw); err == nil {
+			t.Errorf("normalizePublicURL(%q) = nil error, want rejection (unregistrable http.ServeMux pattern)", raw)
 		}
 	}
 }
@@ -317,6 +355,9 @@ func TestRequireOAuthPRMConfig_OAuthIssuerMustBeAbsoluteHTTPSURL(t *testing.T) {
 		{"bare word rejected", "auth0", true},
 		{"http scheme rejected", "http://tenant.auth0.com/", true},
 		{"absolute https accepted", "https://tenant.auth0.com/", false},
+		{"query rejected", "https://tenant.auth0.com/?x=1", true},
+		{"fragment rejected", "https://tenant.auth0.com/#f", true},
+		{"bare question mark rejected", "https://tenant.auth0.com/?", true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := base

--- a/mcp/oauth_prm_test.go
+++ b/mcp/oauth_prm_test.go
@@ -53,3 +53,39 @@ func TestWellKnownPaths_PathMountedPublicURL(t *testing.T) {
 		})
 	}
 }
+
+// Audience derivation (design doc (a)): --oauth-audience defaults to the
+// published resource (<public-url>/mcp) when unset; an explicit value that
+// agrees is accepted; one that disagrees is refused at startup.
+func TestRequireOAuthPRMConfig_AudienceDerivationMatrix(t *testing.T) {
+	t.Parallel()
+	base := HTTPServerOptions{
+		OAuthIntrospectionURL: "https://idp.example.org/oauth/introspect",
+		OAuthIssuer:           "https://tenant.auth0.com/",
+		PublicURL:             "https://travel.example.org",
+	}
+
+	t.Run("audience unset derives from resource, no error", func(t *testing.T) {
+		opts := base
+		if err := requireOAuthPRMConfig(opts); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("explicit audience equal to derived resource accepted", func(t *testing.T) {
+		opts := base
+		opts.OAuthAudience = "https://travel.example.org/mcp"
+		if err := requireOAuthPRMConfig(opts); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("explicit audience differing from derived resource refused", func(t *testing.T) {
+		opts := base
+		opts.OAuthAudience = "trvl-mcp"
+		err := requireOAuthPRMConfig(opts)
+		if err == nil {
+			t.Fatal("expected refusal for mismatched --oauth-audience")
+		}
+	})
+}

--- a/mcp/oauth_prm_test.go
+++ b/mcp/oauth_prm_test.go
@@ -339,6 +339,27 @@ func TestNormalizePublicURL_RejectsUnregistrablePatterns(t *testing.T) {
 	}
 }
 
+// A --public-url path segment whose percent-encoding changes segment
+// structure (e.g. %2F for a literal "/") makes RawPath diverge from Path,
+// so the well-known route registered from the decoded Path and the
+// resource identifier published from the encoded String() disagree — a
+// client following the published URL 404s. Encodings that don't change
+// segment structure (café, "a+b") leave RawPath empty and must still work.
+func TestNormalizePublicURL_RejectsPathEncodingThatChangesSegments(t *testing.T) {
+	t.Parallel()
+	if _, err := normalizePublicURL("https://h/a%2Fb"); err == nil {
+		t.Error(`normalizePublicURL("https://h/a%2Fb") = nil error, want rejection (RawPath diverges from Path)`)
+	}
+	for _, raw := range []string{
+		"https://h/caf%C3%A9",
+		"https://h/a+b",
+	} {
+		if _, err := normalizePublicURL(raw); err != nil {
+			t.Errorf("normalizePublicURL(%q) = %v, want acceptance (no segment-structure change)", raw, err)
+		}
+	}
+}
+
 // RFC 8414 §2: --oauth-issuer must be an absolute https:// URL, not any
 // nonempty string.
 func TestRequireOAuthPRMConfig_OAuthIssuerMustBeAbsoluteHTTPSURL(t *testing.T) {
@@ -358,6 +379,8 @@ func TestRequireOAuthPRMConfig_OAuthIssuerMustBeAbsoluteHTTPSURL(t *testing.T) {
 		{"query rejected", "https://tenant.auth0.com/?x=1", true},
 		{"fragment rejected", "https://tenant.auth0.com/#f", true},
 		{"bare question mark rejected", "https://tenant.auth0.com/?", true},
+		{"bare hash rejected", "https://host/#", true},
+		{"port-only host with empty hostname rejected", "https://:443", true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := base

--- a/mcp/oauth_prm_test.go
+++ b/mcp/oauth_prm_test.go
@@ -106,6 +106,58 @@ func TestStaticTokenOnlyMode_WellKnownRoutesUnregistered(t *testing.T) {
 	}
 }
 
+// OAuth configured (design doc (d)): both well-known routes serve the same
+// two-field document, GET only, and the 401 challenge carries the
+// path-suffixed well-known URL plus the picked scope.
+func TestOAuthConfigured_PRMDocumentAndChallenge(t *testing.T) {
+	t.Parallel()
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{
+		Port:                  0,
+		OAuthIntrospectionURL: "https://idp.example.org/oauth/introspect",
+		OAuthIssuer:           "https://tenant.auth0.com/",
+		PublicURL:             "https://travel.example.org",
+	})
+	mux := hs.newMux()
+
+	for _, path := range []string{
+		"/.well-known/oauth-protected-resource",
+		"/.well-known/oauth-protected-resource/mcp",
+	} {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("GET %s = %d, want 200", path, rr.Code)
+		}
+		if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+		body := rr.Body.String()
+		if !strings.Contains(body, `"resource":"https://travel.example.org/mcp"`) {
+			t.Errorf("body = %s, want resource field", body)
+		}
+		if !strings.Contains(body, `"authorization_servers":["https://tenant.auth0.com/"]`) {
+			t.Errorf("body = %s, want authorization_servers array", body)
+		}
+
+		rr = httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, path, nil))
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("POST %s = %d, want 405", path, rr.Code)
+		}
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	hs.handleMCP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated POST /mcp = %d, want 401", rr.Code)
+	}
+	want := `Bearer resource_metadata="https://travel.example.org/.well-known/oauth-protected-resource/mcp", scope="trvl:read"`
+	if got := rr.Header().Get("WWW-Authenticate"); got != want {
+		t.Errorf("WWW-Authenticate = %q, want %q", got, want)
+	}
+}
+
 // RFC 9728 §3: the well-known path segment goes immediately after the
 // authority; any path component --public-url carries (a reverse-proxy mount
 // prefix) comes after the well-known segment, not before it.

--- a/mcp/oauth_prm_test.go
+++ b/mcp/oauth_prm_test.go
@@ -299,6 +299,8 @@ func TestNormalizePublicURL_RejectsQueryFragmentAndBraces(t *testing.T) {
 		"https://host/{id}",
 		"https://host/}",
 		"https://host/%7Bid%7D", // decodes to /{id} — still a wildcard, still rejected
+		"https://:443/x",        // port-only authority, empty hostname
+		"https://host/base#",    // bare fragment marker, Fragment=="" but still a fragment
 	} {
 		if _, err := normalizePublicURL(raw); err == nil {
 			t.Errorf("normalizePublicURL(%q) = nil error, want rejection", raw)
@@ -306,17 +308,26 @@ func TestNormalizePublicURL_RejectsQueryFragmentAndBraces(t *testing.T) {
 	}
 }
 
-// A --public-url path with a bare `?` must not leak into the resource
-// identifier or the challenge URL served in WWW-Authenticate.
+// The same rejections normalizePublicURL enforces on --public-url must also
+// stop buildProtectedResourceMetadata from publishing a resource identifier
+// or challenge URL built from one: a real query, a real fragment, and a
+// bare "?" (ForceQuery) all take the same path through normalizePublicURL,
+// so all three must make buildProtectedResourceMetadata return nil.
 func TestBuildProtectedResourceMetadata_RejectsForceQueryPublicURL(t *testing.T) {
 	t.Parallel()
-	prm := buildProtectedResourceMetadata(HTTPServerOptions{
-		OAuthIntrospectionURL: "https://idp.example.org/oauth/introspect",
-		OAuthIssuer:           "https://tenant.auth0.com/",
-		PublicURL:             "https://host/base?",
-	})
-	if prm != nil {
-		t.Fatalf("buildProtectedResourceMetadata with ForceQuery public-url = %+v, want nil", prm)
+	for _, publicURL := range []string{
+		"https://host/base?",
+		"https://host/base?x=1",
+		"https://host/base#frag",
+	} {
+		prm := buildProtectedResourceMetadata(HTTPServerOptions{
+			OAuthIntrospectionURL: "https://idp.example.org/oauth/introspect",
+			OAuthIssuer:           "https://tenant.auth0.com/",
+			PublicURL:             publicURL,
+		})
+		if prm != nil {
+			t.Errorf("buildProtectedResourceMetadata(publicURL=%q) = %+v, want nil", publicURL, prm)
+		}
 	}
 }
 
@@ -343,8 +354,13 @@ func TestNormalizePublicURL_RejectsUnregistrablePatterns(t *testing.T) {
 // structure (e.g. %2F for a literal "/") makes RawPath diverge from Path,
 // so the well-known route registered from the decoded Path and the
 // resource identifier published from the encoded String() disagree — a
-// client following the published URL 404s. Encodings that don't change
-// segment structure (café, "a+b") leave RawPath empty and must still work.
+// client following the published URL 404s. The RawPath!="" check is a
+// deliberately conservative proxy for "encoding changes segment
+// structure", not an exact test of it — it also rejects benign
+// non-default encodings that don't change structure (%41 for "A"), which
+// is an accepted false positive, not a claim that every such encoding is
+// unsupported. Encodings that don't set RawPath at all (café, "a+b")
+// leave it empty and must still work.
 func TestNormalizePublicURL_RejectsPathEncodingThatChangesSegments(t *testing.T) {
 	t.Parallel()
 	if _, err := normalizePublicURL("https://h/a%2Fb"); err == nil {

--- a/mcp/oauth_prm_test.go
+++ b/mcp/oauth_prm_test.go
@@ -1,6 +1,11 @@
 package mcp
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
 
 // 401 challenge scope (design doc (d)): default trvl:read, escalate to
 // trvl:write only for a tools/call naming a write tool; anything else
@@ -68,6 +73,36 @@ func TestRequireOAuthPRMConfig_NoOAuthConfiguredIsNoop(t *testing.T) {
 	t.Parallel()
 	if err := requireOAuthPRMConfig(HTTPServerOptions{}); err != nil {
 		t.Fatalf("unexpected error with no OAuth configured: %v", err)
+	}
+}
+
+// Static-token-only mode (design doc (c)): no authorization server to name,
+// so both well-known routes stay unregistered (404) and the 401 carries no
+// resource_metadata challenge.
+func TestStaticTokenOnlyMode_WellKnownRoutesUnregistered(t *testing.T) {
+	t.Parallel()
+	hs := NewHTTPServerWithOptions(HTTPServerOptions{Port: 0, Token: "secret-token"})
+	mux := hs.newMux()
+
+	for _, path := range []string{
+		"/.well-known/oauth-protected-resource",
+		"/.well-known/oauth-protected-resource/mcp",
+	} {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("GET %s = %d, want 404 in static-token-only mode", path, rr.Code)
+		}
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	hs.handleMCP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated POST /mcp = %d, want 401", rr.Code)
+	}
+	if wa := rr.Header().Get("WWW-Authenticate"); strings.Contains(wa, "resource_metadata") {
+		t.Errorf("WWW-Authenticate = %q, want no resource_metadata in static-token-only mode", wa)
 	}
 }
 

--- a/mcp/server_extra_test.go
+++ b/mcp/server_extra_test.go
@@ -80,8 +80,8 @@ func TestHTTPHandler_POST_ReadTokenDeniesMutatingTool(t *testing.T) {
 	resp, status := postHTTPToolCall(t, hs, "read-token", "update_preferences", map[string]any{
 		"display_currency": "EUR",
 	})
-	if status != http.StatusOK {
-		t.Fatalf("status = %d, want 200 JSON-RPC permission error", status)
+	if status != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (RFC 6750 §3.1 insufficient_scope)", status)
 	}
 	if resp.Error == nil {
 		t.Fatalf("expected permission error, got result %#v", resp.Result)
@@ -173,8 +173,8 @@ func TestHTTPHandler_POST_OAuthIntrospectionScopes(t *testing.T) {
 	}
 
 	deniedResp, status := postHTTPToolCall(t, hs, "oauth-read", "update_preferences", map[string]any{"display_currency": "EUR"})
-	if status != http.StatusOK {
-		t.Fatalf("denied status = %d, want 200 JSON-RPC error", status)
+	if status != http.StatusForbidden {
+		t.Fatalf("denied status = %d, want 403 (RFC 6750 §3.1 insufficient_scope)", status)
 	}
 	if deniedResp.Error == nil || !strings.Contains(deniedResp.Error.Message, "requires trvl:write") {
 		t.Fatalf("denied error = %+v, want write-scope denial", deniedResp.Error)


### PR DESCRIPTION
Publishes OAuth 2.0 Protected Resource Metadata (RFC 9728) from the MCP HTTP
server, so a client can discover which authorization server guards this
resource and how to authenticate against it.

## What changes

- `GET /.well-known/oauth-protected-resource` returns the metadata document.
- `WWW-Authenticate` on a 401 now carries a `resource_metadata` parameter
  pointing at that document, which is how RFC 9728 expects a client to find it.
- Startup refuses a misconfigured public URL or issuer rather than serving a
  resource identifier that cannot be trusted.
- `docs/design/oauth-protected-resource-metadata.md` records the design and the
  rationale for each refusal.

## Validation, and why it is shared

Both the issuer and the public URL are user-supplied and both must satisfy
nearly the same rules. They were originally two separate checks, and they
drifted: a fix applied to one was twice missed on the other. The two are now a
single `validateAuthorityAndQuery` helper, with the genuinely caller-specific
parts kept at each call site (the issuer still requires `https`; the public URL
keeps its own brace, `RawPath`, trailing-slash and registrability checks).

The defect class the shared helper closes is a URL component that is **empty
but present**, which a non-empty test cannot detect:

- `https://:443` has a non-empty `Host` and an empty `Hostname()`.
- A trailing `#` yields `Fragment == ""`, because `net/url` has `ForceQuery`
  and no equivalent for fragments.

Left unhandled on the public-URL path, `--public-url https://:443/x` was
accepted and would have published `https://:443/x/mcp` as this server's own
resource identifier.

## Verification

- The extraction was checked by calling the committed function rather than by
  reading the diff: 8 URL shapes that must stay accepted and 12 that must stay
  rejected, no regressions in either direction.
- `make lint` green at the head commit: `go vet`, `golangci-lint` v2.12.2
  (0 issues), `staticcheck`, `govulncheck` (0 vulnerabilities in called code).
- `go test -race ./mcp/` green, no data races.
- Four rounds of independent review, closing every blocker raised.

## Known gap

Coverage is enforced repo-wide at 80% from a single whole-repo profile
(`.github/workflows/ci.yaml`). The figure measured here is 74.5% for `./mcp/`
alone, which does not answer that threshold in either direction. The repo-wide
number was not measured locally because the full suite makes live outbound
calls; this run is the first CI verdict this branch has had.
