### PR TITLE
fix(deps): bump grpc to v1.83.2 for GHSA-2v4p-qf9q-27wj

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	golang.org/x/crypto v0.56.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 // indirect
-	google.golang.org/grpc v1.83.1 // indirect
+	google.golang.org/grpc v1.83.2 // indirect
 	google.golang.org/protobuf v1.36.12 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688/go.mod h1:1RJ9BQGyNdZwkGc1eTqkErfRZ6RJyYPHZo73BZ1vQqI=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 h1:cYNAzI2sUwhmCcoj9TxvihSrqsxt6uIkj3rDRhSDmW4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688/go.mod h1:DjtHYE8FKJLivXcBEjGwndXfIC23G0VpXiXKqG179uA=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
+google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
 google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## What

Bumps the indirect dependency `google.golang.org/grpc` from `v1.83.1` to `v1.83.2`.

## Why

The `OSV vulnerability scan` job fails on **every** open pull request against `main`, and the failure is inherited from the merge target rather than introduced by any branch:

- `origin/main:go.mod:68` carries `google.golang.org/grpc v1.83.1 // indirect`, unchanged since `dd9e0838`.
- Neither #650 nor #651 touches `go.mod`; #651 changes `server.json` only.
- Scanner output on #651 (run `34462260141`): `https://osv.dev/GHSA-2v4p-qf9q-27wj | Go | google.golang.org/grpc | 1.83.1 | 1.83.2 | go.mod`, `Exit code: 1`.

A fixed version exists, so the bump is the correct remedy; the `.github/osv-scanner.toml` ignore list is reserved for advisories with no upstream fix (its one entry, `GO-2026-5932`, documents exactly that).

## Verification

Run locally in a worktree cut from `origin/main`, with the workflow's exact arguments:

```
$ osv-scanner --config=.github/osv-scanner.toml --no-call-analysis=all --recursive ./
Scanned go.mod file and found 63 packages
GO-2026-5932 has been filtered out because: ...
Filtered 1 vulnerability from output

No issues found
OSV_EXIT=0
```

`go build ./...` exits 0. No Go source changes, so no regression test applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)