### PR TITLE
fix(flights): rotate Wizz Air API version to 29.15.1

### DIFF
--- a/.github/workflows/wizzair-version-sentinel.yml
+++ b/.github/workflows/wizzair-version-sentinel.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           set -euo pipefail
           title="Wizz Air version rotated beyond auto-discovery range"
-          body="The Wizz Air version sentinel found that \`${CUR}\` rotated away (404 on the live oracle) but no candidate version in the bounded search range (next minors/patches/majors) is live. Wizz likely jumped further than the walk covers. Read the current version from be.wizzair.com (DevTools Network tab -> any be.wizzair.com request -> /<version>/Api/...) and bump \`wizzDefaultVersion\` in internal/flights/wizzair.go, or widen the search in scripts/wizzair-discover-version.sh."
+          body="The Wizz Air version sentinel found that \`${CUR}\` rotated away (404 on the live oracle), the homepage bootstrap config named no version that probes live, and no candidate in the bounded walk (next minors/patches/majors) is live either. Read the current version from the homepage config (view-source on https://www.wizzair.com/en-gb, search for \`be.wizzair.com/\`) or from DevTools (Network tab -> any be.wizzair.com request -> /<version>/Api/...), then bump \`wizzDefaultVersion\` in internal/flights/wizzair.go. Widening the walk is not the fix: it probes shifted minors at patch .0 only, so a rotation to X.Y.Z with Z > 0 on a new minor is outside its reach at any range (#641)."
           existing="$(gh issue list --state open --label provider-drift --search "in:title $title" --json number -q '.[0].number')"
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"

--- a/internal/flights/wizzair.go
+++ b/internal/flights/wizzair.go
@@ -125,7 +125,15 @@ var ErrWizzRejected = errors.New("wizzair declined the request (validationCodes)
 // the old path returning 404 and the new path live, but its pre-existing orphan
 // branch caused a non-fast-forward push failure. The sentinel push path now
 // recovers that exact automation-owned branch with a force-with-lease.
-const wizzDefaultVersion = "29.11.0"
+// 2026-09-10: rotated "29.11.0" -> "29.15.1" (#641). The sentinel had been
+// reporting `exhausted` rather than `rotated` for weeks, so nothing proposed
+// the bump. Probing says why: 29.12.0 through 29.16.0 all return 404 and only
+// the patch release 29.15.1 answers (405 on GET). The candidate walk probes
+// shifted minors at patch .0 only, so a rotation to X.Y.Z with Z > 0 on a new
+// minor is outside its reach by construction. The homepage bootstrap config
+// named 29.15.1 outright, which is why the sentinel now reads it first, as
+// wizzDiscoverFromConfig already does at runtime.
+const wizzDefaultVersion = "29.15.1"
 
 // wizzVersion is the active API version. Overridable in tests; the env var
 // WIZZAIR_API_VERSION takes precedence at request time via wizzResolvedVersion.

--- a/internal/flights/wizzair_version_discovery_test.go
+++ b/internal/flights/wizzair_version_discovery_test.go
@@ -188,6 +188,9 @@ func TestWizzConfigVersionRequiresWizzOrigin(t *testing.T) {
 		`apiUrl:"https://be.wizzair.com.evil.example/29.8.0/Api"`,
 		// Right host, wrong path shape.
 		`apiUrl:"https://be.wizzair.com/29.8.0/NotApi"`,
+		// Right host, path merely BEGINNING with /Api -- the shape the shell
+		// mirror accepted until its match gained a closing delimiter.
+		`apiUrl:"https://be.wizzair.com/29.8.0/Apiary"`,
 	}
 	for _, page := range reject {
 		if got := wizzVersionFromConfigBody([]byte(page)); got != "" {

--- a/internal/flights/wizzair_version_discovery_test.go
+++ b/internal/flights/wizzair_version_discovery_test.go
@@ -195,3 +195,18 @@ func TestWizzConfigVersionRequiresWizzOrigin(t *testing.T) {
 		}
 	}
 }
+
+// A *quoted* URL nested inside another URL's query value is accepted: the
+// candidate scan breaks on quotes, so the inner URL is parsed as its own
+// candidate and its host does compare equal. That is a known ceiling, not an
+// oversight -- extraction is not the safeguard here, wizzHeal probes a
+// discovered version against the live host before adopting it. The shell mirror
+// scripts/ci/wizzair-config-version.sh has the same property and pins the same
+// case, so hardening either side fails the other's test instead of drifting
+// apart unnoticed.
+func TestWizzConfigVersionAcceptsQuotedNestedURL(t *testing.T) {
+	const page = `apiUrl:"https://evil.example/?next='https://be.wizzair.com/29.8.0/Api'"`
+	if got := wizzVersionFromConfigBody([]byte(page)); got != "29.8.0" {
+		t.Fatalf("extracted %q, want %q: the shell mirror accepts this shape, and parity is what leaves the live probe as the single guard", got, "29.8.0")
+	}
+}

--- a/scripts/ci/check-workflow-hygiene.sh
+++ b/scripts/ci/check-workflow-hygiene.sh
@@ -121,6 +121,7 @@ release_homebrew_stays_formula_only_until_notarized() {
 check "workflow action uses refs are pinned to commit SHAs" all_workflow_uses_are_sha_pinned
 check "setup-node jobs use Node 24" all_setup_node_jobs_use_node24
 check "Wizz sentinel safely recovers orphaned automation branches" scripts/ci/push-wizzair-version-branch_test.sh
+check "Wizz sentinel reads the version only from the Wizz API host" scripts/ci/wizzair-config-version_test.sh
 check "GitNexus CLI calls include an explicit npm package version" no_unpinned_gitnexus_cli_calls
 check "GitNexus CI and local refresh use the same pinned CLI version" gitnexus_version_is_pinned_consistently
 check "GitNexus cached-index docs use a SHA-pinned cache action example" gitnexus_docs_use_sha_pinned_cache_example

--- a/scripts/ci/check-workflow-hygiene.sh
+++ b/scripts/ci/check-workflow-hygiene.sh
@@ -121,7 +121,7 @@ release_homebrew_stays_formula_only_until_notarized() {
 check "workflow action uses refs are pinned to commit SHAs" all_workflow_uses_are_sha_pinned
 check "setup-node jobs use Node 24" all_setup_node_jobs_use_node24
 check "Wizz sentinel safely recovers orphaned automation branches" scripts/ci/push-wizzair-version-branch_test.sh
-check "Wizz sentinel reads the version only from the Wizz API host" scripts/ci/wizzair-config-version_test.sh
+check "Wizz sentinel version extraction matches the runtime reader" scripts/ci/wizzair-config-version_test.sh
 check "GitNexus CLI calls include an explicit npm package version" no_unpinned_gitnexus_cli_calls
 check "GitNexus CI and local refresh use the same pinned CLI version" gitnexus_version_is_pinned_consistently
 check "GitNexus cached-index docs use a SHA-pinned cache action example" gitnexus_docs_use_sha_pinned_cache_example

--- a/scripts/ci/wizzair-config-version.sh
+++ b/scripts/ci/wizzair-config-version.sh
@@ -8,11 +8,15 @@
 # the shell mirror of wizzVersionFromConfigBody in
 # internal/flights/wizzair_selfheal.go, used by the version sentinel.
 #
-# The match requires the URL to begin at a quote delimiter, so a lookalike host
-# (notbe.wizzair.com), the host appearing as a path segment
+# The match is delimited by quotes at BOTH ends. The opening quote is what stops
+# a lookalike host (notbe.wizzair.com), the host appearing as a path segment
 # (https://evil.example/be.wizzair.com/1.2.3/Api) and a bare URL in another URL's
-# query string (https://evil.example/?u=https://be.wizzair.com/1.2.3/Api) cannot
-# contribute a version.
+# query string (https://evil.example/?u=https://be.wizzair.com/1.2.3/Api) from
+# contributing a version. The closing quote is what stops a longer path that
+# merely begins with /Api (.../1.2.3/Apiary) being read as the API base:
+# wizzVersionFromConfigBody anchors its path pattern end to end, so without that
+# delimiter this side would accept a version the runtime rejects, and a page
+# carrying such a URL ahead of the real config would shadow it.
 #
 # The ceiling, stated rather than glossed over: a *quoted* URL nested inside
 # another URL's query value (?next='https://be.wizzair.com/1.2.3/Api') still
@@ -26,7 +30,7 @@ set -euo pipefail
 # No qualifying URL is a normal outcome, not an error: the caller falls back to
 # the candidate walk. Exit 0 with empty output rather than making "nothing found"
 # indistinguishable from "the page could not be read".
-version="$(grep -oE "[\"']https://be\.wizzair\.com/[0-9]+\.[0-9]+\.[0-9]+/Api" \
+version="$(grep -oE "[\"']https://be\.wizzair\.com/[0-9]+\.[0-9]+\.[0-9]+/Api[\"']" \
 	| grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
 	| head -1 || true)"
 [ -z "$version" ] || echo "$version"

--- a/scripts/ci/wizzair-config-version.sh
+++ b/scripts/ci/wizzair-config-version.sh
@@ -9,12 +9,18 @@
 # internal/flights/wizzair_selfheal.go, used by the version sentinel.
 #
 # The match requires the URL to begin at a quote delimiter, so a lookalike host
-# (notbe.wizzair.com) or a URL embedded in another URL's query string
-# (https://evil.example/?u=https://be.wizzair.com/1.2.3/Api) cannot contribute a
-# version. The Go side parses each candidate and compares the host for exact
-# equality, which a shell pattern cannot do — hence the delimiter requirement
-# here, and hence the caller's obligation to probe the result. What this emits
-# is a claim, never a verdict.
+# (notbe.wizzair.com), the host appearing as a path segment
+# (https://evil.example/be.wizzair.com/1.2.3/Api) and a bare URL in another URL's
+# query string (https://evil.example/?u=https://be.wizzair.com/1.2.3/Api) cannot
+# contribute a version.
+#
+# The ceiling, stated rather than glossed over: a *quoted* URL nested inside
+# another URL's query value (?next='https://be.wizzair.com/1.2.3/Api') still
+# matches. wizzVersionFromConfigBody has the identical property — its candidate
+# regex also breaks on quotes, so the inner URL is scanned as its own candidate
+# and its host does compare equal. Neither side treats extraction as the
+# safeguard. What this emits is a claim; the caller MUST confirm it against the
+# live host with a probe before acting on it, and does.
 set -euo pipefail
 
 # No qualifying URL is a normal outcome, not an error: the caller falls back to

--- a/scripts/ci/wizzair-config-version.sh
+++ b/scripts/ci/wizzair-config-version.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# wizzair-config-version.sh — read the Wizz Air API version out of the homepage
+# HTML on stdin. Echoes X.Y.Z, or nothing when the page names no qualifying URL.
+#
+# The Wizz homepage embeds its API base URL in an inline bootstrap config
+# (apiUrl:"https://be.wizzair.com/<version>/Api"), so the version the real
+# browser client uses is published in plain HTML — no JS, no cookies. This is
+# the shell mirror of wizzVersionFromConfigBody in
+# internal/flights/wizzair_selfheal.go, used by the version sentinel.
+#
+# The match requires the URL to begin at a quote delimiter, so a lookalike host
+# (notbe.wizzair.com) or a URL embedded in another URL's query string
+# (https://evil.example/?u=https://be.wizzair.com/1.2.3/Api) cannot contribute a
+# version. The Go side parses each candidate and compares the host for exact
+# equality, which a shell pattern cannot do — hence the delimiter requirement
+# here, and hence the caller's obligation to probe the result. What this emits
+# is a claim, never a verdict.
+set -euo pipefail
+
+# No qualifying URL is a normal outcome, not an error: the caller falls back to
+# the candidate walk. Exit 0 with empty output rather than making "nothing found"
+# indistinguishable from "the page could not be read".
+version="$(grep -oE "[\"']https://be\.wizzair\.com/[0-9]+\.[0-9]+\.[0-9]+/Api" \
+	| grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
+	| head -1 || true)"
+[ -z "$version" ] || echo "$version"

--- a/scripts/ci/wizzair-config-version_test.sh
+++ b/scripts/ci/wizzair-config-version_test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Fixture test for wizzair-config-version.sh. The extraction it guards decides
+# which upstream API version the sentinel proposes, so the shapes that must be
+# REJECTED matter as much as the one that must be accepted: a match that reaches
+# inside another URL lets an unrelated page choose the version.
+set -euo pipefail
+
+helper="$(dirname "$0")/wizzair-config-version.sh"
+fail=0
+
+expect() {
+	local name="$1" want="$2" body="$3" got
+	got="$(printf '%s' "$body" | bash "$helper")"
+	if [ "$got" = "$want" ]; then
+		echo "ok: $name"
+	else
+		echo "FAIL: $name — want '${want}', got '${got}'" >&2
+		fail=1
+	fi
+}
+
+expect "double-quoted apiUrl" 29.15.1 \
+	'{"apiUrl":"https://be.wizzair.com/29.15.1/Api","x":1}'
+expect "single-quoted apiUrl" 29.15.1 \
+	"var cfg={apiUrl:'https://be.wizzair.com/29.15.1/Api'};"
+expect "first match wins when the page repeats itself" 29.15.1 \
+	'"https://be.wizzair.com/29.15.1/Api" ... "https://be.wizzair.com/29.15.1/Api"'
+
+expect "lookalike host is not the API host" "" \
+	'"https://notbe.wizzair.com/1.2.3/Api"'
+expect "host as a path segment elsewhere" "" \
+	'"https://evil.example/be.wizzair.com/1.2.3/Api"'
+expect "URL embedded in another URL query string" "" \
+	'"https://evil.example/?u=https://be.wizzair.com/1.2.3/Api"'
+expect "http is not https" "" \
+	'"http://be.wizzair.com/1.2.3/Api"'
+expect "a different path is not the API base" "" \
+	'"https://be.wizzair.com/29.15.1/Assets"'
+expect "a page naming no version" "" \
+	'<html><body>no config here</body></html>'
+
+exit "$fail"

--- a/scripts/ci/wizzair-config-version_test.sh
+++ b/scripts/ci/wizzair-config-version_test.sh
@@ -41,6 +41,16 @@ expect "a different path is not the API base" "" \
 expect "a page naming no version" "" \
 	'<html><body>no config here</body></html>'
 
+# A longer path that merely BEGINS with /Api is not the API base. Without the
+# closing delimiter this matched, and because the first match wins, a page
+# carrying such a URL ahead of the real config would shadow it -- while
+# wizzVersionFromConfigBody, whose path pattern is anchored end to end, would
+# have rejected the same string. The pair below pins both halves.
+expect "a longer path beginning with /Api is not the API base" "" \
+	'"https://be.wizzair.com/1.2.3/Apiary"'
+expect "a prefix lookalike does not shadow the real config" 29.15.1 \
+	'"https://be.wizzair.com/1.2.3/Apiary" {apiUrl:"https://be.wizzair.com/29.15.1/Api"}'
+
 # Known ceiling, pinned deliberately rather than left to be discovered: a QUOTED
 # URL nested in another URL's query value is accepted. wizzVersionFromConfigBody
 # behaves the same way — its candidate regex also breaks on quotes — so this

--- a/scripts/ci/wizzair-config-version_test.sh
+++ b/scripts/ci/wizzair-config-version_test.sh
@@ -23,14 +23,16 @@ expect "double-quoted apiUrl" 29.15.1 \
 	'{"apiUrl":"https://be.wizzair.com/29.15.1/Api","x":1}'
 expect "single-quoted apiUrl" 29.15.1 \
 	"var cfg={apiUrl:'https://be.wizzair.com/29.15.1/Api'};"
-expect "first match wins when the page repeats itself" 29.15.1 \
-	'"https://be.wizzair.com/29.15.1/Api" ... "https://be.wizzair.com/29.15.1/Api"'
+expect "first match wins" 29.15.1 \
+	'"https://be.wizzair.com/29.15.1/Api" ... "https://be.wizzair.com/30.0.0/Api"'
+expect "rejected noise before the real config does not shadow it" 29.15.1 \
+	'"https://notbe.wizzair.com/1.2.3/Api" then {apiUrl:"https://be.wizzair.com/29.15.1/Api"}'
 
 expect "lookalike host is not the API host" "" \
 	'"https://notbe.wizzair.com/1.2.3/Api"'
 expect "host as a path segment elsewhere" "" \
 	'"https://evil.example/be.wizzair.com/1.2.3/Api"'
-expect "URL embedded in another URL query string" "" \
+expect "bare URL in another URL query string" "" \
 	'"https://evil.example/?u=https://be.wizzair.com/1.2.3/Api"'
 expect "http is not https" "" \
 	'"http://be.wizzair.com/1.2.3/Api"'
@@ -38,5 +40,13 @@ expect "a different path is not the API base" "" \
 	'"https://be.wizzair.com/29.15.1/Assets"'
 expect "a page naming no version" "" \
 	'<html><body>no config here</body></html>'
+
+# Known ceiling, pinned deliberately rather than left to be discovered: a QUOTED
+# URL nested in another URL's query value is accepted. wizzVersionFromConfigBody
+# behaves the same way — its candidate regex also breaks on quotes — so this
+# fixture records parity, not an oversight. The probe in the caller is what stops
+# a version sourced this way from being reported.
+expect "quoted URL nested in a query value is accepted (probe is the guard)" 1.2.3 \
+	"\"https://evil.example/?next='https://be.wizzair.com/1.2.3/Api'\""
 
 exit "$fail"

--- a/scripts/wizzair-discover-version.sh
+++ b/scripts/wizzair-discover-version.sh
@@ -54,8 +54,38 @@ case "$(probe "$current")" in
 	absent) : ;;  # rotated — fall through to discovery
 esac
 
-# Discovery walk, most-likely first. History (10.1.0 -> 29.3.0 -> 29.4.0) shows
-# minor +1 is the common rotation, with occasional larger jumps. Bounded probes.
+# discover_from_config -> echoes a version, or nothing.
+#
+# Mirrors wizzDiscoverFromConfig in internal/flights/wizzair_selfheal.go: the
+# homepage embeds its API base URL in an inline bootstrap config, so Wizz
+# publishes the answer in plain HTML. That matters because the candidate walk
+# below is blind to a whole class of rotation (see its comment), and #641 was
+# exactly that class. Extraction lives in scripts/ci/wizzair-config-version.sh,
+# which is tested against fixtures; this function only supplies the page.
+#
+# The result is a claim, never a verdict: nothing is reported until probe()
+# confirms it against the live host.
+discover_from_config() {
+	curl -s -m 20 -A "$UA" "https://www.wizzair.com/en-gb" 2>/dev/null \
+		| bash "$(dirname "$0")/ci/wizzair-config-version.sh"
+}
+
+config_version="$(discover_from_config || true)"
+if [ -n "$config_version" ] && [ "$config_version" != "$current" ]; then
+	if [ "$(probe "$config_version")" = live ]; then
+		echo "STATUS=rotated CURRENT=$current NEW=$config_version"; exit 10
+	fi
+fi
+
+# Discovery walk, most-likely first. Fallback only: it runs when the config read
+# failed, named the stale version, or named one that did not probe live.
+#
+# History (10.1.0 -> 29.3.0 -> 29.4.0) shows minor +1 is the common rotation,
+# with occasional larger jumps. Bounded probes. Note the blind spot this cannot
+# close: shifted minors are probed at patch .0 only, so a rotation to X.Y.Z with
+# Z > 0 on a new minor is unreachable here however wide the range. That is #641
+# (29.15.0 absent, 29.15.1 live) and the reason config discovery runs first
+# rather than as a second fallback. Widening the walk would not have found it.
 candidates=()
 for d in 1 2 3 4 5 6; do candidates+=("$MA.$((MI+d)).0"); done   # next minors
 for d in 1 2 3;       do candidates+=("$MA.$MI.$((PA+d))"); done    # next patches

--- a/scripts/wizzair-discover-version.sh
+++ b/scripts/wizzair-discover-version.sh
@@ -66,7 +66,10 @@ esac
 # The result is a claim, never a verdict: nothing is reported until probe()
 # confirms it against the live host.
 discover_from_config() {
-	curl -s -m 20 -A "$UA" "https://www.wizzair.com/en-gb" 2>/dev/null \
+	# -L because a silent locale or canonicalization redirect would otherwise
+	# yield an empty body and drop the sentinel back into the blind walk this
+	# exists to bypass -- the runtime client (wizzClient.Do) follows redirects too.
+	curl -sL -m 20 -A "$UA" "https://www.wizzair.com/en-gb" 2>/dev/null \
 		| bash "$(dirname "$0")/ci/wizzair-config-version.sh"
 }
 

--- a/scripts/wizzair-discover-version.sh
+++ b/scripts/wizzair-discover-version.sh
@@ -73,11 +73,18 @@ discover_from_config() {
 		| bash "$(dirname "$0")/ci/wizzair-config-version.sh"
 }
 
+# Declared before the config probe so a throttled edge there is carried into the
+# final verdict. Discarding it reported STATUS=exhausted -- "rotated, and nothing
+# is live" -- when the truth was "we could not tell", and exhausted is the status
+# that files an issue at a human.
+saw_inconclusive=false
+
 config_version="$(discover_from_config || true)"
 if [ -n "$config_version" ] && [ "$config_version" != "$current" ]; then
-	if [ "$(probe "$config_version")" = live ]; then
-		echo "STATUS=rotated CURRENT=$current NEW=$config_version"; exit 10
-	fi
+	case "$(probe "$config_version")" in
+		live) echo "STATUS=rotated CURRENT=$current NEW=$config_version"; exit 10 ;;
+		inconclusive) saw_inconclusive=true ;;
+	esac
 fi
 
 # Discovery walk, most-likely first. Fallback only: it runs when the config read
@@ -94,7 +101,6 @@ for d in 1 2 3 4 5 6; do candidates+=("$MA.$((MI+d)).0"); done   # next minors
 for d in 1 2 3;       do candidates+=("$MA.$MI.$((PA+d))"); done    # next patches
 candidates+=("$((MA+1)).0.0" "$((MA+1)).1.0" "$((MA+2)).0.0")        # next majors
 
-saw_inconclusive=false
 for c in "${candidates[@]}"; do
 	case "$(probe "$c")" in
 		live) echo "STATUS=rotated CURRENT=$current NEW=$c"; exit 10 ;;


### PR DESCRIPTION
Closes #641.

## What broke

`be.wizzair.com/29.11.0/Api` returns 404. Probed against the repo's own oracle
(`GET /<v>/Api/asset/culture`, 404 = absent, 405 = live) on 2026-09-10:

| version | oracle |
|---|---|
| 29.11.0 (was the constant) | 404 |
| 29.12.0 – 29.14.0 | 404 |
| 29.15.0 | 404 |
| **29.15.1** | **405 — live** |
| 29.16.0 | 404 |

Searches did not fail outright: `wizzHeal` reads the homepage config, probes the version it
names and retries in-request (`internal/flights/wizzair.go:305`), so a stale constant costs a
404 plus a discovery fetch, a probe and a retry on every cold start — and only holds that
ground while self-healing is on (`WIZZAIR_API_VERSION` or `WIZZAIR_NO_AUTOHEAL=1` turns it
off and restores the fail-clean path). What failed silently is the sentinel, which is what
#641 reports.

## Why the sentinel never proposed the bump

The daily sentinel had been reporting `STATUS=exhausted` rather than `rotated`. Its candidate
walk probes shifted minors at patch `.0` only (`$MA.$((MI+d)).0`), so a rotation to `X.Y.Z`
with `Z > 0` on a **new minor** is outside its reach by construction — exactly this case, where
`29.15.0` is absent and only `29.15.1` answers. Widening the range would not have found it.

## The structural half

Wizz publishes the answer in plain HTML: the homepage bootstrap config embeds
`apiUrl:"https://be.wizzair.com/<version>/Api"`. `wizzDiscoverFromConfig` already reads it at
runtime; the sentinel did not. It now does, **before** the walk, and the walk stays as the
fallback for when the config read fails or names a version that does not probe live.

Config discovery never bypasses the probe. The extracted version is confirmed against the live
host before any rotation is reported — its own doc says the result is a claim, not a fact.

Known ceiling, stated rather than left to be rediscovered: discovery runs only after `current`
404s, so the sentinel stays reactive. The next rotation still costs a cold-start window until
the daily run proposes the bump.

An inconclusive config probe — a throttled or 5xx edge — is now carried into the final status
rather than dropped. Discarding it let a walk of 404s report `STATUS=exhausted`, which is the
status that files an issue at a human, when the honest answer was "could not tell".

## Host safety

Extraction lives in `scripts/ci/wizzair-config-version.sh`. The match is delimited by quotes at
both ends. The opening quote is what rejects a lookalike host, the host as a path segment, and a
*bare* URL in another URL's query string. The closing quote is what rejects a longer path that
merely begins with `/Api` (`.../1.2.3/Apiary`) — `wizzVersionFromConfigBody` anchors its path
pattern end to end, so without it this side would have proposed a version the runtime rejects,
and a page carrying such a URL ahead of the real config would have shadowed it. A **quoted** URL nested in a query value
(`?next='https://be.wizzair.com/1.2.3/Api'`) is accepted — `wizzVersionFromConfigBody` has the
same property, because its candidate scan also breaks on quotes, so the inner URL is parsed as
its own candidate and its host does compare equal. Neither side treats extraction as the
safeguard; the live probe is. Both sides now pin that case in a test, so hardening one fails
the other instead of drifting apart.

Thirteen fixture cases cover the accept and reject boundary, wired into
`check-workflow-hygiene.sh` (`make lint`).

## Verification

- `bash scripts/ci/wizzair-config-version_test.sh` — thirteen cases, all pass
- `bash scripts/ci/check-workflow-hygiene.sh` — exit 0
- `go test -count=1 -run TestWizzConfigVersion ./internal/flights/` — ok
- `go test -short -count=1 ./internal/flights/` — ok
- Extractor run against the live `https://www.wizzair.com/en-gb` returns `29.15.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
