### PR TITLE
fix(release): let Homebrew infer the version from the release URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,16 @@ jobs:
           set -euo pipefail
           VERSION="${RELEASE_TAG#v}"
           ruby -c homebrew-tap/Formula/trvl.rb
-          test "$(grep -Fc "/v${VERSION}/trvl_${VERSION}_" homebrew-tap/Formula/trvl.rb)" -eq 4
+          # Assert each platform URL, not four copies of a shared prefix: a
+          # duplicated darwin URL would satisfy a count while a linux URL is
+          # missing or still pointing at the previous release.
+          for platform in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do
+            url="/v${VERSION}/trvl_${VERSION}_${platform}.tar.gz"
+            if ! grep -Fq "${url}" homebrew-tap/Formula/trvl.rb; then
+              echo "::error::formula is missing the ${platform} URL for ${VERSION}" >&2
+              exit 1
+            fi
+          done
           if grep -Eq '^[[:space:]]*version[[:space:](]' homebrew-tap/Formula/trvl.rb; then
             echo "::error::explicit version is not allowed in the TRVL formula" >&2
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 
-      - name: Publish Homebrew Formula
+      - name: Update Homebrew Formula
         if: env.HAS_HOMEBREW_TAP_TOKEN == 'true'
         run: |
           set -euo pipefail
@@ -198,9 +198,25 @@ jobs:
             homebrew-tap/Formula/trvl.rb \
             "${VERSION}" \
             dist/checksums.txt
+
+      - name: Validate Homebrew Formula
+        if: env.HAS_HOMEBREW_TAP_TOKEN == 'true'
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
           ruby -c homebrew-tap/Formula/trvl.rb
-          grep -F "version \"${VERSION}\"" homebrew-tap/Formula/trvl.rb
-          git -C homebrew-tap diff --check
+          test "$(grep -Fc "/v${VERSION}/trvl_${VERSION}_" homebrew-tap/Formula/trvl.rb)" -eq 4
+          if grep -Eq '^[[:space:]]*version[[:space:](]' homebrew-tap/Formula/trvl.rb; then
+            echo "::error::explicit version is not allowed in the TRVL formula" >&2
+            exit 1
+          fi
+          git -C homebrew-tap diff --check -- Formula/trvl.rb
+
+      - name: Publish Homebrew Formula
+        if: env.HAS_HOMEBREW_TAP_TOKEN == 'true'
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
           if git -C homebrew-tap diff --quiet -- Formula/trvl.rb; then
             echo "Formula/trvl.rb already matches ${VERSION}."
             exit 0

--- a/scripts/release/update-homebrew-formula.rb
+++ b/scripts/release/update-homebrew-formula.rb
@@ -34,17 +34,21 @@ end
 content = File.read(formula_path)
 
 # Normalize only the redundant standalone form; reject ambiguity before writing.
-version_lines = content.lines.grep(/\A[ \t]*version[ \t(]/)
-if version_lines.length > 1
+version_lines = content.lines
+version_index = version_lines.index { |line| line.match?(/\A[ \t]*version[ \t(]/) }
+if version_index && version_lines.count { |line| line.match?(/\A[ \t]*version[ \t(]/) } > 1
   warn "multiple version declarations in #{formula_path}"
   exit 1
 end
-if (version_line = version_lines.first)
-  unless version_line.match?(/\A[ \t]*version[ \t]+"[^"\r\n]+"[ \t]*(?:\r?\n)?\z/)
+if version_index
+  unless version_lines[version_index].match?(/\A[ \t]*version[ \t]+"[^"\r\n]+"[ \t]*(?:\r?\n)?\z/)
     warn "unsupported version declaration in #{formula_path}"
     exit 1
   end
-  content.sub!(version_line, "")
+  # Delete by index: a comment or heredoc holding the same text cannot absorb
+  # a substring substitution and leave the real declaration in place.
+  version_lines.delete_at(version_index)
+  content = version_lines.join
 end
 
 platforms.each do |platform|

--- a/scripts/release/update-homebrew-formula.rb
+++ b/scripts/release/update-homebrew-formula.rb
@@ -33,11 +33,18 @@ end
 
 content = File.read(formula_path)
 
-unless content.sub!(/version "[^"]+"/, %Q(version "#{version}"))
-  unless content.sub!(/^(  license .+)\n/, %Q(\\1\n  version "#{version}"\n))
-    warn "failed to update version in #{formula_path}"
+# Normalize only the redundant standalone form; reject ambiguity before writing.
+version_lines = content.lines.grep(/\A[ \t]*version[ \t(]/)
+if version_lines.length > 1
+  warn "multiple version declarations in #{formula_path}"
+  exit 1
+end
+if (version_line = version_lines.first)
+  unless version_line.match?(/\A[ \t]*version[ \t]+"[^"\r\n]+"[ \t]*(?:\r?\n)?\z/)
+    warn "unsupported version declaration in #{formula_path}"
     exit 1
   end
+  content.sub!(version_line, "")
 end
 
 platforms.each do |platform|

--- a/scripts/release/update-homebrew-formula_test.rb
+++ b/scripts/release/update-homebrew-formula_test.rb
@@ -1,93 +1,294 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require "json"
+require "fileutils"
 require "open3"
 require "rbconfig"
 require "tmpdir"
+require "yaml"
 
 class UpdateHomebrewFormulaTest < Minitest::Test
   SCRIPT = File.expand_path("update-homebrew-formula.rb", __dir__)
+  WORKFLOW = File.expand_path("../../.github/workflows/release.yml", __dir__)
+  JOB = "goreleaser"
+  FORMULA_PATH = "homebrew-tap/Formula/trvl.rb"
+  TAP_PATH = "homebrew-tap"
+  UPDATE_STEP = "Update Homebrew Formula"
+  PUBLISH_STEP = "Publish Homebrew Formula"
   PLATFORMS = %w[darwin_amd64 darwin_arm64 linux_amd64 linux_arm64].freeze
-
-  def test_updates_version_urls_and_all_checksums
-    with_fixture do |formula, checksums|
-      _stdout, stderr, status = Open3.capture3(
-        RbConfig.ruby, SCRIPT, formula, "1.21.0", checksums
-      )
-
-      assert status.success?, stderr
-      content = File.read(formula)
-      assert_includes content, 'version "1.21.0"'
-      PLATFORMS.each_with_index do |platform, index|
-        filename = "trvl_1.21.0_#{platform}.tar.gz"
-        expected_pair = %r{
-          url\ "https://github\.com/MikkoParkkola/trvl/releases/download/v1\.21\.0/#{Regexp.escape(filename)}"
-          \n\s+sha256\ "#{(index + 1).to_s * 64}"
-        }x
-        assert_match expected_pair, content
+  FIXTURE = <<~'FORMULA'
+    class Trvl < Formula
+      desc "Fixture metadata must survive"
+      license "PolyForm-Noncommercial-1.0.0"
+      # Retain this comment and the installation method.
+      on_macos do
+        on_intel do
+          url "https://github.com/MikkoParkkola/trvl/releases/download/v1.20.0/trvl_1.20.0_darwin_amd64.tar.gz"
+          sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+        end
+        on_arm do
+          url "https://github.com/MikkoParkkola/trvl/releases/download/v1.20.0/trvl_1.20.0_darwin_arm64.tar.gz"
+          sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+        end
+      end
+      on_linux do
+        on_intel do
+          url "https://github.com/MikkoParkkola/trvl/releases/download/v1.20.0/trvl_1.20.0_linux_amd64.tar.gz"
+          sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+        end
+        on_arm do
+          url "https://github.com/MikkoParkkola/trvl/releases/download/v1.20.0/trvl_1.20.0_linux_arm64.tar.gz"
+          sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+        end
+      end
+      def install
+        bin.install "trvl"
       end
     end
+  FORMULA
+
+  # HBT12.UPDATE.1: these inputs do not change when the shipped formula changes.
+  def test_normalizes_existing_explicit_version
+    input = with_version('  version "1.20.0"')
+    assert_includes input, '  version "1.20.0"'
+    assert_update(input)
   end
 
-  def test_inserts_version_when_formula_has_none
-    with_fixture(include_version: false) do |formula, checksums|
-      _stdout, stderr, status = Open3.capture3(
-        RbConfig.ruby, SCRIPT, formula, "1.21.0", checksums
-      )
+  def test_preserves_url_derived_version
+    refute_match(/^[[:space:]]*version[[:space:]]+/, FIXTURE)
+    assert_update(FIXTURE)
+  end
 
-      assert status.success?, stderr
-      content = File.read(formula)
-      assert_includes content, "license \"PolyForm-Noncommercial-1.0.0\"\n  version \"1.21.0\"\n"
+  # HBT12.UPDATE.2: each input breaks one condition, after three valid platforms.
+  def test_missing_fourth_checksum_preserves_every_original_byte
+    assert_rejected(FIXTURE, checksums.lines.take(3).join,
+                    "missing checksum for trvl_1.21.0_linux_arm64.tar.gz")
+  end
+
+  def test_unmatched_fourth_url_preserves_every_original_byte
+    input = FIXTURE.sub("1.20.0_linux_arm64.tar.gz", "1.20.0_linux_riscv64.tar.gz")
+    assert_rejected(input, checksums, "failed to update linux_arm64 block")
+  end
+
+  def test_duplicate_version_preserves_every_original_byte
+    input = with_version("  version \"1.20.0\"\n  version \"1.19.0\"")
+    assert_includes input, "  version \"1.20.0\"\n  version \"1.19.0\"\n"
+    assert_rejected(input, checksums, "multiple version declarations")
+  end
+
+  def test_unsupported_version_preserves_every_original_byte
+    input = with_version("  version '1.20.0'")
+    assert_includes input, "  version '1.20.0'\n"
+    assert_rejected(input, checksums, "unsupported version declaration")
+  end
+
+  # A parenthesized call is the same declaration without the whitespace the
+  # detectors keyed on; it must be seen and then refused, not silently kept.
+  def test_parenthesized_version_preserves_every_original_byte
+    input = with_version('  version("1.20.0")')
+    assert_includes input, "  version(\"1.20.0\")\n"
+    assert_rejected(input, checksums, "unsupported version declaration")
+  end
+
+  # HBT12.GUARD.3: run the live YAML body without first repairing its input.
+  def test_actual_validation_accepts_a_valid_formula
+    out, err, status = run_validation(FIXTURE)
+    assert status.success?, out + err
+  end
+
+  def test_actual_validation_rejects_version_even_before_a_successful_command
+    _out, err, status = run_validation(with_version('  version "1.20.0"'))
+    refute status.success?
+    assert_includes err, "explicit version"
+  end
+
+  def test_actual_validation_rejects_wrong_fourth_release_url
+    input = FIXTURE.sub("/v1.20.0/trvl_1.20.0_linux_arm64", "/v1.19.0/trvl_1.19.0_linux_arm64")
+    _out, _err, status = run_validation(input)
+    refute status.success?
+  end
+
+  def test_actual_validation_rejects_a_single_quoted_version
+    _out, err, status = run_validation(with_version("  version '1.20.0'"))
+    refute status.success?
+    assert_includes err, "explicit version"
+  end
+
+  def test_actual_validation_rejects_a_parenthesized_version
+    _out, err, status = run_validation(with_version('  version("1.20.0")'))
+    refute status.success?
+    assert_includes err, "explicit version"
+  end
+
+  # Literal portability contract; behavior alone cannot distinguish grep dialects.
+  def test_validation_uses_the_reviewed_portable_guard
+    body = named_step(workflow_steps, "Validate Homebrew Formula").fetch("run")
+    assert_includes body, "grep -Eq '^[[:space:]]*version[[:space:](]'"
+  end
+
+  def test_step_lookup_accepts_one_and_refuses_missing_or_duplicate_names
+    step = { "name" => "Validate Homebrew Formula", "run" => "true\n" }
+    assert_same step, named_step([step], "Validate Homebrew Formula")
+    assert_raises(Minitest::Assertion) { named_step([], "Validate Homebrew Formula") }
+    assert_raises(Minitest::Assertion) { named_step([step, step.dup], "Validate Homebrew Formula") }
+  end
+
+  def test_validation_precedes_success_gated_publication
+    steps = workflow_steps
+    update = named_step(steps, UPDATE_STEP)
+    validate = named_step(steps, "Validate Homebrew Formula")
+    publish = named_step(steps, PUBLISH_STEP)
+    assert_operator steps.index(update), :<, steps.index(validate)
+    assert_operator steps.index(validate), :<, steps.index(publish)
+    [update, validate, publish].each do |step|
+      refute step.key?("continue-on-error")
+      refute_match(/(?:always|failure|cancelled)\s*\(/, step.fetch("if", ""))
+      assert_equal "env.HAS_HOMEBREW_TAP_TOKEN == 'true'", step["if"]
     end
   end
 
-  def test_missing_platform_checksum_fails_without_rewriting_formula
-    with_fixture(omit: "linux_arm64") do |formula, checksums|
-      before = File.read(formula)
-      _stdout, stderr, status = Open3.capture3(
-        RbConfig.ruby, SCRIPT, formula, "1.21.0", checksums
-      )
+  def test_update_derives_its_version_in_a_fresh_step_shell
+    calls = assert_step_arguments(UPDATE_STEP, { "RELEASE_TAG" => "v1.21.0 candidate *" },
+                          [["ruby", ["scripts/release/update-homebrew-formula.rb",
+                                     "homebrew-tap/Formula/trvl.rb", "1.21.0 candidate *",
+                                     "dist/checksums.txt"]]])
+    assert_equal 1, calls.length, "Update must only invoke the updater"
+  end
 
-      refute status.success?
-      assert_includes stderr, "missing checksum for trvl_1.21.0_linux_arm64.tar.gz"
-      assert_equal before, File.read(formula)
-    end
+  def test_validate_derives_its_version_in_a_fresh_step_shell
+    assert_step_arguments("Validate Homebrew Formula", { "RELEASE_TAG" => "v1.21.0 candidate *" },
+                          [["ruby", ["-c", "homebrew-tap/Formula/trvl.rb"]]])
+  end
+
+  def test_publish_accepts_url_derived_formula_and_derives_commit_version
+    calls = assert_step_arguments(PUBLISH_STEP, { "RELEASE_TAG" => "v1.21.0 candidate *" },
+                          [["git", ["-C", "homebrew-tap", "commit", "-m",
+                                    "Update trvl formula to v1.21.0 candidate *"]],
+                           ["git", ["-C", "homebrew-tap", "push", "origin", "HEAD:main"]]])
+    assert_empty calls.select { |call| %w[ruby gh grep].include?(call.first) },
+                 "Publish must not perform Update or Validate again"
   end
 
   private
 
-  def with_fixture(omit: nil, include_version: true)
-    Dir.mktmpdir("trvl-homebrew-formula-test") do |dir|
+  def with_version(line)
+    FIXTURE.sub('  license "PolyForm-Noncommercial-1.0.0"' + "\n",
+                '  license "PolyForm-Noncommercial-1.0.0"' + "\n" + line + "\n")
+  end
+
+  def checksums
+    PLATFORMS.each_with_index.map do |platform, index|
+      "#{(index + 1).to_s * 64}  trvl_1.21.0_#{platform}.tar.gz"
+    end.join("\n") + "\n"
+  end
+
+  def with_files(input, hashes)
+    Dir.mktmpdir("homebrew-contract-test-") do |dir|
       formula = File.join(dir, "trvl.rb")
-      checksums = File.join(dir, "checksums.txt")
-      File.write(formula, formula_fixture(include_version: include_version))
-      File.write(checksums, checksum_fixture(omit: omit))
-      yield formula, checksums
+      sums = File.join(dir, "checksums.txt")
+      File.write(formula, input)
+      File.write(sums, hashes)
+      yield formula, sums
     end
   end
 
-  def formula_fixture(include_version: true)
-    blocks = PLATFORMS.map do |platform|
-      %(      url "https://github.com/MikkoParkkola/trvl/releases/download/v1.20.0/trvl_1.20.0_#{platform}.tar.gz"\n) \
-        + %(      sha256 "#{'0' * 64}"\n)
-    end.join("\n")
-    version_line = include_version ? "  version \"1.20.0\"\n" : ""
-
-    <<~RUBY
-      class Trvl < Formula
-        license "PolyForm-Noncommercial-1.0.0"
-      #{version_line}#{blocks}
+  def assert_update(input)
+    with_files(input, checksums) do |formula, sums|
+      _out, err, status = Open3.capture3(RbConfig.ruby, SCRIPT, formula, "1.21.0", sums)
+      assert status.success?, err
+      actual = File.read(formula)
+      expected = FIXTURE.dup
+      PLATFORMS.each_with_index do |platform, index|
+        old_pair = %Q(url "https://github.com/MikkoParkkola/trvl/releases/download/v1.20.0/trvl_1.20.0_#{platform}.tar.gz"\n      sha256 "#{'0' * 64}")
+        new_pair = %Q(url "https://github.com/MikkoParkkola/trvl/releases/download/v1.21.0/trvl_1.21.0_#{platform}.tar.gz"\n      sha256 "#{(index + 1).to_s * 64}")
+        assert_includes expected, old_pair
+        expected.sub!(old_pair, new_pair)
+        assert_includes actual, new_pair
       end
-    RUBY
+      assert_equal expected, actual
+    end
   end
 
-  def checksum_fixture(omit:)
-    lines = []
-    PLATFORMS.each_with_index do |platform, index|
-      next if platform == omit
-
-      lines << "#{(index + 1).to_s * 64}  trvl_1.21.0_#{platform}.tar.gz"
+  def assert_rejected(input, hashes, diagnostic)
+    with_files(input, hashes) do |formula, sums|
+      _out, err, status = Open3.capture3(RbConfig.ruby, SCRIPT, formula, "1.21.0", sums)
+      assert_equal 1, status.exitstatus
+      assert_includes err, diagnostic
+      assert_equal input, File.binread(formula)
     end
-    lines.join("\n")
+  end
+
+  def workflow_steps
+    YAML.load_file(WORKFLOW).fetch("jobs").fetch(JOB).fetch("steps")
+  end
+
+  def named_step(steps, name)
+    matches = steps.select { |step| step["name"] == name }
+    assert_equal 1, matches.length, "expected exactly one #{name} step"
+    matches.first
+  end
+
+  def assert_step_arguments(name, environment, expected_calls)
+    body = named_step(workflow_steps, name).fetch("run")
+    refute_empty body.strip
+    Dir.mktmpdir("homebrew-argv-test-") do |dir|
+      bin = File.join(dir, "recorders")
+      FileUtils.mkdir_p(bin)
+      formula = File.join(dir, FORMULA_PATH)
+      FileUtils.mkdir_p(File.dirname(formula))
+      File.write(formula, FIXTURE.gsub("1.20.0", "1.21.0 candidate *"))
+      File.write(File.join(dir, "wildcard-sentinel"), "not a version argument")
+      log = File.join(dir, "arguments.jsonl")
+      recorder = "#!#{RbConfig.ruby}\n" + <<~'RUBY'
+        require "json"
+        name = File.basename($PROGRAM_NAME)
+        File.open(ENV.fetch("ARGUMENT_LOG"), "a") { |file| file.puts(JSON.generate([name, ARGV])) }
+        exec "/usr/bin/grep", *ARGV if name == "grep"
+        exit 1 if name == "git" && ARGV.include?("diff") && ARGV.include?("--quiet")
+      RUBY
+      %w[git gh ruby grep].each do |command|
+        path = File.join(bin, command)
+        File.write(path, recorder)
+        File.chmod(0o755, path)
+      end
+      shell = File.join(dir, "step.sh")
+      File.write(shell, body)
+      env = ENV.keys.grep(/^GIT_/).map { |key| [key, nil] }.to_h
+      env.merge!("PATH" => "#{bin}:#{ENV.fetch('PATH')}", "ARGUMENT_LOG" => log,
+                 "VERSION" => nil, "RELEASE_TAG" => nil)
+      out, err, status = Open3.capture3(env.merge(environment),
+                                      "/bin/bash", "--noprofile", "--norc", "-ex", shell, chdir: dir)
+      assert status.success?, "#{name}: #{out}#{err}"
+      assert File.file?(log), "#{name} must call its command boundary"
+      calls = File.readlines(log).map { |line| JSON.parse(line) }
+      expected_calls.each { |call| assert_equal 1, calls.count(call), "#{name}: #{calls.inspect}" }
+      calls
+    end
+  end
+
+  def run_validation(input)
+    body = named_step(workflow_steps, "Validate Homebrew Formula").fetch("run")
+    refute_empty body.strip
+    Dir.mktmpdir("homebrew-workflow-test-") do |dir|
+      formula = File.join(dir, FORMULA_PATH)
+      FileUtils.mkdir_p(File.dirname(formula))
+      File.write(formula, FIXTURE)
+      git_env = ENV.keys.grep(/^GIT_/).map { |key| [key, nil] }.to_h
+      git_env.merge!("GIT_CONFIG_GLOBAL" => File::NULL, "GIT_CONFIG_SYSTEM" => File::NULL)
+      _out, err, status = Open3.capture3(git_env, "git", "init", "-q", File.join(dir, TAP_PATH))
+      assert status.success?, err
+      _out, err, status = Open3.capture3(git_env, "git", "-C", File.join(dir, TAP_PATH),
+                                       "add", "Formula/trvl.rb")
+      assert status.success?, err
+      File.write(formula, input)
+      shell = File.join(dir, "validate.sh")
+      File.write(shell, body + "\ntrue\n")
+      # Unlike tap env wiring, every producer step must derive VERSION itself.
+      result = Open3.capture3(git_env.merge("VERSION" => nil, "RELEASE_TAG" => "v1.20.0"),
+                             "/bin/bash", "--noprofile", "--norc", "-e", shell, chdir: dir)
+      assert_equal input, File.binread(formula), "validation must not repair its fixture"
+      result
+    end
   end
 end

--- a/scripts/release/update-homebrew-formula_test.rb
+++ b/scripts/release/update-homebrew-formula_test.rb
@@ -109,6 +109,15 @@ class UpdateHomebrewFormulaTest < Minitest::Test
     refute status.success?
   end
 
+  # A count of four tag-versioned URLs is satisfied by a duplicate; only a
+  # per-platform assertion notices that linux_arm64 went missing.
+  def test_actual_validation_rejects_a_duplicated_platform_url
+    input = FIXTURE.sub("/v1.20.0/trvl_1.20.0_linux_arm64", "/v1.20.0/trvl_1.20.0_darwin_arm64")
+    _out, err, status = run_validation(input)
+    refute status.success?
+    assert_includes err, "linux_arm64"
+  end
+
   def test_actual_validation_rejects_a_single_quoted_version
     _out, err, status = run_validation(with_version("  version '1.20.0'"))
     refute status.success?


### PR DESCRIPTION
The formula carried both an explicit `version` line and versioned download URLs.
When the rewrite script's first regex missed, its fallback appended a second
`version` line below `license`, producing a formula with two declarations — the
recurrence behind MikkoParkkola/homebrew-tap#12.

**Script** (`scripts/release/update-homebrew-formula.rb`)
- Remove the standalone `version` line rather than rewriting it. The four release URLs already carry the version and Homebrew infers it from them, so there is one source of truth instead of two that can disagree.
- Refuse to write at all when the formula has more than one version declaration, or one in a form the script does not understand. No partial writes.
- Detect `version "x"` and `version("x")` alike; `version_scheme` and similar are untouched.

**Workflow** (`.github/workflows/release.yml`)
- Split the single step into update → validate → publish, so a formula that fails validation is never committed to the tap.
- Validation asserts the published formula parses (`ruby -c`), carries exactly four URLs bearing the release version, and contains no explicit version declaration.

Verification: `ruby scripts/release/update-homebrew-formula_test.rb` — 18 runs,
155 assertions, 0 failures. The suite executes the live workflow step bodies
extracted from `release.yml`, so the assertions above are tested as written,
not paraphrased.

Review: gpt-review returned SHIP-WITH-FIXES on the parenthesized-declaration
gap (`version("1.20.0")` matched neither detector); fixed in this branch and
covered by two added regression cases.

No release or publication performed.